### PR TITLE
Google Assistant SDK: TTS for response playback

### DIFF
--- a/homeassistant/components/google_assistant_sdk/__init__.py
+++ b/homeassistant/components/google_assistant_sdk/__init__.py
@@ -88,7 +88,7 @@ async def async_setup_service(hass: HomeAssistant) -> None:
     async def send_text_command(call: ServiceCall) -> None:
         """Send a text command to Google Assistant SDK."""
         command: str = call.data[SERVICE_SEND_TEXT_COMMAND_FIELD_COMMAND]
-        await async_send_text_commands([command], hass)
+        await async_send_text_commands(hass, [command])
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/google_assistant_sdk/manifest.json
+++ b/homeassistant/components/google_assistant_sdk/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/google_assistant_sdk/",
-  "requirements": ["gassist-text==0.0.7"],
+  "requirements": ["gassist-text==0.0.8"],
   "codeowners": ["@tronikos"],
   "iot_class": "cloud_polling",
   "integration_type": "service"

--- a/homeassistant/components/google_assistant_sdk/notify.py
+++ b/homeassistant/components/google_assistant_sdk/notify.py
@@ -70,4 +70,4 @@ class BroadcastNotificationService(BaseNotificationService):
                 commands.append(
                     broadcast_commands(language_code)[1].format(message, target)
                 )
-        await async_send_text_commands(commands, self.hass)
+        await async_send_text_commands(self.hass, commands)

--- a/homeassistant/components/google_assistant_sdk/tts.py
+++ b/homeassistant/components/google_assistant_sdk/tts.py
@@ -1,0 +1,63 @@
+"""Support for playback of Google Assistant's audio response."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.tts import (
+    CONF_LANG,
+    PLATFORM_SCHEMA,
+    Provider,
+    TtsAudioType,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import SUPPORTED_LANGUAGE_CODES
+from .helpers import async_send_text_command_with_audio, default_language_code
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_LANG): vol.In(SUPPORTED_LANGUAGE_CODES),
+    }
+)
+
+
+async def async_get_engine(
+    hass: HomeAssistant,
+    config: ConfigType | None,
+    discovery_info: DiscoveryInfoType | None = None,
+):
+    """Set up Google Assistant SDK TTS provider."""
+    return GoogleAssistantSDKProvider(hass)
+
+
+class GoogleAssistantSDKProvider(Provider):
+    """The Google Assistant SDK TTS provider."""
+
+    hass: HomeAssistant
+
+    def __init__(self, hass):
+        """Init Google Assistant SDK TTS provider."""
+        self.hass = hass
+        self.name = "Google Assistant SDK"
+
+    @property
+    def default_language(self) -> str | None:
+        """Return the default language."""
+        return default_language_code(self.hass)
+
+    @property
+    def supported_languages(self) -> list[str] | None:
+        """Return a list of supported languages."""
+        return SUPPORTED_LANGUAGE_CODES
+
+    async def async_get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any] | None = None
+    ) -> TtsAudioType:
+        """Load tts audio file from provider.
+
+        Return a tuple of file extension and data as bytes.
+        """
+        return "mp3", await async_send_text_command_with_audio(self.hass, message)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -751,7 +751,7 @@ fritzconnection==1.10.3
 gTTS==2.2.4
 
 # homeassistant.components.google_assistant_sdk
-gassist-text==0.0.7
+gassist-text==0.0.8
 
 # homeassistant.components.google
 gcal-sync==4.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -570,7 +570,7 @@ fritzconnection==1.10.3
 gTTS==2.2.4
 
 # homeassistant.components.google_assistant_sdk
-gassist-text==0.0.7
+gassist-text==0.0.8
 
 # homeassistant.components.google
 gcal-sync==4.1.2

--- a/tests/components/google_assistant_sdk/test_init.py
+++ b/tests/components/google_assistant_sdk/test_init.py
@@ -129,7 +129,7 @@ async def test_send_text_command(
             blocking=True,
         )
     mock_text_assistant.assert_called_once_with(
-        ExpectedCredentials(), expected_language_code
+        ExpectedCredentials(), expected_language_code, audio_out=False
     )
     mock_text_assistant.assert_has_calls([call().__enter__().assist(command)])
 

--- a/tests/components/google_assistant_sdk/test_notify.py
+++ b/tests/components/google_assistant_sdk/test_notify.py
@@ -42,9 +42,11 @@ async def test_broadcast_no_targets(
             notify.DOMAIN,
             DOMAIN,
             {notify.ATTR_MESSAGE: message},
+            blocking=True,
         )
-        await hass.async_block_till_done()
-    mock_text_assistant.assert_called_once_with(ExpectedCredentials(), language_code)
+    mock_text_assistant.assert_called_once_with(
+        ExpectedCredentials(), language_code, audio_out=False
+    )
     mock_text_assistant.assert_has_calls([call().__enter__().assist(expected_command)])
 
 
@@ -84,14 +86,14 @@ async def test_broadcast_one_target(
 
     with patch(
         "homeassistant.components.google_assistant_sdk.helpers.TextAssistant.assist",
-        return_value=["text_response", None],
+        return_value=["text_response", None, b""],
     ) as mock_assist_call:
         await hass.services.async_call(
             notify.DOMAIN,
             DOMAIN,
             {notify.ATTR_MESSAGE: message, notify.ATTR_TARGET: [target]},
+            blocking=True,
         )
-        await hass.async_block_till_done()
     mock_assist_call.assert_called_once_with(expected_command)
 
 
@@ -108,14 +110,14 @@ async def test_broadcast_two_targets(
     expected_command2 = "broadcast to master bedroom time for dinner"
     with patch(
         "homeassistant.components.google_assistant_sdk.helpers.TextAssistant.assist",
-        return_value=["text_response", None],
+        return_value=["text_response", None, b""],
     ) as mock_assist_call:
         await hass.services.async_call(
             notify.DOMAIN,
             DOMAIN,
             {notify.ATTR_MESSAGE: message, notify.ATTR_TARGET: [target1, target2]},
+            blocking=True,
         )
-        await hass.async_block_till_done()
     mock_assist_call.assert_has_calls(
         [call(expected_command1), call(expected_command2)]
     )
@@ -129,14 +131,14 @@ async def test_broadcast_empty_message(
 
     with patch(
         "homeassistant.components.google_assistant_sdk.helpers.TextAssistant.assist",
-        return_value=["text_response", None],
+        return_value=["text_response", None, b""],
     ) as mock_assist_call:
         await hass.services.async_call(
             notify.DOMAIN,
             DOMAIN,
             {notify.ATTR_MESSAGE: ""},
+            blocking=True,
         )
-        await hass.async_block_till_done()
     mock_assist_call.assert_not_called()
 
 

--- a/tests/components/google_assistant_sdk/test_tts.py
+++ b/tests/components/google_assistant_sdk/test_tts.py
@@ -1,0 +1,90 @@
+"""The tests for the Google Assistant SDK TTS platform."""
+import os
+import shutil
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import media_source, tts
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_CONTENT_ID,
+    DOMAIN as DOMAIN_MP,
+    SERVICE_PLAY_MEDIA,
+)
+from homeassistant.config import async_process_ha_core_config
+from homeassistant.setup import async_setup_component
+
+from .conftest import ComponentSetup
+
+from tests.common import async_mock_service
+
+
+async def get_media_source_url(hass, media_content_id):
+    """Get the media source url."""
+    if media_source.DOMAIN not in hass.config.components:
+        assert await async_setup_component(hass, media_source.DOMAIN, {})
+
+    resolved = await media_source.async_resolve_media(hass, media_content_id, None)
+    return resolved.url
+
+
+@pytest.fixture(autouse=True)
+def cleanup_cache(hass):
+    """Clean up TTS cache."""
+    yield
+    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
+    if os.path.isdir(default_tts):
+        shutil.rmtree(default_tts)
+
+
+@pytest.fixture
+async def media_player_calls(hass):
+    """Mock media player calls."""
+    return async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+
+@pytest.fixture(autouse=True)
+async def setup_internal_url(hass):
+    """Set up internal url."""
+    await async_process_ha_core_config(
+        hass, {"internal_url": "http://example.local:8123"}
+    )
+
+
+@pytest.fixture
+def mock_text_assistant():
+    """Mock gtts."""
+    with patch(
+        "homeassistant.components.google_assistant_sdk.helpers.TextAssistant.assist",
+        return_value=["text_response", None, b"audio_response"],
+    ) as mock_text_assistant:
+        yield mock_text_assistant
+
+
+async def test_service_say(
+    hass, mock_text_assistant, media_player_calls, setup_integration: ComponentSetup
+):
+    """Test service call say."""
+    await setup_integration()
+
+    await async_setup_component(
+        hass, tts.DOMAIN, {tts.DOMAIN: {"platform": "google_assistant_sdk"}}
+    )
+
+    message = "tell me a joke"
+    await hass.services.async_call(
+        tts.DOMAIN,
+        "google_assistant_sdk_say",
+        {
+            "entity_id": "media_player.something",
+            tts.ATTR_MESSAGE: message,
+        },
+        blocking=True,
+    )
+
+    assert len(media_player_calls) == 1
+    url = await get_media_source_url(
+        hass, media_player_calls[0].data[ATTR_MEDIA_CONTENT_ID]
+    )
+    assert url.endswith(".mp3")
+    mock_text_assistant.assert_called_once_with(message)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support TTS in Google Assistant SDK to be able to playback Google Assistant's audio response.

Users will need to add:
```
tts:
  - platform: google_assistant_sdk
```

and then they can call:
```
service: tts.google_assistant_sdk_say
data:
  message: tell me a joke
  entity_id: media_player.living_room_speaker
  cache: false
```

Underlyging library changes:
https://github.com/tronikos/gassist_text/compare/0.0.7...0.0.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25653

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
