### PR TITLE
Fix unknown data in vultr

### DIFF
--- a/homeassistant/components/vultr/sensor.py
+++ b/homeassistant/components/vultr/sensor.py
@@ -109,10 +109,13 @@ class VultrSensor(SensorEntity):
     @property
     def native_value(self):
         """Return the value of this given sensor type."""
+        value = self.data.get(self.entity_description.key)
+        if value == "not a number":
+            return None
         try:
-            return round(float(self.data.get(self.entity_description.key)), 2)
+            return round(float(value), 2)
         except (TypeError, ValueError):
-            return self.data.get(self.entity_description.key)
+            return value
 
     def update(self) -> None:
         """Update state of sensor."""

--- a/homeassistant/components/vultr/sensor.py
+++ b/homeassistant/components/vultr/sensor.py
@@ -109,13 +109,10 @@ class VultrSensor(SensorEntity):
     @property
     def native_value(self):
         """Return the value of this given sensor type."""
-        value = self.data.get(self.entity_description.key)
-        if value == "not a number":
-            return None
         try:
-            return round(float(value), 2)
+            return round(float(self.data.get(self.entity_description.key)), 2)
         except (TypeError, ValueError):
-            return value
+            return self.data.get(self.entity_description.key)
 
     def update(self) -> None:
         """Update state of sensor."""

--- a/tests/components/vultr/fixtures/server_list.json
+++ b/tests/components/vultr/fixtures/server_list.json
@@ -50,7 +50,7 @@
     "DCID": "1",
     "default_password": "nreqnusibni",
     "date_created": "2014-10-13 14:45:41",
-    "pending_charges": "not a number",
+    "pending_charges": "3.72",
     "status": "active",
     "cost_per_month": "73.25",
     "current_bandwidth_gb": 957.457,

--- a/tests/components/vultr/test_sensor.py
+++ b/tests/components/vultr/test_sensor.py
@@ -82,7 +82,7 @@ def test_sensor(hass: HomeAssistant):
 
             elif device.subscription == "123456":  # Custom name with 1 {}
                 assert device.name == "Server Pending Charges"
-                assert device.state is None
+                assert device.state == 3.72
                 tested += 1
 
             elif device.subscription == "555555":  # No {} in name

--- a/tests/components/vultr/test_sensor.py
+++ b/tests/components/vultr/test_sensor.py
@@ -82,7 +82,7 @@ def test_sensor(hass: HomeAssistant):
 
             elif device.subscription == "123456":  # Custom name with 1 {}
                 assert device.name == "Server Pending Charges"
-                assert device.state == "not a number"
+                assert device.state is None
                 tested += 1
 
             elif device.subscription == "555555":  # No {} in name


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #85605
`ValueError: Sensor None has device class None, state class None and unit US$ thus indicating it has a numeric value; however, it has the non-numeric value: not a number (<class 'str'>)`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
