### PR TITLE
Downgrade integrations without code owner

### DIFF
--- a/homeassistant/components/directv/manifest.json
+++ b/homeassistant/components/directv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/directv",
   "requirements": ["directv==0.4.0"],
   "codeowners": [],
-  "quality_scale": "gold",
+  "quality_scale": "silver",
   "config_flow": true,
   "ssdp": [
     {

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "requirements": ["homematicip==1.0.13"],
   "codeowners": [],
-  "quality_scale": "platinum",
+  "quality_scale": "silver",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"]
 }

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -309,25 +309,19 @@ def validate_manifest(integration: Integration, core_components_dir: Path) -> No
             "manifest", f"Invalid manifest: {humanize_error(integration.manifest, err)}"
         )
 
-    if integration.manifest["domain"] != integration.path.name:
+    if (domain := integration.manifest["domain"]) != integration.path.name:
         integration.add_error("manifest", "Domain does not match dir name")
 
-    if (
-        not integration.core
-        and (core_components_dir / integration.manifest["domain"]).exists()
-    ):
+    if not integration.core and (core_components_dir / domain).exists():
         integration.add_warning(
             "manifest", "Domain collides with built-in core integration"
         )
 
-    if (
-        integration.manifest["domain"] in NO_IOT_CLASS
-        and "iot_class" in integration.manifest
-    ):
+    if domain in NO_IOT_CLASS and "iot_class" in integration.manifest:
         integration.add_error("manifest", "Domain should not have an IoT Class")
 
     if (
-        integration.manifest["domain"] not in NO_IOT_CLASS
+        domain not in NO_IOT_CLASS
         and "iot_class" not in integration.manifest
         and integration.manifest.get("integration_type") != "virtual"
     ):
@@ -341,6 +335,15 @@ def validate_manifest(integration: Integration, core_components_dir: Path) -> No
         integration.add_error(
             "manifest",
             "Virtual integration points to non-existing supported_by integration",
+        )
+
+    if (quality_scale := integration.manifest.get("quality_scale")) in {
+        "gold",
+        "platinum",
+    } and not integration.manifest.get("codeowners"):
+        integration.add_error(
+            "manifest",
+            f"{quality_scale} integration does not have a code owner",
         )
 
     if not integration.core:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there are no code owners left for a gold or platinum integration, should it be downgraded to silver?
https://developers.home-assistant.io/docs/integration_quality_scale_index/#gold-

Current failures:
- [x] directv
- [x] homematicip_cloud

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
