### PR TITLE
Replace abodepy library with jaraco.abode to enable new Abode devices

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 
 from functools import partial
 
-from abodepy import Abode, AbodeAutomation as AbodeAuto
-from abodepy.devices import AbodeDevice as AbodeDev
-from abodepy.exceptions import AbodeAuthenticationException, AbodeException
-import abodepy.helpers.timeline as TIMELINE
+from jaraco.abode.automation import Automation as AbodeAuto
+from jaraco.abode.client import Client as Abode
+from jaraco.abode.devices.base import Device as AbodeDev
+from jaraco.abode.exceptions import (
+    AuthenticationException as AbodeAuthenticationException,
+    Exception as AbodeException,
+)
+from jaraco.abode.helpers.timeline import Groups as GROUPS
 from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
 
@@ -26,7 +30,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, entity
 from homeassistant.helpers.dispatcher import dispatcher_send
 
-from .const import ATTRIBUTION, CONF_POLLING, DEFAULT_CACHEDB, DOMAIN, LOGGER
+from .const import ATTRIBUTION, CONF_POLLING, DOMAIN, LOGGER
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"
@@ -82,7 +86,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     polling = entry.data[CONF_POLLING]
-    cache = hass.config.path(DEFAULT_CACHEDB)
 
     # For previous config entries where unique_id is None
     if entry.unique_id is None:
@@ -92,7 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         abode = await hass.async_add_executor_job(
-            Abode, username, password, True, True, True, cache
+            Abode, username, password, True, True, True
         )
 
     except AbodeAuthenticationException as ex:
@@ -225,17 +228,17 @@ def setup_abode_events(hass: HomeAssistant) -> None:
         hass.bus.fire(event, data)
 
     events = [
-        TIMELINE.ALARM_GROUP,
-        TIMELINE.ALARM_END_GROUP,
-        TIMELINE.PANEL_FAULT_GROUP,
-        TIMELINE.PANEL_RESTORE_GROUP,
-        TIMELINE.AUTOMATION_GROUP,
-        TIMELINE.DISARM_GROUP,
-        TIMELINE.ARM_GROUP,
-        TIMELINE.ARM_FAULT_GROUP,
-        TIMELINE.TEST_GROUP,
-        TIMELINE.CAPTURE_GROUP,
-        TIMELINE.DEVICE_GROUP,
+        GROUPS.ALARM,
+        GROUPS.ALARM_END,
+        GROUPS.PANEL_FAULT,
+        GROUPS.PANEL_RESTORE,
+        GROUPS.AUTOMATION,
+        GROUPS.DISARM,
+        GROUPS.ARM,
+        GROUPS.ARM_FAULT,
+        GROUPS.TEST,
+        GROUPS.CAPTURE,
+        GROUPS.DEVICE,
     ]
 
     for event in events:

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -1,7 +1,7 @@
 """Support for Abode Security System alarm control panels."""
 from __future__ import annotations
 
-from abodepy.devices.alarm import AbodeAlarm as AbodeAl
+from jaraco.abode.devices.alarm import Alarm as AbodeAl
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from contextlib import suppress
 from typing import cast
 
-from abodepy.devices.binary_sensor import AbodeBinarySensor as ABBinarySensor
-import abodepy.helpers.constants as CONST
+from jaraco.abode.devices.sensor import BinarySensor as ABBinarySensor
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, cast
 
-from abodepy.devices import CONST, AbodeDevice as AbodeDev
-from abodepy.devices.camera import AbodeCamera as AbodeCam
-import abodepy.helpers.timeline as TIMELINE
+from jaraco.abode.devices.base import Device as AbodeDev
+from jaraco.abode.devices.camera import Camera as AbodeCam
+from jaraco.abode.helpers import constants as CONST
+from jaraco.abode.helpers.timeline import Groups as TIMELINE
 import requests
 from requests.models import Response
 
@@ -30,7 +31,7 @@ async def async_setup_entry(
     data: AbodeSystem = hass.data[DOMAIN]
 
     async_add_entities(
-        AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE)
+        AbodeCamera(data, device, TIMELINE.CAPTURE)
         for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA)
     )
 

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -6,8 +6,7 @@ from typing import Any, cast
 
 from jaraco.abode.devices.base import Device as AbodeDev
 from jaraco.abode.devices.camera import Camera as AbodeCam
-from jaraco.abode.helpers import constants as CONST
-from jaraco.abode.helpers.timeline import Groups as TIMELINE
+from jaraco.abode.helpers import constants as CONST, timeline as TIMELINE
 import requests
 from requests.models import Response
 
@@ -31,7 +30,7 @@ async def async_setup_entry(
     data: AbodeSystem = hass.data[DOMAIN]
 
     async_add_entities(
-        AbodeCamera(data, device, TIMELINE.CAPTURE)
+        AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE)  # pylint: disable=no-member
         for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA)
     )
 

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -6,5 +6,4 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "abode"
 ATTRIBUTION = "Data provided by goabode.com"
 
-DEFAULT_CACHEDB = "abodepy_cache.pickle"
 CONF_POLLING = "polling"

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -1,8 +1,8 @@
 """Support for Abode Security System covers."""
 from typing import Any
 
-from abodepy.devices.cover import AbodeCover as AbodeCV
-import abodepy.helpers.constants as CONST
+from jaraco.abode.devices.cover import Cover as AbodeCV
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from math import ceil
 from typing import Any
 
-from abodepy.devices.light import AbodeLight as AbodeLT
-import abodepy.helpers.constants as CONST
+from jaraco.abode.devices.light import Light as AbodeLT
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -1,8 +1,8 @@
 """Support for the Abode Security System locks."""
 from typing import Any
 
-from abodepy.devices.lock import AbodeLock as AbodeLK
-import abodepy.helpers.constants as CONST
+from jaraco.abode.devices.lock import Lock as AbodeLK
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -3,11 +3,11 @@
   "name": "Abode",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
-  "requirements": ["abodepy==1.2.0"],
+  "requirements": ["jaraco.abode==3.1.2"],
   "codeowners": ["@shred86"],
   "homekit": {
     "models": ["Abode", "Iota"]
   },
   "iot_class": "cloud_push",
-  "loggers": ["abodepy", "lomond"]
+  "loggers": ["jaraco.abode", "lomond"]
 }

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -3,7 +3,7 @@
   "name": "Abode",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
-  "requirements": ["jaraco.abode==3.1.2"],
+  "requirements": ["jaraco.abode==3.2.1"],
   "codeowners": ["@shred86"],
   "homekit": {
     "models": ["Abode", "Iota"]

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from typing import cast
 
-from abodepy.devices.sensor import CONST, AbodeSensor as AbodeSense
+from jaraco.abode.devices.sensor import Sensor as AbodeSense
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from abodepy.devices.switch import CONST, AbodeSwitch as AbodeSW
+from jaraco.abode.devices.switch import Switch as AbodeSW
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -70,9 +70,6 @@ WSDiscovery==2.0.0
 # homeassistant.components.waze_travel_time
 WazeRouteCalculator==0.14
 
-# homeassistant.components.abode
-abodepy==1.2.0
-
 # homeassistant.components.accuweather
 accuweather==0.5.0
 
@@ -989,6 +986,9 @@ ismartgate==4.0.4
 
 # homeassistant.components.file_upload
 janus==1.0.0
+
+# homeassistant.components.abode
+jaraco.abode==3.1.2
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -988,7 +988,7 @@ ismartgate==4.0.4
 janus==1.0.0
 
 # homeassistant.components.abode
-jaraco.abode==3.1.2
+jaraco.abode==3.2.1
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,9 +60,6 @@ WSDiscovery==2.0.0
 # homeassistant.components.waze_travel_time
 WazeRouteCalculator==0.14
 
-# homeassistant.components.abode
-abodepy==1.2.0
-
 # homeassistant.components.accuweather
 accuweather==0.5.0
 
@@ -742,6 +739,9 @@ ismartgate==4.0.4
 
 # homeassistant.components.file_upload
 janus==1.0.0
+
+# homeassistant.components.abode
+jaraco.abode==3.1.2
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -741,7 +741,7 @@ ismartgate==4.0.4
 janus==1.0.0
 
 # homeassistant.components.abode
-jaraco.abode==3.1.2
+jaraco.abode==3.2.1
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2

--- a/tests/components/abode/common.py
+++ b/tests/components/abode/common.py
@@ -23,8 +23,8 @@ async def setup_platform(hass: HomeAssistant, platform: str) -> MockConfigEntry:
     mock_entry.add_to_hass(hass)
 
     with patch("homeassistant.components.abode.PLATFORMS", [platform]), patch(
-        "abodepy.event_controller.sio"
-    ), patch("abodepy.utils.save_cache"):
+        "jaraco.abode.event_controller.sio"
+    ):
         assert await async_setup_component(hass, ABODE_DOMAIN, {})
     await hass.async_block_till_done()
 

--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -1,5 +1,5 @@
 """Configuration for Abode tests."""
-import abodepy.helpers.constants as CONST
+from jaraco.abode.helpers import urls as URL
 import pytest
 
 from tests.common import load_fixture
@@ -10,18 +10,14 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 def requests_mock_fixture(requests_mock) -> None:
     """Fixture to provide a requests mocker."""
     # Mocks the login response for abodepy.
-    requests_mock.post(CONST.LOGIN_URL, text=load_fixture("login.json", "abode"))
+    requests_mock.post(URL.LOGIN, text=load_fixture("login.json", "abode"))
     # Mocks the logout response for abodepy.
-    requests_mock.post(CONST.LOGOUT_URL, text=load_fixture("logout.json", "abode"))
+    requests_mock.post(URL.LOGOUT, text=load_fixture("logout.json", "abode"))
     # Mocks the oauth claims response for abodepy.
-    requests_mock.get(
-        CONST.OAUTH_TOKEN_URL, text=load_fixture("oauth_claims.json", "abode")
-    )
+    requests_mock.get(URL.OAUTH_TOKEN, text=load_fixture("oauth_claims.json", "abode"))
     # Mocks the panel response for abodepy.
-    requests_mock.get(CONST.PANEL_URL, text=load_fixture("panel.json", "abode"))
+    requests_mock.get(URL.PANEL, text=load_fixture("panel.json", "abode"))
     # Mocks the automations response for abodepy.
-    requests_mock.get(
-        CONST.AUTOMATION_URL, text=load_fixture("automation.json", "abode")
-    )
+    requests_mock.get(URL.AUTOMATION, text=load_fixture("automation.json", "abode"))
     # Mocks the devices response for abodepy.
-    requests_mock.get(CONST.DEVICES_URL, text=load_fixture("devices.json", "abode"))
+    requests_mock.get(URL.DEVICES, text=load_fixture("devices.json", "abode"))

--- a/tests/components/abode/test_alarm_control_panel.py
+++ b/tests/components/abode/test_alarm_control_panel.py
@@ -1,7 +1,7 @@
 """Tests for the Abode alarm control panel device."""
 from unittest.mock import PropertyMock, patch
 
-import abodepy.helpers.constants as CONST
+from jaraco.abode.helpers import constants as CONST
 
 from homeassistant.components.abode import ATTR_DEVICE_ID
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
@@ -49,8 +49,10 @@ async def test_attributes(hass: HomeAssistant) -> None:
 
 async def test_set_alarm_away(hass: HomeAssistant) -> None:
     """Test the alarm control panel can be set to away."""
-    with patch("abodepy.AbodeEventController.add_device_callback") as mock_callback:
-        with patch("abodepy.ALARM.AbodeAlarm.set_away") as mock_set_away:
+    with patch(
+        "jaraco.abode.event_controller.EventController.add_device_callback"
+    ) as mock_callback:
+        with patch("jaraco.abode.devices.alarm.Alarm.set_away") as mock_set_away:
             await setup_platform(hass, ALARM_DOMAIN)
 
             await hass.services.async_call(
@@ -63,7 +65,7 @@ async def test_set_alarm_away(hass: HomeAssistant) -> None:
             mock_set_away.assert_called_once()
 
         with patch(
-            "abodepy.ALARM.AbodeAlarm.mode",
+            "jaraco.abode.devices.alarm.Alarm.mode",
             new_callable=PropertyMock,
         ) as mock_mode:
             mock_mode.return_value = CONST.MODE_AWAY
@@ -78,8 +80,10 @@ async def test_set_alarm_away(hass: HomeAssistant) -> None:
 
 async def test_set_alarm_home(hass: HomeAssistant) -> None:
     """Test the alarm control panel can be set to home."""
-    with patch("abodepy.AbodeEventController.add_device_callback") as mock_callback:
-        with patch("abodepy.ALARM.AbodeAlarm.set_home") as mock_set_home:
+    with patch(
+        "jaraco.abode.event_controller.EventController.add_device_callback"
+    ) as mock_callback:
+        with patch("jaraco.abode.devices.alarm.Alarm.set_home") as mock_set_home:
             await setup_platform(hass, ALARM_DOMAIN)
 
             await hass.services.async_call(
@@ -92,7 +96,7 @@ async def test_set_alarm_home(hass: HomeAssistant) -> None:
             mock_set_home.assert_called_once()
 
         with patch(
-            "abodepy.ALARM.AbodeAlarm.mode", new_callable=PropertyMock
+            "jaraco.abode.devices.alarm.Alarm.mode", new_callable=PropertyMock
         ) as mock_mode:
             mock_mode.return_value = CONST.MODE_HOME
 
@@ -106,8 +110,10 @@ async def test_set_alarm_home(hass: HomeAssistant) -> None:
 
 async def test_set_alarm_standby(hass: HomeAssistant) -> None:
     """Test the alarm control panel can be set to standby."""
-    with patch("abodepy.AbodeEventController.add_device_callback") as mock_callback:
-        with patch("abodepy.ALARM.AbodeAlarm.set_standby") as mock_set_standby:
+    with patch(
+        "jaraco.abode.event_controller.EventController.add_device_callback"
+    ) as mock_callback:
+        with patch("jaraco.abode.devices.alarm.Alarm.set_standby") as mock_set_standby:
             await setup_platform(hass, ALARM_DOMAIN)
             await hass.services.async_call(
                 ALARM_DOMAIN,
@@ -119,7 +125,7 @@ async def test_set_alarm_standby(hass: HomeAssistant) -> None:
             mock_set_standby.assert_called_once()
 
         with patch(
-            "abodepy.ALARM.AbodeAlarm.mode", new_callable=PropertyMock
+            "jaraco.abode.devices.alarm.Alarm.mode", new_callable=PropertyMock
         ) as mock_mode:
             mock_mode.return_value = CONST.MODE_STANDBY
 
@@ -133,7 +139,9 @@ async def test_set_alarm_standby(hass: HomeAssistant) -> None:
 
 async def test_state_unknown(hass: HomeAssistant) -> None:
     """Test an unknown alarm control panel state."""
-    with patch("abodepy.ALARM.AbodeAlarm.mode", new_callable=PropertyMock) as mock_mode:
+    with patch(
+        "jaraco.abode.devices.alarm.Alarm.mode", new_callable=PropertyMock
+    ) as mock_mode:
         await setup_platform(hass, ALARM_DOMAIN)
         await hass.async_block_till_done()
 

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -31,7 +31,7 @@ async def test_capture_image(hass: HomeAssistant) -> None:
     """Test the camera capture image service."""
     await setup_platform(hass, CAMERA_DOMAIN)
 
-    with patch("abodepy.AbodeCamera.capture") as mock_capture:
+    with patch("jaraco.abode.devices.camera.Camera.capture") as mock_capture:
         await hass.services.async_call(
             ABODE_DOMAIN,
             "capture_image",
@@ -46,7 +46,7 @@ async def test_camera_on(hass: HomeAssistant) -> None:
     """Test the camera turn on service."""
     await setup_platform(hass, CAMERA_DOMAIN)
 
-    with patch("abodepy.AbodeCamera.privacy_mode") as mock_capture:
+    with patch("jaraco.abode.devices.camera.Camera.privacy_mode") as mock_capture:
         await hass.services.async_call(
             CAMERA_DOMAIN,
             "turn_on",
@@ -61,7 +61,7 @@ async def test_camera_off(hass: HomeAssistant) -> None:
     """Test the camera turn off service."""
     await setup_platform(hass, CAMERA_DOMAIN)
 
-    with patch("abodepy.AbodeCamera.privacy_mode") as mock_capture:
+    with patch("jaraco.abode.devices.camera.Camera.privacy_mode") as mock_capture:
         await hass.services.async_call(
             CAMERA_DOMAIN,
             "turn_off",

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -2,8 +2,10 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
-from abodepy.exceptions import AbodeAuthenticationException
-from abodepy.helpers.errors import MFA_CODE_REQUIRED
+from jaraco.abode.exceptions import (
+    AuthenticationException as AbodeAuthenticationException,
+)
+from jaraco.abode.helpers.errors import MFA_CODE_REQUIRED
 from requests.exceptions import ConnectTimeout
 
 from homeassistant import data_entry_flow
@@ -96,9 +98,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
-    with patch("homeassistant.components.abode.config_flow.Abode"), patch(
-        "abodepy.UTILS"
-    ):
+    with patch("homeassistant.components.abode.config_flow.Abode"):
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=conf
@@ -140,9 +140,7 @@ async def test_step_mfa(hass: HomeAssistant) -> None:
 
         assert result["errors"] == {"base": "invalid_mfa_code"}
 
-    with patch("homeassistant.components.abode.config_flow.Abode"), patch(
-        "abodepy.UTILS"
-    ):
+    with patch("homeassistant.components.abode.config_flow.Abode"):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={"mfa_code": "123456"}
         )
@@ -166,9 +164,7 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
         data=conf,
     ).add_to_hass(hass)
 
-    with patch("homeassistant.components.abode.config_flow.Abode"), patch(
-        "abodepy.UTILS"
-    ):
+    with patch("homeassistant.components.abode.config_flow.Abode"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_REAUTH},

--- a/tests/components/abode/test_cover.py
+++ b/tests/components/abode/test_cover.py
@@ -44,7 +44,7 @@ async def test_open(hass: HomeAssistant) -> None:
     """Test the cover can be opened."""
     await setup_platform(hass, COVER_DOMAIN)
 
-    with patch("abodepy.AbodeCover.open_cover") as mock_open:
+    with patch("jaraco.abode.devices.cover.Cover.open_cover") as mock_open:
         await hass.services.async_call(
             COVER_DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -56,7 +56,7 @@ async def test_close(hass: HomeAssistant) -> None:
     """Test the cover can be closed."""
     await setup_platform(hass, COVER_DOMAIN)
 
-    with patch("abodepy.AbodeCover.close_cover") as mock_close:
+    with patch("jaraco.abode.devices.cover.Cover.close_cover") as mock_close:
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER,

--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -2,7 +2,10 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
-from abodepy.exceptions import AbodeAuthenticationException, AbodeException
+from jaraco.abode.exceptions import (
+    AuthenticationException as AbodeAuthenticationException,
+    Exception as AbodeException,
+)
 
 from homeassistant import data_entry_flow
 from homeassistant.components.abode import (
@@ -23,7 +26,7 @@ async def test_change_settings(hass: HomeAssistant) -> None:
     """Test change_setting service."""
     await setup_platform(hass, ALARM_DOMAIN)
 
-    with patch("abodepy.Abode.set_setting") as mock_set_setting:
+    with patch("jaraco.abode.client.Client.set_setting") as mock_set_setting:
         await hass.services.async_call(
             ABODE_DOMAIN,
             SERVICE_SETTINGS,
@@ -43,9 +46,8 @@ async def test_add_unique_id(hass: HomeAssistant) -> None:
 
     assert mock_entry.unique_id is None
 
-    with patch("abodepy.UTILS"):
-        await hass.config_entries.async_reload(mock_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_reload(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert mock_entry.unique_id == mock_entry.data[CONF_USERNAME]
 
@@ -54,8 +56,8 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unloading the Abode entry."""
     mock_entry = await setup_platform(hass, ALARM_DOMAIN)
 
-    with patch("abodepy.Abode.logout") as mock_logout, patch(
-        "abodepy.event_controller.AbodeEventController.stop"
+    with patch("jaraco.abode.client.Client.logout") as mock_logout, patch(
+        "jaraco.abode.event_controller.EventController.stop"
     ) as mock_events_stop:
         assert await hass.config_entries.async_unload(mock_entry.entry_id)
         mock_logout.assert_called_once()

--- a/tests/components/abode/test_light.py
+++ b/tests/components/abode/test_light.py
@@ -62,7 +62,7 @@ async def test_switch_off(hass: HomeAssistant) -> None:
     """Test the light can be turned off."""
     await setup_platform(hass, LIGHT_DOMAIN)
 
-    with patch("abodepy.AbodeLight.switch_off") as mock_switch_off:
+    with patch("jaraco.abode.devices.light.Light.switch_off") as mock_switch_off:
         assert await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -74,7 +74,7 @@ async def test_switch_on(hass: HomeAssistant) -> None:
     """Test the light can be turned on."""
     await setup_platform(hass, LIGHT_DOMAIN)
 
-    with patch("abodepy.AbodeLight.switch_on") as mock_switch_on:
+    with patch("jaraco.abode.devices.light.Light.switch_on") as mock_switch_on:
         await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -86,7 +86,7 @@ async def test_set_brightness(hass: HomeAssistant) -> None:
     """Test the brightness can be set."""
     await setup_platform(hass, LIGHT_DOMAIN)
 
-    with patch("abodepy.AbodeLight.set_level") as mock_set_level:
+    with patch("jaraco.abode.devices.light.Light.set_level") as mock_set_level:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -102,7 +102,7 @@ async def test_set_color(hass: HomeAssistant) -> None:
     """Test the color can be set."""
     await setup_platform(hass, LIGHT_DOMAIN)
 
-    with patch("abodepy.AbodeLight.set_color") as mock_set_color:
+    with patch("jaraco.abode.devices.light.Light.set_color") as mock_set_color:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -117,7 +117,9 @@ async def test_set_color_temp(hass: HomeAssistant) -> None:
     """Test the color temp can be set."""
     await setup_platform(hass, LIGHT_DOMAIN)
 
-    with patch("abodepy.AbodeLight.set_color_temp") as mock_set_color_temp:
+    with patch(
+        "jaraco.abode.devices.light.Light.set_color_temp"
+    ) as mock_set_color_temp:
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,

--- a/tests/components/abode/test_lock.py
+++ b/tests/components/abode/test_lock.py
@@ -44,7 +44,7 @@ async def test_lock(hass: HomeAssistant) -> None:
     """Test the lock can be locked."""
     await setup_platform(hass, LOCK_DOMAIN)
 
-    with patch("abodepy.AbodeLock.lock") as mock_lock:
+    with patch("jaraco.abode.devices.lock.Lock.lock") as mock_lock:
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -56,7 +56,7 @@ async def test_unlock(hass: HomeAssistant) -> None:
     """Test the lock can be unlocked."""
     await setup_platform(hass, LOCK_DOMAIN)
 
-    with patch("abodepy.AbodeLock.unlock") as mock_unlock:
+    with patch("jaraco.abode.devices.lock.Lock.unlock") as mock_unlock:
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )

--- a/tests/components/abode/test_switch.py
+++ b/tests/components/abode/test_switch.py
@@ -48,7 +48,7 @@ async def test_switch_on(hass: HomeAssistant) -> None:
     """Test the switch can be turned on."""
     await setup_platform(hass, SWITCH_DOMAIN)
 
-    with patch("abodepy.AbodeSwitch.switch_on") as mock_switch_on:
+    with patch("jaraco.abode.devices.switch.Switch.switch_on") as mock_switch_on:
         assert await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -61,7 +61,7 @@ async def test_switch_off(hass: HomeAssistant) -> None:
     """Test the switch can be turned off."""
     await setup_platform(hass, SWITCH_DOMAIN)
 
-    with patch("abodepy.AbodeSwitch.switch_off") as mock_switch_off:
+    with patch("jaraco.abode.devices.switch.Switch.switch_off") as mock_switch_off:
         assert await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -81,7 +81,7 @@ async def test_automation_attributes(hass: HomeAssistant) -> None:
 
 async def test_turn_automation_off(hass: HomeAssistant) -> None:
     """Test the automation can be turned off."""
-    with patch("abodepy.AbodeAutomation.enable") as mock_trigger:
+    with patch("jaraco.abode.automation.Automation.enable") as mock_trigger:
         await setup_platform(hass, SWITCH_DOMAIN)
 
         await hass.services.async_call(
@@ -97,7 +97,7 @@ async def test_turn_automation_off(hass: HomeAssistant) -> None:
 
 async def test_turn_automation_on(hass: HomeAssistant) -> None:
     """Test the automation can be turned on."""
-    with patch("abodepy.AbodeAutomation.enable") as mock_trigger:
+    with patch("jaraco.abode.automation.Automation.enable") as mock_trigger:
         await setup_platform(hass, SWITCH_DOMAIN)
 
         await hass.services.async_call(
@@ -115,7 +115,7 @@ async def test_trigger_automation(hass: HomeAssistant) -> None:
     """Test the trigger automation service."""
     await setup_platform(hass, SWITCH_DOMAIN)
 
-    with patch("abodepy.AbodeAutomation.trigger") as mock:
+    with patch("jaraco.abode.automation.Automation.trigger") as mock:
         await hass.services.async_call(
             ABODE_DOMAIN,
             SERVICE_TRIGGER_AUTOMATION,


### PR DESCRIPTION
## Proposed change
The `abodepy` library used by the `abode` component has not been updated in 1.5 years. It does not support newer Abode devices like the popular Abode Cam 2. This PR replaces the `abodepy` library with the `jaraco.abode` fork, which is being actively maintained.

Fixes #69635 and replaces #85081.

New library: https://github.com/jaraco/jaraco.abode/releases/tag/v3.2.1

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #69635

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
