### PR TITLE
Bump screenlogicpy to 0.6.2

### DIFF
--- a/homeassistant/components/screenlogic/__init__.py
+++ b/homeassistant/components/screenlogic/__init__.py
@@ -219,7 +219,6 @@ class ScreenlogicEntity(CoordinatorEntity[ScreenlogicDataUpdateCoordinator]):
             equipment_model = f"Unknown Model C:{controller_type} H:{hardware_type}"
         return DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, self.mac)},
-            identifiers={(DOMAIN, self.mac)},
             manufacturer="Pentair",
             model=equipment_model,
             name=self.gateway_name,

--- a/homeassistant/components/screenlogic/__init__.py
+++ b/homeassistant/components/screenlogic/__init__.py
@@ -219,6 +219,7 @@ class ScreenlogicEntity(CoordinatorEntity[ScreenlogicDataUpdateCoordinator]):
             equipment_model = f"Unknown Model C:{controller_type} H:{hardware_type}"
         return DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, self.mac)},
+            identifiers={(DOMAIN, self.mac)},
             manufacturer="Pentair",
             model=equipment_model,
             name=self.gateway_name,
@@ -240,10 +241,12 @@ class ScreenlogicEntity(CoordinatorEntity[ScreenlogicDataUpdateCoordinator]):
 class ScreenLogicCircuitEntity(ScreenlogicEntity):
     """ScreenLogic circuit entity."""
 
+    _attr_has_entity_name = True
+
     @property
     def name(self):
         """Get the name of the switch."""
-        return f"{self.gateway_name} {self.circuit['name']}"
+        return self.circuit["name"]
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/screenlogic/binary_sensor.py
+++ b/homeassistant/components/screenlogic/binary_sensor.py
@@ -66,6 +66,7 @@ class ScreenLogicBinarySensor(ScreenlogicEntity, BinarySensorEntity):
     """Representation of the basic ScreenLogic binary sensor entity."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def name(self):
@@ -77,11 +78,6 @@ class ScreenLogicBinarySensor(ScreenlogicEntity, BinarySensorEntity):
         """Return the device class."""
         device_type = self.sensor.get("device_type")
         return SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS.get(device_type)
-
-    @property
-    def entity_category(self) -> EntityCategory:
-        """Entity Category of the sensor."""
-        return EntityCategory.DIAGNOSTIC
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/screenlogic/binary_sensor.py
+++ b/homeassistant/components/screenlogic/binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ScreenlogicEntity
@@ -64,16 +65,23 @@ async def async_setup_entry(
 class ScreenLogicBinarySensor(ScreenlogicEntity, BinarySensorEntity):
     """Representation of the basic ScreenLogic binary sensor entity."""
 
+    _attr_has_entity_name = True
+
     @property
     def name(self):
         """Return the sensor name."""
-        return f"{self.gateway_name} {self.sensor['name']}"
+        return self.sensor["name"]
 
     @property
     def device_class(self):
         """Return the device class."""
         device_type = self.sensor.get("device_type")
         return SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS.get(device_type)
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Entity Category of the sensor."""
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/screenlogic/climate.py
+++ b/homeassistant/components/screenlogic/climate.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class ScreenLogicClimate(ScreenlogicEntity, ClimateEntity, RestoreEntity):
     """Represents a ScreenLogic climate entity."""
 
+    _attr_has_entity_name = True
+
     _attr_hvac_modes = SUPPORTED_MODES
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
@@ -71,8 +73,7 @@ class ScreenLogicClimate(ScreenlogicEntity, ClimateEntity, RestoreEntity):
     @property
     def name(self) -> str:
         """Name of the heater."""
-        ent_name = self.body["heat_status"]["name"]
-        return f"{self.gateway_name} {ent_name}"
+        return self.body["heat_status"]["name"]
 
     @property
     def min_temp(self) -> float:

--- a/homeassistant/components/screenlogic/diagnostics.py
+++ b/homeassistant/components/screenlogic/diagnostics.py
@@ -20,4 +20,5 @@ async def async_get_config_entry_diagnostics(
     return {
         "config_entry": config_entry.as_dict(),
         "data": coordinator.data,
+        "debug": coordinator.gateway.get_debug(),
     }

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Pentair ScreenLogic",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
-  "requirements": ["screenlogicpy==0.5.4"],
+  "requirements": ["screenlogicpy==0.6.0"],
   "codeowners": ["@dieselrabbit", "@bdraco"],
   "dhcp": [
     { "registered_devices": true },

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Pentair ScreenLogic",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
-  "requirements": ["screenlogicpy==0.6.0"],
+  "requirements": ["screenlogicpy==0.6.2"],
   "codeowners": ["@dieselrabbit", "@bdraco"],
   "dhcp": [
     { "registered_devices": true },

--- a/homeassistant/components/screenlogic/number.py
+++ b/homeassistant/components/screenlogic/number.py
@@ -6,6 +6,7 @@ from screenlogicpy.const import BODY_TYPE, DATA as SL_DATA, EQUIPMENT, SCG
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ScreenlogicEntity
@@ -42,13 +43,16 @@ async def async_setup_entry(
 class ScreenLogicNumber(ScreenlogicEntity, NumberEntity):
     """Class to represent a ScreenLogic Number."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, data_key, enabled=True):
         """Initialize of the entity."""
         super().__init__(coordinator, data_key, enabled)
         self._body_type = SUPPORTED_SCG_NUMBERS.index(self._data_key)
         self._attr_native_max_value = SCG.LIMIT_FOR_BODY[self._body_type]
-        self._attr_name = f"{self.gateway_name} {self.sensor['name']}"
+        self._attr_name = self.sensor["name"]
         self._attr_native_unit_of_measurement = self.sensor["unit"]
+        self._attr_entity_category = EntityCategory.CONFIG
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -4,6 +4,7 @@ from screenlogicpy.const import (
     DATA as SL_DATA,
     DEVICE_TYPE,
     EQUIPMENT,
+    UNIT,
 )
 
 from homeassistant.components.sensor import (
@@ -12,6 +13,15 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    PERCENTAGE,
+    REVOLUTIONS_PER_MINUTE,
+    UnitOfElectricPotential,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -62,6 +72,18 @@ SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS = {
     DEVICE_TYPE.POWER: SensorDeviceClass.POWER,
     DEVICE_TYPE.TEMPERATURE: SensorDeviceClass.TEMPERATURE,
     DEVICE_TYPE.VOLUME: SensorDeviceClass.VOLUME,
+}
+
+SL_UNIT_TO_HA_UNIT = {
+    UNIT.CELSIUS: UnitOfTemperature.CELSIUS,
+    UNIT.FAHRENHEIT: UnitOfTemperature.FAHRENHEIT,
+    UNIT.MILLIVOLT: UnitOfElectricPotential.MILLIVOLT,
+    UNIT.WATT: UnitOfPower.WATT,
+    UNIT.HOUR: UnitOfTime.HOURS,
+    UNIT.SECOND: UnitOfTime.SECONDS,
+    UNIT.REVOLUTIONS_PER_MINUTE: REVOLUTIONS_PER_MINUTE,
+    UNIT.PARTS_PER_MILLION: CONCENTRATION_PARTS_PER_MILLION,
+    UNIT.PERCENT: PERCENTAGE,
 }
 
 
@@ -143,7 +165,8 @@ class ScreenLogicSensor(ScreenlogicEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
-        return self.sensor.get("unit")
+        sl_unit = self.sensor.get("unit")
+        return SL_UNIT_TO_HA_UNIT[sl_unit] if sl_unit in SL_UNIT_TO_HA_UNIT else sl_unit
 
     @property
     def device_class(self):

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ScreenlogicEntity
@@ -56,8 +57,11 @@ SUPPORTED_SCG_SENSORS = (
 SUPPORTED_PUMP_SENSORS = ("currentWatts", "currentRPM", "currentGPM")
 
 SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS = {
-    DEVICE_TYPE.TEMPERATURE: SensorDeviceClass.TEMPERATURE,
+    DEVICE_TYPE.DURATION: SensorDeviceClass.DURATION,
     DEVICE_TYPE.ENERGY: SensorDeviceClass.POWER,
+    DEVICE_TYPE.POWER: SensorDeviceClass.POWER,
+    DEVICE_TYPE.TEMPERATURE: SensorDeviceClass.TEMPERATURE,
+    DEVICE_TYPE.VOLUME: SensorDeviceClass.VOLUME,
 }
 
 
@@ -129,10 +133,12 @@ async def async_setup_entry(
 class ScreenLogicSensor(ScreenlogicEntity, SensorEntity):
     """Representation of the basic ScreenLogic sensor entity."""
 
+    _attr_has_entity_name = True
+
     @property
     def name(self):
         """Name of the sensor."""
-        return f"{self.gateway_name} {self.sensor['name']}"
+        return self.sensor["name"]
 
     @property
     def native_unit_of_measurement(self):
@@ -144,6 +150,13 @@ class ScreenLogicSensor(ScreenlogicEntity, SensorEntity):
         """Device class of the sensor."""
         device_type = self.sensor.get("device_type")
         return SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS.get(device_type)
+
+    @property
+    def entity_category(self):
+        """Entity Category of the sensor."""
+        return (
+            None if self._data_key == "air_temperature" else EntityCategory.DIAGNOSTIC
+        )
 
     @property
     def state_class(self):

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -166,7 +166,7 @@ class ScreenLogicSensor(ScreenlogicEntity, SensorEntity):
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         sl_unit = self.sensor.get("unit")
-        return SL_UNIT_TO_HA_UNIT[sl_unit] if sl_unit in SL_UNIT_TO_HA_UNIT else sl_unit
+        return SL_UNIT_TO_HA_UNIT.get(sl_unit, sl_unit)
 
     @property
     def device_class(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ satel_integra==0.3.7
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.5.4
+screenlogicpy==0.6.0
 
 # homeassistant.components.scsgate
 scsgate==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ satel_integra==0.3.7
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.6.0
+screenlogicpy==0.6.2
 
 # homeassistant.components.scsgate
 scsgate==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1599,7 +1599,7 @@ samsungtvws[async,encrypted]==2.5.0
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.5.4
+screenlogicpy==0.6.0
 
 # homeassistant.components.backup
 securetar==2022.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1599,7 +1599,7 @@ samsungtvws[async,encrypted]==2.5.0
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.6.0
+screenlogicpy==0.6.2
 
 # homeassistant.components.backup
 securetar==2022.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps screenlogicpy to v0.6.2 to support features, bugfixes, and optimization:
https://github.com/dieselrabbit/screenlogicpy/compare/v0.5.4...v0.6.2
**Summary of library changes:**
- Refactor request code to share common code
- Include all unknown message bytes in data for debugging
- Save raw bytes for each last message for debugging
- Define device types for data with compatible HA device classes
- Bump spa chlor max percent to 100 (#72233)
- Add ability to set IntelliChem values (Not exposed in HA yet)
- Define unit const. so consuming code can convert if desired
- Use asyncio.timeout/async_timeout to avoid creating tasks

**HA Changes:**
- Support `has_entity_name`
- Support `EntityCategory`
  - All sensors EXCEPT Air Temperature as `EntityCategory.DIAGNOSTIC`
  - SCG level numbers as `EntityCategory.CONFIG`
- Support `SensorDeviceClass` for applicable sensors
  - Last pH/ORP Dose Time: `DURATION`
  - Last pH/ORP Dose Volume: `VOLUME`
- Map SL prefered units to HA `UnitOf*` enums (and existing consts) to better support `native_unit_of_measurement`
- Include the saved raw bytes from each last SL message in diagnostic export

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #72233
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
