### PR TITLE
Use jemalloc in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,22 +11,45 @@ WORKDIR /usr/src
 COPY requirements.txt homeassistant/
 COPY homeassistant/package_constraints.txt homeassistant/homeassistant/
 RUN \
-    pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver
+    pip3 install \
+        --no-cache-dir \
+        --no-index \
+        --only-binary=:all: \
+        --find-links "${WHEELS_LINKS}" \
+        --use-deprecated=legacy-resolver \
+        -r homeassistant/requirements.txt
+
 COPY requirements_all.txt home_assistant_frontend-* homeassistant/
 RUN \
     if ls homeassistant/home_assistant_frontend*.whl 1> /dev/null 2>&1; then \
-        pip3 install --no-cache-dir --no-index homeassistant/home_assistant_frontend-*.whl; \
+        pip3 install \
+            --no-cache-dir \
+            --no-index \
+            homeassistant/home_assistant_frontend-*.whl; \
     fi \
-    && pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements_all.txt --use-deprecated=legacy-resolver
+    && \
+        LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
+        MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
+        pip3 install \
+            --no-cache-dir \
+            --no-index \
+            --only-binary=:all: \
+            --find-links "${WHEELS_LINKS}" \
+            --use-deprecated=legacy-resolver \
+            -r homeassistant/requirements_all.txt
 
 ## Setup Home Assistant Core
 COPY . homeassistant/
 RUN \
-    pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -e ./homeassistant --use-deprecated=legacy-resolver \
-    && python3 -m compileall homeassistant/homeassistant
+    pip3 install \
+        --no-cache-dir \
+        --no-index \
+        --only-binary=:all: \
+        --find-links "${WHEELS_LINKS}" \
+        --use-deprecated=legacy-resolver \
+        -e ./homeassistant \
+    && python3 -m compileall \
+        homeassistant/homeassistant
 
 # Home Assistant S6-Overlay
 COPY rootfs /


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We have been running into issues with releasing/building `armhf` and `armv7` images (including nightly). 

`pip install` runs into a `MemoryError`, the reason why it isn't completely clear. Something is eating up all available address space (thanks, @agners, for spotting/providing more details on that one).

This PR activates jemalloc as the memory allocator for the installation of `requirements_all.txt`. We use jemalloc in our environment to run `hass` itself already.

I've been able to reproduce the original issue locally; this change, for now, passes for all architectures. That said, the original behavior (even with jemalloc) is still visible in the maps, but at least is stays within limits for now.

ℹ️ Not tagging this for a patch release just yet, as I want to test a nightly first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
