### PR TITLE
Improve Huawei LTE SSDP inclusion

### DIFF
--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -244,6 +244,12 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
         )
 
+        unique_id = discovery_info.upnp.get(
+            ssdp.ATTR_UPNP_SERIAL, discovery_info.upnp[ssdp.ATTR_UPNP_UDN]
+        )
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured(updates={CONF_URL: url})
+
         def _is_supported_device() -> bool:
             """
             See if we are looking at a possibly supported device.
@@ -261,12 +267,6 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not await self.hass.async_add_executor_job(_is_supported_device):
             return self.async_abort(reason="unsupported_device")
-
-        unique_id = discovery_info.upnp.get(
-            ssdp.ATTR_UPNP_SERIAL, discovery_info.upnp[ssdp.ATTR_UPNP_UDN]
-        )
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured(updates={CONF_URL: url})
 
         self.context.update(
             {

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unsupported_device": "Unsupported device"
     },
     "error": {
       "connection_timeout": "Connection timeout",

--- a/homeassistant/components/huawei_lte/translations/en.json
+++ b/homeassistant/components/huawei_lte/translations/en.json
@@ -1,8 +1,8 @@
 {
     "config": {
         "abort": {
-            "not_huawei_lte": "Not a Huawei LTE device",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "unsupported_device": "Unsupported device"
         },
         "error": {
             "connection_timeout": "Connection timeout",

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -211,9 +211,14 @@ async def test_success(hass, login_requests_mock):
 
 
 @pytest.mark.parametrize(
-    ("upnp_data", "expected_result"),
+    ("requests_mock_request_kwargs", "upnp_data", "expected_result"),
     (
         (
+            {
+                "method": ANY,
+                "url": f"{FIXTURE_USER_INPUT[CONF_URL]}api/device/basic_information",
+                "text": "<response><devicename>Mock device</devicename></response>",
+            },
             {
                 ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
                 ssdp.ATTR_UPNP_SERIAL: "00000000",
@@ -226,6 +231,11 @@ async def test_success(hass, login_requests_mock):
         ),
         (
             {
+                "method": ANY,
+                "url": f"{FIXTURE_USER_INPUT[CONF_URL]}api/device/basic_information",
+                "text": "<error><code>100002</code><message/></error>",
+            },
+            {
                 ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
                 # No ssdp.ATTR_UPNP_SERIAL
             },
@@ -235,19 +245,36 @@ async def test_success(hass, login_requests_mock):
                 "errors": {},
             },
         ),
+        (
+            {
+                "method": ANY,
+                "url": f"{FIXTURE_USER_INPUT[CONF_URL]}api/device/basic_information",
+                "exc": Exception("Something unexpected"),
+            },
+            {
+                # Does not matter
+            },
+            {
+                "type": data_entry_flow.FlowResultType.ABORT,
+                "reason": "unsupported_device",
+            },
+        ),
     ),
 )
-async def test_ssdp(hass, upnp_data, expected_result):
+async def test_ssdp(
+    hass, login_requests_mock, requests_mock_request_kwargs, upnp_data, expected_result
+):
     """Test SSDP discovery initiates config properly."""
-    url = "http://192.168.100.1/"
+    url = FIXTURE_USER_INPUT[CONF_URL][:-1]  # strip trailing slash for appending port
     context = {"source": config_entries.SOURCE_SSDP}
+    login_requests_mock.request(**requests_mock_request_kwargs)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context=context,
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="upnp:rootdevice",
-            ssdp_location="http://192.168.100.1:60957/rootDesc.xml",
+            ssdp_location=f"{url}:60957/rootDesc.xml",
             upnp={
                 ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
                 ssdp.ATTR_UPNP_MANUFACTURER: "Huawei",

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -291,7 +291,7 @@ async def test_ssdp(
     for k, v in expected_result.items():
         assert result[k] == v
     if result.get("data_schema"):
-        result["data_schema"]({})[CONF_URL] == url
+        assert result["data_schema"]({})[CONF_URL] == url + "/"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

More or less as expected, the loosening of SSDP/UPnP data matches done in #81643 started to yield false positives, as in #85402.

Coming up with robust matches solely based on the SSDP/UPnP data still does not seem possible, so keep the matches as loose as they were made, but additionally invoke a probe request on the API to determine if the device looks like a supported one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85402
- This PR is related to issue: #81643
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
