### PR TITLE
Revert "Bump steamodd to 4.23"

### DIFF
--- a/homeassistant/components/steam_online/manifest.json
+++ b/homeassistant/components/steam_online/manifest.json
@@ -3,7 +3,7 @@
   "name": "Steam",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/steam_online",
-  "requirements": ["steamodd==4.23"],
+  "requirements": ["steamodd==4.21"],
   "codeowners": ["@tkdrob"],
   "iot_class": "cloud_polling",
   "loggers": ["steam"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2391,7 +2391,7 @@ starlink-grpc-core==1.1.1
 statsd==3.2.1
 
 # homeassistant.components.steam_online
-steamodd==4.23
+steamodd==4.21
 
 # homeassistant.components.stookalert
 stookalert==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1682,7 +1682,7 @@ starlink-grpc-core==1.1.1
 statsd==3.2.1
 
 # homeassistant.components.steam_online
-steamodd==4.23
+steamodd==4.21
 
 # homeassistant.components.stookalert
 stookalert==0.1.4


### PR DESCRIPTION
Reverts home-assistant/core#85071

The change causes dependency issues.

Closes https://github.com/home-assistant/core/issues/85650