### PR TITLE
Improve Diagnostics result type

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -1,7 +1,7 @@
 """The Diagnostics integration."""
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Mapping
 from dataclasses import dataclass, field
 from http import HTTPStatus
 import json
@@ -38,10 +38,11 @@ class DiagnosticsPlatformData:
     """Diagnostic platform data."""
 
     config_entry_diagnostics: Callable[
-        [HomeAssistant, ConfigEntry], Coroutine[Any, Any, Any]
+        [HomeAssistant, ConfigEntry], Coroutine[Any, Any, Mapping[str, Any]]
     ] | None
     device_diagnostics: Callable[
-        [HomeAssistant, ConfigEntry, DeviceEntry], Coroutine[Any, Any, Any]
+        [HomeAssistant, ConfigEntry, DeviceEntry],
+        Coroutine[Any, Any, Mapping[str, Any]],
     ] | None
 
 
@@ -72,12 +73,12 @@ class DiagnosticsProtocol(Protocol):
 
     async def async_get_config_entry_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> dict[str, Any]:
+    ) -> Mapping[str, Any]:
         """Return diagnostics for a config entry."""
 
     async def async_get_device_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
-    ) -> dict[str, Any]:
+    ) -> Mapping[str, Any]:
         """Return diagnostics for a device."""
 
 
@@ -148,7 +149,7 @@ def handle_get(
 
 async def _async_get_json_file_response(
     hass: HomeAssistant,
-    data: Any,
+    data: Mapping[str, Any],
     filename: str,
     domain: str,
     d_id: str,

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -1,12 +1,12 @@
 """The Diagnostics integration."""
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine, Mapping, Sequence
+from collections.abc import Callable, Coroutine, Mapping
 from dataclasses import dataclass, field
 from http import HTTPStatus
 import json
 import logging
-from typing import Any, Protocol, Union
+from typing import Any, Protocol
 
 from aiohttp import web
 import voluptuous as vol
@@ -18,7 +18,7 @@ from homeassistant.helpers import integration_platform
 from homeassistant.helpers.device_registry import DeviceEntry, async_get
 from homeassistant.helpers.json import ExtendedJSONEncoder
 from homeassistant.helpers.system_info import async_get_system_info
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, JsonValueReadOnlyType
 from homeassistant.loader import async_get_custom_components, async_get_integration
 from homeassistant.util.json import (
     find_paths_unserializable_data,
@@ -31,18 +31,7 @@ from .util import async_redact_data
 __all__ = ["REDACTED", "async_redact_data"]
 
 _LOGGER = logging.getLogger(__name__)
-DiagnosticsContent = Mapping[
-    Union[str, int, float],
-    Union[
-        str,
-        int,
-        float,
-        bool,
-        None,
-        Sequence[Union[str, int, float, bool, "DiagnosticsContent"]],
-        "DiagnosticsContent",
-    ],
-]
+DiagnosticsContent = Mapping[str, JsonValueReadOnlyType]
 
 
 @dataclass

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -72,12 +72,12 @@ class DiagnosticsProtocol(Protocol):
 
     async def async_get_config_entry_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> Any:
+    ) -> dict[str, Any]:
         """Return diagnostics for a config entry."""
 
     async def async_get_device_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
-    ) -> Any:
+    ) -> dict[str, Any]:
         """Return diagnostics for a device."""
 
 

--- a/homeassistant/components/wiz/diagnostics.py
+++ b/homeassistant/components/wiz/diagnostics.py
@@ -1,9 +1,7 @@
 """Diagnostics support for WiZ."""
 from __future__ import annotations
 
-from typing import Any
-
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import DiagnosticsContent, async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -15,7 +13,7 @@ TO_REDACT = {"roomId", "homeId"}
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     wiz_data: WizData = hass.data[DOMAIN][entry.entry_id]
     return {

--- a/homeassistant/components/wled/diagnostics.py
+++ b/homeassistant/components/wled/diagnostics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import DiagnosticsContent, async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -13,7 +13,7 @@ from .coordinator import WLEDDataUpdateCoordinator
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     coordinator: WLEDDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 

--- a/homeassistant/components/xiaomi_miio/diagnostics.py
+++ b/homeassistant/components/xiaomi_miio/diagnostics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import DiagnosticsContent, async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC, CONF_TOKEN, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
@@ -21,7 +21,7 @@ TO_REDACT = {
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     diagnostics_data: dict[str, Any] = {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT)

--- a/homeassistant/components/yale_smart_alarm/diagnostics.py
+++ b/homeassistant/components/yale_smart_alarm/diagnostics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import DiagnosticsContent, async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -24,7 +24,7 @@ TO_REDACT = {
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     coordinator: YaleDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         COORDINATOR
@@ -32,4 +32,5 @@ async def async_get_config_entry_diagnostics(
 
     assert coordinator.yale
     get_all_data = await hass.async_add_executor_job(coordinator.yale.get_all)
-    return async_redact_data(get_all_data, TO_REDACT)
+    redacted_data: dict[str, Any] = async_redact_data(get_all_data, TO_REDACT)
+    return redacted_data

--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -15,6 +15,7 @@ import zigpy_xbee
 import zigpy_zigate
 import zigpy_znp
 
+from homeassistant.components.diagnostics import DiagnosticsContent
 from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_UNIQUE_ID
@@ -69,7 +70,7 @@ def shallow_asdict(obj: Any) -> dict:
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     config: dict = hass.data[DATA_ZHA].get(DATA_ZHA_CONFIG, {})
     gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
@@ -94,7 +95,7 @@ async def async_get_config_entry_diagnostics(
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry, device: dr.DeviceEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a device."""
     zha_device: ZHADevice = async_get_zha_device(hass, device.id)
     device_info: dict[str, Any] = zha_device.zha_device_info

--- a/homeassistant/components/zwave_js/diagnostics.py
+++ b/homeassistant/components/zwave_js/diagnostics.py
@@ -10,7 +10,7 @@ from zwave_js_server.dump import dump_msgs
 from zwave_js_server.model.node import Node, NodeDataType
 from zwave_js_server.model.value import ValueDataType
 
-from homeassistant.components.diagnostics import REDACTED
+from homeassistant.components.diagnostics import REDACTED, DiagnosticsContent
 from homeassistant.components.diagnostics.util import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
@@ -106,7 +106,7 @@ def get_device_entities(
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a config entry."""
     msgs: list[dict] = async_redact_data(
         await dump_msgs(
@@ -124,7 +124,7 @@ async def async_get_config_entry_diagnostics(
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry, device: dr.DeviceEntry
-) -> dict[str, Any]:
+) -> DiagnosticsContent:
     """Return diagnostics for a device."""
     client: Client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     identifiers = get_home_and_node_id_from_device_entry(device)
@@ -145,5 +145,5 @@ async def async_get_device_diagnostics(
             "maxSchemaVersion": client.version.max_schema_version,
         },
         "entities": entities,
-        "state": node_state,
+        "state": node_state,  # type: ignore[dict-item]
     }

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,5 +1,7 @@
 """Typing Helpers for Home Assistant."""
-from collections.abc import Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
 from enum import Enum
 from typing import Any, Optional, Union
 
@@ -16,6 +18,25 @@ TemplateVarsType = Optional[Mapping[str, Any]]
 
 # Custom type for recorder Queries
 QueryType = Any
+
+JsonValueType = Union[
+    None,
+    str,
+    int,
+    float,
+    bool,
+    list["JsonValueType"],
+    dict[str, "JsonValueType"],
+]
+JsonValueReadOnlyType = Union[
+    None,
+    str,
+    int,
+    float,
+    bool,
+    Sequence["JsonValueReadOnlyType"],
+    Mapping[str, "JsonValueReadOnlyType"],
+]
 
 
 class UndefinedType(Enum):

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -375,7 +375,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
                 1: "ConfigEntry",
             },
-            return_type=["DiagnosticsData", "Mapping[str, Any]"],
+            return_type=["DiagnosticsContent", "Mapping[str, Any]"],
         ),
         TypeHintMatch(
             function_name="async_get_device_diagnostics",
@@ -384,7 +384,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
                 2: "DeviceEntry",
             },
-            return_type=["DiagnosticsData", "Mapping[str, Any]"],
+            return_type=["DiagnosticsContent", "Mapping[str, Any]"],
         ),
     ],
     "notify": [

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -375,7 +375,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
                 1: "ConfigEntry",
             },
-            return_type="Mapping[str, Any]",
+            return_type=["DiagnosticsData", "Mapping[str, Any]"],
         ),
         TypeHintMatch(
             function_name="async_get_device_diagnostics",
@@ -384,7 +384,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
                 2: "DeviceEntry",
             },
-            return_type="Mapping[str, Any]",
+            return_type=["DiagnosticsData", "Mapping[str, Any]"],
         ),
     ],
     "notify": [

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -375,7 +375,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
                 1: "ConfigEntry",
             },
-            return_type="dict[str, Any]",
+            return_type="Mapping[str, Any]",
         ),
         TypeHintMatch(
             function_name="async_get_device_diagnostics",
@@ -384,7 +384,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
                 2: "DeviceEntry",
             },
-            return_type="dict[str, Any]",
+            return_type="Mapping[str, Any]",
         ),
     ],
     "notify": [

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -375,7 +375,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
                 1: "ConfigEntry",
             },
-            return_type=_Special.UNDEFINED,
+            return_type="dict[str, Any]",
         ),
         TypeHintMatch(
             function_name="async_get_device_diagnostics",
@@ -384,7 +384,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
                 2: "DeviceEntry",
             },
-            return_type=_Special.UNDEFINED,
+            return_type="dict[str, Any]",
         ),
     ],
     "notify": [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As an alternative to #85525

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
