### PR TITLE
Default disable voltage sensors in Plugwise

### DIFF
--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -268,6 +268,7 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_phase_two",
@@ -275,6 +276,7 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_phase_three",
@@ -282,6 +284,7 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="gas_consumed_interval",

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -16,8 +16,6 @@ async def test_diagnostics(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test diagnostics."""
-    print("HOI")
-    print(await get_diagnostics_for_config_entry(hass, hass_client, init_integration))
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == {

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -16,6 +16,8 @@ async def test_diagnostics(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test diagnostics."""
+    print("HOI")
+    print(await get_diagnostics_for_config_entry(hass, hass_client, init_integration))
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == {

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock
 
-from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -112,8 +111,7 @@ async def test_p1_3ph_dsmr_sensor_entities(
     assert float(state.state) == 2080.0
 
     state = hass.states.get("sensor.p1_voltage_phase_one")
-    assert state
-    assert state.state == STATE_OFF
+    assert not state
 
 
 async def test_stretch_sensor_entities(

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -112,15 +113,7 @@ async def test_p1_3ph_dsmr_sensor_entities(
 
     state = hass.states.get("sensor.p1_voltage_phase_one")
     assert state
-    assert float(state.state) == 233.2
-
-    state = hass.states.get("sensor.p1_voltage_phase_two")
-    assert state
-    assert float(state.state) == 234.4
-
-    state = hass.states.get("sensor.p1_voltage_phase_three")
-    assert state
-    assert float(state.state) == 234.7
+    assert state.state == STATE_OFF
 
 
 async def test_stretch_sensor_entities(

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import MockConfigEntry
 
@@ -110,8 +111,20 @@ async def test_p1_3ph_dsmr_sensor_entities(
     assert state
     assert float(state.state) == 2080.0
 
-    state = hass.states.get("sensor.p1_voltage_phase_one")
+    entity_id = "sensor.p1_voltage_phase_one"
+    state = hass.states.get(entity_id)
     assert not state
+
+    entity_registry = async_get(hass)
+    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_reload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.p1_voltage_phase_one")
+    assert state
+    assert float(state.state) == 233.2
 
 
 async def test_stretch_sensor_entities(


### PR DESCRIPTION
## Proposed change
Default disable voltage sensors as requested in #85421 for advanced properties handling

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #85421
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.
