### PR TITLE
Fix apcupsd spamming logs when host is unavailable

### DIFF
--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -68,17 +68,16 @@ class OnlineStatus(BinarySensorEntity):
         """Get the status report from APCUPSd and set this entity's state."""
         try:
             self._data_service.update()
-            self._attr_available = True
-
-            key = self.entity_description.key.upper()
-            if key not in self._data_service.status:
-                self._attr_is_on = None
-                return
-
-            self._attr_is_on = (
-                int(self._data_service.status[key], 16) & VALUE_ONLINE > 0
-            )
         except OSError as ex:
             if self._attr_available:
                 self._attr_available = False
                 _LOGGER.exception("Got exception while fetching state: %s", ex)
+            return
+
+        self._attr_available = True
+        key = self.entity_description.key.upper()
+        if key not in self._data_service.status:
+            self._attr_is_on = None
+            return
+
+        self._attr_is_on = int(self._data_service.status[key], 16) & VALUE_ONLINE > 0

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -62,14 +62,23 @@ class OnlineStatus(BinarySensorEntity):
             )
         self.entity_description = description
         self._data_service = data_service
+        self._attr_available = False
 
     def update(self) -> None:
         """Get the status report from APCUPSd and set this entity's state."""
-        self._data_service.update()
+        try:
+            self._data_service.update()
+            self._attr_available = True
 
-        key = self.entity_description.key.upper()
-        if key not in self._data_service.status:
-            self._attr_is_on = None
-            return
+            key = self.entity_description.key.upper()
+            if key not in self._data_service.status:
+                self._attr_is_on = None
+                return
 
-        self._attr_is_on = int(self._data_service.status[key], 16) & VALUE_ONLINE > 0
+            self._attr_is_on = (
+                int(self._data_service.status[key], 16) & VALUE_ONLINE > 0
+            )
+        except OSError as ex:
+            if self._attr_available:
+                self._attr_available = False
+                _LOGGER.exception("Got exception while fetching state: %s", ex)

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -62,7 +62,6 @@ class OnlineStatus(BinarySensorEntity):
             )
         self.entity_description = description
         self._data_service = data_service
-        self._attr_available = False
 
     def update(self) -> None:
         """Get the status report from APCUPSd and set this entity's state."""

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -500,7 +500,6 @@ class APCUPSdSensor(SensorEntity):
 
         self.entity_description = description
         self._data_service = data_service
-        self._attr_available = False
 
     def update(self) -> None:
         """Get the latest status and use it to update our sensor state."""

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -506,19 +506,20 @@ class APCUPSdSensor(SensorEntity):
         """Get the latest status and use it to update our sensor state."""
         try:
             self._data_service.update()
-            self._attr_available = True
-
-            key = self.entity_description.key.upper()
-            if key not in self._data_service.status:
-                self._attr_native_value = None
-                return
-
-            self._attr_native_value, inferred_unit = infer_unit(
-                self._data_service.status[key]
-            )
-            if not self.native_unit_of_measurement:
-                self._attr_native_unit_of_measurement = inferred_unit
         except OSError as ex:
             if self._attr_available:
                 self._attr_available = False
                 _LOGGER.exception("Got exception while fetching state: %s", ex)
+            return
+
+        self._attr_available = True
+        key = self.entity_description.key.upper()
+        if key not in self._data_service.status:
+            self._attr_native_value = None
+            return
+
+        self._attr_native_value, inferred_unit = infer_unit(
+            self._data_service.status[key]
+        )
+        if not self.native_unit_of_measurement:
+            self._attr_native_unit_of_measurement = inferred_unit

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -500,18 +500,25 @@ class APCUPSdSensor(SensorEntity):
 
         self.entity_description = description
         self._data_service = data_service
+        self._attr_available = False
 
     def update(self) -> None:
         """Get the latest status and use it to update our sensor state."""
-        self._data_service.update()
+        try:
+            self._data_service.update()
+            self._attr_available = True
 
-        key = self.entity_description.key.upper()
-        if key not in self._data_service.status:
-            self._attr_native_value = None
-            return
+            key = self.entity_description.key.upper()
+            if key not in self._data_service.status:
+                self._attr_native_value = None
+                return
 
-        self._attr_native_value, inferred_unit = infer_unit(
-            self._data_service.status[key]
-        )
-        if not self.native_unit_of_measurement:
-            self._attr_native_unit_of_measurement = inferred_unit
+            self._attr_native_value, inferred_unit = infer_unit(
+                self._data_service.status[key]
+            )
+            if not self.native_unit_of_measurement:
+                self._attr_native_unit_of_measurement = inferred_unit
+        except OSError as ex:
+            if self._attr_available:
+                self._attr_available = False
+                _LOGGER.exception("Got exception while fetching state: %s", ex)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`apcupsd` entities should go unavailable when polling fails. Only one set of errors should be logged when this happens.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85919 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
