### PR TITLE
Z-Wave.Me: Cover: Fixed calibration errors and add missing is_closed

### DIFF
--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -71,25 +71,25 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
     @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover.
-        
+
         None is unknown, 0 is closed, 100 is fully open.
-        
+
         Allow small calibration errors (some devices after a long time become not well calibrated)
         """
         if self.device.level > 95:
             return 100
-        
+
         return self.device.level
 
     @property
     def is_closed(self) -> bool | None:
         """Return true if cover is closed.
-        
+
         None is unknown.
-        
+
         Allow small calibration errors (some devices after a long time become not well calibrated)
         """
         if self.device.level is None:
             return None
-        
+
         return self.device.level < 5

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -71,15 +71,14 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
     @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover.
-
+        
         None is unknown, 0 is closed, 100 is fully open.
         
         Allow small calibration errors (some devices after a long time become not well calibrated)
         """
-        
         if self.device.level > 95:
             return 100
-
+        
         return self.device.level
 
     @property

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -74,7 +74,17 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        if self.device.level == 99:  # Scale max value
+        if self.device.level > 95: # Scale max value and allow small calibration errors (some devices after a long time become not well calibrated)
             return 100
 
         return self.device.level
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return true if cover is closed.
+        
+        None is unknown."
+        """
+        if self.device.level is None:
+            return None
+        return self.device.level < 5 # Allow small calibration errors (some devices after a long time become not well calibrated)

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -73,8 +73,11 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
         """Return current position of cover.
 
         None is unknown, 0 is closed, 100 is fully open.
+        
+        Allow small calibration errors (some devices after a long time become not well calibrated)
         """
-        if self.device.level > 95: # Scale max value and allow small calibration errors (some devices after a long time become not well calibrated)
+        
+        if self.device.level > 95:
             return 100
 
         return self.device.level
@@ -83,8 +86,11 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
     def is_closed(self) -> bool | None:
         """Return true if cover is closed.
         
-        None is unknown."
+        None is unknown.
+        
+        Allow small calibration errors (some devices after a long time become not well calibrated)
         """
         if self.device.level is None:
             return None
-        return self.device.level < 5 # Allow small calibration errors (some devices after a long time become not well calibrated)
+        
+        return self.device.level < 5


### PR DESCRIPTION
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #77279
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
