### PR TITLE
Add errors and handling for devices disabled in ISY994

### DIFF
--- a/homeassistant/components/isy994/button.py
+++ b/homeassistant/components/isy994/button.py
@@ -73,7 +73,7 @@ class ISYNodeButtonEntity(ButtonEntity):
             identifiers={(ISY994_DOMAIN, base_unique_id)}
         )
 
-    def check_disabled(self) -> bool:
+    def _raise_if_disabled(self) -> bool:
         """Warn the user if the device is disabled in the ISY."""
         if not getattr(self._node, "enabled", True):
             raise HomeAssistantError(
@@ -97,8 +97,8 @@ class ISYNodeQueryButtonEntity(ISYNodeButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        if self.check_disabled():
-            await self._node.query()
+        self._raise_if_disabled()
+        await self._node.query()
 
 
 class ISYNodeBeepButtonEntity(ISYNodeButtonEntity):
@@ -119,8 +119,8 @@ class ISYNodeBeepButtonEntity(ISYNodeButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        if self.check_disabled():
-            await self._node.beep()
+        self._raise_if_disabled()
+        await self._node.beep()
 
 
 class ISYNetworkResourceButtonEntity(ButtonEntity):

--- a/homeassistant/components/isy994/climate.py
+++ b/homeassistant/components/isy994/climate.py
@@ -193,6 +193,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
+        self._raise_if_disabled()
         target_temp = kwargs.get(ATTR_TEMPERATURE)
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
@@ -201,11 +202,11 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
                 target_temp_high = target_temp
             if self.hvac_mode == HVACMode.HEAT:
                 target_temp_low = target_temp
-        if target_temp_low is not None and self.check_disabled():
+        if target_temp_low is not None:
             await self._node.set_climate_setpoint_heat(int(target_temp_low))
             # Presumptive setting--event stream will correct if cmd fails:
             self._target_temp_low = target_temp_low
-        if target_temp_high is not None and self.check_disabled():
+        if target_temp_high is not None:
             await self._node.set_climate_setpoint_cool(int(target_temp_high))
             # Presumptive setting--event stream will correct if cmd fails:
             self._target_temp_high = target_temp_high
@@ -214,17 +215,17 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         _LOGGER.debug("Requested fan mode %s", fan_mode)
-        if self.check_disabled():
-            await self._node.set_fan_mode(HA_FAN_TO_ISY.get(fan_mode))
-            # Presumptive setting--event stream will correct if cmd fails:
-            self._fan_mode = fan_mode
-            self.async_write_ha_state()
+        self._raise_if_disabled()
+        await self._node.set_fan_mode(HA_FAN_TO_ISY.get(fan_mode))
+        # Presumptive setting--event stream will correct if cmd fails:
+        self._fan_mode = fan_mode
+        self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         _LOGGER.debug("Requested operation mode %s", hvac_mode)
-        if self.check_disabled():
-            await self._node.set_climate_mode(HA_HVAC_TO_ISY.get(hvac_mode))
-            # Presumptive setting--event stream will correct if cmd fails:
-            self._hvac_mode = hvac_mode
-            self.async_write_ha_state()
+        self._raise_if_disabled()
+        await self._node.set_climate_mode(HA_HVAC_TO_ISY.get(hvac_mode))
+        # Presumptive setting--event stream will correct if cmd fails:
+        self._hvac_mode = hvac_mode
+        self.async_write_ha_state()

--- a/homeassistant/components/isy994/climate.py
+++ b/homeassistant/components/isy994/climate.py
@@ -201,11 +201,11 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
                 target_temp_high = target_temp
             if self.hvac_mode == HVACMode.HEAT:
                 target_temp_low = target_temp
-        if target_temp_low is not None:
+        if target_temp_low is not None and self.check_disabled():
             await self._node.set_climate_setpoint_heat(int(target_temp_low))
             # Presumptive setting--event stream will correct if cmd fails:
             self._target_temp_low = target_temp_low
-        if target_temp_high is not None:
+        if target_temp_high is not None and self.check_disabled():
             await self._node.set_climate_setpoint_cool(int(target_temp_high))
             # Presumptive setting--event stream will correct if cmd fails:
             self._target_temp_high = target_temp_high
@@ -214,15 +214,17 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         _LOGGER.debug("Requested fan mode %s", fan_mode)
-        await self._node.set_fan_mode(HA_FAN_TO_ISY.get(fan_mode))
-        # Presumptive setting--event stream will correct if cmd fails:
-        self._fan_mode = fan_mode
-        self.async_write_ha_state()
+        if self.check_disabled():
+            await self._node.set_fan_mode(HA_FAN_TO_ISY.get(fan_mode))
+            # Presumptive setting--event stream will correct if cmd fails:
+            self._fan_mode = fan_mode
+            self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         _LOGGER.debug("Requested operation mode %s", hvac_mode)
-        await self._node.set_climate_mode(HA_HVAC_TO_ISY.get(hvac_mode))
-        # Presumptive setting--event stream will correct if cmd fails:
-        self._hvac_mode = hvac_mode
-        self.async_write_ha_state()
+        if self.check_disabled():
+            await self._node.set_climate_mode(HA_HVAC_TO_ISY.get(hvac_mode))
+            # Presumptive setting--event stream will correct if cmd fails:
+            self._hvac_mode = hvac_mode
+            self.async_write_ha_state()

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -70,21 +70,24 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send the open cover command to the ISY cover device."""
+        self._raise_if_disabled()
         val = 100 if self._node.uom == UOM_BARRIER else None
-        if self.check_disabled() and not await self._node.turn_on(val=val):
+        if not await self._node.turn_on(val=val):
             _LOGGER.error("Unable to open the cover")
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send the close cover command to the ISY cover device."""
-        if self.check_disabled() and not await self._node.turn_off():
+        self._raise_if_disabled()
+        if not await self._node.turn_off():
             _LOGGER.error("Unable to close the cover")
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
+        self._raise_if_disabled()
         position = kwargs[ATTR_POSITION]
         if self._node.uom == UOM_8_BIT_RANGE:
             position = round(position * 255.0 / 100.0)
-        if self.check_disabled() and not await self._node.turn_on(val=position):
+        if not await self._node.turn_on(val=position):
             _LOGGER.error("Unable to set cover position")
 
 

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -71,12 +71,12 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send the open cover command to the ISY cover device."""
         val = 100 if self._node.uom == UOM_BARRIER else None
-        if not await self._node.turn_on(val=val):
+        if self.check_disabled() and not await self._node.turn_on(val=val):
             _LOGGER.error("Unable to open the cover")
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send the close cover command to the ISY cover device."""
-        if not await self._node.turn_off():
+        if self.check_disabled() and not await self._node.turn_off():
             _LOGGER.error("Unable to close the cover")
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
@@ -84,7 +84,7 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
         position = kwargs[ATTR_POSITION]
         if self._node.uom == UOM_8_BIT_RANGE:
             position = round(position * 255.0 / 100.0)
-        if not await self._node.turn_on(val=position):
+        if self.check_disabled() and not await self._node.turn_on(val=position):
             _LOGGER.error("Unable to set cover position")
 
 

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -197,7 +197,7 @@ class ISYNodeEntity(ISYEntity):
 
     async def async_get_zwave_parameter(self, parameter: Any) -> None:
         """Respond to an entity service command to request a Z-Wave device parameter from the ISY."""
-        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+        if self._node.protocol != PROTO_ZWAVE:
             raise HomeAssistantError(
                 "Invalid service call: cannot request Z-Wave Parameter for non-Z-Wave"
                 f" device {self.entity_id}"
@@ -208,7 +208,7 @@ class ISYNodeEntity(ISYEntity):
         self, parameter: Any, value: Any | None, size: int | None
     ) -> None:
         """Respond to an entity service command to set a Z-Wave device parameter via the ISY."""
-        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+        if self._node.protocol != PROTO_ZWAVE:
             raise HomeAssistantError(
                 "Invalid service call: cannot set Z-Wave Parameter for non-Z-Wave"
                 f" device {self.entity_id}"
@@ -220,13 +220,12 @@ class ISYNodeEntity(ISYEntity):
         """Respond to an entity service command to rename a node on the ISY."""
         await self._node.rename(name)
 
-    def check_disabled(self) -> bool:
+    def _raise_if_disabled(self) -> None:
         """Error if a device is attempted to be controlled while disabled in the ISY."""
         if not getattr(self._node, "enabled", True):
             raise HomeAssistantError(
                 f"Attempted to send command to device disabled in ISY. Use isy994.send_node_command to enable {self.entity_id}"
             )
-        return True
 
 
 class ISYProgramEntity(ISYEntity):

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -36,6 +36,7 @@ class ISYEntity(Entity):
         self._attrs: dict[str, Any] = {}
         self._change_handler: EventListener | None = None
         self._control_handler: EventListener | None = None
+        self._attr_entity_registry_enabled_default = getattr(node, "enabled", True)
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node change events."""
@@ -218,6 +219,14 @@ class ISYNodeEntity(ISYEntity):
     async def async_rename_node(self, name: str) -> None:
         """Respond to an entity service command to rename a node on the ISY."""
         await self._node.rename(name)
+
+    def check_disabled(self) -> bool:
+        """Error if a device is attempted to be controlled while disabled in the ISY."""
+        if not getattr(self._node, "enabled", True):
+            raise HomeAssistantError(
+                f"Attempted to send command to device disabled in ISY. Use isy994.send_node_command to enable {self.entity_id}"
+            )
+        return True
 
 
 class ISYProgramEntity(ISYEntity):

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -69,14 +69,13 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set node to speed percentage for the ISY fan device."""
+        self._raise_if_disabled()
         if percentage == 0:
             await self._node.turn_off()
             return
 
         isy_speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
-
-        if self.check_disabled():
-            await self._node.turn_on(val=isy_speed)
+        await self._node.turn_on(val=isy_speed)
 
     async def async_turn_on(
         self,
@@ -89,8 +88,8 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY fan device."""
-        if self.check_disabled():
-            await self._node.turn_off()
+        self._raise_if_disabled()
+        await self._node.turn_off()
 
 
 class ISYFanProgramEntity(ISYProgramEntity, FanEntity):

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -75,7 +75,8 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
         isy_speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
 
-        await self._node.turn_on(val=isy_speed)
+        if self.check_disabled():
+            await self._node.turn_on(val=isy_speed)
 
     async def async_turn_on(
         self,
@@ -88,7 +89,8 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY fan device."""
-        await self._node.turn_off()
+        if self.check_disabled():
+            await self._node.turn_off()
 
 
 class ISYFanProgramEntity(ISYProgramEntity, FanEntity):

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -286,6 +286,14 @@ def _categorize_nodes(
             # Don't import this node as a device at all
             continue
 
+        if not getattr(node, "enabled", True):
+            # Warn about this node if it's disabled in the ISY
+            _LOGGER.info(
+                "Node %s (%s) is disabled in the ISY, use 'isy994.send_node_command' service with command 'enable' to enable from Home Assistant",
+                node.name,
+                node.address,
+            )
+
         if hasattr(node, "parent_node") and node.parent_node is None:
             # This is a physical device / parent node, add a query button
             hass_isy_data[ISY994_NODES][Platform.BUTTON].append(node)

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -76,8 +76,9 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY light device."""
+        self._raise_if_disabled()
         self._last_brightness = self.brightness
-        if self.check_disabled() and not await self._node.turn_off():
+        if not await self._node.turn_off():
             _LOGGER.debug("Unable to turn off light")
 
     @callback
@@ -93,12 +94,13 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
 
     async def async_turn_on(self, brightness: int | None = None, **kwargs: Any) -> None:
         """Send the turn on command to the ISY light device."""
+        self._raise_if_disabled()
         if self._restore_light_state and brightness is None and self._last_brightness:
             brightness = self._last_brightness
         # Special Case for ISY Z-Wave Devices using % instead of 0-255:
         if brightness is not None and self._node.uom == UOM_PERCENTAGE:
             brightness = round(brightness * 100.0 / 255.0)
-        if self.check_disabled() and not await self._node.turn_on(val=brightness):
+        if not await self._node.turn_on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
 
     @property

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -77,7 +77,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY light device."""
         self._last_brightness = self.brightness
-        if not await self._node.turn_off():
+        if self.check_disabled() and not await self._node.turn_off():
             _LOGGER.debug("Unable to turn off light")
 
     @callback
@@ -98,7 +98,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
         # Special Case for ISY Z-Wave Devices using % instead of 0-255:
         if brightness is not None and self._node.uom == UOM_PERCENTAGE:
             brightness = round(brightness * 100.0 / 255.0)
-        if not await self._node.turn_on(val=brightness):
+        if self.check_disabled() and not await self._node.turn_on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
 
     @property

--- a/homeassistant/components/isy994/lock.py
+++ b/homeassistant/components/isy994/lock.py
@@ -46,12 +46,12 @@ class ISYLockEntity(ISYNodeEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send the lock command to the ISY device."""
-        if not await self._node.secure_lock():
+        if self.check_disabled() and not await self._node.secure_lock():
             _LOGGER.error("Unable to lock device")
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send the unlock command to the ISY device."""
-        if not await self._node.secure_unlock():
+        if self.check_disabled() and not await self._node.secure_unlock():
             _LOGGER.error("Unable to lock device")
 
 

--- a/homeassistant/components/isy994/lock.py
+++ b/homeassistant/components/isy994/lock.py
@@ -46,12 +46,14 @@ class ISYLockEntity(ISYNodeEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send the lock command to the ISY device."""
-        if self.check_disabled() and not await self._node.secure_lock():
+        self._raise_if_disabled()
+        if not await self._node.secure_lock():
             _LOGGER.error("Unable to lock device")
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send the unlock command to the ISY device."""
-        if self.check_disabled() and not await self._node.secure_unlock():
+        self._raise_if_disabled()
+        if not await self._node.secure_unlock():
             _LOGGER.error("Unable to lock device")
 
 

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,8 +3,13 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.0.12"],
-  "codeowners": ["@bdraco", "@shbatm"],
+  "requirements": [
+    "pyisy==3.1.1"
+  ],
+  "codeowners": [
+    "@bdraco",
+    "@shbatm"
+  ],
   "config_flow": true,
   "ssdp": [
     {
@@ -30,5 +35,7 @@
     }
   ],
   "iot_class": "local_push",
-  "loggers": ["pyisy"]
+  "loggers": [
+    "pyisy"
+  ]
 }

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -71,7 +71,6 @@ VALID_NODE_COMMANDS = [
     "brighten",
     "dim",
     "disable",
-    "enable",
     "fade_down",
     "fade_stop",
     "fade_up",

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -71,6 +71,7 @@ VALID_NODE_COMMANDS = [
     "brighten",
     "dim",
     "disable",
+    "enable",
     "fade_down",
     "fade_stop",
     "fade_up",

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -44,12 +44,14 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY switch."""
-        if self.check_disabled() and not await self._node.turn_off():
+        self._raise_if_disabled()
+        if not await self._node.turn_off():
             _LOGGER.debug("Unable to turn off switch")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the turn on command to the ISY switch."""
-        if self.check_disabled() and not await self._node.turn_on():
+        self._raise_if_disabled()
+        if not await self._node.turn_on():
             _LOGGER.debug("Unable to turn on switch")
 
     @property

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -44,12 +44,12 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY switch."""
-        if not await self._node.turn_off():
+        if self.check_disabled() and not await self._node.turn_off():
             _LOGGER.debug("Unable to turn off switch")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the turn on command to the ISY switch."""
-        if not await self._node.turn_on():
+        if self.check_disabled() and not await self._node.turn_on():
             _LOGGER.debug("Unable to turn on switch")
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.0.12
+pyisy==3.1.1
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1209,7 +1209,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.0.12
+pyisy==3.1.1
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Devices that are disabled inside of the ISY controller will be added as disabled by default in Home Assistant. If a user enables and attempts to control an ISY-disabled device, an error will be raised.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There is currently no protection against loading and controlling devices that are disabled on the ISY/IoX controller side. These get loaded and all commands sent just fail (relatively) silently with no indication as to why.

This PR will disable devices by default if they are disabled on the ISY. If a user attempts to control a disabled device, an error will be raised.

Devices are still being added to Home Assistant since it is still possible to enable/disable the device remotely--a service call to `isy994.send_node_command` with data `{ "entity_id": "device", "control": "enable" }` will enable the device.

Note: I'm open to go a different direction with this and just not add the devices if they are disabled on loading of the integration. However, the service to enable them is an entity-specific service--to preserve this method I would need to add another integration service to accept the address, since the enitity won't be available.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
