### PR TITLE
Bump PyISY to 3.1.5 and fix bad Z-Wave properties from eisy

### DIFF
--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -280,32 +280,32 @@ def _is_sensor_a_binary_sensor(isy_data: IsyData, node: Group | Node) -> bool:
 def _generate_device_info(node: Node) -> DeviceInfo:
     """Generate the device info for a root node device."""
     isy = node.isy
-    basename = node.name
     device_info = DeviceInfo(
         identifiers={(DOMAIN, f"{isy.uuid}_{node.address}")},
-        manufacturer=node.protocol,
-        name=f"{basename} ({(str(node.address).rpartition(' ')[0] or node.address)})",
+        manufacturer=node.protocol.title(),
+        name=node.name,
         via_device=(DOMAIN, isy.uuid),
         configuration_url=isy.conn.url,
         suggested_area=node.folder,
     )
 
     # ISYv5 Device Types can provide model and manufacturer
-    model: str = "Unknown"
+    model: str = str(node.address).rpartition(" ")[0] or node.address
     if node.node_def_id is not None:
-        model = str(node.node_def_id)
+        model += f": {node.node_def_id}"
 
     # Numerical Device Type
     if node.type is not None:
         model += f" ({node.type})"
 
     # Get extra information for Z-Wave Devices
-    if node.protocol == PROTO_ZWAVE:
-        device_info[ATTR_MANUFACTURER] = f"Z-Wave MfrID:{node.zwave_props.mfr_id}"
+    if node.protocol == PROTO_ZWAVE and node.zwave_props.mfr_id != "0":
+        device_info[
+            ATTR_MANUFACTURER
+        ] = f"Z-Wave MfrID:{int(node.zwave_props.mfr_id):#0{6}x}"
         model += (
-            f" Type:{node.zwave_props.devtype_gen} "
-            f"ProductTypeID:{node.zwave_props.prod_type_id} "
-            f"ProductID:{node.zwave_props.product_id}"
+            f"Type:{int(node.zwave_props.prod_type_id):#0{6}x} "
+            f"Product:{int(node.zwave_props.product_id):#0{6}x}"
         )
     device_info[ATTR_MODEL] = model
 

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,7 +3,7 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.1.4"],
+  "requirements": ["pyisy==3.1.5"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.4
+pyisy==3.1.5
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1215,7 +1215,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.4
+pyisy==3.1.5
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump PyISY to 3.1.5 to pick up a bug fix for UDI's new eisy controller and ZMatter board.

https://github.com/automicus/PyISY/releases/tag/v3.1.5

- There is a data structure change in the XML returned from the controller for Z-Wave nodes
- Adds support for better filtering of node updates in future PR.

Home Assistant Changes: Changes to device info display: Ignore invalid z-wave properties, correct device info display for no id, fix address

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://forum.universal-devices.com/topic/39708-homeassistant-isy-eisy-migration/?do=findComment&comment=356867
- Link to documentation pull request: 

Error reported on UDI Forum when trying to load `isy994` integration:

```shell
Logger: homeassistant.config_entries
Source: components/isy994/__init__.py:180
First occurred: 15:11:34 (1 occurrences)
Last logged: 15:11:34

Error setting up entry Riften (172.16.5.251) for isy994
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 382, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/isy994/__init__.py", line 180, in async_setup_entry
    await isy.initialize()
  File "/usr/local/lib/python3.10/site-packages/pyisy/isy.py", line 138, in initialize
    self.nodes = Nodes(self, xml=isy_setup_results[2])
  File "/usr/local/lib/python3.10/site-packages/pyisy/nodes/__init__.py", line 110, in __init__
    self.parse(xml)
  File "/usr/local/lib/python3.10/site-packages/pyisy/nodes/__init__.py", line 329, in parse
    feature.getElementsByTagName(TAG_DEVICE_TYPE)[0]
IndexError: list index out of range
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
