### PR TITLE
Add option for multiple models and manufacturers

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -104,9 +104,9 @@ SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Integration linked to it with a config entry
         vol.Optional("integration"): str,
         # Manufacturer of device
-        vol.Optional("manufacturer"): str,
+        vol.Optional("manufacturer"): vol.Any(str, [str]),
         # Model of device
-        vol.Optional("model"): str,
+        vol.Optional("model"): vol.Any(str, [str]),
         # Device has to contain entities matching this selector
         vol.Optional("entity"): SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA,
     }
@@ -117,8 +117,8 @@ class SingleDeviceSelectorConfig(TypedDict, total=False):
     """Class to represent a single device selector config."""
 
     integration: str
-    manufacturer: str
-    model: str
+    manufacturer: str | list[str]
+    model: str | list[str]
     entity: SingleEntitySelectorConfig
 
 
@@ -397,8 +397,8 @@ class DeviceSelectorConfig(TypedDict, total=False):
     """Class to represent a device selector config."""
 
     integration: str
-    manufacturer: str
-    model: str
+    manufacturer: str | list[str]
+    model: str | list[str]
     entity: SingleEntitySelectorConfig
     multiple: bool
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -84,8 +84,15 @@ def _test_selector(
         ({}, ("abc123",), (None,)),
         ({"integration": "zha"}, ("abc123",), (None,)),
         ({"manufacturer": "mock-manuf"}, ("abc123",), (None,)),
+        ({"manufacturer": ["mock-manuf", "mock-manf-2"]}, ("abc123",), (None,)),
         ({"model": "mock-model"}, ("abc123",), (None,)),
+        ({"model": ["mock-model", "mock-model-2"]}, ("abc123",), (None,)),
         ({"manufacturer": "mock-manuf", "model": "mock-model"}, ("abc123",), (None,)),
+        (
+            {"manufacturer": "mock-manuf", "model": ["mock-model", "mock-model-2"]},
+            ("abc123",),
+            (None,),
+        ),
         (
             {"integration": "zha", "manufacturer": "mock-manuf", "model": "mock-model"},
             ("abc123",),
@@ -198,6 +205,16 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections):
         ),
         (
             {"device": {"integration": "demo", "model": "mock-model"}},
+            ("abc123",),
+            (None,),
+        ),
+        (
+            {
+                "device": {
+                    "integration": "demo",
+                    "model": ["mock-model", "mock-model-2"],
+                }
+            },
             ("abc123",),
             (None,),
         ),
@@ -355,6 +372,16 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections):
             (),
         ),
         ({"device": {"integration": "demo", "model": "mock-model"}}, (), ()),
+        (
+            {
+                "device": {
+                    "integration": "demo",
+                    "model": ["mock-model", "mock-model-2"],
+                }
+            },
+            (),
+            (),
+        ),
         (
             {
                 "entity": {"domain": "binary_sensor", "device_class": "motion"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change (coupled with a corresponding one in frontend) enables multiple manufacturers or models to be specified in device selectors. This is useful in blueprints where there are multiple identically-behaving models that have different names - the change enables these to share a blueprint and avoids a lot of duplication. 

e.g.
```
selector:
  device:
    model:
      - Model X
      - Model Y
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
