### PR TITLE
2023.1.2

### DIFF
--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -560,8 +560,8 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     DSMRReaderSensorEntityDescription(
         key="dsmr/consumption/quarter-hour-peak-electricity/average_delivered",
         name="Previous quarter-hour peak usage",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/consumption/quarter-hour-peak-electricity/read_at_start",

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
-  "requirements": ["gcal-sync==4.1.0", "oauth2client==4.1.3"],
+  "requirements": ["gcal-sync==4.1.1", "oauth2client==4.1.3"],
   "codeowners": ["@allenporter"],
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"]

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -28,7 +28,7 @@ DATA_HYDRAWISE = "hydrawise"
 DOMAIN = "hydrawise"
 DEFAULT_WATERING_TIME = 15
 
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=120)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
 

--- a/homeassistant/components/life360/manifest.json
+++ b/homeassistant/components/life360/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/life360",
   "codeowners": ["@pnbruckner"],
-  "requirements": ["life360==5.3.0"],
+  "requirements": ["life360==5.5.0"],
   "iot_class": "cloud_polling",
   "loggers": ["life360"]
 }

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Local Calendar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
-  "requirements": ["ical==4.2.8"],
+  "requirements": ["ical==4.2.9"],
   "codeowners": ["@allenporter"],
   "iot_class": "local_polling",
   "loggers": ["ical"]

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -213,7 +213,7 @@ class NumberDeviceClass(StrEnum):
     POWER_FACTOR = "power_factor"
     """Power factor.
 
-    Unit of measurement: `%`
+    Unit of measurement: `%`, `None`
     """
 
     POWER = "power"

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -210,7 +210,7 @@ class PhilipsTVMediaPlayer(
     async def async_media_play_pause(self) -> None:
         """Send pause command to media player."""
         if self._tv.quirk_playpause_spacebar:
-            await self._tv.sendUnicode(" ")
+            await self._tv.sendKey("Confirm")
         else:
             await self._tv.sendKey("PlayPause")
         await self._async_update_soon()
@@ -508,6 +508,8 @@ class PhilipsTVMediaPlayer(
             self._media_content_id = None
             self._media_title = self._sources.get(self._tv.source_id)
             self._media_channel = None
+
+        self._attr_assumed_state = True
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Reolink IP NVR/camera",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/reolink",
-  "requirements": ["reolink-aio==0.1.2"],
+  "requirements": ["reolink-aio==0.1.3"],
   "codeowners": ["@starkillerOG"],
   "iot_class": "local_polling",
   "loggers": ["reolink-aio"]

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -309,7 +309,7 @@ class SensorDeviceClass(StrEnum):
     POWER_FACTOR = "power_factor"
     """Power factor.
 
-    Unit of measurement: `%`
+    Unit of measurement: `%`, `None`
     """
 
     POWER = "power"
@@ -521,7 +521,7 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.PM1: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.PM10: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.PM25: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.POWER_FACTOR: {PERCENTAGE},
+    SensorDeviceClass.POWER_FACTOR: {PERCENTAGE, None},
     SensorDeviceClass.POWER: {UnitOfPower.WATT, UnitOfPower.KILO_WATT},
     SensorDeviceClass.PRECIPITATION: set(UnitOfPrecipitationDepth),
     SensorDeviceClass.PRECIPITATION_INTENSITY: set(UnitOfVolumetricFlux),

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.36.2"],
+  "requirements": ["PySwitchbot==0.36.3"],
   "config_flow": true,
   "dependencies": ["bluetooth"],
   "codeowners": [

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -24,7 +24,7 @@
         }
       },
       "lock_auth": {
-        "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key.",
+        "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key. Usernames and passwords are case sensitive.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/switchbot/translations/en.json
+++ b/homeassistant/components/switchbot/translations/en.json
@@ -21,7 +21,7 @@
                     "password": "Password",
                     "username": "Username"
                 },
-                "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key."
+                "description": "Please provide your SwitchBot app username and password. This data won't be saved and only used to retrieve your locks encryption key. Usernames and passwords are case sensitive."
             },
             "lock_choose_method": {
                 "description": "A SwitchBot lock can be set up in Home Assistant in two different ways.\n\nYou can enter the key id and encryption key yourself, or Home Assistant can import them from your SwitchBot account.",

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -17,6 +17,7 @@ from zigpy.application import ControllerApplication
 from zigpy.config import CONF_DEVICE
 import zigpy.device
 import zigpy.endpoint
+import zigpy.exceptions
 import zigpy.group
 from zigpy.types.named import EUI64
 
@@ -24,6 +25,7 @@ from homeassistant import __path__ as HOMEASSISTANT_PATH
 from homeassistant.components.system_log import LogEntry, _figure_out_source
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo
@@ -172,6 +174,8 @@ class ZHAGateway:
                 self.application_controller = await app_controller_cls.new(
                     app_config, auto_form=True, start_radio=True
                 )
+            except zigpy.exceptions.TransientConnectionError as exc:
+                raise ConfigEntryNotReady from exc
             except Exception as exc:  # pylint: disable=broad-except
                 _LOGGER.warning(
                     "Couldn't start %s coordinator (attempt %s of %s)",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,12 +4,12 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows==0.34.5",
+    "bellows==0.34.6",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.90",
     "zigpy-deconz==0.19.2",
-    "zigpy==0.52.3",
+    "zigpy==0.53.0",
     "zigpy-xbee==0.16.2",
     "zigpy-zigate==0.10.3",
     "zigpy-znp==0.9.2"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 1
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.1.1"
+version     = "2023.1.2"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1029,7 +1029,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==5.3.0
+life360==5.5.0
 
 # homeassistant.components.osramlightify
 lightify==1.0.7.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -930,7 +930,7 @@ ibm-watson==5.2.2
 ibmiotf==0.3.4
 
 # homeassistant.components.local_calendar
-ical==4.2.8
+ical==4.2.9
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -744,7 +744,7 @@ gTTS==2.2.4
 gassist-text==0.0.7
 
 # homeassistant.components.google
-gcal-sync==4.1.0
+gcal-sync==4.1.1
 
 # homeassistant.components.geniushub
 geniushub-client==0.6.30

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -419,7 +419,7 @@ beautifulsoup4==4.11.1
 # beewi_smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.34.5
+bellows==0.34.6
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.12.0
@@ -2668,7 +2668,7 @@ zigpy-zigate==0.10.3
 zigpy-znp==0.9.2
 
 # homeassistant.components.zha
-zigpy==0.52.3
+zigpy==0.53.0
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2190,7 +2190,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.11
 
 # homeassistant.components.reolink
-reolink-aio==0.1.2
+reolink-aio==0.1.3
 
 # homeassistant.components.python_script
 restrictedpython==5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.36.2
+PySwitchbot==0.36.3
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1529,7 +1529,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.11
 
 # homeassistant.components.reolink
-reolink-aio==0.1.2
+reolink-aio==0.1.3
 
 # homeassistant.components.python_script
 restrictedpython==5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.36.2
+PySwitchbot==0.36.3
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -560,7 +560,7 @@ gTTS==2.2.4
 gassist-text==0.0.7
 
 # homeassistant.components.google
-gcal-sync==4.1.0
+gcal-sync==4.1.1
 
 # homeassistant.components.geocaching
 geocachingapi==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -695,7 +695,7 @@ iaqualink==0.5.0
 ibeacon_ble==1.0.1
 
 # homeassistant.components.local_calendar
-ical==4.2.8
+ical==4.2.9
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -767,7 +767,7 @@ librouteros==3.2.0
 libsoundtouch==0.8
 
 # homeassistant.components.life360
-life360==5.3.0
+life360==5.5.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -346,7 +346,7 @@ base36==0.1.1
 beautifulsoup4==4.11.1
 
 # homeassistant.components.zha
-bellows==0.34.5
+bellows==0.34.6
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.12.0
@@ -1869,7 +1869,7 @@ zigpy-zigate==0.10.3
 zigpy-znp==0.9.2
 
 # homeassistant.components.zha
-zigpy==0.52.3
+zigpy==0.53.0
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.44.0

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -77,7 +77,7 @@ def update_attribute_cache(cluster):
             attrid = zigpy.types.uint16_t(attrid)
         attrs.append(make_attribute(attrid, value))
 
-    hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
+    hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
     hdr.frame_control.disable_default_response = True
     msg = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Report_Attributes].schema(
         attribute_reports=attrs


### PR DESCRIPTION
- Allow SensorDeviceClass.POWER_FACTOR unit None ([@epenet] - [#85287]) ([sensor docs]) ([number docs])
- Retry ZHA config entry setup when `ENETUNREACH` is caught ([@puddly] - [#84615]) ([zha docs])
- Fix dsmr_reader peak hour consumption unit of measurement ([@Glodenox] - [#85301]) ([dsmr_reader docs])
- Bump reolink-aio to 0.1.3 ([@starkillerOG] - [#85309]) ([reolink docs])
- Bump life360 package to 5.5.0 ([@pnbruckner] - [#85322]) ([life360 docs])
- Switch play pause method in philips js ([@elupus] - [#85343]) ([philips_js docs])
- Bump ZHA dependencies ([@puddly] - [#85355]) ([zha docs])
- Add note to SwitchBot locks that usernames are case sensitive ([@bdraco] - [#85359]) ([switchbot docs])
- Bump pySwitchbot to 0.36.3 ([@bdraco] - [#85360]) ([switchbot docs])
- Increase Hydrawise default scan interval ([@mobilutz] - [#85398]) ([hydrawise docs])
- Bump ical to 4.2.9 ([@allenporter] - [#85401]) ([local_calendar docs])
- Bump gcal_sync to 4.1.1 ([@allenporter] - [#85453]) ([google docs])

[#84615]: https://github.com/home-assistant/core/pull/84615
[#85120]: https://github.com/home-assistant/core/pull/85120
[#85277]: https://github.com/home-assistant/core/pull/85277
[#85287]: https://github.com/home-assistant/core/pull/85287
[#85301]: https://github.com/home-assistant/core/pull/85301
[#85309]: https://github.com/home-assistant/core/pull/85309
[#85322]: https://github.com/home-assistant/core/pull/85322
[#85343]: https://github.com/home-assistant/core/pull/85343
[#85355]: https://github.com/home-assistant/core/pull/85355
[#85359]: https://github.com/home-assistant/core/pull/85359
[#85360]: https://github.com/home-assistant/core/pull/85360
[#85398]: https://github.com/home-assistant/core/pull/85398
[#85401]: https://github.com/home-assistant/core/pull/85401
[#85453]: https://github.com/home-assistant/core/pull/85453
[@Glodenox]: https://github.com/Glodenox
[@allenporter]: https://github.com/allenporter
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@elupus]: https://github.com/elupus
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@mobilutz]: https://github.com/mobilutz
[@pnbruckner]: https://github.com/pnbruckner
[@puddly]: https://github.com/puddly
[@starkillerOG]: https://github.com/starkillerOG
[dsmr_reader docs]: https://www.home-assistant.io/integrations/dsmr_reader/
[google docs]: https://www.home-assistant.io/integrations/google/
[hydrawise docs]: https://www.home-assistant.io/integrations/hydrawise/
[life360 docs]: https://www.home-assistant.io/integrations/life360/
[local_calendar docs]: https://www.home-assistant.io/integrations/local_calendar/
[number docs]: https://www.home-assistant.io/integrations/number/
[philips_js docs]: https://www.home-assistant.io/integrations/philips_js/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[sensor docs]: https://www.home-assistant.io/integrations/sensor/
[switchbot docs]: https://www.home-assistant.io/integrations/switchbot/
[zha docs]: https://www.home-assistant.io/integrations/zha/
