### PR TITLE
Bump pylitejet to 0.4.6 (now with async!)

### DIFF
--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -61,10 +61,10 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 system = await pylitejet.open(port)
-                await system.close()
             except SerialException:
                 errors[CONF_PORT] = "open_failed"
             else:
+                await system.close()
                 return self.async_create_entry(
                     title=port,
                     data={CONF_PORT: port},

--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -59,12 +59,9 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             port = user_input[CONF_PORT]
 
-            await self.async_set_unique_id(port)
-            self._abort_if_unique_id_configured()
-
             try:
-                system = pylitejet.LiteJet(port)
-                system.close()
+                system = await pylitejet.open(port)
+                await system.close()
             except SerialException:
                 errors[CONF_PORT] = "open_failed"
             else:

--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -2,7 +2,7 @@
   "domain": "litejet",
   "name": "LiteJet",
   "documentation": "https://www.home-assistant.io/integrations/litejet",
-  "requirements": ["pylitejet==0.3.0"],
+  "requirements": ["pylitejet==0.4.6"],
   "codeowners": ["@joncar"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -1,6 +1,8 @@
 """Support for LiteJet scenes."""
 from typing import Any
 
+from pylitejet import LiteJet
+
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -18,22 +20,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry."""
 
-    system = hass.data[DOMAIN]
+    system: LiteJet = hass.data[DOMAIN]
 
-    def get_entities(system):
-        entities = []
-        for i in system.scenes():
-            name = system.get_scene_name(i)
-            entities.append(LiteJetScene(config_entry.entry_id, system, i, name))
-        return entities
+    entities = []
+    for i in system.scenes():
+        name = await system.get_scene_name(i)
+        entities.append(LiteJetScene(config_entry.entry_id, system, i, name))
 
-    async_add_entities(await hass.async_add_executor_job(get_entities, system), True)
+    async_add_entities(entities, True)
 
 
 class LiteJetScene(Scene):
     """Representation of a single LiteJet scene."""
 
-    def __init__(self, entry_id, lj, i, name):  # pylint: disable=invalid-name
+    def __init__(self, entry_id, lj: LiteJet, i, name):  # pylint: disable=invalid-name
         """Initialize the scene."""
         self._entry_id = entry_id
         self._lj = lj
@@ -55,9 +55,9 @@ class LiteJetScene(Scene):
         """Return the device-specific state attributes."""
         return {ATTR_NUMBER: self._index}
 
-    def activate(self, **kwargs: Any) -> None:
+    async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
-        self._lj.activate_scene(self._index)
+        await self._lj.activate_scene(self._index)
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Any
 
+from pylitejet import LiteJet
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -21,16 +23,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry."""
 
-    system = hass.data[DOMAIN]
+    system: LiteJet = hass.data[DOMAIN]
 
-    def get_entities(system):
-        entities = []
-        for i in system.button_switches():
-            name = system.get_switch_name(i)
-            entities.append(LiteJetSwitch(config_entry.entry_id, system, i, name))
-        return entities
+    entities = []
+    for i in system.button_switches():
+        name = await system.get_switch_name(i)
+        entities.append(LiteJetSwitch(config_entry.entry_id, system, i, name))
 
-    async_add_entities(await hass.async_add_executor_job(get_entities, system), True)
+    async_add_entities(entities, True)
 
 
 class LiteJetSwitch(SwitchEntity):
@@ -86,13 +86,13 @@ class LiteJetSwitch(SwitchEntity):
         """Return the device-specific state attributes."""
         return {ATTR_NUMBER: self._index}
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Press the switch."""
-        self._lj.press_switch(self._index)
+        await self._lj.press_switch(self._index)
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Release the switch."""
-        self._lj.release_switch(self._index)
+        await self._lj.release_switch(self._index)
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/litejet/trigger.py
+++ b/homeassistant/components/litejet/trigger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from pylitejet import LiteJet
 import voluptuous as vol
 
 from homeassistant.const import CONF_PLATFORM
@@ -104,7 +105,7 @@ async def async_attach_trigger(
         ):
             hass.add_job(call_action)
 
-    system = hass.data[DOMAIN]
+    system: LiteJet = hass.data[DOMAIN]
 
     system.on_switch_pressed(number, pressed)
     system.on_switch_released(number, released)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1716,7 +1716,7 @@ pylgnetcast==0.3.7
 pylibrespot-java==0.1.1
 
 # homeassistant.components.litejet
-pylitejet==0.3.0
+pylitejet==0.4.6
 
 # homeassistant.components.litterrobot
 pylitterbot==2022.12.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1217,7 +1217,7 @@ pylaunches==1.3.0
 pylibrespot-java==0.1.1
 
 # homeassistant.components.litejet
-pylitejet==0.3.0
+pylitejet==0.4.6
 
 # homeassistant.components.litterrobot
 pylitterbot==2022.12.0

--- a/tests/components/litejet/conftest.py
+++ b/tests/components/litejet/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for LiteJet testing."""
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,13 +12,13 @@ def mock_litejet():
     """Mock LiteJet system."""
     with patch("pylitejet.LiteJet") as mock_pylitejet:
 
-        def get_load_name(number):
+        async def get_load_name(number):
             return f"Mock Load #{number}"
 
-        def get_scene_name(number):
+        async def get_scene_name(number):
             return f"Mock Scene #{number}"
 
-        def get_switch_name(number):
+        async def get_switch_name(number):
             return f"Mock Switch #{number}"
 
         mock_lj = mock_pylitejet.return_value
@@ -45,16 +45,26 @@ def mock_litejet():
         mock_lj.on_load_activated.side_effect = on_load_activated
         mock_lj.on_load_deactivated.side_effect = on_load_deactivated
 
+        mock_lj.open = AsyncMock()
+        mock_lj.close = AsyncMock()
+
         mock_lj.loads.return_value = range(1, 3)
-        mock_lj.get_load_name.side_effect = get_load_name
-        mock_lj.get_load_level.return_value = 0
+        mock_lj.get_load_name = AsyncMock(side_effect=get_load_name)
+        mock_lj.get_load_level = AsyncMock(return_value=0)
+        mock_lj.activate_load = AsyncMock()
+        mock_lj.activate_load_at = AsyncMock()
+        mock_lj.deactivate_load = AsyncMock()
 
         mock_lj.button_switches.return_value = range(1, 3)
         mock_lj.all_switches.return_value = range(1, 6)
-        mock_lj.get_switch_name.side_effect = get_switch_name
+        mock_lj.get_switch_name = AsyncMock(side_effect=get_switch_name)
+        mock_lj.press_switch = AsyncMock()
+        mock_lj.release_switch = AsyncMock()
 
         mock_lj.scenes.return_value = range(1, 3)
-        mock_lj.get_scene_name.side_effect = get_scene_name
+        mock_lj.get_scene_name = AsyncMock(side_effect=get_scene_name)
+        mock_lj.activate_scene = AsyncMock()
+        mock_lj.deactivate_scene = AsyncMock()
 
         mock_lj.start_time = dt_util.utcnow()
         mock_lj.last_delta = timedelta(0)

--- a/tests/components/litejet/test_light.py
+++ b/tests/components/litejet/test_light.py
@@ -113,7 +113,7 @@ async def test_activated_event(hass, mock_litejet):
     # Light 1
     mock_litejet.get_load_level.return_value = 99
     mock_litejet.get_load_level.reset_mock()
-    mock_litejet.load_activated_callbacks[ENTITY_LIGHT_NUMBER]()
+    mock_litejet.load_activated_callbacks[ENTITY_LIGHT_NUMBER](99)
     await hass.async_block_till_done()
 
     mock_litejet.get_load_level.assert_called_once_with(ENTITY_LIGHT_NUMBER)
@@ -128,7 +128,7 @@ async def test_activated_event(hass, mock_litejet):
 
     mock_litejet.get_load_level.return_value = 40
     mock_litejet.get_load_level.reset_mock()
-    mock_litejet.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+    mock_litejet.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER](40)
     await hass.async_block_till_done()
 
     mock_litejet.get_load_level.assert_called_once_with(ENTITY_OTHER_LIGHT_NUMBER)
@@ -147,7 +147,7 @@ async def test_deactivated_event(hass, mock_litejet):
     # Initial state is on.
     mock_litejet.get_load_level.return_value = 99
 
-    mock_litejet.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+    mock_litejet.load_activated_callbacks[ENTITY_OTHER_LIGHT_NUMBER](99)
     await hass.async_block_till_done()
 
     assert light.is_on(hass, ENTITY_OTHER_LIGHT)
@@ -157,7 +157,7 @@ async def test_deactivated_event(hass, mock_litejet):
     mock_litejet.get_load_level.reset_mock()
     mock_litejet.get_load_level.return_value = 0
 
-    mock_litejet.load_deactivated_callbacks[ENTITY_OTHER_LIGHT_NUMBER]()
+    mock_litejet.load_deactivated_callbacks[ENTITY_OTHER_LIGHT_NUMBER](0)
     await hass.async_block_till_done()
 
     # (Requesting the level is not strictly needed with a deactivated


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
LiteJet integration is now fully async.

Updated to the latest pylitejet (0.4.6) dependency which exposes its interface as async. As compared to the previous version (0.3.0), the library also has minor internal cleanup and feature additions (automatic re-connection, automatic detection of protocol start signal, testability improvments). Full diff: https://github.com/joncar/pylitejet/compare/0.3.0...v0.4.6


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
