### PR TITLE
Automatically set up HomeWizard during onboarding

### DIFF
--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -10,7 +10,7 @@ from homewizard_energy.errors import DisabledError, RequestError, UnsupportedErr
 from homewizard_energy.models import Device
 from voluptuous import Required, Schema
 
-from homeassistant.components import zeroconf
+from homeassistant.components import onboarding, zeroconf
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
@@ -113,7 +113,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Confirm discovery."""
         errors: dict[str, str] | None = None
-        if user_input is not None:
+        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             try:
                 await self._async_try_connect(self.discovery.ip)
             except RecoverableError as ex:

--- a/tests/components/homewizard/conftest.py
+++ b/tests/components/homewizard/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for HomeWizard integration tests."""
+from collections.abc import Generator
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homewizard_energy.features import Features
 from homewizard_energy.models import Data, Device, State, System
@@ -80,3 +81,13 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+@pytest.fixture
+def mock_onboarding() -> Generator[MagicMock, None, None]:
+    """Mock that Home Assistant is currently onboarding."""
+    with patch(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        return_value=False,
+    ) as mock_onboarding:
+        yield mock_onboarding

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -192,8 +192,9 @@ async def test_discovery_flow_during_onboarding_disabled_api(
     assert result["step_id"] == "discovery_confirm"
     assert result["errors"] == {"base": "api_not_enabled"}
 
-    # User enabled API again and picks up from discovery/config flow
+    # We are onboarded, user enabled API again and picks up from discovery/config flow
     device.device.side_effect = None
+    mock_onboarding.return_value = True
 
     with patch(
         "homeassistant.components.homewizard.async_setup_entry",

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the homewizard config flow."""
-import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from homewizard_energy.errors import DisabledError, RequestError, UnsupportedError
 
@@ -13,8 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from .generator import get_mock_device
 
 from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_manual_flow_works(hass, aioclient_mock):
@@ -110,6 +108,49 @@ async def test_discovery_flow_works(hass, aioclient_mock):
 
     assert result["result"]
     assert result["result"].unique_id == "HWE-P1_aabbccddeeff"
+
+
+async def test_discovery_flow_during_onboarding(
+    hass, aioclient_mock: AiohttpClientMocker, mock_onboarding: MagicMock
+) -> None:
+    """Test discovery setup flow during onboarding."""
+
+    with patch(
+        "homeassistant.components.homewizard.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.homewizard.config_flow.HomeWizardEnergy",
+        return_value=get_mock_device(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=zeroconf.ZeroconfServiceInfo(
+                host="192.168.43.183",
+                addresses=["192.168.43.183"],
+                port=80,
+                hostname="p1meter-ddeeff.local.",
+                type="mock_type",
+                name="mock_name",
+                properties={
+                    "api_enabled": "1",
+                    "path": "/api/v1",
+                    "product_name": "P1 meter",
+                    "product_type": "HWE-P1",
+                    "serial": "aabbccddeeff",
+                },
+            ),
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "P1 meter (aabbccddeeff)"
+    assert result["data"][CONF_IP_ADDRESS] == "192.168.43.183"
+
+    assert result["result"]
+    assert result["result"].unique_id == "HWE-P1_aabbccddeeff"
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_onboarding.mock_calls) == 1
 
 
 async def test_discovery_disabled_api(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adjusts the HomeWizard integration to automatically set up HomeWizard devices in Home Assistant when onboarding Home Assistant for the first time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
