### PR TITLE
Adjust invalid test values in tcp

### DIFF
--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -18,8 +18,8 @@ TEST_CONFIG = {
         tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT + 1,
         tcp.CONF_PAYLOAD: "test_payload",
         tcp.CONF_UNIT_OF_MEASUREMENT: "test_unit",
-        tcp.CONF_VALUE_TEMPLATE: "{{ 'test_' + value }}",
-        tcp.CONF_VALUE_ON: "test_on",
+        tcp.CONF_VALUE_TEMPLATE: "{{ '7.' + value }}",
+        tcp.CONF_VALUE_ON: "7.on",
         tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE + 1,
     }
 }
@@ -35,7 +35,7 @@ KEYS_AND_DEFAULTS = {
     tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE,
 }
 
-socket_test_value = "value"
+socket_test_value = "123"
 
 
 @pytest.fixture(name="mock_socket")
@@ -64,7 +64,7 @@ def mock_ssl_context_fixture():
         "homeassistant.components.tcp.common.ssl.create_default_context",
     ) as mock_ssl_context:
         mock_ssl_context.return_value.wrap_socket.return_value.recv.return_value = (
-            socket_test_value + "_ssl"
+            socket_test_value + "567"
         ).encode()
         yield mock_ssl_context
 
@@ -93,7 +93,7 @@ async def test_state(hass, mock_socket, mock_select):
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    assert state.state == "test_value"
+    assert state.state == "7.123"
     assert (
         state.attributes["unit_of_measurement"]
         == SENSOR_TEST_CONFIG[tcp.CONF_UNIT_OF_MEASUREMENT]
@@ -125,7 +125,7 @@ async def test_config_uses_defaults(hass, mock_socket):
     state = hass.states.get("sensor.tcp_sensor")
 
     assert state
-    assert state.state == "value"
+    assert state.state == "123"
 
     for key, default in KEYS_AND_DEFAULTS.items():
         assert result_config["sensor"][0].get(key) == default
@@ -184,7 +184,7 @@ async def test_ssl_state(hass, mock_socket, mock_select, mock_ssl_context):
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    assert state.state == "test_value_ssl"
+    assert state.state == "7.123567"
     assert mock_socket.connect.called
     assert mock_socket.connect.call_args == call(
         (SENSOR_TEST_CONFIG["host"], SENSOR_TEST_CONFIG["port"])
@@ -216,7 +216,7 @@ async def test_ssl_state_verify_off(hass, mock_socket, mock_select, mock_ssl_con
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    assert state.state == "test_value_ssl"
+    assert state.state == "7.123567"
     assert mock_socket.connect.called
     assert mock_socket.connect.call_args == call(
         (SENSOR_TEST_CONFIG["host"], SENSOR_TEST_CONFIG["port"])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted whilst working on sensor validation in #85605

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
