### PR TITLE
Remove 'tariff' edition from options-flow

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/__init__.py
+++ b/homeassistant/components/pvpc_hourly_pricing/__init__.py
@@ -104,7 +104,7 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     if any(
         entry.data.get(attrib) != entry.options.get(attrib)
-        for attrib in (ATTR_TARIFF, ATTR_POWER, ATTR_POWER_P3)
+        for attrib in (ATTR_POWER, ATTR_POWER_P3)
     ):
         # update entry replacing data with new options
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from . import CONF_NAME, UI_CONFIG_SCHEMA, VALID_POWER, VALID_TARIFF
+from . import CONF_NAME, UI_CONFIG_SCHEMA, VALID_POWER
 from .const import ATTR_POWER, ATTR_POWER_P3, ATTR_TARIFF, DOMAIN
 
 
@@ -53,9 +53,6 @@ class PVPCOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         # Fill options with entry data
-        tariff = self.config_entry.options.get(
-            ATTR_TARIFF, self.config_entry.data[ATTR_TARIFF]
-        )
         power = self.config_entry.options.get(
             ATTR_POWER, self.config_entry.data[ATTR_POWER]
         )
@@ -64,7 +61,6 @@ class PVPCOptionsFlowHandler(config_entries.OptionsFlow):
         )
         schema = vol.Schema(
             {
-                vol.Required(ATTR_TARIFF, default=tariff): VALID_TARIFF,
                 vol.Required(ATTR_POWER, default=power): VALID_POWER,
                 vol.Required(ATTR_POWER_P3, default=power_valley): VALID_POWER,
             }

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -1,10 +1,13 @@
 """Config flow for pvpc_hourly_pricing."""
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 
 from . import CONF_NAME, UI_CONFIG_SCHEMA, VALID_POWER, VALID_TARIFF
 from .const import ATTR_POWER, ATTR_POWER_P3, ATTR_TARIFF, DOMAIN
@@ -23,7 +26,9 @@ class TariffSelectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return PVPCOptionsFlowHandler(config_entry)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial step."""
         if user_input is not None:
             await self.async_set_unique_id(user_input[ATTR_TARIFF])
@@ -40,7 +45,9 @@ class PVPCOptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/pvpc_hourly_pricing/strings.json
+++ b/homeassistant/components/pvpc_hourly_pricing/strings.json
@@ -18,8 +18,8 @@
     "step": {
       "init": {
         "data": {
-          "power": "Contracted power (kW)",
-          "power_p3": "Contracted power for valley period P3 (kW)"
+          "power": "[%key:component::pvpc_hourly_pricing::config::step::user::data::power%]",
+          "power_p3": "[%key:component::pvpc_hourly_pricing::config::step::user::data::power_p3%]"
         }
       }
     }

--- a/homeassistant/components/pvpc_hourly_pricing/strings.json
+++ b/homeassistant/components/pvpc_hourly_pricing/strings.json
@@ -18,7 +18,6 @@
     "step": {
       "init": {
         "data": {
-          "tariff": "Applicable tariff by geographic zone",
           "power": "Contracted power (kW)",
           "power_p3": "Contracted power for valley period P3 (kW)"
         }

--- a/homeassistant/components/pvpc_hourly_pricing/translations/en.json
+++ b/homeassistant/components/pvpc_hourly_pricing/translations/en.json
@@ -19,8 +19,7 @@
             "init": {
                 "data": {
                     "power": "Contracted power (kW)",
-                    "power_p3": "Contracted power for valley period P3 (kW)",
-                    "tariff": "Applicable tariff by geographic zone"
+                    "power_p3": "Contracted power for valley period P3 (kW)"
                 }
             }
         }

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -102,11 +102,11 @@ async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
-            user_input={ATTR_TARIFF: TARIFFS[0], ATTR_POWER: 3.0, ATTR_POWER_P3: 4.6},
+            user_input={ATTR_POWER: 3.0, ATTR_POWER_P3: 4.6},
         )
         await hass.async_block_till_done()
         state = hass.states.get("sensor.test")
-        check_valid_state(state, tariff=TARIFFS[0])
+        check_valid_state(state, tariff=TARIFFS[1])
         assert pvpc_aioclient_mock.call_count == 3
         assert state.attributes["period"] == "P3"
         assert state.attributes["next_period"] == "P2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**TL;DR**

The `entry.data[ATTR_TARIFF]` is what makes the `entry.unique_id`, so it's an incoherence to be able to change it in the Options flow.

**Long version**
There are only 2 tariffs, and it's a _geographical_ option, so normally the user has only 1 entry, and does not play with that, 

BUT,  in this _borderline-scenario_:

- setup of 1st entry with tariff-1
- go to options and change to tariff-2 (it's _unique_ ID doesn't change, and it's equal to tariff-1)
- setup a 2nd entry with tariff-1 ==> 🧨 Invalid, as already configured
- setup a 2nd entry with tariff-2 --> OK, setting unique_id=tariff-2, but the sensor it's the same as the 1st entry, and needs to go to options to swap tariff 💩🤪

So the best action to prevent that is to remove that option 🔥

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
