### PR TITLE
Google Assistant SDK: support Korean and Japanese

### DIFF
--- a/homeassistant/components/google_assistant_sdk/const.py
+++ b/homeassistant/components/google_assistant_sdk/const.py
@@ -20,5 +20,7 @@ SUPPORTED_LANGUAGE_CODES: Final = [
     "fr-CA",
     "fr-FR",
     "it-IT",
+    "ja-JP",
+    "ko-KR",
     "pt-BR",
 ]

--- a/homeassistant/components/google_assistant_sdk/helpers.py
+++ b/homeassistant/components/google_assistant_sdk/helpers.py
@@ -18,6 +18,8 @@ DEFAULT_LANGUAGE_CODES = {
     "es": "es-ES",
     "fr": "fr-FR",
     "it": "it-IT",
+    "ja": "ja-JP",
+    "ko": "ko-KR",
     "pt": "pt-BR",
 }
 

--- a/homeassistant/components/google_assistant_sdk/notify.py
+++ b/homeassistant/components/google_assistant_sdk/notify.py
@@ -13,12 +13,14 @@ from .helpers import async_send_text_commands, default_language_code
 
 # https://support.google.com/assistant/answer/9071582?hl=en
 LANG_TO_BROADCAST_COMMAND = {
-    "en": ("broadcast", "broadcast to"),
-    "de": ("Nachricht an alle", "Nachricht an alle an"),
-    "es": ("Anuncia", "Anuncia en"),
-    "fr": ("Diffuse", "Diffuse dans"),
-    "it": ("Trasmetti", "Trasmetti in"),
-    "pt": ("Transmite", "Transmite para"),
+    "en": ("broadcast {0}", "broadcast to {1} {0}"),
+    "de": ("Nachricht an alle {0}", "Nachricht an alle an {1} {0}"),
+    "es": ("Anuncia {0}", "Anuncia en {1} {0}"),
+    "fr": ("Diffuse {0}", "Diffuse dans {1} {0}"),
+    "it": ("Trasmetti {0}", "Trasmetti in {1} {0}"),
+    "ja": ("{0}、とブロードキャストして", "{1}に、{0}、とブロードキャストして"),
+    "ko": ("{0} 방송", "{1}에 방송해 줘, {0}"),
+    "pt": ("Transmite {0}", "Transmite para {1} {0}"),
 }
 
 
@@ -62,10 +64,10 @@ class BroadcastNotificationService(BaseNotificationService):
         commands = []
         targets = kwargs.get(ATTR_TARGET)
         if not targets:
-            commands.append(f"{broadcast_commands(language_code)[0]} {message}")
+            commands.append(broadcast_commands(language_code)[0].format(message))
         else:
             for target in targets:
                 commands.append(
-                    f"{broadcast_commands(language_code)[1]} {target} {message}"
+                    broadcast_commands(language_code)[1].format(message, target)
                 )
         await async_send_text_commands(commands, self.hass)

--- a/homeassistant/components/google_assistant_sdk/notify.py
+++ b/homeassistant/components/google_assistant_sdk/notify.py
@@ -18,8 +18,8 @@ LANG_TO_BROADCAST_COMMAND = {
     "es": ("Anuncia {0}", "Anuncia en {1} {0}"),
     "fr": ("Diffuse {0}", "Diffuse dans {1} {0}"),
     "it": ("Trasmetti {0}", "Trasmetti in {1} {0}"),
-    "ja": ("{0}、とブロードキャストして", "{1}に、{0}、とブロードキャストして"),
-    "ko": ("{0} 방송", "{1}에 방송해 줘, {0}"),
+    "ja": ("{0}とほうそうして", "{0}と{1}にブロードキャストして"),
+    "ko": ("{0} 라고 방송해 줘", "{0} 라고 {1}에 방송해 줘"),
     "pt": ("Transmite {0}", "Transmite para {1} {0}"),
 }
 

--- a/tests/components/google_assistant_sdk/test_notify.py
+++ b/tests/components/google_assistant_sdk/test_notify.py
@@ -17,8 +17,8 @@ from .conftest import ComponentSetup, ExpectedCredentials
     [
         ("en-US", "Dinner is served", "broadcast Dinner is served"),
         ("es-ES", "La cena está en la mesa", "Anuncia La cena está en la mesa"),
-        ("ko-KR", "저녁 식사가 준비됐어요", "저녁 식사가 준비됐어요 방송"),
-        ("ja-JP", "晩ご飯できたよ", "晩ご飯できたよ、とブロードキャストして"),
+        ("ko-KR", "저녁 식사가 준비됐어요", "저녁 식사가 준비됐어요 라고 방송해 줘"),
+        ("ja-JP", "晩ご飯できたよ", "晩ご飯できたよとほうそうして"),
     ],
     ids=["english", "spanish", "korean", "japanese"],
 )
@@ -63,8 +63,8 @@ async def test_broadcast_no_targets(
             "el salón",
             "Anuncia en el salón Es hora de hacer los deberes",
         ),
-        ("ko-KR", "숙제할 시간이야", "거실", "거실에 방송해 줘, 숙제할 시간이야"),
-        ("ja-JP", "宿題の時間だよ", "リビングルーム", "リビングルームに、宿題の時間だよ、とブロードキャストして"),
+        ("ko-KR", "숙제할 시간이야", "거실", "숙제할 시간이야 라고 거실에 방송해 줘"),
+        ("ja-JP", "宿題の時間だよ", "リビング", "宿題の時間だよとリビングにブロードキャストして"),
     ],
     ids=["english", "spanish", "korean", "japanese"],
 )

--- a/tests/components/google_assistant_sdk/test_notify.py
+++ b/tests/components/google_assistant_sdk/test_notify.py
@@ -1,6 +1,8 @@
 """Tests for the Google Assistant notify."""
 from unittest.mock import call, patch
 
+import pytest
+
 from homeassistant.components import notify
 from homeassistant.components.google_assistant_sdk import DOMAIN
 from homeassistant.components.google_assistant_sdk.const import SUPPORTED_LANGUAGE_CODES
@@ -10,14 +12,29 @@ from homeassistant.core import HomeAssistant
 from .conftest import ComponentSetup, ExpectedCredentials
 
 
+@pytest.mark.parametrize(
+    "language_code,message,expected_command",
+    [
+        ("en-US", "Dinner is served", "broadcast Dinner is served"),
+        ("es-ES", "La cena está en la mesa", "Anuncia La cena está en la mesa"),
+        ("ko-KR", "저녁 식사가 준비됐어요", "저녁 식사가 준비됐어요 방송"),
+        ("ja-JP", "晩ご飯できたよ", "晩ご飯できたよ、とブロードキャストして"),
+    ],
+    ids=["english", "spanish", "korean", "japanese"],
+)
 async def test_broadcast_no_targets(
-    hass: HomeAssistant, setup_integration: ComponentSetup
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    language_code: str,
+    message: str,
+    expected_command: str,
 ) -> None:
     """Test broadcast to all."""
     await setup_integration()
 
-    message = "time for dinner"
-    expected_command = "broadcast time for dinner"
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    entry.options = {"language_code": language_code}
+
     with patch(
         "homeassistant.components.google_assistant_sdk.helpers.TextAssistant"
     ) as mock_text_assistant:
@@ -27,19 +44,44 @@ async def test_broadcast_no_targets(
             {notify.ATTR_MESSAGE: message},
         )
         await hass.async_block_till_done()
-    mock_text_assistant.assert_called_once_with(ExpectedCredentials(), "en-US")
+    mock_text_assistant.assert_called_once_with(ExpectedCredentials(), language_code)
     mock_text_assistant.assert_has_calls([call().__enter__().assist(expected_command)])
 
 
+@pytest.mark.parametrize(
+    "language_code,message,target,expected_command",
+    [
+        (
+            "en-US",
+            "it's time for homework",
+            "living room",
+            "broadcast to living room it's time for homework",
+        ),
+        (
+            "es-ES",
+            "Es hora de hacer los deberes",
+            "el salón",
+            "Anuncia en el salón Es hora de hacer los deberes",
+        ),
+        ("ko-KR", "숙제할 시간이야", "거실", "거실에 방송해 줘, 숙제할 시간이야"),
+        ("ja-JP", "宿題の時間だよ", "リビングルーム", "リビングルームに、宿題の時間だよ、とブロードキャストして"),
+    ],
+    ids=["english", "spanish", "korean", "japanese"],
+)
 async def test_broadcast_one_target(
-    hass: HomeAssistant, setup_integration: ComponentSetup
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    language_code: str,
+    message: str,
+    target: str,
+    expected_command: str,
 ) -> None:
     """Test broadcast to one target."""
     await setup_integration()
 
-    message = "time for dinner"
-    target = "basement"
-    expected_command = "broadcast to basement time for dinner"
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    entry.options = {"language_code": language_code}
+
     with patch(
         "homeassistant.components.google_assistant_sdk.helpers.TextAssistant.assist"
     ) as mock_assist_call:
@@ -95,30 +137,6 @@ async def test_broadcast_empty_message(
     mock_assist_call.assert_not_called()
 
 
-async def test_broadcast_spanish(
-    hass: HomeAssistant, setup_integration: ComponentSetup
-) -> None:
-    """Test broadcast in Spanish."""
-    await setup_integration()
-
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    entry.options = {"language_code": "es-ES"}
-
-    message = "comida"
-    expected_command = "Anuncia comida"
-    with patch(
-        "homeassistant.components.google_assistant_sdk.helpers.TextAssistant"
-    ) as mock_text_assistant:
-        await hass.services.async_call(
-            notify.DOMAIN,
-            DOMAIN,
-            {notify.ATTR_MESSAGE: message},
-        )
-        await hass.async_block_till_done()
-    mock_text_assistant.assert_called_once_with(ExpectedCredentials(), "es-ES")
-    mock_text_assistant.assert_has_calls([call().__enter__().assist(expected_command)])
-
-
 def test_broadcast_language_mapping(
     hass: HomeAssistant, setup_integration: ComponentSetup
 ) -> None:
@@ -128,4 +146,8 @@ def test_broadcast_language_mapping(
         assert cmds
         assert len(cmds) == 2
         assert cmds[0]
+        assert "{0}" in cmds[0]
+        assert "{1}" not in cmds[0]
         assert cmds[1]
+        assert "{0}" in cmds[1]
+        assert "{1}" in cmds[1]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support Korean and Japanese languages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85306 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
