### PR TITLE
Remove WebOS TV client wrapper

### DIFF
--- a/homeassistant/components/webostv/device_trigger.py
+++ b/homeassistant/components/webostv/device_trigger.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.typing import ConfigType
 from . import trigger
 from .const import DOMAIN
 from .helpers import (
-    async_get_client_wrapper_by_device_entry,
+    async_get_client_by_device_entry,
     async_get_device_entry_by_device_id,
 )
 from .triggers.turn_on import (
@@ -43,7 +43,7 @@ async def async_validate_trigger_config(
         try:
             device = async_get_device_entry_by_device_id(hass, device_id)
             if DOMAIN in hass.data:
-                async_get_client_wrapper_by_device_entry(hass, device)
+                async_get_client_by_device_entry(hass, device)
         except ValueError as err:
             raise InvalidDeviceAutomationConfig(err) from err
 

--- a/homeassistant/components/webostv/diagnostics.py
+++ b/homeassistant/components/webostv/diagnostics.py
@@ -27,7 +27,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    client: WebOsClient = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id].client
+    client: WebOsClient = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
 
     client_data = {
         "is_registered": client.is_registered(),

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -1,11 +1,13 @@
 """Helper functions for webOS Smart TV."""
 from __future__ import annotations
 
+from aiowebostv import WebOsClient
+
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from . import WebOsClientWrapper, async_control_connect
+from . import async_control_connect
 from .const import DATA_CONFIG_ENTRY, DOMAIN, LIVE_TV_APP_ID, WEBOSTV_EXCEPTIONS
 
 
@@ -46,25 +48,24 @@ def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> s
 
 
 @callback
-def async_get_client_wrapper_by_device_entry(
+def async_get_client_by_device_entry(
     hass: HomeAssistant, device: DeviceEntry
-) -> WebOsClientWrapper:
+) -> WebOsClient:
     """
-    Get WebOsClientWrapper from Device Registry by device entry.
+    Get WebOsClient from Device Registry by device entry.
 
-    Raises ValueError if client wrapper is not found.
+    Raises ValueError if client is not found.
     """
     for config_entry_id in device.config_entries:
-        wrapper: WebOsClientWrapper | None
-        if wrapper := hass.data[DOMAIN][DATA_CONFIG_ENTRY].get(config_entry_id):
+        if client := hass.data[DOMAIN][DATA_CONFIG_ENTRY].get(config_entry_id):
             break
 
-    if not wrapper:
+    if not client:
         raise ValueError(
             f"Device {device.id} is not from an existing {DOMAIN} config entry"
         )
 
-    return wrapper
+    return client
 
 
 async def async_get_sources(host: str, key: str) -> list[str]:

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -39,7 +39,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.trigger import PluggableAction
 
-from . import WebOsClientWrapper
 from .const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
@@ -83,9 +82,9 @@ async def async_setup_entry(
     assert unique_id
     name = config_entry.title
     sources = config_entry.options.get(CONF_SOURCES)
-    wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
 
-    async_add_entities([LgWebOSMediaPlayerEntity(wrapper, name, sources, unique_id)])
+    async_add_entities([LgWebOSMediaPlayerEntity(client, name, sources, unique_id)])
 
 
 _T = TypeVar("_T", bound="LgWebOSMediaPlayerEntity")
@@ -126,14 +125,13 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
     def __init__(
         self,
-        wrapper: WebOsClientWrapper,
+        client: WebOsClient,
         name: str,
         sources: list[str] | None,
         unique_id: str,
     ) -> None:
         """Initialize the webos device."""
-        self._wrapper = wrapper
-        self._client: WebOsClient = wrapper.client
+        self._client = client
         self._attr_assumed_state = True
         self._attr_name = name
         self._attr_unique_id = unique_id

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -26,9 +26,7 @@ async def async_get_service(
     if discovery_info is None:
         return None
 
-    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        discovery_info[ATTR_CONFIG_ENTRY_ID]
-    ].client
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][discovery_info[ATTR_CONFIG_ENTRY_ID]]
 
     return LgWebOSNotificationService(client)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`WebOsClientWrapper` class was used to connect between a the webOS client and a trigger action.
webOS TV plugable actions moved to core in https://github.com/home-assistant/core/pull/81900 and the `WebOsClientWrapper` class is not needed anymore.

Cleanup the code by directly storing and accessing the client.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
