### PR TITLE
Fix Matter unique_id generation

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, cast
 
 from chip.clusters import Objects as all_clusters
 from matter_server.common.models.events import EventType
-from matter_server.common.models.node_device import AbstractMatterNodeDevice
+from matter_server.common.models.node_device import (
+    AbstractMatterNodeDevice,
+    MatterBridgedNodeDevice,
+)
 from matter_server.common.models.server_information import ServerInfo
 
 from homeassistant.config_entries import ConfigEntry
@@ -16,7 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
 from .device_platform import DEVICE_PLATFORM
-from .helpers import get_node_unique_id
+from .helpers import get_device_id
 
 if TYPE_CHECKING:
     from matter_server.client import MatterClient
@@ -68,40 +71,49 @@ class MatterAdapter:
         bridge_unique_id: str | None = None
 
         if node.aggregator_device_type_instance is not None and (
-            node_info := node.root_device_type_instance.get_cluster(all_clusters.Basic)
+            node.root_device_type_instance.get_cluster(all_clusters.Basic)
         ):
-            self._create_device_registry(
-                node, node_info, node_info.nodeLabel or "Hub device", None
+            # create virtual (parent) device for bridge node device
+            bridge_device = MatterBridgedNodeDevice(
+                node.aggregator_device_type_instance
             )
+            self._create_device_registry(bridge_device)
             server_info = cast(ServerInfo, self.matter_client.server_info)
-            bridge_unique_id = get_node_unique_id(server_info, node, is_bridge=True)
+            bridge_unique_id = get_device_id(server_info, bridge_device)
 
         for node_device in node.node_devices:
             self._setup_node_device(node_device, bridge_unique_id)
 
     def _create_device_registry(
         self,
-        node: MatterNode,
-        info: all_clusters.Basic | all_clusters.BridgedDeviceBasic,
-        name: str,
-        bridge_unique_id: str | None,
-        is_bridge: bool = False,
+        node_device: AbstractMatterNodeDevice,
+        bridge_unique_id: str | None = None,
     ) -> None:
         """Create a device registry entry."""
         server_info = cast(ServerInfo, self.matter_client.server_info)
-        node_unique_id = get_node_unique_id(
+        node_unique_id = get_device_id(
             server_info,
-            node,
-            is_bridge=is_bridge,
+            node_device,
         )
+        basic_info = node_device.device_info()
+        device_type_instances = node_device.device_type_instances()
+
+        name = basic_info.nodeLabel
+        if not name and isinstance(node_device, MatterBridgedNodeDevice):
+            # fallback name for Bridge
+            name = "Hub device"
+        elif not name and device_type_instances:
+            # fallback name based on device type
+            name = f"{device_type_instances[0].device_type.__doc__[:-1]} {node_device.node().node_id}"
+
         dr.async_get(self.hass).async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
             identifiers={(DOMAIN, node_unique_id)},
-            hw_version=info.hardwareVersionString,
-            sw_version=info.softwareVersionString,
-            manufacturer=info.vendorName,
-            model=info.productName,
+            hw_version=basic_info.hardwareVersionString,
+            sw_version=basic_info.softwareVersionString,
+            manufacturer=basic_info.vendorName,
+            model=basic_info.productName,
             via_device=(DOMAIN, bridge_unique_id) if bridge_unique_id else None,
         )
 
@@ -109,17 +121,9 @@ class MatterAdapter:
         self, node_device: AbstractMatterNodeDevice, bridge_unique_id: str | None
     ) -> None:
         """Set up a node device."""
-        node = node_device.node()
-        basic_info = node_device.device_info()
-        device_type_instances = node_device.device_type_instances()
-
-        name = basic_info.nodeLabel
-        if not name and device_type_instances:
-            name = f"{device_type_instances[0].device_type.__doc__[:-1]} {node.node_id}"
-
-        self._create_device_registry(node, basic_info, name, bridge_unique_id)
-
-        for instance in device_type_instances:
+        self._create_device_registry(node_device, bridge_unique_id)
+        # run platform discovery from device type instances
+        for instance in node_device.device_type_instances():
             created = False
 
             for platform, devices in DEVICE_PLATFORM.items():

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -13,7 +13,7 @@ from matter_server.common.models.node_device import AbstractMatterNodeDevice
 from matter_server.common.models.server_information import ServerInfo
 
 from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 
 from .const import DOMAIN
 from .helpers import get_device_id, get_operational_instance_id
@@ -68,9 +68,9 @@ class MatterEntity(Entity):
             f"{device_type_instance.endpoint}-"
             f"{device_type_instance.device_type.device_type}"
         )
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, get_device_id(server_info, node_device))}
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, get_device_id(server_info, node_device))}
+        )
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -65,7 +65,7 @@ class MatterEntity(Entity):
         # create unique_id based on "Operational Instance Name" and endpoint/device type
         fab_id_hex = f"{server_info.compressed_fabric_id:016X}"
         node_id_hex = f"{node.node_id:016X}"
-        operational_instance_name = f"{fab_id_hex.upper()}-{node_id_hex.upper()}"
+        operational_instance_name = f"{fab_id_hex}-{node_id_hex}"
         # NOTE: use 'operational instance name' property of the node instance later
         self._attr_unique_id = (
             f"{operational_instance_name}-"

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -13,7 +13,7 @@ from matter_server.common.models.node_device import AbstractMatterNodeDevice
 from matter_server.common.models.server_information import ServerInfo
 
 from homeassistant.core import callback
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+from homeassistant.helpers.entity import Entity, EntityDescription
 
 from .const import DOMAIN
 from .helpers import get_device_id, get_operational_instance_id
@@ -68,13 +68,9 @@ class MatterEntity(Entity):
             f"{device_type_instance.endpoint}-"
             f"{device_type_instance.device_type.device_type}"
         )
-
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device info for device registry."""
-        server_info = cast(ServerInfo, self.matter_client.server_info)
-        dev_id = get_device_id(server_info, self._node_device)
-        return {"identifiers": {(DOMAIN, dev_id)}}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, get_device_id(server_info, node_device))}
+        }
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -62,9 +62,13 @@ class MatterEntity(Entity):
         server_info = matter_client.server_info
         # The server info is set when the client connects to the server.
         assert server_info is not None
+        # create unique_id based on "Operational Instance Name" and endpoint/device type
+        fab_id_hex = f"{server_info.compressed_fabric_id:016X}"
+        node_id_hex = f"{node.node_id:016X}"
+        operational_instance_name = f"{fab_id_hex.upper()}-{node_id_hex.upper()}"
+        # NOTE: use 'operational instance name' property of the node instance later
         self._attr_unique_id = (
-            f"{server_info.compressed_fabric_id}-"
-            f"{node.unique_id}-"
+            f"{operational_instance_name}-"
             f"{device_type_instance.endpoint}-"
             f"{device_type_instance.device_type.device_type}"
         )

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -59,10 +59,9 @@ class MatterEntity(Entity):
         self.entity_description = entity_description
         self._unsubscribes: list[Callable] = []
         # for fast lookups we create a mapping to the attribute paths
+        # The server info is set when the client connects to the server.
         self._attributes_map: dict[type, str] = {}
         server_info = cast(ServerInfo, self.matter_client.server_info)
-        # The server info is set when the client connects to the server.
-        assert server_info is not None
         # create unique_id based on "Operational Instance Name" and endpoint/device type
         self._attr_unique_id = (
             f"{get_operational_instance_id(server_info, self._node_device.node())}-"

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -10,6 +10,9 @@ from homeassistant.core import HomeAssistant, callback
 from .const import DOMAIN
 
 if TYPE_CHECKING:
+    from matter_server.common.models.node_device import MatterNode
+    from matter_server.common.models.server_information import ServerInfo
+
     from .adapter import MatterAdapter
 
 
@@ -29,3 +32,16 @@ def get_matter(hass: HomeAssistant) -> MatterAdapter:
     # In case of the config entry we need to fix this.
     matter_entry_data: MatterEntryData = next(iter(hass.data[DOMAIN].values()))
     return matter_entry_data.adapter
+
+
+def get_node_unique_id(
+    server_info: ServerInfo, node: MatterNode, is_bridge: bool = False
+) -> str:
+    """Return unique id for a Matter node based on `Operational Instance Name`."""
+    fab_id_hex = f"{server_info.compressed_fabric_id:016X}"
+    node_id_hex = f"{node.node_id:016X}"
+    node_unique_id = f"{fab_id_hex}-{node_id_hex}"
+    if is_bridge:
+        # create 'virtual' device(id) for a root/bridge device
+        node_unique_id += "-bridge"
+    return node_unique_id

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -40,11 +40,11 @@ def get_operational_instance_id(
     node: MatterNode,
 ) -> str:
     """Return `Operational Instance Name` for given MatterNode."""
-    fab_id_hex = f"{server_info.compressed_fabric_id:016X}"
+    fabric_id_hex = f"{server_info.compressed_fabric_id:016X}"
     node_id_hex = f"{node.node_id:016X}"
     # operational instance id matches the mdns advertisement for the node
     # this is the recommended ID to recognize a unique matter node (within a fabric)
-    return f"{fab_id_hex}-{node_id_hex}"
+    return f"{fabric_id_hex}-{node_id_hex}"
 
 
 def get_device_id(

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -27,8 +27,9 @@ async def test_device_registry_single_node_device(
     )
 
     dev_reg = dr.async_get(hass)
-
-    entry = dev_reg.async_get_device({(DOMAIN, "mock-onoff-light")})
+    entry = dev_reg.async_get_device(
+        {(DOMAIN, "00000000000004D2-0000000000000001-MatterNodeDevice")}
+    )
     assert entry is not None
 
     assert entry.name == "Mock OnOff Light"


### PR DESCRIPTION
## Breaking change
Due to the refactored unique_id generation any already paired devices will be recreated. If you had any test devices already commissioned and working in HA, best to re-add the Matter integration in HA to clear out orphan entities. 


## Proposed change
The unique_id attribute within the Basic cluster has been phased out in the V1.0 spec so it does not make sense to rely on that attribute for our unique id generation within the entity model.
There is no common identifier (like serial) we can use to detect a device inter-fabric or even after factory resets.
Instead just go with the flow and use what the specs recommend: 'Operational Instance Name'.

Our unique_id is now based on the Operational Instance Name (which is the same as the mdns name advertised by the node) together with the endpoint id and instance type.

Technically a breaking change but actually a bugfix because currently most devices that are actually available for purchase are not working.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85091 fixes #84807
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
