### PR TITLE
Add support for telnet connections for Denonavr integration

### DIFF
--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,6 +1,7 @@
 """The denonavr component."""
 import logging
 
+from denonavr import DenonAVR
 from denonavr.exceptions import AvrNetworkError, AvrTimoutError
 
 from homeassistant.config_entries import ConfigEntry
@@ -12,10 +13,12 @@ from homeassistant.helpers.httpx_client import get_async_client
 
 from .config_flow import (
     CONF_SHOW_ALL_SOURCES,
+    CONF_USE_TELNET,
     CONF_ZONE2,
     CONF_ZONE3,
     DEFAULT_SHOW_SOURCES,
     DEFAULT_TIMEOUT,
+    DEFAULT_USE_TELNET,
     DEFAULT_ZONE2,
     DEFAULT_ZONE3,
     DOMAIN,
@@ -40,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(CONF_SHOW_ALL_SOURCES, DEFAULT_SHOW_SOURCES),
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
+        entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET),
         lambda: get_async_client(hass),
     )
     try:
@@ -65,6 +69,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
+
+    if config_entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET):
+        receiver: DenonAVR = hass.data[DOMAIN][config_entry.entry_id][CONF_RECEIVER]
+        await receiver.async_telnet_disconnect()
 
     hass.data[DOMAIN][config_entry.entry_id][UNDO_UPDATE_LISTENER]()
 

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -13,11 +13,13 @@ from homeassistant.helpers.httpx_client import get_async_client
 
 from .config_flow import (
     CONF_SHOW_ALL_SOURCES,
+    CONF_UPDATE_AUDYSSEY,
     CONF_USE_TELNET,
     CONF_ZONE2,
     CONF_ZONE3,
     DEFAULT_SHOW_SOURCES,
     DEFAULT_TIMEOUT,
+    DEFAULT_UPDATE_AUDYSSEY,
     DEFAULT_USE_TELNET,
     DEFAULT_ZONE2,
     DEFAULT_ZONE3,
@@ -44,6 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
         entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET),
+        entry.options.get(CONF_UPDATE_AUDYSSEY, DEFAULT_UPDATE_AUDYSSEY),
         lambda: get_async_client(hass),
     )
     try:

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -63,18 +63,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    use_telnet = entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET)
 
-    async def disconnect(event: Event) -> None:
+    async def _async_disconnect(event: Event) -> None:
         """Disconnect from Telnet."""
-        if (
-            entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET)
-            and receiver is not None
-        ):
+        if use_telnet and receiver is not None:
             await receiver.async_telnet_disconnect()
 
-    if entry.options.get(CONF_USE_TELNET, DEFAULT_USE_TELNET):
+    if use_telnet:
         entry.async_on_unload(
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, disconnect)
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_disconnect)
         )
 
     return True

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -39,6 +39,7 @@ DEFAULT_ZONE2 = False
 DEFAULT_ZONE3 = False
 DEFAULT_UPDATE_AUDYSSEY = False
 DEFAULT_USE_TELNET = False
+DEFAULT_USE_TELNET_NEW_INSTALL = True
 
 CONFIG_SCHEMA = vol.Schema({vol.Optional(CONF_HOST): str})
 
@@ -105,7 +106,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.show_all_sources = DEFAULT_SHOW_SOURCES
         self.zone2 = DEFAULT_ZONE2
         self.zone3 = DEFAULT_ZONE3
-        self.use_telnet = DEFAULT_USE_TELNET
+        self.use_telnet = DEFAULT_USE_TELNET_NEW_INSTALL
         self.d_receivers: list[dict[str, Any]] = []
 
     @staticmethod
@@ -185,7 +186,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.show_all_sources,
             self.zone2,
             self.zone3,
-            self.use_telnet,
+            False,
             lambda: get_async_client(self.hass),
         )
 
@@ -226,6 +227,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_MANUFACTURER: receiver.manufacturer,
                 CONF_SERIAL_NUMBER: self.serial_number,
             },
+            options={CONF_USE_TELNET: DEFAULT_USE_TELNET_NEW_INSTALL},
         )
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -186,8 +186,9 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.show_all_sources,
             self.zone2,
             self.zone3,
-            False,
-            lambda: get_async_client(self.hass),
+            use_telnet=False,
+            update_audyssey=False,
+            async_client_getter=lambda: get_async_client(self.hass),
         )
 
         try:

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -31,12 +31,14 @@ CONF_ZONE3 = "zone3"
 CONF_MANUFACTURER = "manufacturer"
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_UPDATE_AUDYSSEY = "update_audyssey"
+CONF_USE_TELNET = "use_telnet"
 
 DEFAULT_SHOW_SOURCES = False
 DEFAULT_TIMEOUT = 5
 DEFAULT_ZONE2 = False
 DEFAULT_ZONE3 = False
 DEFAULT_UPDATE_AUDYSSEY = False
+DEFAULT_USE_TELNET = False
 
 CONFIG_SCHEMA = vol.Schema({vol.Optional(CONF_HOST): str})
 
@@ -77,6 +79,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_UPDATE_AUDYSSEY, DEFAULT_UPDATE_AUDYSSEY
                     ),
                 ): bool,
+                vol.Optional(
+                    CONF_USE_TELNET,
+                    default=self.config_entry.options.get(
+                        CONF_USE_TELNET, DEFAULT_USE_TELNET
+                    ),
+                ): bool,
             }
         )
 
@@ -97,6 +105,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.show_all_sources = DEFAULT_SHOW_SOURCES
         self.zone2 = DEFAULT_ZONE2
         self.zone3 = DEFAULT_ZONE3
+        self.use_telnet = DEFAULT_USE_TELNET
         self.d_receivers: list[dict[str, Any]] = []
 
     @staticmethod
@@ -176,6 +185,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.show_all_sources,
             self.zone2,
             self.zone3,
+            self.use_telnet,
             lambda: get_async_client(self.hass),
         )
 

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@ol-iver", "@starkillerOG"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "iot_class": "local_polling",
+  "iot_class": "local_push",
   "loggers": ["denonavr"],
-  "requirements": ["denonavr==0.10.12"],
+  "requirements": ["denonavr==0.11.0"],
   "ssdp": [
     {
       "manufacturer": "Denon",

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
   "iot_class": "local_push",
   "loggers": ["denonavr"],
-  "requirements": ["denonavr==0.11.0"],
+  "requirements": ["denonavr==0.11.1"],
   "ssdp": [
     {
       "manufacturer": "Denon",

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -247,6 +247,19 @@ class DenonDevice(MediaPlayerEntity):
             and MediaPlayerEntityFeature.SELECT_SOUND_MODE
         )
 
+        self._receiver.register_callback("ALL", self._telnet_callback)
+
+    async def _telnet_callback(self, zone, event, parameter):
+        """Process a telnet command callback."""
+        if zone != self._receiver.zone:
+            return
+
+        self.async_schedule_update_ha_state(False)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up the entity."""
+        self._receiver.unregister_callback("ALL", self._telnet_callback)
+
     @async_log_errors
     async def async_update(self) -> None:
         """Get the latest status information from device."""

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -254,7 +254,7 @@ class DenonDevice(MediaPlayerEntity):
         if zone != self._receiver.zone:
             return
 
-        self.async_schedule_update_ha_state(False)
+        self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up the entity."""

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -263,6 +263,13 @@ class DenonDevice(MediaPlayerEntity):
     @async_log_errors
     async def async_update(self) -> None:
         """Get the latest status information from device."""
+        if (
+            self._receiver.telnet_connected is True
+            and self._receiver.telnet_healthy is True
+        ):
+            await self._receiver.input.async_update_media_state()
+            return
+
         await self._receiver.async_update()
         if self._update_audyssey:
             await self._receiver.async_update_audyssey()

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -19,6 +19,7 @@ class ConnectDenonAVR:
         show_all_inputs: bool,
         zone2: bool,
         zone3: bool,
+        use_telnet: bool,
         async_client_getter: Callable,
     ) -> None:
         """Initialize the class."""
@@ -27,6 +28,7 @@ class ConnectDenonAVR:
         self._host = host
         self._show_all_inputs = show_all_inputs
         self._timeout = timeout
+        self._use_telnet = use_telnet
 
         self._zones: dict[str, str | None] = {}
         if zone2:
@@ -85,5 +87,7 @@ class ConnectDenonAVR:
         # Use httpx.AsyncClient getter provided by Home Assistant
         receiver.set_async_client_getter(self._async_client_getter)
         await receiver.async_setup()
+        if self._use_telnet:
+            await receiver.async_telnet_connect()
 
         self._receiver = receiver

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -20,6 +20,7 @@ class ConnectDenonAVR:
         zone2: bool,
         zone3: bool,
         use_telnet: bool,
+        update_audyssey: bool,
         async_client_getter: Callable,
     ) -> None:
         """Initialize the class."""
@@ -29,6 +30,7 @@ class ConnectDenonAVR:
         self._show_all_inputs = show_all_inputs
         self._timeout = timeout
         self._use_telnet = use_telnet
+        self._update_audyssey = update_audyssey
 
         self._zones: dict[str, str | None] = {}
         if zone2:
@@ -87,7 +89,11 @@ class ConnectDenonAVR:
         # Use httpx.AsyncClient getter provided by Home Assistant
         receiver.set_async_client_getter(self._async_client_getter)
         await receiver.async_setup()
+        # Do an initial update if telnet is used.
         if self._use_telnet:
+            await receiver.async_update()
+            if self._update_audyssey:
+                await receiver.async_update_audyssey()
             await receiver.async_telnet_connect()
 
         self._receiver = receiver

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "By default this integration will poll your device to receive updates. You can enable the Telnet option after setting up the integration by using the Configure button which will enable local push updates. Note that this may interfere with the Denon AVR Remote app on your phone.",
+        "description": "By default this integration use a Telnet connection to your receiver to receive realtime updates. Note that this may interfere with the Denon AVR Remote app on your phone. You can turn this option off after setting up the integration by clicking the Configure button.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         },

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "By default this integration use a Telnet connection to your receiver to receive realtime updates. Note that only one telnet connection to your receiver can be established. This may interfere with your current setup. You can turn this option off after setting up the integration by clicking the Configure button.",
+        "description": "By default, this integration uses a Telnet connection to your receiver to receive real-time updates. Only one Telnet connection to your receiver can be established at a time. The Telnet connection can be disabled after setting up the integration.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         },

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -3,6 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
+        "description": "By default this integration will poll your device to receive updates. You can enable the Telnet option after setting up the integration by using the Configure button which will enable local push updates. Note that this may interfere with the Denon AVR Remote app on your phone.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         },

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -40,7 +40,8 @@
           "show_all_sources": "Show all sources",
           "zone2": "Set up Zone 2",
           "zone3": "Set up Zone 3",
-          "update_audyssey": "Update Audyssey settings"
+          "update_audyssey": "Update Audyssey settings",
+          "use_telnet": "Use Telnet connection"
         }
       }
     }

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "By default this integration use a Telnet connection to your receiver to receive realtime updates. Note that this may interfere with the Denon AVR Remote app on your phone. You can turn this option off after setting up the integration by clicking the Configure button.",
+        "description": "By default this integration use a Telnet connection to your receiver to receive realtime updates. Note that only one telnet connection to your receiver can be established. This may interfere with your current setup. You can turn this option off after setting up the integration by clicking the Configure button.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -997,7 +997,7 @@
         "denonavr": {
           "integration_type": "hub",
           "config_flow": true,
-          "iot_class": "local_polling",
+          "iot_class": "local_push",
           "name": "Denon AVR Network Receivers"
         },
         "heos": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -586,7 +586,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.0-dev
+denonavr==0.11.0
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -586,7 +586,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.12
+denonavr==0.11.0-dev
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -586,7 +586,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.0
+denonavr==0.11.1
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -463,7 +463,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.12
+denonavr==0.11.0-dev
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -463,7 +463,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.0-dev
+denonavr==0.11.0
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -463,7 +463,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.0
+denonavr==0.11.1
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.2

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.denonavr.config_flow import (
     CONF_SHOW_ALL_SOURCES,
     CONF_TYPE,
     CONF_UPDATE_AUDYSSEY,
+    CONF_USE_TELNET,
     CONF_ZONE2,
     CONF_ZONE3,
     DOMAIN,
@@ -430,6 +431,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         CONF_ZONE2: True,
         CONF_ZONE3: True,
         CONF_UPDATE_AUDYSSEY: False,
+        CONF_USE_TELNET: False,
     }
 
 

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -426,7 +426,12 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_SHOW_ALL_SOURCES: True, CONF_ZONE2: True, CONF_ZONE3: True},
+        user_input={
+            CONF_SHOW_ALL_SOURCES: True,
+            CONF_ZONE2: True,
+            CONF_ZONE3: True,
+            CONF_USE_TELNET: False,
+        },
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -97,6 +97,7 @@ async def test_config_flow_manual_host_success(hass: HomeAssistant) -> None:
         CONF_MANUFACTURER: TEST_MANUFACTURER,
         CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
     }
+    assert result["options"] == {CONF_USE_TELNET: True}
 
 
 async def test_config_flow_manual_discover_1_success(hass: HomeAssistant) -> None:
@@ -130,6 +131,7 @@ async def test_config_flow_manual_discover_1_success(hass: HomeAssistant) -> Non
         CONF_MANUFACTURER: TEST_MANUFACTURER,
         CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
     }
+    assert result["options"] == {CONF_USE_TELNET: True}
 
 
 async def test_config_flow_manual_discover_2_success(hass: HomeAssistant) -> None:
@@ -172,6 +174,7 @@ async def test_config_flow_manual_discover_2_success(hass: HomeAssistant) -> Non
         CONF_MANUFACTURER: TEST_MANUFACTURER,
         CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
     }
+    assert result["options"] == {CONF_USE_TELNET: True}
 
 
 async def test_config_flow_manual_discover_error(hass: HomeAssistant) -> None:
@@ -323,6 +326,7 @@ async def test_config_flow_ssdp(hass: HomeAssistant) -> None:
         CONF_MANUFACTURER: TEST_MANUFACTURER,
         CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
     }
+    assert result["options"] == {CONF_USE_TELNET: True}
 
 
 async def test_config_flow_ssdp_not_denon(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support to the DenonAVR integration to optionally make use of telnet connections to the AVR. This converts the integration from the current local_polling to local_push for many values. Polling is still maintained as well in case the user cannot use telnet, and also to refresh the properties that are not available through telnet.  For new installs this defaults to true, for existing installs it is false to prevent a possible breaking change.

This updates the denonavr library to 0.11.1, https://github.com/ol-iver/denonavr/releases/tag/0.11.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25790

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
