### PR TITLE
Bump screenlogicpy to 0.6.3

### DIFF
--- a/homeassistant/components/screenlogic/binary_sensor.py
+++ b/homeassistant/components/screenlogic/binary_sensor.py
@@ -15,6 +15,13 @@ from .const import DOMAIN
 
 SL_DEVICE_TYPE_TO_HA_DEVICE_CLASS = {DEVICE_TYPE.ALARM: BinarySensorDeviceClass.PROBLEM}
 
+SUPPORTED_CONFIG_BINARY_SENSORS = (
+    "freeze_mode",
+    "pool_delay",
+    "spa_delay",
+    "cleaner_delay",
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -27,6 +34,14 @@ async def async_setup_entry(
 
     # Generic binary sensor
     entities.append(ScreenLogicBinarySensor(coordinator, "chem_alarm"))
+
+    entities.extend(
+        [
+            ScreenlogicConfigBinarySensor(coordinator, cfg_sensor)
+            for cfg_sensor in coordinator.data[SL_DATA.KEY_CONFIG]
+            if cfg_sensor in SUPPORTED_CONFIG_BINARY_SENSORS
+        ]
+    )
 
     if (
         coordinator.data[SL_DATA.KEY_CONFIG]["equipment_flags"]
@@ -119,3 +134,12 @@ class ScreenlogicSCGBinarySensor(ScreenLogicBinarySensor):
     def sensor(self):
         """Shortcut to access the sensor data."""
         return self.coordinator.data[SL_DATA.KEY_SCG][self._data_key]
+
+
+class ScreenlogicConfigBinarySensor(ScreenLogicBinarySensor):
+    """Representation of a ScreenLogic config data binary sensor entity."""
+
+    @property
+    def sensor(self):
+        """Shortcut to access the sensor data."""
+        return self.coordinator.data[SL_DATA.KEY_CONFIG][self._data_key]

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Pentair ScreenLogic",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
-  "requirements": ["screenlogicpy==0.6.2"],
+  "requirements": ["screenlogicpy==0.6.3"],
   "codeowners": ["@dieselrabbit", "@bdraco"],
   "dhcp": [
     { "registered_devices": true },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ satel_integra==0.3.7
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.6.2
+screenlogicpy==0.6.3
 
 # homeassistant.components.scsgate
 scsgate==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1599,7 +1599,7 @@ samsungtvws[async,encrypted]==2.5.0
 scapy==2.5.0
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.6.2
+screenlogicpy==0.6.3
 
 # homeassistant.components.backup
 securetar==2022.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump screenlogicpy to v0.6.3
https://github.com/dieselrabbit/screenlogicpy/compare/v0.6.2...v0.6.3
**Summary of changes in library:**
- Convert and save `freeze_mode` as standard 1=on, 0=off instead of the raw 8=on.


**HA changes:**
- Add binary sensors for `freeze_mode`, `pool_delay`, `spa_delay`, and `cleaner_delay`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84401
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
