### PR TITLE
2023.1.3

### DIFF
--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -2,7 +2,7 @@
   "domain": "emulated_kasa",
   "name": "Emulated Kasa",
   "documentation": "https://www.home-assistant.io/integrations/emulated_kasa",
-  "requirements": ["sense_energy==0.11.0"],
+  "requirements": ["sense_energy==0.11.1"],
   "codeowners": ["@kbickar"],
   "quality_scale": "internal",
   "iot_class": "local_push",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
-  "requirements": ["home-assistant-frontend==20230104.0"],
+  "requirements": ["home-assistant-frontend==20230110.0"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/calendar.google/",
-  "requirements": ["gcal-sync==4.1.1", "oauth2client==4.1.3"],
+  "requirements": ["gcal-sync==4.1.2", "oauth2client==4.1.3"],
   "codeowners": ["@allenporter"],
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"]

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -59,6 +59,7 @@ SENSOR_TYPES = {
         name="signal strength",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:wifi",
     ),
     "ssid": SensorEntityDescription(
         key="ssid",

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -58,7 +58,6 @@ SENSOR_TYPES = {
         key="signal",
         name="signal strength",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "ssid": SensorEntityDescription(

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -31,7 +31,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .coordinator import InvalidApiKeyMonitor, OpenUvCoordinator
+from .coordinator import OpenUvCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -45,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_LONGITUDE, hass.config.longitude),
         altitude=entry.data.get(CONF_ELEVATION, hass.config.elevation),
         session=websession,
+        check_status_before_request=True,
     )
 
     async def async_update_protection_data() -> dict[str, Any]:
@@ -53,16 +54,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         high = entry.options.get(CONF_TO_WINDOW, DEFAULT_TO_WINDOW)
         return await client.uv_protection_window(low=low, high=high)
 
-    invalid_api_key_monitor = InvalidApiKeyMonitor(hass, entry)
-
     coordinators: dict[str, OpenUvCoordinator] = {
         coordinator_name: OpenUvCoordinator(
             hass,
+            entry=entry,
             name=coordinator_name,
             latitude=client.latitude,
             longitude=client.longitude,
             update_method=update_method,
-            invalid_api_key_monitor=invalid_api_key_monitor,
         )
         for coordinator_name, update_method in (
             (DATA_UV, client.uv_index),
@@ -70,16 +69,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     }
 
-    # We disable the client's request retry abilities here to avoid a lengthy (and
-    # blocking) startup; then, if the initial update is successful, we re-enable client
-    # request retries:
-    client.disable_request_retries()
     init_tasks = [
         coordinator.async_config_entry_first_refresh()
         for coordinator in coordinators.values()
     ]
     await asyncio.gather(*init_tasks)
-    client.enable_request_retries()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinators

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -103,7 +103,6 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Verify the credentials and create/re-auth the entry."""
         websession = aiohttp_client.async_get_clientsession(self.hass)
         client = Client(data.api_key, 0, 0, session=websession)
-        client.disable_request_retries()
 
         try:
             await client.uv_index()

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -1,79 +1,20 @@
 """Define an update coordinator for OpenUV."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import LOGGER
 
 DEFAULT_DEBOUNCER_COOLDOWN_SECONDS = 15 * 60
-
-
-class InvalidApiKeyMonitor:
-    """Define a monitor for failed API calls (due to bad keys) across coordinators."""
-
-    DEFAULT_FAILED_API_CALL_THRESHOLD = 5
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize."""
-        self._count = 1
-        self._lock = asyncio.Lock()
-        self._reauth_flow_manager = ReauthFlowManager(hass, entry)
-        self.entry = entry
-
-    async def async_increment(self) -> None:
-        """Increment the counter."""
-        async with self._lock:
-            self._count += 1
-            if self._count > self.DEFAULT_FAILED_API_CALL_THRESHOLD:
-                LOGGER.info("Starting reauth after multiple failed API calls")
-                self._reauth_flow_manager.start_reauth()
-
-    async def async_reset(self) -> None:
-        """Reset the counter."""
-        async with self._lock:
-            self._count = 0
-            self._reauth_flow_manager.cancel_reauth()
-
-
-class ReauthFlowManager:
-    """Define an OpenUV reauth flow manager."""
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize."""
-        self.entry = entry
-        self.hass = hass
-
-    @callback
-    def _get_active_reauth_flow(self) -> FlowResult | None:
-        """Get an active reauth flow (if it exists)."""
-        return next(
-            iter(self.entry.async_get_active_flows(self.hass, {SOURCE_REAUTH})),
-            None,
-        )
-
-    @callback
-    def cancel_reauth(self) -> None:
-        """Cancel a reauth flow (if appropriate)."""
-        if reauth_flow := self._get_active_reauth_flow():
-            LOGGER.debug("API seems to have recovered; canceling reauth flow")
-            self.hass.config_entries.flow.async_abort(reauth_flow["flow_id"])
-
-    @callback
-    def start_reauth(self) -> None:
-        """Start a reauth flow (if appropriate)."""
-        if not self._get_active_reauth_flow():
-            LOGGER.debug("Multiple API failures in a row; starting reauth flow")
-            self.entry.async_start_reauth(self.hass)
 
 
 class OpenUvCoordinator(DataUpdateCoordinator):
@@ -86,11 +27,11 @@ class OpenUvCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         *,
+        entry: ConfigEntry,
         name: str,
         latitude: str,
         longitude: str,
         update_method: Callable[[], Awaitable[dict[str, Any]]],
-        invalid_api_key_monitor: InvalidApiKeyMonitor,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -106,7 +47,7 @@ class OpenUvCoordinator(DataUpdateCoordinator):
             ),
         )
 
-        self._invalid_api_key_monitor = invalid_api_key_monitor
+        self._entry = entry
         self.latitude = latitude
         self.longitude = longitude
 
@@ -115,10 +56,18 @@ class OpenUvCoordinator(DataUpdateCoordinator):
         try:
             data = await self.update_method()
         except InvalidApiKeyError as err:
-            await self._invalid_api_key_monitor.async_increment()
-            raise UpdateFailed(str(err)) from err
+            raise ConfigEntryAuthFailed("Invalid API key") from err
         except OpenUvError as err:
             raise UpdateFailed(str(err)) from err
 
-        await self._invalid_api_key_monitor.async_reset()
+        # OpenUV uses HTTP 403 to indicate both an invalid API key and an API key that
+        # has hit its daily/monthly limit; both cases will result in a reauth flow. If
+        # coordinator update succeeds after a reauth flow has been started, terminate
+        # it:
+        if reauth_flow := next(
+            iter(self._entry.async_get_active_flows(self.hass, {SOURCE_REAUTH})),
+            None,
+        ):
+            self.hass.config_entries.flow.async_abort(reauth_flow["flow_id"])
+
         return cast(dict[str, Any], data["result"])

--- a/homeassistant/components/openuv/manifest.json
+++ b/homeassistant/components/openuv/manifest.json
@@ -3,7 +3,7 @@
   "name": "OpenUV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openuv",
-  "requirements": ["pyopenuv==2022.04.0"],
+  "requirements": ["pyopenuv==2023.01.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "loggers": ["pyopenuv"],

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sense",
   "name": "Sense",
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "requirements": ["sense_energy==0.11.0"],
+  "requirements": ["sense_energy==0.11.1"],
   "codeowners": ["@kbickar"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -509,7 +509,8 @@ class ShellyRpcCoordinator(DataUpdateCoordinator[None]):
         This will be executed on connect or when the config entry
         is updated.
         """
-        await self._async_connect_ble_scanner()
+        if not self.entry.data.get(CONF_SLEEP_PERIOD):
+            await self._async_connect_ble_scanner()
 
     async def _async_connect_ble_scanner(self) -> None:
         """Connect BLE scanner."""

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==5.2.0"],
+  "requirements": ["aioshelly==5.2.1"],
   "dependencies": ["bluetooth", "http"],
   "zeroconf": [
     {

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -131,7 +131,6 @@ EV_SENSORS = [
         key=sc.EV_TIME_TO_FULLY_CHARGED_UTC,
         device_class=SensorDeviceClass.TIMESTAMP,
         name="EV time to full charge",
-        state_class=SensorStateClass.MEASUREMENT,
     ),
 ]
 

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.6.2"],
+  "requirements": ["hatasmota==0.6.3"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"],

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -337,7 +337,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         name="Doorbell",
         device_class=BinarySensorDeviceClass.OCCUPANCY,
         icon="mdi:doorbell-video",
-        ufp_required_field="feature_flags.has_chime",
+        ufp_required_field="feature_flags.is_doorbell",
         ufp_value="is_ringing",
         ufp_event_obj="last_ring_event",
     ),

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "integration_type": "hub",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
-  "requirements": ["pyunifiprotect==4.5.2", "unifi-discovery==1.1.7"],
+  "requirements": ["pyunifiprotect==4.6.0", "unifi-discovery==1.1.7"],
   "dependencies": ["http", "repairs"],
   "codeowners": ["@briis", "@AngellusMortis", "@bdraco"],
   "quality_scale": "platinum",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "integration_type": "hub",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
-  "requirements": ["pyunifiprotect==4.6.0", "unifi-discovery==1.1.7"],
+  "requirements": ["pyunifiprotect==4.6.1", "unifi-discovery==1.1.7"],
   "dependencies": ["http", "repairs"],
   "codeowners": ["@briis", "@AngellusMortis", "@bdraco"],
   "quality_scale": "platinum",

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -770,7 +770,7 @@ class ProtectMediaSource(MediaSource):
             if camera is None:
                 raise BrowseError(f"Unknown Camera ID: {camera_id}")
             name = camera.name or camera.market_name or camera.type
-            is_doorbell = camera.feature_flags.has_chime
+            is_doorbell = camera.feature_flags.is_doorbell
             has_smart = camera.feature_flags.has_smart_detect
 
         thumbnail_url: str | None = None

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -206,7 +206,7 @@ CAMERA_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         name="Last Doorbell Ring",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:doorbell-video",
-        ufp_required_field="feature_flags.has_chime",
+        ufp_required_field="feature_flags.is_doorbell",
         ufp_value="last_ring",
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 1
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ dbus-fast==1.82.0
 fnvhash==0.1.0
 hass-nabucasa==0.61.0
 home-assistant-bluetooth==1.9.2
-home-assistant-frontend==20230104.0
+home-assistant-frontend==20230110.0
 httpx==0.23.2
 ifaddr==0.1.7
 janus==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.1.2"
+version     = "2023.1.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -858,7 +858,7 @@ hass-nabucasa==0.61.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.6.2
+hatasmota==0.6.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -744,7 +744,7 @@ gTTS==2.2.4
 gassist-text==0.0.7
 
 # homeassistant.components.google
-gcal-sync==4.1.1
+gcal-sync==4.1.2
 
 # homeassistant.components.geniushub
 geniushub-client==0.6.30

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -888,7 +888,7 @@ hole==0.8.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230104.0
+home-assistant-frontend==20230110.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2109,7 +2109,7 @@ pytrafikverket==0.2.2
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.6.0
+pyunifiprotect==4.6.1
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2269,7 +2269,7 @@ sendgrid==6.8.2
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.11.0
+sense_energy==0.11.1
 
 # homeassistant.components.sensirion_ble
 sensirion-ble==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2109,7 +2109,7 @@ pytrafikverket==0.2.2
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.5.2
+pyunifiprotect==4.6.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -267,7 +267,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==5.2.0
+aioshelly==5.2.1
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1803,7 +1803,7 @@ pyoctoprintapi==0.1.9
 pyombi==0.1.10
 
 # homeassistant.components.openuv
-pyopenuv==2022.04.0
+pyopenuv==2023.01.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1283,7 +1283,7 @@ pynzbgetapi==0.2.0
 pyoctoprintapi==0.1.9
 
 # homeassistant.components.openuv
-pyopenuv==2022.04.0
+pyopenuv==2023.01.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1578,7 +1578,7 @@ securetar==2022.2.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.11.0
+sense_energy==0.11.1
 
 # homeassistant.components.sensirion_ble
 sensirion-ble==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1475,7 +1475,7 @@ pytrafikverket==0.2.2
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.5.2
+pyunifiprotect==4.6.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -242,7 +242,7 @@ aiosenseme==0.6.1
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==5.2.0
+aioshelly==5.2.1
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -647,7 +647,7 @@ habitipy==0.2.0
 hass-nabucasa==0.61.0
 
 # homeassistant.components.tasmota
-hatasmota==0.6.2
+hatasmota==0.6.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1475,7 +1475,7 @@ pytrafikverket==0.2.2
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.6.0
+pyunifiprotect==4.6.1
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -668,7 +668,7 @@ hole==0.8.0
 holidays==0.17.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230104.0
+home-assistant-frontend==20230110.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -560,7 +560,7 @@ gTTS==2.2.4
 gassist-text==0.0.7
 
 # homeassistant.components.google
-gcal-sync==4.1.1
+gcal-sync==4.1.2
 
 # homeassistant.components.geocaching
 geocachingapi==0.2.1

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -214,6 +214,7 @@ def doorbell_fixture(camera: Camera, fixed_now: datetime):
     doorbell.feature_flags.has_lcd_screen = True
     doorbell.feature_flags.has_speaker = True
     doorbell.feature_flags.has_privacy_mask = True
+    doorbell.feature_flags.is_doorbell = True
     doorbell.feature_flags.has_chime = True
     doorbell.feature_flags.has_smart_detect = True
     doorbell.feature_flags.has_package_camera = True


### PR DESCRIPTION
- Bump pyunifiprotect to 4.6.0 ([@AngellusMortis] - [#85483]) ([unifiprotect docs])
- Remove invalid Signal Strength device class from NETGEAR ([@frenck] - [#85510]) ([netgear docs])
- Restore Netgear signal strength icon ([@starkillerOG] - [#85512])
- Remove invalid state class in Subaru sensor ([@epenet] - [#85520]) ([subaru docs])
- Bump sense_energy to 0.11.1 ([@kbickar] - [#85533]) ([sense docs]) ([emulated_kasa docs])
- Bump pyunifiprotect to 4.6.1 ([@AngellusMortis] - [#85547]) ([unifiprotect docs])
- Do not check ble scanner state for sleepy shelly devices ([@bdraco] - [#85566]) ([shelly docs])
- Remove no-longer-needed invalid API key monitor for OpenUV ([@bachya] - [#85573]) ([openuv docs])
- Bump aioshelly to 5.2.1 to fix Task exception was never retrieved ([@thecode] - [#85575]) ([shelly docs])
- Bump gcal-sync to 4.1.2 ([@allenporter] - [#85631]) ([google docs])
- Bump hatasmota to 0.6.3 ([@emontnemery] - [#85633]) ([tasmota docs])
- Update frontend to 20230110.0 ([@piitaya] - [#85640]) ([frontend docs])

[#85120]: https://github.com/home-assistant/core/pull/85120
[#85277]: https://github.com/home-assistant/core/pull/85277
[#85481]: https://github.com/home-assistant/core/pull/85481
[#85483]: https://github.com/home-assistant/core/pull/85483
[#85510]: https://github.com/home-assistant/core/pull/85510
[#85512]: https://github.com/home-assistant/core/pull/85512
[#85520]: https://github.com/home-assistant/core/pull/85520
[#85533]: https://github.com/home-assistant/core/pull/85533
[#85547]: https://github.com/home-assistant/core/pull/85547
[#85566]: https://github.com/home-assistant/core/pull/85566
[#85573]: https://github.com/home-assistant/core/pull/85573
[#85575]: https://github.com/home-assistant/core/pull/85575
[#85631]: https://github.com/home-assistant/core/pull/85631
[#85633]: https://github.com/home-assistant/core/pull/85633
[#85640]: https://github.com/home-assistant/core/pull/85640
[@AngellusMortis]: https://github.com/AngellusMortis
[@allenporter]: https://github.com/allenporter
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@kbickar]: https://github.com/kbickar
[@piitaya]: https://github.com/piitaya
[@starkillerOG]: https://github.com/starkillerOG
[@thecode]: https://github.com/thecode
[emulated_kasa docs]: https://www.home-assistant.io/integrations/emulated_kasa/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[google docs]: https://www.home-assistant.io/integrations/google/
[netgear docs]: https://www.home-assistant.io/integrations/netgear/
[openuv docs]: https://www.home-assistant.io/integrations/openuv/
[sense docs]: https://www.home-assistant.io/integrations/sense/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[subaru docs]: https://www.home-assistant.io/integrations/subaru/
[tasmota docs]: https://www.home-assistant.io/integrations/tasmota/
[unifiprotect docs]: https://www.home-assistant.io/integrations/unifiprotect/
