### PR TITLE
Use subscription callbacks to discover Sonos speakers

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -287,12 +287,17 @@ class SonosDiscoveryManager:
         zgs_subscription_uid: str | None,
     ) -> None:
         """Create and set up new SonosSpeaker instances."""
-        async with self.creation_lock:
+
+        def _add_speakers():
+            """Add all speakers in a single executor job."""
             for soco in socos:
                 sub = None
                 if soco.uid == zgs_subscription_uid and zgs_subscription:
                     sub = zgs_subscription
-                await self.hass.async_add_executor_job(self._add_speaker, soco, sub)
+                self._add_speaker(soco, sub)
+
+        async with self.creation_lock:
+            await self.hass.async_add_executor_job(_add_speakers)
 
     def _add_speaker(
         self, soco: SoCo, zone_group_state_sub: SubscriptionBase | None

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -11,9 +11,10 @@ import socket
 from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import urlparse
 
-from soco import events_asyncio
+from soco import events_asyncio, zonegroupstate
 import soco.config as soco_config
 from soco.core import SoCo
+from soco.events_base import Event as SonosEvent, SubscriptionBase
 from soco.exceptions import SoCoException
 import voluptuous as vol
 
@@ -24,8 +25,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOSTS, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
-from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval, call_later
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
 from .alarms import SonosAlarms
@@ -40,6 +41,7 @@ from .const import (
     SONOS_REBOOTED,
     SONOS_SPEAKER_ACTIVITY,
     SONOS_VANISHED,
+    SUBSCRIPTION_TIMEOUT,
     UPNP_ST,
 )
 from .exception import SonosUpdateError
@@ -51,7 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ADVERTISE_ADDR = "advertise_addr"
 CONF_INTERFACE_ADDR = "interface_addr"
 DISCOVERY_IGNORED_MODELS = ["Sonos Boost"]
-
+ZGS_SUBSCRIPTION_TIMEOUT = 2
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -122,6 +124,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Sonos from a config entry."""
     soco_config.EVENTS_MODULE = events_asyncio
     soco_config.REQUEST_TIMEOUT = 9.5
+    zonegroupstate.EVENT_CACHE_TIMEOUT = SUBSCRIPTION_TIMEOUT
 
     if DATA_SONOS not in hass.data:
         hass.data[DATA_SONOS] = SonosData()
@@ -172,6 +175,7 @@ class SonosDiscoveryManager:
         self.data = data
         self.hosts = set(hosts)
         self.discovery_lock = asyncio.Lock()
+        self.creation_lock = asyncio.Lock()
         self._known_invisible: set[SoCo] = set()
         self._manual_config_required = bool(hosts)
 
@@ -184,21 +188,63 @@ class SonosDiscoveryManager:
         """Check if device at provided IP is known to be invisible."""
         return any(x for x in self._known_invisible if x.ip_address == ip_address)
 
-    def _create_visible_speakers(self, ip_address: str) -> None:
-        """Create all visible SonosSpeaker instances with the provided seed IP."""
-        try:
-            soco = SoCo(ip_address)
+    async def async_subscribe_to_zone_updates(self, ip_address: str) -> None:
+        """Test subscriptions and create SonosSpeakers based on results."""
+        soco = SoCo(ip_address)
+        # Cache now to avoid household ID lookup during first ZoneGroupState processing
+        await self.hass.async_add_executor_job(
+            getattr,
+            soco,
+            "household_id",
+        )
+        sub = await soco.zoneGroupTopology.subscribe()
+
+        @callback
+        def _async_add_visible_zones(subscription_succeeded: bool = False) -> None:
+            """Determine visible zones and create SonosSpeaker instances."""
+            subscription = None
             visible_zones = soco.visible_zones
             self._known_invisible = soco.all_zones - visible_zones
-        except (OSError, SoCoException) as ex:
-            _LOGGER.warning(
-                "Failed to request visible zones from %s: %s", ip_address, ex
-            )
-            return
+            for zone in visible_zones:
+                if zone.uid not in self.data.discovered:
+                    if subscription_succeeded and zone is soco:
+                        subscription = sub
+                    self.hass.async_create_task(
+                        self.async_add_speaker(zone, subscription)
+                    )
 
-        for zone in visible_zones:
-            if zone.uid not in self.data.discovered:
-                self._add_speaker(zone)
+        async def async_subscription_failed(now: datetime.datetime) -> None:
+            """Fallback logic if the subscription callback never arrives."""
+            await sub.unsubscribe()
+            _LOGGER.warning(
+                "Subscription to %s failed, attempting to poll directly", ip_address
+            )
+            try:
+                await self.hass.async_add_executor_job(soco.zone_group_state.poll, soco)
+            except (OSError, SoCoException) as ex:
+                _LOGGER.warning(
+                    "Fallback pollling to %s failed, setup cannot continue: %s",
+                    ip_address,
+                    ex,
+                )
+                return
+            _LOGGER.debug("Fallback ZoneGroupState poll to %s succeeded", ip_address)
+            _async_add_visible_zones()
+
+        cancel_failure_callback = async_call_later(
+            self.hass, ZGS_SUBSCRIPTION_TIMEOUT, async_subscription_failed
+        )
+
+        @callback
+        def _async_subscription_succeeded(event: SonosEvent) -> None:
+            """Create SonosSpeakers when subscription callbacks successfully arrive."""
+            _LOGGER.debug("Subscription to %s succeeded", ip_address)
+            cancel_failure_callback()
+            _async_add_visible_zones(subscription_succeeded=True)
+
+        sub.callback = _async_subscription_succeeded
+        # Hold lock to prevent concurrent subscription attempts
+        await asyncio.sleep(ZGS_SUBSCRIPTION_TIMEOUT * 2)
 
     async def _async_stop_event_listener(self, event: Event | None = None) -> None:
         for speaker in self.data.discovered.values():
@@ -227,14 +273,27 @@ class SonosDiscoveryManager:
             self.data.hosts_heartbeat()
             self.data.hosts_heartbeat = None
 
-    def _add_speaker(self, soco: SoCo) -> None:
+    async def async_add_speaker(
+        self, soco: SoCo, zone_group_state_sub: SubscriptionBase | None = None
+    ) -> None:
+        """Create and set up a new SonosSpeaker instance."""
+        async with self.creation_lock:
+            if soco.uid in self.data.discovered:
+                return
+            await self.hass.async_add_executor_job(
+                self._add_speaker, soco, zone_group_state_sub
+            )
+
+    def _add_speaker(
+        self, soco: SoCo, zone_group_state_sub: SubscriptionBase | None
+    ) -> None:
         """Create and set up a new SonosSpeaker instance."""
         try:
             speaker_info = soco.get_speaker_info(True, timeout=7)
             if soco.uid not in self.data.boot_counts:
                 self.data.boot_counts[soco.uid] = soco.boot_seqnum
             _LOGGER.debug("Adding new speaker: %s", speaker_info)
-            speaker = SonosSpeaker(self.hass, soco, speaker_info)
+            speaker = SonosSpeaker(self.hass, soco, speaker_info, zone_group_state_sub)
             self.data.discovered[soco.uid] = speaker
             for coordinator, coord_dict in (
                 (SonosAlarms, self.data.alarms),
@@ -250,13 +309,25 @@ class SonosDiscoveryManager:
         except (OSError, SoCoException):
             _LOGGER.warning("Failed to add SonosSpeaker using %s", soco, exc_info=True)
 
-    def _poll_manual_hosts(self, now: datetime.datetime | None = None) -> None:
+    async def async_poll_manual_hosts(
+        self, now: datetime.datetime | None = None
+    ) -> None:
         """Add and maintain Sonos devices from a manual configuration."""
+
+        def get_sync_attributes(soco: SoCo) -> set[SoCo]:
+            """Ensure I/O attributes are cached and return visible zones."""
+            _ = soco.household_id
+            _ = soco.uid
+            return soco.visible_zones
+
         for host in self.hosts:
             ip_addr = socket.gethostbyname(host)
             soco = SoCo(ip_addr)
             try:
-                visible_zones = soco.visible_zones
+                visible_zones = await self.hass.async_add_executor_job(
+                    get_sync_attributes,
+                    soco,
+                )
             except OSError:
                 _LOGGER.warning("Could not get visible Sonos devices from %s", ip_addr)
             else:
@@ -267,7 +338,7 @@ class SonosDiscoveryManager:
                 }:
                     _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
                     self.hosts.update(new_hosts)
-                dispatcher_send(
+                async_dispatcher_send(
                     self.hass,
                     f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
                     "manual zone scan",
@@ -290,7 +361,9 @@ class SonosDiscoveryManager:
                 None,
             )
             if not known_speaker:
-                self._create_visible_speakers(ip_addr)
+                await self._async_handle_discovery_message(
+                    soco.uid, ip_addr, "manual zone scan"
+                )
             elif not known_speaker.available:
                 try:
                     known_speaker.ping()
@@ -299,33 +372,32 @@ class SonosDiscoveryManager:
                         "Manual poll to %s failed, keeping unavailable", ip_addr
                     )
 
-        self.data.hosts_heartbeat = call_later(
-            self.hass, DISCOVERY_INTERVAL.total_seconds(), self._poll_manual_hosts
+        self.data.hosts_heartbeat = async_call_later(
+            self.hass, DISCOVERY_INTERVAL.total_seconds(), self.async_poll_manual_hosts
         )
 
     async def _async_handle_discovery_message(
-        self, uid: str, discovered_ip: str, boot_seqnum: int | None
+        self,
+        uid: str,
+        discovered_ip: str,
+        source: str,
+        boot_seqnum: int | None = None,
     ) -> None:
         """Handle discovered player creation and activity."""
         async with self.discovery_lock:
             if not self.data.discovered:
                 # Initial discovery, attempt to add all visible zones
-                await self.hass.async_add_executor_job(
-                    self._create_visible_speakers,
-                    discovered_ip,
-                )
+                await self.async_subscribe_to_zone_updates(discovered_ip)
             elif uid not in self.data.discovered:
                 if self.is_device_invisible(discovered_ip):
                     return
-                await self.hass.async_add_executor_job(
-                    self._add_speaker, SoCo(discovered_ip)
-                )
+                await self.async_add_speaker(SoCo(discovered_ip))
             elif boot_seqnum and boot_seqnum > self.data.boot_counts[uid]:
                 self.data.boot_counts[uid] = boot_seqnum
                 async_dispatcher_send(self.hass, f"{SONOS_REBOOTED}-{uid}")
             else:
                 async_dispatcher_send(
-                    self.hass, f"{SONOS_SPEAKER_ACTIVITY}-{uid}", "discovery"
+                    self.hass, f"{SONOS_SPEAKER_ACTIVITY}-{uid}", source
                 )
 
     async def _async_ssdp_discovered_player(
@@ -389,7 +461,10 @@ class SonosDiscoveryManager:
             self.data.discovery_known.add(uid)
         asyncio.create_task(
             self._async_handle_discovery_message(
-                uid, discovered_ip, cast(Optional[int], boot_seqnum)
+                uid,
+                discovered_ip,
+                "discovery",
+                boot_seqnum=cast(Optional[int], boot_seqnum),
             )
         )
 
@@ -408,7 +483,7 @@ class SonosDiscoveryManager:
                     EVENT_HOMEASSISTANT_STOP, self._stop_manual_heartbeat
                 )
             )
-            await self.hass.async_add_executor_job(self._poll_manual_hosts)
+            await self.async_poll_manual_hosts()
 
         self.entry.async_on_unload(
             await ssdp.async_register_callback(

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -391,7 +391,7 @@ class SonosDiscoveryManager:
             elif uid not in self.data.discovered:
                 if self.is_device_invisible(discovered_ip):
                     return
-                await self.async_add_speaker(SoCo(discovered_ip))
+                await self.async_subscribe_to_zone_updates(discovered_ip)
             elif boot_seqnum and boot_seqnum > self.data.boot_counts[uid]:
                 self.data.boot_counts[uid] = boot_seqnum
                 async_dispatcher_send(self.hass, f"{SONOS_REBOOTED}-{uid}")

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -10,7 +10,7 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.sonos import DOMAIN
 from homeassistant.const import CONF_HOSTS
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_fixture
 
 
 class SonosMockService:
@@ -66,13 +66,14 @@ async def async_autosetup_sonos(async_setup_sonos):
 
 
 @pytest.fixture
-def async_setup_sonos(hass, config_entry):
+def async_setup_sonos(hass, config_entry, fire_zgs_event):
     """Return a coroutine to set up a Sonos integration instance on demand."""
 
     async def _wrapper():
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+        await fire_zgs_event()
 
     return _wrapper
 
@@ -349,3 +350,24 @@ def tv_event_fixture(soco):
 def mock_get_source_ip(mock_get_source_ip):
     """Mock network util's async_get_source_ip in all sonos tests."""
     return mock_get_source_ip
+
+
+@pytest.fixture(name="zgs_discovery", scope="session")
+def zgs_discovery_fixture():
+    """Load ZoneGroupState discovery payload and return it."""
+    return load_fixture("sonos/zgs_discovery.xml")
+
+
+@pytest.fixture(name="fire_zgs_event")
+def zgs_event_fixture(hass, soco, zgs_discovery):
+    """Create alarm_event fixture."""
+    variables = {"ZoneGroupState": zgs_discovery}
+
+    async def _wrapper():
+        event = SonosMockEvent(soco, soco.zoneGroupTopology, variables)
+        subscription = soco.zoneGroupTopology.subscribe.return_value
+        sub_callback = subscription.callback
+        sub_callback(event)
+        await hass.async_block_till_done()
+
+    return _wrapper

--- a/tests/components/sonos/fixtures/zgs_discovery.xml
+++ b/tests/components/sonos/fixtures/zgs_discovery.xml
@@ -1,0 +1,7 @@
+<ZoneGroupState>
+    <ZoneGroups>
+        <ZoneGroup Coordinator="RINCON_test" ID="RINCON_test:1384750254">
+            <ZoneGroupMember UUID="RINCON_test" Location="http://192.168.4.2:1400/xml/device_description.xml" ZoneName="Zone A" Icon="" Configuration="1" SoftwareVersion="70.4-36090" SWGen="2" MinCompatibleVersion="69.0-00000" LegacyCompatibleVersion="58.0-00000" BootSeq="1234" TVConfigurationError="0" HdmiCecAvailable="0" WirelessMode="1" WirelessLeafOnly="0" ChannelFreq="5180" BehindWifiExtender="0" WifiEnabled="1" EthLink="0" Orientation="0" RoomCalibrationState="4" SecureRegState="3" VoiceConfigState="0" MicEnabled="1" AirPlayEnabled="1" IdleState="1" MoreInfo="" SSLPort="1443" HHSSLPort="1843"/>
+        </ZoneGroup>
+    </ZoneGroups>
+</ZoneGroupState>

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -62,8 +62,12 @@ async def test_user_form(
 async def test_user_form_already_created(hass: core.HomeAssistant):
     """Ensure we abort a flow if the entry is already created from config."""
     config = {DOMAIN: {MP_DOMAIN: {CONF_HOSTS: "192.168.4.2"}}}
-    await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.sonos.async_setup_entry",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -184,7 +184,7 @@ async def test_microphone_binary_sensor(
     assert mic_binary_sensor_state.state == STATE_ON
 
 
-async def test_favorites_sensor(hass, async_autosetup_sonos, soco):
+async def test_favorites_sensor(hass, async_autosetup_sonos, soco, fire_zgs_event):
     """Test Sonos favorites sensor."""
     entity_registry = ent_reg.async_get(hass)
     favorites = entity_registry.entities["sensor.sonos_favorites"]
@@ -207,6 +207,9 @@ async def test_favorites_sensor(hass, async_autosetup_sonos, soco):
         dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
+
+    # Trigger subscription callback for speaker discovery
+    await fire_zgs_event()
 
     favorites_updated_event = SonosMockEvent(
         soco, service, {"favorites_update_id": "2", "container_update_i_ds": "FV:2,2"}

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -37,7 +37,7 @@ async def test_entity_registry(hass, async_autosetup_sonos):
     assert "switch.zone_a_touch_controls" in entity_registry.entities
 
 
-async def test_switch_attributes(hass, async_autosetup_sonos, soco):
+async def test_switch_attributes(hass, async_autosetup_sonos, soco, fire_zgs_event):
     """Test for correct Sonos switch states."""
     entity_registry = ent_reg.async_get(hass)
 
@@ -113,6 +113,9 @@ async def test_switch_attributes(hass, async_autosetup_sonos, soco):
         )
         await hass.async_block_till_done()
         assert m.called
+
+    # Trigger subscription callback for speaker discovery
+    await fire_zgs_event()
 
     status_light_state = hass.states.get(status_light.entity_id)
     assert status_light_state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Polling Sonos devices for the ZoneGroupState (which describes the device topology of the whole system) can fail with large installations of many speakers. It appears that this is a firmware limitation on the Sonos devices. This prevents the integration from starting once there are 20+ devices. 

Subscription callbacks can be used instead to obtain the same information without errors. This changes the behavior of discovery to avoid polling and rely on subscriptions whenever possible.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82513
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
