### PR TITLE
Don't use force_update for Tasmota sensors

### DIFF
--- a/homeassistant/components/tasmota/binary_sensor.py
+++ b/homeassistant/components/tasmota/binary_sensor.py
@@ -58,7 +58,6 @@ class TasmotaBinarySensor(
 ):
     """Representation a Tasmota binary sensor."""
 
-    _attr_force_update = True
     _tasmota_entity: tasmota_switch.TasmotaSwitch
 
     def __init__(self, **kwds: Any) -> None:

--- a/homeassistant/components/tasmota/binary_sensor.py
+++ b/homeassistant/components/tasmota/binary_sensor.py
@@ -58,16 +58,17 @@ class TasmotaBinarySensor(
 ):
     """Representation a Tasmota binary sensor."""
 
+    _delay_listener: Callable | None = None
+    _on_off_state: bool | None = None
     _tasmota_entity: tasmota_switch.TasmotaSwitch
 
     def __init__(self, **kwds: Any) -> None:
         """Initialize the Tasmota binary sensor."""
-        self._delay_listener: Callable | None = None
-        self._on_off_state: bool | None = None
-
         super().__init__(
             **kwds,
         )
+        if self._tasmota_entity.off_delay is not None:
+            self._attr_force_update = True
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""

--- a/homeassistant/components/tasmota/sensor.py
+++ b/homeassistant/components/tasmota/sensor.py
@@ -266,7 +266,6 @@ async def async_setup_entry(
 class TasmotaSensor(TasmotaAvailability, TasmotaDiscoveryUpdate, SensorEntity):
     """Representation of a Tasmota sensor."""
 
-    _attr_force_update = True
     _tasmota_entity: tasmota_sensor.TasmotaSensor
 
     def __init__(self, **kwds: Any) -> None:

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -101,7 +101,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     entity = hass.data["entity_components"]["binary_sensor"].get_entity(
         "binary_sensor.tasmota_binary_sensor_1"
     )
-    assert entity.force_update
+    assert not entity.force_update
 
 
 async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -529,7 +529,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     entity = hass.data["entity_components"]["sensor"].get_entity(
         "sensor.tasmota_status"
     )
-    assert entity.force_update
+    assert not entity.force_update
 
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Tasmota `binary_sensor` no longer sets the `force_update` flag to True, with the exception of `binary_sensor` mapped to a Tasmota switch with switchmode set to 13 or 14.
Tasmota `sensor` no longer sets the `force_update` flag to True.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes the linked issue by not enabling `force_update` anymore. This restores the expected behavior of the state machine, and thus, for example, makes it possible to display the actual time a sensor was last changed in a dashboard.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74357
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
