### PR TITLE
Initial Airtouch5 support

### DIFF
--- a/homeassistant/components/airtouch4/__init__.py
+++ b/homeassistant/components/airtouch4/__init__.py
@@ -67,7 +67,7 @@ class AirtouchDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed("Airtouch connection issue")
         return {
             "acs": [
-                {"ac_number": ac.AcNumber, "is_on": ac.IsOn}
+                {"ac_number": ac.AcNumber, "is_on": ac.IsOn, "ac_name": ac.AcName}
                 for ac in self.airtouch.GetAcs()
             ],
             "groups": [

--- a/homeassistant/components/airtouch4/config_flow.py
+++ b/homeassistant/components/airtouch4/config_flow.py
@@ -1,13 +1,18 @@
 """Config flow for AirTouch4."""
-from airtouch4pyapi import AirTouch, AirTouchStatus
+import logging
+
+from airtouch4pyapi import AirTouch, AirTouchStatus, AirTouchVersion
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.selector import selector
 
 from .const import DOMAIN
 
-DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+DATA_SCHEMA = {vol.Required(CONF_HOST): str}
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AirtouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -18,14 +23,36 @@ class AirtouchConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+            if self.show_advanced_options:
+                DATA_SCHEMA[vol.Optional(CONF_PORT, default="")] = str
+                DATA_SCHEMA[vol.Optional("airtouch_version")] = selector(
+                    {
+                        "select": {
+                            "options": ["Auto", "4", "5"],
+                        }
+                    }
+                )
+
+            return self.async_show_form(
+                step_id="user", data_schema=vol.Schema(DATA_SCHEMA)
+            )
 
         errors = {}
 
         host = user_input[CONF_HOST]
         self._async_abort_entries_match({CONF_HOST: host})
+        if CONF_PORT in user_input and user_input[CONF_PORT] != "":
+            _LOGGER.debug("Performing advanced airtouch config with port and version")
+            port = user_input[CONF_PORT]
+            if user_input["airtouch_version"] == "4":
+                version = AirTouchVersion.AIRTOUCH4
+            if user_input["airtouch_version"] == "5":
+                version = AirTouchVersion.AIRTOUCH5
+            airtouch = AirTouch(host, version, port)
+        else:
+            _LOGGER.debug("Performing standard airtouch config with just host")
+            airtouch = AirTouch(host)
 
-        airtouch = AirTouch(host)
         await airtouch.UpdateInfo()
         airtouch_status = airtouch.Status
         airtouch_has_groups = bool(

--- a/homeassistant/components/airtouch4/manifest.json
+++ b/homeassistant/components/airtouch4/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "airtouch4",
-  "name": "AirTouch 4",
+  "name": "AirTouch",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airtouch4",
-  "requirements": ["airtouch4pyapi==1.0.5"],
+  "requirements": ["airtouch4pyapi==1.0.7"],
   "codeowners": ["@LonePurpleWolf"],
   "iot_class": "local_polling",
   "loggers": ["airtouch4pyapi"]

--- a/homeassistant/components/airtouch4/strings.json
+++ b/homeassistant/components/airtouch4/strings.json
@@ -5,13 +5,16 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_units": "Could not find any AirTouch 4 Groups."
+      "no_units": "Could not find any AirTouch Groups."
     },
     "step": {
       "user": {
-        "title": "Set up your AirTouch 4 connection details.",
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "airtouch_version": "AirTouch Version"
         }
       }
     }

--- a/homeassistant/components/airtouch4/translations/en.json
+++ b/homeassistant/components/airtouch4/translations/en.json
@@ -5,14 +5,17 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "no_units": "Could not find any AirTouch 4 Groups."
+            "no_units": "Could not find any AirTouch Groups."
         },
         "step": {
             "user": {
                 "data": {
-                    "host": "Host"
+                    "host": "Host",
+                    "port": "Port",
+                    "airtouch_version": "AirTouch Version"
                 },
-                "title": "Set up your AirTouch 4 connection details."
+                "description": "In most cases, you only need a host. If you want to specify port, you must specify version. You must turn on advanced config in your settings to see this option.",
+                "title": "Set up your AirTouch connection details."
             }
         }
     }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -113,7 +113,7 @@
       }
     },
     "airtouch4": {
-      "name": "AirTouch 4",
+      "name": "AirTouch",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ airthings-ble==0.5.3
 airthings_cloud==0.1.0
 
 # homeassistant.components.airtouch4
-airtouch4pyapi==1.0.5
+airtouch4pyapi==1.0.7
 
 # homeassistant.components.alpha_vantage
 alpha_vantage==2.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -293,7 +293,7 @@ airthings-ble==0.5.3
 airthings_cloud==0.1.0
 
 # homeassistant.components.airtouch4
-airtouch4pyapi==1.0.5
+airtouch4pyapi==1.0.7
 
 # homeassistant.components.amberelectric
 amberelectric==1.0.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added AirTouch5 support to both upstream library (and bumped version requirement) and to this repo.  It's done in a non-breaking way, although I did add a couple of very small features (better naming, version number on "model").  Also improved the config flow to support advanced config with port & version, not just host.  


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/25696

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]   https://github.com/home-assistant/home-assistant.io/pull/25696

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
