### PR TITLE
Add custom labels setting for Prometheus exporter

### DIFF
--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -75,7 +75,7 @@ class FilterTest:
 
 
 @pytest.fixture(name="client")
-async def setup_prometheus_client(hass, hass_client, namespace, custom_labels={}):
+async def setup_prometheus_client(hass, hass_client, namespace, custom_labels):
     """Initialize an hass_client with Prometheus component."""
     # Reset registry
     prometheus_client.REGISTRY = prometheus_client.CollectorRegistry(auto_describe=True)
@@ -83,7 +83,9 @@ async def setup_prometheus_client(hass, hass_client, namespace, custom_labels={}
     prometheus_client.PlatformCollector(registry=prometheus_client.REGISTRY)
     prometheus_client.GCCollector(registry=prometheus_client.REGISTRY)
 
-    config = {custom_labels: custom_labels}
+    config = {}
+    if custom_labels is not None:
+        config[prometheus.CONF_CUSTOM_LABELS] = custom_labels
     if namespace is not None:
         config[prometheus.CONF_PROM_NAMESPACE] = namespace
     assert await async_setup_component(
@@ -92,6 +94,11 @@ async def setup_prometheus_client(hass, hass_client, namespace, custom_labels={}
     await hass.async_block_till_done()
 
     return await hass_client()
+
+
+@pytest.fixture(name="custom_labels")
+def custom_labels():
+    return None
 
 
 async def generate_latest_metrics(client):
@@ -883,18 +890,22 @@ async def test_disabling_entity(
         'friendly_name="Outside Humidity"} 1.0' in body
     )
 
-@pytest.mark.parametrize("namespace", [None])
-@pytest.mark.parametrize("custom_labels", {"area_name": "{{ area_name(state.entity_id) }}"})
+
+@pytest.mark.parametrize(
+    "namespace, custom_labels", [(None, {"object_id": "{{ state.object_id }}"})]
+)
 async def test_custom_labels(client, sensor_entities):
-    """Test prometheus metrics view."""
+    """Test custom_labels setting."""
+
     body = await generate_latest_metrics(client)
 
     assert (
         'homeassistant_sensor_temperature_celsius{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature",'
-        'area_name="Garage"} 15.6' in body
+        'object_id="outside_temperature"} 15.6' in body
     )
+
 
 @pytest.fixture(name="registry")
 def entity_registry_fixture(hass):
@@ -1581,9 +1592,7 @@ async def test_full_config(hass, mock_client):
                 "exclude_entity_globs": ["climate.excluded_*"],
                 "exclude_entities": ["fake.time_excluded"],
             },
-            "custom_labels": {
-                "area_name": "{{ area_name(state.entity_id) }}"
-            }
+            "custom_labels": {"area_name": "{{ area_name(state.entity_id) }}"},
         }
     }
     assert await async_setup_component(hass, prometheus.DOMAIN, config)

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -97,7 +97,7 @@ async def setup_prometheus_client(hass, hass_client, namespace, custom_labels):
 
 
 @pytest.fixture(name="custom_labels")
-def custom_labels():
+def empty_custom_labels():
     return None
 
 
@@ -892,7 +892,8 @@ async def test_disabling_entity(
 
 
 @pytest.mark.parametrize(
-    "namespace, custom_labels", [(None, {"object_id": "{{ state.object_id }}"})]
+    "namespace, custom_labels",
+    [(None, [{"name": "object_id", "template": "{{ state.object_id }}"}])],
 )
 async def test_custom_labels(client, sensor_entities):
     """Test custom_labels setting."""
@@ -1592,7 +1593,9 @@ async def test_full_config(hass, mock_client):
                 "exclude_entity_globs": ["climate.excluded_*"],
                 "exclude_entities": ["fake.time_excluded"],
             },
-            "custom_labels": {"area_name": "{{ area_name(state.entity_id) }}"},
+            "custom_labels": [
+                {"name": "area_name", "template": "{{ area_name(state.entity_id) }}"},
+            ],
         }
     }
     assert await async_setup_component(hass, prometheus.DOMAIN, config)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've added new `custom_labels` setting for Prometheus integration, that could be used to enhance exported metrics with additional, dynamically rendered labels. As an example, you could add `area_name` to all exported metrics:

```
prometheus:
  custom_labels:
    - name: area
      template: "{{ area_name(state.entity_id) }}"
```

This change resolves following feature suggestions:
https://community.home-assistant.io/t/add-support-to-set-custom-labels-for-prometheus/163966
https://community.home-assistant.io/t/area-property-in-prometheus-metrics/325476/2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
