### PR TITLE
Add service to create calendar events

### DIFF
--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -23,3 +23,20 @@ EVENT_LOCATION = "location"
 EVENT_RECURRENCE_ID = "recurrence_id"
 EVENT_RECURRENCE_RANGE = "recurrence_range"
 EVENT_RRULE = "rrule"
+
+# Service call fields
+EVENT_START_DATE = "start_date"
+EVENT_END_DATE = "end_date"
+EVENT_START_DATETIME = "start_date_time"
+EVENT_END_DATETIME = "end_date_time"
+EVENT_IN = "in"
+EVENT_IN_DAYS = "days"
+EVENT_IN_WEEKS = "weeks"
+EVENT_TIME_FIELDS = {
+    EVENT_START_DATE,
+    EVENT_END_DATE,
+    EVENT_START_DATETIME,
+    EVENT_END_DATETIME,
+    EVENT_IN,
+}
+EVENT_TYPES = "event_types"

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -1,1 +1,48 @@
-# Describes the format for available calendar services
+create_event:
+  name: Create event
+  description: Add a new calendar event.
+  target:
+    entity:
+      domain: calendar
+  fields:
+    summary:
+      name: Summary
+      description: Defines the short summary or subject for the event
+      required: true
+      example: "Department Party"
+      selector:
+        text:
+    description:
+      name: Description
+      description: A more complete description of the event than that provided by the summary.
+      example: "Meeting to provide technical review for 'Phoenix' design."
+      selector:
+        text:
+    start_date_time:
+      name: Start time
+      description: The date and time the event should start.
+      example: "2022-03-22 20:00:00"
+      selector:
+        datetime:
+    end_date_time:
+      name: End time
+      description: The date and time the event should end.
+      example: "2022-03-22 22:00:00"
+      selector:
+        datetime:
+    start_date:
+      name: Start date
+      description: The date the all-day event should start.
+      example: "2022-03-22"
+      selector:
+        date:
+    end_date:
+      name: End date
+      description: The date the all-day event should end (exclusive).
+      example: "2022-03-23"
+      selector:
+        date:
+    in:
+      name: In
+      description: Days or weeks that you want to create the event in.
+      example: '"days": 2 or "weeks": 2'

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -19,9 +19,9 @@ from gcal_sync.model import AccessRole, DateOrDatetime, Event
 from gcal_sync.store import ScopedCalendarStore
 from gcal_sync.sync import CalendarEventSyncManager
 from gcal_sync.timeline import Timeline
-import voluptuous as vol
 
 from homeassistant.components.calendar import (
+    CREATE_EVENT_SCHEMA,
     ENTITY_ID_FORMAT,
     EVENT_DESCRIPTION,
     EVENT_END,
@@ -38,11 +38,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID, CONF_ENTITIES, CONF_NAME, CONF_OFFSET
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
-from homeassistant.helpers import (
-    config_validation as cv,
-    entity_platform,
-    entity_registry as er,
-)
+from homeassistant.helpers import entity_platform, entity_registry as er
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -74,7 +70,6 @@ from .const import (
     EVENT_IN_WEEKS,
     EVENT_START_DATE,
     EVENT_START_DATETIME,
-    EVENT_TYPES_CONF,
     FeatureAccess,
 )
 
@@ -95,41 +90,7 @@ OPAQUE = "opaque"
 # we need to strip when working with the frontend recurrence rule values
 RRULE_PREFIX = "RRULE:"
 
-_EVENT_IN_TYPES = vol.Schema(
-    {
-        vol.Exclusive(EVENT_IN_DAYS, EVENT_TYPES_CONF): cv.positive_int,
-        vol.Exclusive(EVENT_IN_WEEKS, EVENT_TYPES_CONF): cv.positive_int,
-    }
-)
-
 SERVICE_CREATE_EVENT = "create_event"
-CREATE_EVENT_SCHEMA = vol.All(
-    cv.has_at_least_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
-    cv.has_at_most_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
-    cv.make_entity_service_schema(
-        {
-            vol.Required(EVENT_SUMMARY): cv.string,
-            vol.Optional(EVENT_DESCRIPTION, default=""): cv.string,
-            vol.Inclusive(
-                EVENT_START_DATE, "dates", "Start and end dates must both be specified"
-            ): cv.date,
-            vol.Inclusive(
-                EVENT_END_DATE, "dates", "Start and end dates must both be specified"
-            ): cv.date,
-            vol.Inclusive(
-                EVENT_START_DATETIME,
-                "datetimes",
-                "Start and end datetimes must both be specified",
-            ): cv.datetime,
-            vol.Inclusive(
-                EVENT_END_DATETIME,
-                "datetimes",
-                "Start and end datetimes must both be specified",
-            ): cv.datetime,
-            vol.Optional(EVENT_IN): _EVENT_IN_TYPES,
-        }
-    ),
-)
 
 
 async def async_setup_entry(
@@ -546,9 +507,12 @@ class GoogleCalendarEntity(
         if rrule := kwargs.get(EVENT_RRULE):
             event.recurrence = [f"{RRULE_PREFIX}{rrule}"]
 
-        await cast(
-            CalendarSyncUpdateCoordinator, self.coordinator
-        ).sync.store_service.async_add_event(event)
+        try:
+            await cast(
+                CalendarSyncUpdateCoordinator, self.coordinator
+            ).sync.store_service.async_add_event(event)
+        except ApiException as err:
+            raise HomeAssistantError(f"Error while creating event: {str(err)}") from err
         await self.coordinator.async_refresh()
 
     async def async_delete_event(

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -1,11 +1,15 @@
 """The tests for the calendar component."""
 from datetime import timedelta
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.calendar import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
 
@@ -157,3 +161,165 @@ async def test_unsupported_websocket(hass, hass_ws_client, payload, code):
     assert resp.get("id") == 1
     assert resp.get("error")
     assert resp["error"].get("code") == code
+
+
+async def test_unsupported_create_event_service(hass):
+    """Test unsupported service call."""
+
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError, match="does not support this service"):
+        await hass.services.async_call(
+            DOMAIN,
+            "create_event",
+            {
+                "start_date_time": "1997-07-14T17:00:00+00:00",
+                "end_date_time": "1997-07-15T04:00:00+00:00",
+                "summary": "Bastille Day Party",
+            },
+            target={"entity_id": "calendar.calendar_1"},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "date_fields,expected_error,error_match",
+    [
+        (
+            {},
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in",
+        ),
+        (
+            {
+                "start_date": "2022-04-01",
+            },
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
+        ),
+        (
+            {
+                "end_date": "2022-04-02",
+            },
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in.",
+        ),
+        (
+            {
+                "start_date_time": "2022-04-01T06:00:00",
+            },
+            vol.error.MultipleInvalid,
+            "Start and end datetimes must both be specified",
+        ),
+        (
+            {
+                "end_date_time": "2022-04-02T07:00:00",
+            },
+            vol.error.MultipleInvalid,
+            "must contain at least one of start_date, start_date_time, in.",
+        ),
+        (
+            {
+                "start_date": "2022-04-01",
+                "start_date_time": "2022-04-01T06:00:00",
+                "end_date_time": "2022-04-02T07:00:00",
+            },
+            vol.error.MultipleInvalid,
+            "must contain at most one of start_date, start_date_time, in.",
+        ),
+        (
+            {
+                "start_date_time": "2022-04-01T06:00:00",
+                "end_date_time": "2022-04-01T07:00:00",
+                "end_date": "2022-04-02",
+            },
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
+        ),
+        (
+            {
+                "start_date": "2022-04-01",
+                "end_date_time": "2022-04-02T07:00:00",
+            },
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
+        ),
+        (
+            {
+                "start_date_time": "2022-04-01T07:00:00",
+                "end_date": "2022-04-02",
+            },
+            vol.error.MultipleInvalid,
+            "Start and end dates must both be specified",
+        ),
+        (
+            {
+                "in": {
+                    "days": 2,
+                    "weeks": 2,
+                }
+            },
+            vol.error.MultipleInvalid,
+            "two or more values in the same group of exclusion 'event_types'",
+        ),
+        (
+            {
+                "start_date": "2022-04-01",
+                "end_date": "2022-04-02",
+                "in": {
+                    "days": 2,
+                },
+            },
+            vol.error.MultipleInvalid,
+            "must contain at most one of start_date, start_date_time, in.",
+        ),
+        (
+            {
+                "start_date_time": "2022-04-01T07:00:00",
+                "end_date_time": "2022-04-01T07:00:00",
+                "in": {
+                    "days": 2,
+                },
+            },
+            vol.error.MultipleInvalid,
+            "must contain at most one of start_date, start_date_time, in.",
+        ),
+    ],
+    ids=[
+        "missing_all",
+        "missing_end_date",
+        "missing_start_date",
+        "missing_end_datetime",
+        "missing_start_datetime",
+        "multiple_start",
+        "multiple_end",
+        "missing_end_date",
+        "missing_end_date_time",
+        "multiple_in",
+        "unexpected_in_with_date",
+        "unexpected_in_with_datetime",
+    ],
+)
+async def test_create_event_service_invalid_params(
+    hass: HomeAssistant,
+    date_fields: dict[str, Any],
+    expected_error: type[Exception],
+    error_match: str | None,
+):
+    """Test creating an event using the create_event service."""
+
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    with pytest.raises(expected_error, match=error_match):
+        await hass.services.async_call(
+            "calendar",
+            "create_event",
+            {
+                "summary": "Bastille Day Party",
+                **date_fields,
+            },
+            target={"entity_id": "calendar.calendar_1"},
+            blocking=True,
+        )

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -1,4 +1,7 @@
 """The tests for the calendar component."""
+
+from __future__ import annotations
+
 from datetime import timedelta
 from http import HTTPStatus
 from typing import Any

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -7,6 +7,7 @@ import http
 import time
 from typing import Any
 from unittest.mock import Mock, patch
+import zoneinfo
 
 from aiohttp.client_exceptions import ClientError
 import pytest
@@ -56,28 +57,36 @@ def assert_state(actual: State | None, expected: State | None) -> None:
 @pytest.fixture(
     params=[
         (
+            DOMAIN,
             SERVICE_ADD_EVENT,
             {"calendar_id": CALENDAR_ID},
             None,
         ),
         (
+            DOMAIN,
+            SERVICE_CREATE_EVENT,
+            {},
+            {"entity_id": TEST_API_ENTITY},
+        ),
+        (
+            "calendar",
             SERVICE_CREATE_EVENT,
             {},
             {"entity_id": TEST_API_ENTITY},
         ),
     ],
-    ids=("add_event", "create_event"),
+    ids=("google.add_event", "google.create_event", "calendar.create_event"),
 )
 def add_event_call_service(
     hass: HomeAssistant,
     request: Any,
 ) -> Callable[dict[str, Any], Awaitable[None]]:
     """Fixture for calling the add or create event service."""
-    (service_call, data, target) = request.param
+    (domain, service_call, data, target) = request.param
 
     async def call_service(params: dict[str, Any]) -> None:
         await hass.services.async_call(
-            DOMAIN,
+            domain,
             service_call,
             {
                 **data,
@@ -536,7 +545,7 @@ async def test_add_event_date_time(
     mock_events_list({})
     assert await component_setup()
 
-    start_datetime = datetime.datetime.now()
+    start_datetime = datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/Regina"))
     delta = datetime.timedelta(days=3, hours=3)
     end_datetime = start_datetime + delta
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add service to create calendar events, a straight port of the existing google calendar service. This event is `calendar.create_event` ported from `google.create_event`. Currently supports both google calendar and local calendar, or any other calendar implementation that supports the create event feature.

Adds a shim to translate service call values to websocket call values. This is needed because service calls do not support fields with multiple types at the moment. (Unclear to me we'd want to build the UI for that)

All the existing validation test cases are ported as is, but we can't delete them from google calendar tests.

Follow up related work includes:
- Add recurrence rule support
- Deprecate original google `google.add_event` service 
- Come up with a plan to migrate google `google.create_event` service. Right now, it can't use this new service because yaml search google calendars don't support to new methods for creating events


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/25834

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
