### PR TITLE
Address invalid keys in translation for whirlpool

### DIFF
--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -28,9 +28,9 @@ from .const import DOMAIN
 TANK_FILL = {
     "0": "unknown",
     "1": "empty",
-    "2": "25%",
-    "3": "50%",
-    "4": "100%",
+    "2": "25_percent",
+    "3": "50_percent",
+    "4": "100_percent",
     "5": "active",
 }
 

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -28,9 +28,9 @@ from .const import DOMAIN
 TANK_FILL = {
     "0": "unknown",
     "1": "empty",
-    "2": "25_percent",
-    "3": "50_percent",
-    "4": "100_percent",
+    "2": "25",
+    "3": "50",
+    "4": "100",
     "5": "active",
 }
 

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -51,9 +51,6 @@
         "state": {
           "unknown": "Unknown",
           "empty": "Empty",
-          "25_percent": "25%",
-          "50_percent": "50%",
-          "100_percent": "100%",
           "active": "[%key:common::state::active%]"
         }
       }

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -51,9 +51,9 @@
         "state": {
           "unknown": "Unknown",
           "empty": "Empty",
-          "25%": "25%",
-          "50%": "50%",
-          "100%": "100%",
+          "25_percent": "25%",
+          "50_percent": "50%",
+          "100_percent": "100%",
           "active": "[%key:common::state::active%]"
         }
       }

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -51,6 +51,9 @@
         "state": {
           "unknown": "Unknown",
           "empty": "Empty",
+          "25": "25%",
+          "50": "50%",
+          "100": "100%",
           "active": "[%key:common::state::active%]"
         }
       }

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -149,7 +149,7 @@ async def test_washer_sensor_values(
     state_id = f"{entity_id.split('_')[0]}_detergent_level"
     state = hass.states.get(state_id)
     assert state is not None
-    assert state.state == "50%"
+    assert state.state == "50_percent"
 
     # Test the washer cycle states
     mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -149,7 +149,7 @@ async def test_washer_sensor_values(
     state_id = f"{entity_id.split('_')[0]}_detergent_level"
     state = hass.states.get(state_id)
     assert state is not None
-    assert state.state == "50_percent"
+    assert state.state == "50"
 
     # Test the washer cycle states
     mock_instance.get_machine_state.return_value = MachineState.RunningMainCycle


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address invalid translation keys in whripool integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
