### PR TITLE
Adapt tplink to use has_entity_name

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -39,7 +39,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator]):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
-        self._attr_name = self.device.alias
+        self._attr_has_entity_name = True
         self._attr_unique_id = self.device.device_id
 
     @property

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -154,14 +154,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         self._attr_unique_id = (
             f"{legacy_device_id(self.device)}_{self.entity_description.key}"
         )
-
-    @property
-    def name(self) -> str:
-        """Return the name of the Smart Plug.
-
-        Overridden to include the description.
-        """
-        return f"{self.device.alias} {self.entity_description.name}"
+        self._attr_name = self.entity_description.name
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -57,7 +57,7 @@ class SmartPlugLedSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         """Initialize the LED switch."""
         super().__init__(device, coordinator)
 
-        self._attr_name = f"{device.alias} LED"
+        self._attr_name = "LED"
         self._attr_unique_id = f"{self.device.mac}_led"
 
     @property

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -93,6 +93,9 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         super().__init__(device, coordinator)
         # For backwards compat with pyHS100
         self._attr_unique_id = legacy_device_id(device)
+        # Define names for single sockets
+        if device.is_strip_socket:
+            self._attr_name = device.alias
 
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -149,6 +149,7 @@ def _mocked_plug() -> SmartPlug:
     plug.is_dimmer = False
     plug.is_strip = False
     plug.is_plug = True
+    plug.is_strip_socket = False
     plug.device_id = MAC_ADDRESS
     plug.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     plug.turn_off = AsyncMock()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adapts the tplink integration to use the `has_entity_name`, to my understanding fixing also #68603.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68603
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
