### PR TITLE
Revert "Adapt tplink to use has_entity_name"

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -39,7 +39,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator]):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
-        self._attr_has_entity_name = True
+        self._attr_name = self.device.alias
         self._attr_unique_id = self.device.device_id
 
     @property

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -154,7 +154,14 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         self._attr_unique_id = (
             f"{legacy_device_id(self.device)}_{self.entity_description.key}"
         )
-        self._attr_name = self.entity_description.name
+
+    @property
+    def name(self) -> str:
+        """Return the name of the Smart Plug.
+
+        Overridden to include the description.
+        """
+        return f"{self.device.alias} {self.entity_description.name}"
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -57,7 +57,7 @@ class SmartPlugLedSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         """Initialize the LED switch."""
         super().__init__(device, coordinator)
 
-        self._attr_name = "LED"
+        self._attr_name = f"{device.alias} LED"
         self._attr_unique_id = f"{self.device.mac}_led"
 
     @property
@@ -93,9 +93,6 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         super().__init__(device, coordinator)
         # For backwards compat with pyHS100
         self._attr_unique_id = legacy_device_id(device)
-        # Define names for single sockets
-        if device.is_strip_socket:
-            self._attr_name = device.alias
 
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -149,7 +149,6 @@ def _mocked_plug() -> SmartPlug:
     plug.is_dimmer = False
     plug.is_strip = False
     plug.is_plug = True
-    plug.is_strip_socket = False
     plug.device_id = MAC_ADDRESS
     plug.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     plug.turn_off = AsyncMock()


### PR DESCRIPTION
Reverts home-assistant/core#85577

The integration set `has_entity_name` in that PR, but many descriptions do not adhere to the rules that this flag has; reverting the PR for that reason.

e.g., all sensor names need to be adjusted to adhere to the new sentence style casing.

/CC @emontnemery @rytilahti