### PR TITLE
Add diagnostics platform to SFR Box

### DIFF
--- a/homeassistant/components/sfr_box/diagnostics.py
+++ b/homeassistant/components/sfr_box/diagnostics.py
@@ -1,0 +1,34 @@
+"""SFR Box diagnostics platform."""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .models import DomainData
+
+TO_REDACT = {"mac_addr", "serial_number"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data: DomainData = hass.data[DOMAIN][entry.entry_id]
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": dict(entry.data),
+        },
+        "data": {
+            "dsl": async_redact_data(dataclasses.asdict(data.dsl.data), TO_REDACT),
+            "system": async_redact_data(
+                dataclasses.asdict(data.system.data), TO_REDACT
+            ),
+        },
+    }

--- a/tests/components/sfr_box/test_diagnostics.py
+++ b/tests/components/sfr_box/test_diagnostics.py
@@ -1,0 +1,69 @@
+"""Test the SFR Box diagnostics."""
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+pytestmark = pytest.mark.usefixtures("system_get_info", "dsl_get_info")
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None, None, None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.sfr_box.PLATFORMS", []):
+        yield
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, hass_client
+) -> None:
+    """Test config entry diagnostics."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        "entry": {
+            "data": {"host": "192.168.0.1"},
+            "title": "Mock Title",
+        },
+        "data": {
+            "dsl": {
+                "attenuation_down": 28.5,
+                "attenuation_up": 20.8,
+                "counter": 16,
+                "crc": 0,
+                "line_status": "No Defect",
+                "linemode": "ADSL2+",
+                "noise_down": 5.8,
+                "noise_up": 6.0,
+                "rate_down": 5549,
+                "rate_up": 187,
+                "status": "up",
+                "training": "Showtime",
+                "uptime": 450796,
+            },
+            "system": {
+                "alimvoltage": 12251,
+                "current_datetime": "202212282233",
+                "idur": "RP3P85K",
+                "mac_addr": REDACTED,
+                "net_infra": "adsl",
+                "net_mode": "router",
+                "product_id": "NB6VAC-FXC-r0",
+                "refclient": "",
+                "serial_number": REDACTED,
+                "temperature": 27560,
+                "uptime": 2353575,
+                "version_bootloader": "NB6VAC-BOOTLOADER-R4.0.8",
+                "version_dsldriver": "NB6VAC-XDSL-A2pv6F039p",
+                "version_mainfirmware": "NB6VAC-MAIN-R4.0.44k",
+                "version_rescuefirmware": "NB6VAC-MAIN-R4.0.44k",
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics platform to SFR Box

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
