### PR TITLE
Remove no-longer-needed invalid API key monitor for OpenUV

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -45,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_LONGITUDE, hass.config.longitude),
         altitude=entry.data.get(CONF_ELEVATION, hass.config.elevation),
         session=websession,
+        check_status_before_request=True,
     )
 
     async def async_update_protection_data() -> dict[str, Any]:

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -56,6 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinators: dict[str, OpenUvCoordinator] = {
         coordinator_name: OpenUvCoordinator(
             hass,
+            entry=entry,
             name=coordinator_name,
             latitude=client.latitude,
             longitude=client.longitude,

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -103,7 +103,6 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Verify the credentials and create/re-auth the entry."""
         websession = aiohttp_client.async_get_clientsession(self.hass)
         client = Client(data.api_key, 0, 0, session=websession)
-        client.disable_request_retries()
 
         try:
             await client.uv_index()

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -1,79 +1,20 @@
 """Define an update coordinator for OpenUV."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import LOGGER
 
 DEFAULT_DEBOUNCER_COOLDOWN_SECONDS = 15 * 60
-
-
-class InvalidApiKeyMonitor:
-    """Define a monitor for failed API calls (due to bad keys) across coordinators."""
-
-    DEFAULT_FAILED_API_CALL_THRESHOLD = 5
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize."""
-        self._count = 1
-        self._lock = asyncio.Lock()
-        self._reauth_flow_manager = ReauthFlowManager(hass, entry)
-        self.entry = entry
-
-    async def async_increment(self) -> None:
-        """Increment the counter."""
-        async with self._lock:
-            self._count += 1
-            if self._count > self.DEFAULT_FAILED_API_CALL_THRESHOLD:
-                LOGGER.info("Starting reauth after multiple failed API calls")
-                self._reauth_flow_manager.start_reauth()
-
-    async def async_reset(self) -> None:
-        """Reset the counter."""
-        async with self._lock:
-            self._count = 0
-            self._reauth_flow_manager.cancel_reauth()
-
-
-class ReauthFlowManager:
-    """Define an OpenUV reauth flow manager."""
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize."""
-        self.entry = entry
-        self.hass = hass
-
-    @callback
-    def _get_active_reauth_flow(self) -> FlowResult | None:
-        """Get an active reauth flow (if it exists)."""
-        return next(
-            iter(self.entry.async_get_active_flows(self.hass, {SOURCE_REAUTH})),
-            None,
-        )
-
-    @callback
-    def cancel_reauth(self) -> None:
-        """Cancel a reauth flow (if appropriate)."""
-        if reauth_flow := self._get_active_reauth_flow():
-            LOGGER.debug("API seems to have recovered; canceling reauth flow")
-            self.hass.config_entries.flow.async_abort(reauth_flow["flow_id"])
-
-    @callback
-    def start_reauth(self) -> None:
-        """Start a reauth flow (if appropriate)."""
-        if not self._get_active_reauth_flow():
-            LOGGER.debug("Multiple API failures in a row; starting reauth flow")
-            self.entry.async_start_reauth(self.hass)
 
 
 class OpenUvCoordinator(DataUpdateCoordinator):
@@ -90,7 +31,6 @@ class OpenUvCoordinator(DataUpdateCoordinator):
         latitude: str,
         longitude: str,
         update_method: Callable[[], Awaitable[dict[str, Any]]],
-        invalid_api_key_monitor: InvalidApiKeyMonitor,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -106,7 +46,6 @@ class OpenUvCoordinator(DataUpdateCoordinator):
             ),
         )
 
-        self._invalid_api_key_monitor = invalid_api_key_monitor
         self.latitude = latitude
         self.longitude = longitude
 
@@ -115,10 +54,8 @@ class OpenUvCoordinator(DataUpdateCoordinator):
         try:
             data = await self.update_method()
         except InvalidApiKeyError as err:
-            await self._invalid_api_key_monitor.async_increment()
-            raise UpdateFailed(str(err)) from err
+            raise ConfigEntryAuthFailed("Invalid API key") from err
         except OpenUvError as err:
             raise UpdateFailed(str(err)) from err
 
-        await self._invalid_api_key_monitor.async_reset()
         return cast(dict[str, Any], data["result"])

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
@@ -27,6 +27,7 @@ class OpenUvCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         *,
+        entry: ConfigEntry,
         name: str,
         latitude: str,
         longitude: str,
@@ -46,6 +47,7 @@ class OpenUvCoordinator(DataUpdateCoordinator):
             ),
         )
 
+        self._entry = entry
         self.latitude = latitude
         self.longitude = longitude
 
@@ -57,5 +59,15 @@ class OpenUvCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed("Invalid API key") from err
         except OpenUvError as err:
             raise UpdateFailed(str(err)) from err
+
+        # OpenUV uses HTTP 403 to indicate both an invalid API key and an API key that
+        # has hit its daily/monthly limit; both cases will result in a reauth flow. If
+        # coordinator update succeeds after a reauth flow has been started, terminate
+        # it:
+        if reauth_flow := next(
+            iter(self._entry.async_get_active_flows(self.hass, {SOURCE_REAUTH})),
+            None,
+        ):
+            self.hass.config_entries.flow.async_abort(reauth_flow["flow_id"])
 
         return cast(dict[str, Any], data["result"])

--- a/homeassistant/components/openuv/manifest.json
+++ b/homeassistant/components/openuv/manifest.json
@@ -3,7 +3,7 @@
   "name": "OpenUV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openuv",
-  "requirements": ["pyopenuv==2022.04.0"],
+  "requirements": ["pyopenuv==2023.01.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "loggers": ["pyopenuv"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1822,7 +1822,7 @@ pyoctoprintapi==0.1.9
 pyombi==0.1.10
 
 # homeassistant.components.openuv
-pyopenuv==2022.04.0
+pyopenuv==2023.01.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1305,7 +1305,7 @@ pynzbgetapi==0.2.0
 pyoctoprintapi==0.1.9
 
 # homeassistant.components.openuv
-pyopenuv==2022.04.0
+pyopenuv==2023.01.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenUV has a new API method that reliably returns the API's current status. This allows us to remove the "track how many errors we receive to see if we're looking at an invalid API key or service disruption" logic introduced in https://github.com/home-assistant/core/pull/79691. Doing so fixes a bug in which the integration will, upon config entry setup, attempt a re-setup every 1-2 minutes and spam the logs if its API key has reached its limit (https://github.com/home-assistant/core/issues/85496).

There is one quirk to keep in mind. In OpenUV, an `HTTP 403` response indicates one of two conditions:

1. An invalid API key
2. An API key whose daily/monthly limit is reached

Unfortunately, we can't deduce which is which when we receive an `HTTP 403` (there is an API endpoint to determine how many calls a user has made per day/month, but there is no way to know what that particular user's call limit is 🤦🏻). So, we follow this strategy:

1. _Any_ `HTTP 403` will trigger a re-auth flow.
2. In the case of an overrun API call limit, once the limit expires and the coordinator successfully retrieves data, any existing re-auth flow is canceled.

`pyopenuv` changelog: https://github.com/bachya/pyopenuv/releases/tag/2023.01.0
`pyopenuv` diff: https://github.com/bachya/pyopenuv/compare/2022.04.0...2023.01.0 (large diff, but the vast majority of it is repo maintenance)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/85496
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25671

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
