### PR TITLE
Remove old migrate unique ID code from ISY994

### DIFF
--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -45,7 +45,6 @@ from .const import (
     TYPE_INSTEON_MOTION,
 )
 from .entity import ISYNodeEntity, ISYProgramEntity
-from .helpers import migrate_old_unique_ids
 
 DEVICE_PARENT_REQUIRED = [
     BinarySensorDeviceClass.OPENING,
@@ -191,7 +190,6 @@ async def async_setup_entry(
     for name, status, _ in hass_isy_data[ISY994_PROGRAMS][Platform.BINARY_SENSOR]:
         entities.append(ISYBinarySensorProgramEntity(name, status))
 
-    await migrate_old_unique_ids(hass, Platform.BINARY_SENSOR, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/climate.py
+++ b/homeassistant/components/isy994/climate.py
@@ -54,7 +54,7 @@ from .const import (
     UOM_TO_STATES,
 )
 from .entity import ISYNodeEntity
-from .helpers import convert_isy_value_to_hass, migrate_old_unique_ids
+from .helpers import convert_isy_value_to_hass
 
 
 async def async_setup_entry(
@@ -67,7 +67,6 @@ async def async_setup_entry(
     for node in hass_isy_data[ISY994_NODES][Platform.CLIMATE]:
         entities.append(ISYThermostatEntity(node))
 
-    await migrate_old_unique_ids(hass, Platform.CLIMATE, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -24,7 +24,6 @@ from .const import (
     UOM_BARRIER,
 )
 from .entity import ISYNodeEntity, ISYProgramEntity
-from .helpers import migrate_old_unique_ids
 
 
 async def async_setup_entry(
@@ -39,7 +38,6 @@ async def async_setup_entry(
     for name, status, actions in hass_isy_data[ISY994_PROGRAMS][Platform.COVER]:
         entities.append(ISYCoverProgramEntity(name, status, actions))
 
-    await migrate_old_unique_ids(hass, Platform.COVER, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -1,7 +1,7 @@
 """Representation of ISYEntity Types."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from pyisy.constants import (
     COMMAND_FRIENDLY_NAME,
@@ -128,13 +128,6 @@ class ISYEntity(Entity):
         """Get the unique identifier of the device."""
         if hasattr(self._node, "address"):
             return f"{self._node.isy.configuration[ISY_CONF_UUID]}_{self._node.address}"
-        return None
-
-    @property
-    def old_unique_id(self) -> str | None:
-        """Get the old unique identifier of the device."""
-        if hasattr(self._node, "address"):
-            return cast(str, self._node.address)
         return None
 
     @property

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -19,7 +19,6 @@ from homeassistant.util.percentage import (
 
 from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
-from .helpers import migrate_old_unique_ids
 
 SPEED_RANGE = (1, 255)  # off is not included
 
@@ -37,7 +36,6 @@ async def async_setup_entry(
     for name, status, actions in hass_isy_data[ISY994_PROGRAMS][Platform.FAN]:
         entities.append(ISYFanProgramEntity(name, status, actions))
 
-    await migrate_old_unique_ids(hass, Platform.FAN, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -1,7 +1,6 @@
 """Sorting helpers for ISY device classifications."""
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
 from pyisy.constants import (
@@ -17,13 +16,10 @@ from pyisy.programs import Programs
 from pyisy.variables import Variables
 
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from .const import (
     _LOGGER,
     DEFAULT_PROGRAM_STRING,
-    DOMAIN,
     FILTER_INSTEON_TYPE,
     FILTER_NODE_DEF_ID,
     FILTER_STATES,
@@ -51,7 +47,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from .entity import ISYEntity
+    pass
 
 BINARY_SENSOR_UOMS = ["2", "78"]
 BINARY_SENSOR_ISY_STATES = ["on", "off"]
@@ -378,40 +374,6 @@ def _categorize_variables(
         return
     for vtype, vname, vid in var_to_add:
         hass_isy_data[ISY994_VARIABLES].append((vname, variables[vtype][vid]))
-
-
-async def migrate_old_unique_ids(
-    hass: HomeAssistant, platform: str, entities: Sequence[ISYEntity]
-) -> None:
-    """Migrate to new controller-specific unique ids."""
-    registry = er.async_get(hass)
-
-    for entity in entities:
-        if entity.old_unique_id is None or entity.unique_id is None:
-            continue
-        old_entity_id = registry.async_get_entity_id(
-            platform, DOMAIN, entity.old_unique_id
-        )
-        if old_entity_id is not None:
-            _LOGGER.debug(
-                "Migrating unique_id from [%s] to [%s]",
-                entity.old_unique_id,
-                entity.unique_id,
-            )
-            registry.async_update_entity(old_entity_id, new_unique_id=entity.unique_id)
-
-        old_entity_id_2 = registry.async_get_entity_id(
-            platform, DOMAIN, entity.unique_id.replace(":", "")
-        )
-        if old_entity_id_2 is not None:
-            _LOGGER.debug(
-                "Migrating unique_id from [%s] to [%s]",
-                entity.unique_id.replace(":", ""),
-                entity.unique_id,
-            )
-            registry.async_update_entity(
-                old_entity_id_2, new_unique_id=entity.unique_id
-            )
 
 
 def convert_isy_value_to_hass(

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -1,7 +1,7 @@
 """Sorting helpers for ISY device classifications."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from pyisy.constants import (
     ISY_VALUE_UNKNOWN,
@@ -45,9 +45,6 @@ from .const import (
     UOM_DOUBLE_TEMP,
     UOM_ISYV4_DEGREES,
 )
-
-if TYPE_CHECKING:
-    pass
 
 BINARY_SENSOR_UOMS = ["2", "78"]
 BINARY_SENSOR_ISY_STATES = ["on", "off"]

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -22,7 +22,6 @@ from .const import (
     UOM_PERCENTAGE,
 )
 from .entity import ISYNodeEntity
-from .helpers import migrate_old_unique_ids
 from .services import async_setup_light_services
 
 ATTR_LAST_BRIGHTNESS = "last_brightness"
@@ -40,7 +39,6 @@ async def async_setup_entry(
     for node in hass_isy_data[ISY994_NODES][Platform.LIGHT]:
         entities.append(ISYLightEntity(node, restore_light_state))
 
-    await migrate_old_unique_ids(hass, Platform.LIGHT, entities)
     async_add_entities(entities)
     async_setup_light_services(hass)
 

--- a/homeassistant/components/isy994/lock.py
+++ b/homeassistant/components/isy994/lock.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
-from .helpers import migrate_old_unique_ids
 
 VALUE_TO_STATE = {0: False, 100: True}
 
@@ -30,7 +29,6 @@ async def async_setup_entry(
     for name, status, actions in hass_isy_data[ISY994_PROGRAMS][Platform.LOCK]:
         entities.append(ISYLockProgramEntity(name, status, actions))
 
-    await migrate_old_unique_ids(hass, Platform.LOCK, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -45,7 +45,7 @@ from .const import (
     UOM_TO_STATES,
 )
 from .entity import ISYEntity, ISYNodeEntity
-from .helpers import convert_isy_value_to_hass, migrate_old_unique_ids
+from .helpers import convert_isy_value_to_hass
 
 # Disable general purpose and redundant sensors by default
 AUX_DISABLED_BY_DEFAULT_MATCH = ["GV", "DO"]
@@ -135,7 +135,6 @@ async def async_setup_entry(
     for vname, vobj in hass_isy_data[ISY994_VARIABLES]:
         entities.append(ISYSensorVariableEntity(vname, vobj))
 
-    await migrate_old_unique_ids(hass, Platform.SENSOR, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import _LOGGER, DOMAIN as ISY994_DOMAIN, ISY994_NODES, ISY994_PROGRAMS
 from .entity import ISYNodeEntity, ISYProgramEntity
-from .helpers import migrate_old_unique_ids
 
 
 async def async_setup_entry(
@@ -28,7 +27,6 @@ async def async_setup_entry(
     for name, status, actions in hass_isy_data[ISY994_PROGRAMS][Platform.SWITCH]:
         entities.append(ISYSwitchProgramEntity(name, status, actions))
 
-    await migrate_old_unique_ids(hass, Platform.SWITCH, entities)
     async_add_entities(entities)
 
 


### PR DESCRIPTION
## Breaking change

It is no longer supported to migrate ISY configurations created in versions earlier than `0.110.0`. The integration must be deleted and recreated when updating from versions older than `0.110.0`.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PR removed the old `migrate_unique_ids` code introduced in version `0.110.0` back in May 2020 (Not marked as a breaking change, because if there is someone who has not updated in ~3 years, they should be probably be reinstalling fresh anyways)

This PR is part of a larger cleanup forthcoming for the ISY integration--it's a small enough piece I wanted to break out into it's own PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
