### PR TITLE
Use device-native kelvins for tplink color temperature

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
@@ -23,10 +23,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.color import (
-    color_temperature_kelvin_to_mired as kelvin_to_mired,
-    color_temperature_mired_to_kelvin as mired_to_kelvin,
-)
 
 from . import legacy_device_id
 from .const import DOMAIN
@@ -206,18 +202,6 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
 
         return brightness, transition
 
-    async def _async_set_color_temp(
-        self, color_temp_mireds: int, brightness: int | None, transition: int | None
-    ) -> None:
-        # Handle temp conversion mireds -> kelvin being slightly outside of valid range
-        kelvin = mired_to_kelvin(color_temp_mireds)
-        kelvin_range = self.device.valid_temperature_range
-        color_tmp = max(kelvin_range.min, min(kelvin_range.max, kelvin))
-        _LOGGER.debug("Changing color temp to %s", color_tmp)
-        await self.device.set_color_temp(
-            color_tmp, brightness=brightness, transition=transition
-        )
-
     async def _async_set_hsv(
         self, hs_color: tuple[int, int], brightness: int | None, transition: int | None
     ) -> None:
@@ -238,9 +222,11 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         brightness, transition = self._async_extract_brightness_transition(**kwargs)
-        if ATTR_COLOR_TEMP in kwargs:
-            await self._async_set_color_temp(
-                int(kwargs[ATTR_COLOR_TEMP]), brightness, transition
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            await self.device.set_color_temp(
+                int(kwargs[ATTR_COLOR_TEMP_KELVIN]),
+                brightness=brightness,
+                transition=transition,
             )
         if ATTR_HS_COLOR in kwargs:
             await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)
@@ -255,19 +241,19 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         await self.device.turn_off(transition=transition)
 
     @property
-    def min_mireds(self) -> int:
+    def min_color_temp_kelvin(self) -> int:
         """Return minimum supported color temperature."""
-        return kelvin_to_mired(self.device.valid_temperature_range.max)
+        return self.device.valid_temperature_range.min
 
     @property
-    def max_mireds(self) -> int:
+    def max_color_temp_kelvin(self) -> int:
         """Return maximum supported color temperature."""
-        return kelvin_to_mired(self.device.valid_temperature_range.min)
+        return self.device.valid_temperature_range.max
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temperature of this light in mireds for HA."""
-        return kelvin_to_mired(self.device.color_temp)
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature of this light."""
+        return self.device.color_temp
 
     @property
     def brightness(self) -> int | None:
@@ -341,14 +327,16 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
             await self.device.set_effect(
                 kwargs[ATTR_EFFECT], brightness=brightness, transition=transition
             )
-        elif ATTR_COLOR_TEMP in kwargs:
+        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
             if self.effect:
                 # If there is an effect in progress
                 # we have to set an HSV value to clear the effect
                 # before we can set a color temp
                 await self.device.set_hsv(0, 0, brightness)
-            await self._async_set_color_temp(
-                int(kwargs[ATTR_COLOR_TEMP]), brightness, transition
+            await self.device.set_color_temp(
+                int(kwargs[ATTR_COLOR_TEMP_KELVIN]),
+                brightness=brightness,
+                transition=transition,
             )
         elif ATTR_HS_COLOR in kwargs:
             await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -243,17 +243,17 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     @property
     def min_color_temp_kelvin(self) -> int:
         """Return minimum supported color temperature."""
-        return self.device.valid_temperature_range.min
+        return cast(int, self.device.valid_temperature_range.min)
 
     @property
     def max_color_temp_kelvin(self) -> int:
         """Return maximum supported color temperature."""
-        return self.device.valid_temperature_range.max
+        return cast(int, self.device.valid_temperature_range.max)
 
     @property
-    def color_temp_kelvin(self) -> int | None:
+    def color_temp_kelvin(self) -> int:
         """Return the color temperature of this light."""
-        return self.device.color_temp
+        return cast(int, self.device.color_temp)
 
     @property
     def brightness(self) -> int | None:

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -10,7 +10,7 @@ from homeassistant.components import tplink
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_EFFECT_LIST,
     ATTR_HS_COLOR,
@@ -113,7 +113,7 @@ async def test_color_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {**BASE_PAYLOAD, ATTR_COLOR_TEMP: 150},
+        {**BASE_PAYLOAD, ATTR_COLOR_TEMP_KELVIN: 6666},
         blocking=True,
     )
     bulb.set_color_temp.assert_called_with(
@@ -124,7 +124,7 @@ async def test_color_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {**BASE_PAYLOAD, ATTR_COLOR_TEMP: 150},
+        {**BASE_PAYLOAD, ATTR_COLOR_TEMP_KELVIN: 6666},
         blocking=True,
     )
     bulb.set_color_temp.assert_called_with(
@@ -233,7 +233,7 @@ async def test_color_temp_light(
         assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness", "color_temp"]
     assert attributes[ATTR_MIN_MIREDS] == 111
     assert attributes[ATTR_MAX_MIREDS] == 250
-    assert attributes[ATTR_COLOR_TEMP] == 250
+    assert attributes[ATTR_COLOR_TEMP_KELVIN] == 4000
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -258,7 +258,7 @@ async def test_color_temp_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 6666},
         blocking=True,
     )
     bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
@@ -417,7 +417,7 @@ async def test_smart_strip_effects(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 250},
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 4000},
         blocking=True,
     )
     strip.set_hsv.assert_called_once_with(0, 0, None)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR converts tplink's light platform to use device-native kelvins for color temperature handling which allows getting rid of mired<->kelvin conversions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
