### PR TITLE
Poll in econet

### DIFF
--- a/homeassistant/components/econet/climate.py
+++ b/homeassistant/components/econet/climate.py
@@ -64,11 +64,12 @@ async def async_setup_entry(
 class EcoNetThermostat(EcoNetEntity, ClimateEntity):
     """Define a Econet thermostat."""
 
+    _attr_should_poll = True
+
     def __init__(self, thermostat):
         """Initialize."""
         super().__init__(thermostat)
         self._running = thermostat.running
-        self._poll = True
         self.econet_state_to_ha = {}
         self.ha_state_to_econet = {}
         self.op_list = []

--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -58,11 +58,11 @@ async def async_setup_entry(
 class EcoNetWaterHeater(EcoNetEntity, WaterHeaterEntity):
     """Define a Econet water heater."""
 
+    _attr_should_poll = True
+
     def __init__(self, water_heater):
         """Initialize."""
         super().__init__(water_heater)
-        self._running = water_heater.running
-        self._attr_should_poll = True  # Override False default from EcoNetEntity
         self.water_heater = water_heater
         self.econet_state_to_ha = {}
         self.ha_state_to_econet = {}
@@ -70,10 +70,6 @@ class EcoNetWaterHeater(EcoNetEntity, WaterHeaterEntity):
     @callback
     def on_update_received(self):
         """Update was pushed from the ecoent API."""
-        if self._running != self.water_heater.running:
-            # Water heater running state has changed so check usage on next update
-            self._attr_should_poll = True
-            self._running = self.water_heater.running
         self.async_write_ha_state()
 
     @property
@@ -154,7 +150,6 @@ class EcoNetWaterHeater(EcoNetEntity, WaterHeaterEntity):
         await self.water_heater.get_energy_usage()
         await self.water_heater.get_water_usage()
         self.async_write_ha_state()
-        self._attr_should_poll = False
 
     def turn_away_mode_on(self) -> None:
         """Turn away mode on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The econet water heater component attempts to limit the polling to only poll the API when the running state of the water heater changes, and then collects the energy usage then. The assumption (I suspect) being that the energy usage of the water heater will peak once it finish running.

Polling for the energy usage when the water heater finish running means that the energy used won't be accounted when it happens. Suppose that my water heater uses 0.1kWh at 2am, and another 0.1kWh at 4am, but only change its running state at 1pm, HA will thus report 0.2kWh used at 1pm, which is somewhat misleading.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
