### PR TITLE
Use parametrize to modify Axis test fixtures

### DIFF
--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -54,15 +54,8 @@ def config_entry_fixture(hass, config, options, config_entry_version):
 
 @pytest.fixture(name="config_entry_version")
 def config_entry_version_fixture(request):
-    """Define a config entry version fixture.
-
-    @pytest.mark.config_entry_version(int)
-    """
-    marker = request.node.get_closest_marker("config_entry_version")
-    version = 3
-    if marker:
-        version = marker.args[0]
-    return version
+    """Define a config entry version fixture."""
+    return 3
 
 
 @pytest.fixture(name="config")
@@ -73,15 +66,8 @@ def config_fixture():
 
 @pytest.fixture(name="options")
 def options_fixture(request):
-    """Define a config entry options fixture.
-
-    @pytest.mark.config_entry_options(dict)
-    """
-    marker = request.node.get_closest_marker("config_entry_options")
-    options = ENTRY_OPTIONS.copy()
-    if marker:
-        options = marker.args[0]
-    return options
+    """Define a config entry options fixture."""
+    return ENTRY_OPTIONS.copy()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/axis/test_camera.py
+++ b/tests/components/axis/test_camera.py
@@ -50,7 +50,7 @@ async def test_camera(hass, config_entry):
     )
 
 
-@pytest.mark.config_entry_options({CONF_STREAM_PROFILE: "profile_1"})
+@pytest.mark.parametrize("options", [{CONF_STREAM_PROFILE: "profile_1"}])
 async def test_camera_with_stream_profile(hass, config_entry):
     """Test that Axis camera entity is using the correct path with stream profike."""
     await setup_axis_integration(hass, config_entry)

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -45,7 +45,7 @@ async def test_unload_entry(hass, config_entry):
     assert not hass.data[AXIS_DOMAIN]
 
 
-@pytest.mark.config_entry_version(1)
+@pytest.mark.parametrize("config_entry_version", [1])
 async def test_migrate_entry(hass, config_entry):
     """Test successful migration of entry data."""
     assert config_entry.version == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix late comments from #85865
Use parametrize to modify fixtures rather than custom marks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #85865
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
