### PR TITLE
Add Insteon backlight control support to ISY994, bump PyISY to 3.1.8

### DIFF
--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from typing import cast
 
 from pyisy.constants import (
+    BACKLIGHT_SUPPORT,
+    CMD_BACKLIGHT,
     ISY_VALUE_UNKNOWN,
     PROP_BUSY,
     PROP_COMMS_ERROR,
@@ -15,6 +17,7 @@ from pyisy.constants import (
     PROTO_PROGRAM,
     PROTO_ZWAVE,
     TAG_FOLDER,
+    UOM_INDEX,
 )
 from pyisy.nodes import Group, Node, Nodes
 from pyisy.programs import Programs
@@ -277,6 +280,16 @@ def _is_sensor_a_binary_sensor(isy_data: IsyData, node: Group | Node) -> bool:
     return False
 
 
+def _add_backlight_if_supported(isy_data: IsyData, node: Node) -> None:
+    """Check if a node supports setting a backlight and add entity."""
+    if not getattr(node, "is_backlight_supported", False):
+        return
+    if BACKLIGHT_SUPPORT[node.node_def_id] == UOM_INDEX:
+        isy_data.aux_properties[Platform.SELECT].append((node, CMD_BACKLIGHT))
+        return
+    isy_data.aux_properties[Platform.NUMBER].append((node, CMD_BACKLIGHT))
+
+
 def _generate_device_info(node: Node) -> DeviceInfo:
     """Generate the device info for a root node device."""
     isy = node.isy
@@ -336,6 +349,7 @@ def _categorize_nodes(
                     isy_data.aux_properties[Platform.SENSOR].append((node, control))
                     platform = NODE_AUX_FILTERS[control]
                     isy_data.aux_properties[platform].append((node, control))
+            _add_backlight_if_supported(isy_data, node)
 
         if node.protocol == PROTO_GROUP:
             isy_data.nodes[ISY_GROUP_PLATFORM].append(node)

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,13 +3,8 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": [
-    "pyisy==3.1.7"
-  ],
-  "codeowners": [
-    "@bdraco",
-    "@shbatm"
-  ],
+  "requirements": ["pyisy==3.1.7"],
+  "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [
     {
@@ -35,7 +30,5 @@
     }
   ],
   "iot_class": "local_push",
-  "loggers": [
-    "pyisy"
-  ]
+  "loggers": ["pyisy"]
 }

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,7 +3,7 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.1.7"],
+  "requirements": ["pyisy==3.1.8"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,8 +3,13 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.1.6"],
-  "codeowners": ["@bdraco", "@shbatm"],
+  "requirements": [
+    "pyisy==3.1.7"
+  ],
+  "codeowners": [
+    "@bdraco",
+    "@shbatm"
+  ],
   "config_flow": true,
   "ssdp": [
     {
@@ -30,5 +35,7 @@
     }
   ],
   "iot_class": "local_push",
-  "loggers": ["pyisy"]
+  "loggers": [
+    "pyisy"
+  ]
 }

--- a/homeassistant/components/isy994/number.py
+++ b/homeassistant/components/isy994/number.py
@@ -247,7 +247,7 @@ class ISYBacklightNumberEntity(ISYAuxControlEntity, RestoreNumber):
         description: NumberEntityDescription,
         device_info: DeviceInfo | None,
     ) -> None:
-        """Initialize the ISY Backlight Select entity."""
+        """Initialize the ISY Backlight number entity."""
         super().__init__(node, control, unique_id, description, device_info)
         self._attr_native_value = 0
 

--- a/homeassistant/components/isy994/select.py
+++ b/homeassistant/components/isy994/select.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 from typing import cast
 
 from pyisy.constants import (
+    BACKLIGHT_INDEX,
+    CMD_BACKLIGHT,
     COMMAND_FRIENDLY_NAME,
     INSTEON_RAMP_RATES,
     ISY_VALUE_UNKNOWN,
     PROP_RAMP_RATE,
+    UOM_INDEX as ISY_UOM_INDEX,
     UOM_TO_STATES,
 )
 from pyisy.helpers import NodeProperty
+from pyisy.nodes import Node
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform, UnitOfTime
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import _LOGGER, DOMAIN, UOM_INDEX
 from .entity import ISYAuxControlEntity
@@ -43,21 +49,26 @@ async def async_setup_entry(
     isy_data: IsyData = hass.data[DOMAIN][config_entry.entry_id]
     isy = isy_data.root
     device_info = isy_data.devices
-    entities: list[ISYAuxControlIndexSelectEntity | ISYRampRateSelectEntity] = []
+    entities: list[
+        ISYAuxControlIndexSelectEntity
+        | ISYRampRateSelectEntity
+        | ISYBacklightSelectEntity
+    ] = []
 
     for node, control in isy_data.aux_properties[Platform.SELECT]:
         name = COMMAND_FRIENDLY_NAME.get(control, control).replace("_", " ").title()
         if node.address != node.primary_node:
             name = f"{node.name} {name}"
 
-        node_prop: NodeProperty = node.aux_properties[control]
-
         options = []
         if control == PROP_RAMP_RATE:
             options = RAMP_RATE_OPTIONS
-        if node_prop.uom == UOM_INDEX:
-            if options_dict := UOM_TO_STATES.get(node_prop.uom):
-                options = list(options_dict.values())
+        elif control == CMD_BACKLIGHT:
+            options = BACKLIGHT_INDEX
+        else:
+            if uom := node.aux_properties[control].uom == UOM_INDEX:
+                if options_dict := UOM_TO_STATES.get(uom):
+                    options = list(options_dict.values())
 
         description = SelectEntityDescription(
             key=f"{node.address}_{control}",
@@ -75,6 +86,9 @@ async def async_setup_entry(
 
         if control == PROP_RAMP_RATE:
             entities.append(ISYRampRateSelectEntity(**entity_detail))
+            continue
+        if control == CMD_BACKLIGHT:
+            entities.append(ISYBacklightSelectEntity(**entity_detail))
             continue
         if node.uom == UOM_INDEX and options:
             entities.append(ISYAuxControlIndexSelectEntity(**entity_detail))
@@ -125,3 +139,41 @@ class ISYAuxControlIndexSelectEntity(ISYAuxControlEntity, SelectEntity):
         await self._node.send_cmd(
             self._control, val=self.options.index(option), uom=node_prop.uom
         )
+
+
+class ISYBacklightSelectEntity(ISYAuxControlEntity, SelectEntity, RestoreEntity):
+    """Representation of a ISY/IoX Backlight Select entity."""
+
+    _assumed_state = True  # Backlight values aren't read from device
+
+    def __init__(
+        self,
+        node: Node,
+        control: str,
+        unique_id: str,
+        description: SelectEntityDescription,
+        device_info: DeviceInfo | None,
+    ) -> None:
+        """Initialize the ISY Backlight Select entity."""
+        super().__init__(node, control, unique_id, description, device_info)
+        self._attr_current_option = None
+
+    async def async_added_to_hass(self) -> None:
+        """Load the last known state when added to hass."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._attr_current_option = last_state.state
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+
+        if not await self._node.send_cmd(
+            CMD_BACKLIGHT, val=BACKLIGHT_INDEX.index(option), uom=ISY_UOM_INDEX
+        ):
+            raise HomeAssistantError(
+                f"Could not set backlight to {option} for {self._node.address}"
+            )
+        self._attr_current_option = option
+        self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.7
+pyisy==3.1.8
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1696,7 +1696,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.6
+pyisy==3.1.7
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1215,7 +1215,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.7
+pyisy==3.1.8
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1215,7 +1215,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.6
+pyisy==3.1.7
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for setting backlight brightness on supported [Insteon Devices](https://github.com/automicus/PyISY/blob/v3.x.x/pyisy/constants.py#L992) with `number` and `select` entities depending on device type.

PyISY bump to 3.1.8 is to support the changes in this PR, no other changes made:

  - Pick up constants definitions and `is_backlight_supported` parameter (added @ 3.1.7)
  - Add ability to listen to device memory write events from the ISY to pick up external backlight changes.
  - https://github.com/automicus/PyISY/compare/v3.1.6...v3.1.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25786

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
