### PR TITLE
Update xknx to 2.3.0 - add some DPTs, Routing security

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,7 +3,7 @@
   "name": "KNX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==2.2.0"],
+  "requirements": ["xknx==2.3.0"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "platinum",
   "iot_class": "local_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2622,7 +2622,7 @@ xboxapi==2.0.1
 xiaomi-ble==0.14.3
 
 # homeassistant.components.knx
-xknx==2.2.0
+xknx==2.3.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1844,7 +1844,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.14.3
 
 # homeassistant.components.knx
-xknx==2.2.0
+xknx==2.3.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -58,6 +58,9 @@ class KNXTestKit:
 
         async def patch_xknx_start():
             """Patch `xknx.start` for unittests."""
+            self.xknx.cemi_handler.send_telegram = AsyncMock(
+                side_effect=self._outgoing_telegrams.put
+            )
             # after XKNX.__init__() to not overwrite it by the config entry again
             # before StateUpdater starts to avoid slow down of tests
             self.xknx.rate_limit = 0
@@ -72,7 +75,6 @@ class KNXTestKit:
             mock = Mock()
             mock.start = AsyncMock(side_effect=patch_xknx_start)
             mock.stop = AsyncMock()
-            mock.send_telegram = AsyncMock(side_effect=self._outgoing_telegrams.put)
             return mock
 
         def fish_xknx(*args, **kwargs):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update xknx to 2.3.0

https://github.com/XKNX/xknx/releases/tag/2.3.0

### DPTs

- Add definitions for DPTs
  - 7.010 "prop_data_type"
  - 8.012 "length_m"
  - 9.009 "air_flow"
  - 9.029 "absolute_humidity"
  - 9.030 "concentration_ugm3"
  - 12.001 "pulse_4_ucount"
  - 12.100 "long_time_period_sec"
  - 12.101 "long_time_period_min"
  - 12.102 "long_time_period_hrs"
  - 13.016 "active_energy_mwh"
  - 14.080 "apparent_power"

### IP Secure

- SecureRouting: verify MAC of received TimerNotify frames.
- SecureRouting: verify and handle timer value of received SecureWrapper frames after verification of MAC.
- SecureRouting: Discard received unencrypted RoutingIndication frames.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85160
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
