### PR TITLE
Adjust invalid test values in rest

### DIFF
--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -182,7 +182,9 @@ async def test_setup_duplicate_resource_template(hass: HomeAssistant) -> None:
 @respx.mock
 async def test_setup_get(hass: HomeAssistant) -> None:
     """Test setup with valid configuration."""
-    respx.get("http://localhost").respond(status_code=HTTPStatus.OK, json={})
+    respx.get("http://localhost").respond(
+        status_code=HTTPStatus.OK, json={"key": "123"}
+    )
     assert await async_setup_component(
         hass,
         "sensor",
@@ -210,7 +212,7 @@ async def test_setup_get(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(hass.states.async_all("sensor")) == 1
 
-    assert hass.states.get("sensor.foo").state == ""
+    assert hass.states.get("sensor.foo").state == "123"
     await hass.services.async_call(
         "homeassistant",
         SERVICE_UPDATE_ENTITY,
@@ -219,7 +221,7 @@ async def test_setup_get(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     state = hass.states.get("sensor.foo")
-    assert state.state == ""
+    assert state.state == "123"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
@@ -325,7 +327,9 @@ async def test_setup_get_templated_headers_params(hass: HomeAssistant) -> None:
 @respx.mock
 async def test_setup_get_digest_auth(hass: HomeAssistant) -> None:
     """Test setup with valid configuration."""
-    respx.get("http://localhost").respond(status_code=HTTPStatus.OK, json={})
+    respx.get("http://localhost").respond(
+        status_code=HTTPStatus.OK, json={"key": "123"}
+    )
     assert await async_setup_component(
         hass,
         "sensor",
@@ -354,7 +358,9 @@ async def test_setup_get_digest_auth(hass: HomeAssistant) -> None:
 @respx.mock
 async def test_setup_post(hass: HomeAssistant) -> None:
     """Test setup with valid configuration."""
-    respx.post("http://localhost").respond(status_code=HTTPStatus.OK, json={})
+    respx.post("http://localhost").respond(
+        status_code=HTTPStatus.OK, json={"key": "123"}
+    )
     assert await async_setup_component(
         hass,
         "sensor",
@@ -386,7 +392,7 @@ async def test_setup_get_xml(hass: HomeAssistant) -> None:
     respx.get("http://localhost").respond(
         status_code=HTTPStatus.OK,
         headers={"content-type": "text/xml"},
-        content="<dog>abc</dog>",
+        content="<dog>123</dog>",
     )
     assert await async_setup_component(
         hass,
@@ -408,7 +414,7 @@ async def test_setup_get_xml(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
-    assert state.state == "abc"
+    assert state.state == "123"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfInformation.MEGABYTES
 
 
@@ -438,7 +444,7 @@ async def test_update_with_json_attrs(hass: HomeAssistant) -> None:
 
     respx.get("http://localhost").respond(
         status_code=HTTPStatus.OK,
-        json={"key": "some_json_value"},
+        json={"key": "123", "other_key": "some_json_value"},
     )
     assert await async_setup_component(
         hass,
@@ -449,7 +455,7 @@ async def test_update_with_json_attrs(hass: HomeAssistant) -> None:
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.key }}",
-                "json_attributes": ["key"],
+                "json_attributes": ["other_key"],
                 "name": "foo",
                 "unit_of_measurement": UnitOfInformation.MEGABYTES,
                 "verify_ssl": "true",
@@ -461,8 +467,8 @@ async def test_update_with_json_attrs(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
-    assert state.state == "some_json_value"
-    assert state.attributes["key"] == "some_json_value"
+    assert state.state == "123"
+    assert state.attributes["other_key"] == "some_json_value"
 
 
 @respx.mock
@@ -483,7 +489,6 @@ async def test_update_with_no_template(hass: HomeAssistant) -> None:
                 "method": "GET",
                 "json_attributes": ["key"],
                 "name": "foo",
-                "unit_of_measurement": UnitOfInformation.MEGABYTES,
                 "verify_ssl": "true",
                 "timeout": 30,
                 "headers": {"Accept": "text/xml"},
@@ -556,7 +561,6 @@ async def test_update_with_json_attrs_not_dict(
                 "value_template": "{{ value_json.key }}",
                 "json_attributes": ["key"],
                 "name": "foo",
-                "unit_of_measurement": UnitOfInformation.MEGABYTES,
                 "verify_ssl": "true",
                 "timeout": 30,
                 "headers": {"Accept": "text/xml"},
@@ -568,7 +572,7 @@ async def test_update_with_json_attrs_not_dict(
 
     state = hass.states.get("sensor.foo")
     assert state.state == ""
-    assert state.attributes == {"unit_of_measurement": "MB", "friendly_name": "foo"}
+    assert state.attributes == {"friendly_name": "foo"}
     assert "not a dictionary or list" in caplog.text
 
 
@@ -618,7 +622,7 @@ async def test_update_with_json_attrs_with_json_attrs_path(hass: HomeAssistant) 
         status_code=HTTPStatus.OK,
         json={
             "toplevel": {
-                "master_value": "master",
+                "master_value": "123",
                 "second_level": {
                     "some_json_key": "some_json_value",
                     "some_json_key2": "some_json_value2",
@@ -649,7 +653,7 @@ async def test_update_with_json_attrs_with_json_attrs_path(hass: HomeAssistant) 
     assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
-    assert state.state == "master"
+    assert state.state == "123"
     assert state.attributes["some_json_key"] == "some_json_value"
     assert state.attributes["some_json_key2"] == "some_json_value2"
 
@@ -663,7 +667,7 @@ async def test_update_with_xml_convert_json_attrs_with_json_attrs_path(
     respx.get("http://localhost").respond(
         status_code=HTTPStatus.OK,
         headers={"content-type": "text/xml"},
-        content="<toplevel><master_value>master</master_value><second_level><some_json_key>some_json_value</some_json_key><some_json_key2>some_json_value2</some_json_key2></second_level></toplevel>",
+        content="<toplevel><master_value>123</master_value><second_level><some_json_key>some_json_value</some_json_key><some_json_key2>some_json_value2</some_json_key2></second_level></toplevel>",
     )
     assert await async_setup_component(
         hass,
@@ -687,7 +691,7 @@ async def test_update_with_xml_convert_json_attrs_with_json_attrs_path(
     assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
-    assert state.state == "master"
+    assert state.state == "123"
     assert state.attributes["some_json_key"] == "some_json_value"
     assert state.attributes["some_json_key2"] == "some_json_value2"
 
@@ -701,7 +705,7 @@ async def test_update_with_xml_convert_json_attrs_with_jsonattr_template(
     respx.get("http://localhost").respond(
         status_code=HTTPStatus.OK,
         headers={"content-type": "text/xml"},
-        content='<?xml version="1.0" encoding="utf-8"?><response><scan>0</scan><ver>12556</ver><count>48</count><ssid>alexander</ssid><bss><valid>0</valid><name>0</name><privacy>0</privacy><wlan>bogus</wlan><strength>0</strength></bss><led0>0</led0><led1>0</led1><led2>0</led2><led3>0</led3><led4>0</led4><led5>0</led5><led6>0</led6><led7>0</led7><btn0>up</btn0><btn1>up</btn1><btn2>up</btn2><btn3>up</btn3><pot0>0</pot0><usr0>0</usr0><temp0>0x0XF0x0XF</temp0><time0> 0</time0></response>',
+        content='<?xml version="1.0" encoding="utf-8"?><response><scan>0</scan><ver>12556</ver><count>48</count><ssid>alexander</ssid><bss><valid>0</valid><name>0</name><privacy>0</privacy><wlan>123</wlan><strength>0</strength></bss><led0>0</led0><led1>0</led1><led2>0</led2><led3>0</led3><led4>0</led4><led5>0</led5><led6>0</led6><led7>0</led7><btn0>up</btn0><btn1>up</btn1><btn2>up</btn2><btn3>up</btn3><pot0>0</pot0><usr0>0</usr0><temp0>0x0XF0x0XF</temp0><time0> 0</time0></response>',
     )
     assert await async_setup_component(
         hass,
@@ -725,7 +729,7 @@ async def test_update_with_xml_convert_json_attrs_with_jsonattr_template(
     assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
-    assert state.state == "bogus"
+    assert state.state == "123"
     assert state.attributes["led0"] == "0"
     assert state.attributes["led1"] == "0"
     assert state.attributes["temp0"] == "0x0XF0x0XF"
@@ -906,7 +910,7 @@ async def test_entity_config(hass: HomeAssistant) -> None:
         },
     }
 
-    respx.get("http://localhost") % HTTPStatus.OK
+    respx.get("http://localhost").respond(status_code=HTTPStatus.OK, text="123")
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
@@ -914,7 +918,7 @@ async def test_entity_config(hass: HomeAssistant) -> None:
     assert entity_registry.async_get("sensor.rest_sensor").unique_id == "very_unique"
 
     state = hass.states.get("sensor.rest_sensor")
-    assert state.state == ""
+    assert state.state == "123"
     assert state.attributes == {
         "device_class": "temperature",
         "entity_picture": "blabla.png",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted whilst working on sensor validation in #85605

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
