### PR TITLE
Code cleanup in litterrobot

### DIFF
--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -8,18 +8,14 @@ from typing import Any, Generic
 
 from pylitterbot import FeederRobot, LitterRobot3
 
-from homeassistant.components.button import (
-    DOMAIN as PLATFORM,
-    ButtonEntity,
-    ButtonEntityDescription,
-)
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import LitterRobotEntity, _RobotT, async_update_unique_id
+from .entity import LitterRobotEntity, _RobotT
 from .hub import LitterRobotHub
 
 
@@ -47,7 +43,6 @@ async def async_setup_entry(
             ),
         )
     )
-    async_update_unique_id(hass, PLATFORM, entities)
     async_add_entities(entities)
 
 
@@ -65,7 +60,7 @@ class RobotButtonEntityDescription(ButtonEntityDescription, RequiredKeysMixin[_R
 
 LITTER_ROBOT_BUTTON = RobotButtonEntityDescription[LitterRobot3](
     key="reset_waste_drawer",
-    name="Reset Waste Drawer",
+    name="Reset waste drawer",
     icon="mdi:delete-variant",
     entity_category=EntityCategory.CONFIG,
     press_fn=lambda robot: robot.reset_waste_drawer(),

--- a/homeassistant/components/litterrobot/entity.py
+++ b/homeassistant/components/litterrobot/entity.py
@@ -1,15 +1,12 @@
 """Litter-Robot entities for common data and methods."""
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Generic, TypeVar
 
 from pylitterbot import Robot
 from pylitterbot.robot import EVENT_UPDATE
 
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
-import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -37,9 +34,6 @@ class LitterRobotEntity(
         self.hub = hub
         self.entity_description = description
         self._attr_unique_id = f"{self.robot.serial}-{description.key}"
-        # The following can be removed in 2022.12 after adjusting names in entities appropriately
-        if description.name is not None:
-            self._attr_name = description.name.capitalize()
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -57,18 +51,3 @@ class LitterRobotEntity(
         """Set up a listener for the entity."""
         await super().async_added_to_hass()
         self.async_on_remove(self.robot.on(EVENT_UPDATE, self.async_write_ha_state))
-
-
-def async_update_unique_id(
-    hass: HomeAssistant, domain: str, entities: Iterable[LitterRobotEntity[_RobotT]]
-) -> None:
-    """Update unique ID to be based on entity description key instead of name.
-
-    Introduced with release 2022.9.
-    """
-    ent_reg = er.async_get(hass)
-    for entity in entities:
-        old_unique_id = f"{entity.robot.serial}-{entity.entity_description.name}"
-        if entity_id := ent_reg.async_get_entity_id(domain, DOMAIN, old_unique_id):
-            new_unique_id = f"{entity.robot.serial}-{entity.entity_description.key}"
-            ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -8,11 +8,7 @@ from typing import Any, Generic, TypeVar
 
 from pylitterbot import FeederRobot, LitterRobot
 
-from homeassistant.components.select import (
-    DOMAIN as PLATFORM,
-    SelectEntity,
-    SelectEntityDescription,
-)
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
@@ -20,7 +16,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import LitterRobotEntity, _RobotT, async_update_unique_id
+from .entity import LitterRobotEntity, _RobotT
 from .hub import LitterRobotHub
 
 _CastTypeT = TypeVar("_CastTypeT", int, float)
@@ -46,7 +42,7 @@ class RobotSelectEntityDescription(
 
 LITTER_ROBOT_SELECT = RobotSelectEntityDescription[LitterRobot, int](
     key="cycle_delay",
-    name="Clean Cycle Wait Time Minutes",
+    name="Clean cycle wait time minutes",
     icon="mdi:timer-outline",
     unit_of_measurement=UnitOfTime.MINUTES,
     current_fn=lambda robot: robot.clean_cycle_wait_time_minutes,
@@ -83,7 +79,6 @@ async def async_setup_entry(
             ),
         )
     )
-    async_update_unique_id(hass, PLATFORM, entities)
     async_add_entities(entities)
 
 

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -9,7 +9,6 @@ from typing import Any, Generic, Union, cast
 from pylitterbot import FeederRobot, LitterRobot, LitterRobot4, Robot
 
 from homeassistant.components.sensor import (
-    DOMAIN as PLATFORM,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -22,7 +21,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import LitterRobotEntity, _RobotT, async_update_unique_id
+from .entity import LitterRobotEntity, _RobotT
 from .hub import LitterRobotHub
 
 
@@ -71,32 +70,32 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
     LitterRobot: [
         RobotSensorEntityDescription[LitterRobot](
             key="waste_drawer_level",
-            name="Waste Drawer",
+            name="Waste drawer",
             native_unit_of_measurement=PERCENTAGE,
             icon_fn=lambda state: icon_for_gauge_level(state, 10),
             state_class=SensorStateClass.MEASUREMENT,
         ),
         RobotSensorEntityDescription[LitterRobot](
             key="sleep_mode_start_time",
-            name="Sleep Mode Start Time",
+            name="Sleep mode start time",
             device_class=SensorDeviceClass.TIMESTAMP,
             should_report=lambda robot: robot.sleep_mode_enabled,
         ),
         RobotSensorEntityDescription[LitterRobot](
             key="sleep_mode_end_time",
-            name="Sleep Mode End Time",
+            name="Sleep mode end time",
             device_class=SensorDeviceClass.TIMESTAMP,
             should_report=lambda robot: robot.sleep_mode_enabled,
         ),
         RobotSensorEntityDescription[LitterRobot](
             key="last_seen",
-            name="Last Seen",
+            name="Last seen",
             device_class=SensorDeviceClass.TIMESTAMP,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         RobotSensorEntityDescription[LitterRobot](
             key="status_code",
-            name="Status Code",
+            name="Status code",
             translation_key="status_code",
             entity_category=EntityCategory.DIAGNOSTIC,
             device_class=SensorDeviceClass.ENUM,
@@ -171,5 +170,4 @@ async def async_setup_entry(
         if isinstance(robot, robot_type)
         for description in entity_descriptions
     ]
-    async_update_unique_id(hass, PLATFORM, entities)
     async_add_entities(entities)

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -7,18 +7,14 @@ from typing import Any, Generic, Union
 
 from pylitterbot import FeederRobot, LitterRobot
 
-from homeassistant.components.switch import (
-    DOMAIN as PLATFORM,
-    SwitchEntity,
-    SwitchEntityDescription,
-)
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import LitterRobotEntity, _RobotT, async_update_unique_id
+from .entity import LitterRobotEntity, _RobotT
 from .hub import LitterRobotHub
 
 
@@ -40,13 +36,13 @@ class RobotSwitchEntityDescription(SwitchEntityDescription, RequiredKeysMixin[_R
 ROBOT_SWITCHES = [
     RobotSwitchEntityDescription[Union[LitterRobot, FeederRobot]](
         key="night_light_mode_enabled",
-        name="Night Light Mode",
+        name="Night light mode",
         icons=("mdi:lightbulb-on", "mdi:lightbulb-off"),
         set_fn=lambda robot, value: robot.set_night_light(value),
     ),
     RobotSwitchEntityDescription[Union[LitterRobot, FeederRobot]](
         key="panel_lock_enabled",
-        name="Panel Lockout",
+        name="Panel lockout",
         icons=("mdi:lock", "mdi:lock-open"),
         set_fn=lambda robot, value: robot.set_panel_lockout(value),
     ),
@@ -91,5 +87,4 @@ async def async_setup_entry(
         for robot in hub.account.robots
         if isinstance(robot, (LitterRobot, FeederRobot))
     ]
-    async_update_unique_id(hass, PLATFORM, entities)
     async_add_entities(entities)

--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -36,10 +36,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up Litter-Robot update platform."""
     hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
-    robots = hub.account.robots
     entities = [
         RobotUpdateEntity(robot=robot, hub=hub, description=FIRMWARE_UPDATE_ENTITY)
-        for robot in robots
+        for robot in hub.litter_robots()
         if isinstance(robot, LitterRobot4)
     ]
     async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -9,7 +9,6 @@ from pylitterbot.enums import LitterBoxStatus
 import voluptuous as vol
 
 from homeassistant.components.vacuum import (
-    DOMAIN as PLATFORM,
     STATE_CLEANING,
     STATE_DOCKED,
     STATE_ERROR,
@@ -26,7 +25,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
-from .entity import LitterRobotEntity, async_update_unique_id
+from .entity import LitterRobotEntity
 from .hub import LitterRobotHub
 
 SERVICE_SET_SLEEP_MODE = "set_sleep_mode"
@@ -43,7 +42,7 @@ LITTER_BOX_STATUS_STATE_MAP = {
     LitterBoxStatus.OFF: STATE_OFF,
 }
 
-LITTER_BOX_ENTITY = StateVacuumEntityDescription("litter_box", name="Litter Box")
+LITTER_BOX_ENTITY = StateVacuumEntityDescription("litter_box", name="Litter box")
 
 
 async def async_setup_entry(
@@ -53,12 +52,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Litter-Robot cleaner using config entry."""
     hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
-
     entities = [
         LitterRobotCleaner(robot=robot, hub=hub, description=LITTER_BOX_ENTITY)
         for robot in hub.litter_robots()
     ]
-    async_update_unique_id(hass, PLATFORM, entities)
     async_add_entities(entities)
 
     platform = entity_platform.async_get_current_platform()

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -24,8 +24,7 @@ import homeassistant.helpers.entity_registry as er
 from .common import VACUUM_ENTITY_ID
 from .conftest import setup_integration
 
-VACUUM_UNIQUE_ID_OLD = "LR3C012345-Litter Box"
-VACUUM_UNIQUE_ID_NEW = "LR3C012345-litter_box"
+VACUUM_UNIQUE_ID = "LR3C012345-litter_box"
 
 COMPONENT_SERVICE_DOMAIN = {
     SERVICE_SET_SLEEP_MODE: DOMAIN,
@@ -36,15 +35,14 @@ async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
     """Tests the vacuum entity was set up."""
     ent_reg = er.async_get(hass)
 
-    # Create entity entry to migrate to new unique ID
     ent_reg.async_get_or_create(
         PLATFORM_DOMAIN,
         DOMAIN,
-        VACUUM_UNIQUE_ID_OLD,
+        VACUUM_UNIQUE_ID,
         suggested_object_id=VACUUM_ENTITY_ID.replace(PLATFORM_DOMAIN, ""),
     )
     ent_reg_entry = ent_reg.async_get(VACUUM_ENTITY_ID)
-    assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID_OLD
+    assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID
 
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
     assert len(ent_reg.entities) == 1
@@ -56,7 +54,7 @@ async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
     assert vacuum.attributes["is_sleeping"] is False
 
     ent_reg_entry = ent_reg.async_get(VACUUM_ENTITY_ID)
-    assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID_NEW
+    assert ent_reg_entry.unique_id == VACUUM_UNIQUE_ID
 
 
 async def test_vacuum_status_when_sleeping(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove old entity id migration code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
