### PR TITLE
Warn if numeric sensors have an invalid value

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -493,7 +493,7 @@ class SensorEntity(Entity):
         if not isinstance(value, (int, float, Decimal)):
             try:
                 _ = float(value)  # type: ignore[arg-type]
-            except ValueError:
+            except (TypeError, ValueError):
                 _LOGGER.warning(
                     "Sensor %s has device class %s, state class %s and unit %s "
                     "thus indicating it has a numeric value; however, it has the "

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -52,6 +52,8 @@ class FritzEntityBaseMock(Mock):
     manufacturer = CONF_FAKE_MANUFACTURER
     name = CONF_FAKE_NAME
     productname = CONF_FAKE_PRODUCTNAME
+    rel_humidity = None
+    battery_level = None
 
 
 class FritzDeviceBinarySensorMock(FritzEntityBaseMock):

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -52,8 +52,6 @@ class FritzEntityBaseMock(Mock):
     manufacturer = CONF_FAKE_MANUFACTURER
     name = CONF_FAKE_NAME
     productname = CONF_FAKE_PRODUCTNAME
-    rel_humidity = None
-    battery_level = None
 
 
 class FritzDeviceBinarySensorMock(FritzEntityBaseMock):

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1242,12 +1242,21 @@ async def test_device_classes_with_invalid_unit_of_measurement(
         (None, None, UnitOfTemperature.CELSIUS),
     ],
 )
-@pytest.mark.parametrize("native_value", ("abc", "13.7.1"))
+@pytest.mark.parametrize(
+    "native_value,expected",
+    [
+        ("abc", "abc"),
+        ("13.7.1", "13.7.1"),
+        (datetime(2012, 11, 10, 7, 35, 1), "2012-11-10 07:35:01"),
+        (date(2012, 11, 10), "2012-11-10"),
+    ],
+)
 async def test_non_numeric_validation(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
     native_value: Any,
+    expected: str,
     device_class: SensorDeviceClass | None,
     state_class: SensorStateClass | None,
     unit: str | None,
@@ -1268,7 +1277,7 @@ async def test_non_numeric_validation(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.state == native_value
+    assert state.state == expected
 
     assert (
         "thus indicating it has a numeric value; "

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1,6 +1,9 @@
 """The test for sensor entity."""
+from __future__ import annotations
+
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from typing import Any
 
 import pytest
 from pytest import approx
@@ -1229,3 +1232,125 @@ async def test_device_classes_with_invalid_unit_of_measurement(
         "is using native unit of measurement 'INVALID!' which is not a valid "
         f"unit for the device class ('{device_class}') it is using"
     ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    "device_class,state_class,unit",
+    [
+        (SensorDeviceClass.AQI, None, None),
+        (None, SensorStateClass.MEASUREMENT, None),
+        (None, None, UnitOfTemperature.CELSIUS),
+    ],
+)
+@pytest.mark.parametrize("native_value", ("abc", "13.7.1"))
+async def test_non_numeric_validation(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+    native_value: Any,
+    device_class: SensorDeviceClass | None,
+    state_class: SensorStateClass | None,
+    unit: str | None,
+) -> None:
+    """Test error on expected numeric entities."""
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=native_value,
+        device_class=device_class,
+        native_unit_of_measurement=unit,
+        state_class=state_class,
+    )
+    entity0 = platform.ENTITIES["0"]
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.state == native_value
+
+    assert (
+        "thus indicating it has a numeric value; "
+        f"however, it has the non-numeric value: {native_value}"
+    ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    "device_class,state_class,unit",
+    [
+        (SensorDeviceClass.AQI, None, None),
+        (None, SensorStateClass.MEASUREMENT, None),
+        (None, None, UnitOfTemperature.CELSIUS),
+    ],
+)
+@pytest.mark.parametrize(
+    "native_value,expected",
+    [
+        (13, "13"),
+        (17.50, "17.5"),
+        (Decimal(18.50), "18.5"),
+        ("19.70", "19.70"),
+        (None, STATE_UNKNOWN),
+    ],
+)
+async def test_numeric_validation(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+    native_value: Any,
+    expected: str,
+    device_class: SensorDeviceClass | None,
+    state_class: SensorStateClass | None,
+    unit: str | None,
+) -> None:
+    """Test does not error on expected numeric entities."""
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=native_value,
+        device_class=device_class,
+        native_unit_of_measurement=unit,
+        state_class=state_class,
+    )
+    entity0 = platform.ENTITIES["0"]
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.state == expected
+
+    assert (
+        "thus indicating it has a numeric value; "
+        f"however, it has the non-numeric value: {native_value}"
+    ) not in caplog.text
+
+
+async def test_numeric_validation_ignores_custom_device_class(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
+    """Test does not error on expected numeric entities."""
+    native_value = "Three elephants"
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=native_value,
+        device_class="custom__deviceclass",
+    )
+    entity0 = platform.ENTITIES["0"]
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.state == "Three elephants"
+
+    assert (
+        "thus indicating it has a numeric value; "
+        f"however, it has the non-numeric value: {native_value}"
+    ) not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sensor that have a numeric device class, a state class or a unit of measurement should have a numeric value (or `None`).
Non-numeric values will no longer be accepted after 2023.4

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #85605

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
