### PR TITLE
Add RGB, RGBW and RGBWW capability to template.light

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -454,6 +454,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 "Optimistically setting color temperature to %s",
                 kwargs[ATTR_COLOR_TEMP],
             )
+            self._color_mode = ColorMode.COLOR_TEMP
             self._temperature = kwargs[ATTR_COLOR_TEMP]
             if self._hs_template is None and self._color_template is None:
                 self._hs_color = None
@@ -474,6 +475,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 "Optimistically setting hs color to %s",
                 kwargs[ATTR_HS_COLOR],
             )
+            self._color_mode = ColorMode.HS
             self._hs_color = kwargs[ATTR_HS_COLOR]
             if self._temperature_template is None:
                 self._temperature = None
@@ -490,6 +492,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 "Optimistically setting rgb color to %s",
                 kwargs[ATTR_RGB_COLOR],
             )
+            self._color_mode = ColorMode.RGB
             self._rgb_color = kwargs[ATTR_RGB_COLOR]
             if self._temperature_template is None:
                 self._temperature = None
@@ -506,6 +509,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 "Optimistically setting rgbw color to %s",
                 kwargs[ATTR_RGBW_COLOR],
             )
+            self._color_mode = ColorMode.RGBW
             self._rgbw_color = kwargs[ATTR_RGBW_COLOR]
             if self._temperature_template is None:
                 self._temperature = None
@@ -522,6 +526,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 "Optimistically setting rgbww color to %s",
                 kwargs[ATTR_RGBWW_COLOR],
             )
+            self._color_mode = ColorMode.RGBWW
             self._rgbww_color = kwargs[ATTR_RGBWW_COLOR]
             if self._temperature_template is None:
                 self._temperature = None
@@ -549,7 +554,6 @@ class LightTemplate(TemplateEntity, LightEntity):
                 run_variables=common_params,
                 context=self._context,
             )
-            self._color_mode = ColorMode.COLOR_TEMP
         elif ATTR_EFFECT in kwargs and self._effect_script:
             effect = kwargs[ATTR_EFFECT]
             if effect not in self._effect_list:
@@ -575,7 +579,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._color_script, run_variables=common_params, context=self._context
             )
-            self._color_mode = ColorMode.HS
         elif ATTR_HS_COLOR in kwargs and self._hs_script:
             hs_value = kwargs[ATTR_HS_COLOR]
             common_params["hs"] = hs_value
@@ -585,7 +588,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._hs_script, run_variables=common_params, context=self._context
             )
-            self._color_mode = ColorMode.HS
         elif ATTR_RGBWW_COLOR in kwargs and self._rgbww_script:
             rgbww_value = kwargs[ATTR_RGBWW_COLOR]
             common_params["rgbww"] = rgbww_value
@@ -603,7 +605,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._rgbww_script, run_variables=common_params, context=self._context
             )
-            self._color_mode = ColorMode.RGBWW
         elif ATTR_RGBW_COLOR in kwargs and self._rgbw_script:
             rgbw_value = kwargs[ATTR_RGBW_COLOR]
             common_params["rgbw"] = rgbw_value
@@ -620,7 +621,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._rgbw_script, run_variables=common_params, context=self._context
             )
-            self._color_mode = ColorMode.RGBW
         elif ATTR_RGB_COLOR in kwargs and self._rgb_script:
             rgb_value = kwargs[ATTR_RGB_COLOR]
             common_params["rgb"] = rgb_value
@@ -631,7 +631,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._rgb_script, run_variables=common_params, context=self._context
             )
-            self._color_mode = ColorMode.RGB
         elif ATTR_BRIGHTNESS in kwargs and self._level_script:
             await self.async_run_script(
                 self._level_script, run_variables=common_params, context=self._context

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -11,6 +11,9 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
     ENTITY_ID_FORMAT,
     ColorMode,
@@ -46,8 +49,14 @@ from .template_entity import (
 _LOGGER = logging.getLogger(__name__)
 _VALID_STATES = [STATE_ON, STATE_OFF, "true", "false"]
 
-CONF_COLOR_ACTION = "set_color"
-CONF_COLOR_TEMPLATE = "color_template"
+CONF_HS_ACTION = "set_hs"
+CONF_HS_TEMPLATE = "hs_template"
+CONF_RGB_ACTION = "set_rgb"
+CONF_RGB_TEMPLATE = "rgb_template"
+CONF_RGBW_ACTION = "set_rgbw"
+CONF_RGBW_TEMPLATE = "rgbw_template"
+CONF_RGBWW_ACTION = "set_rgbww"
+CONF_RGBWW_TEMPLATE = "rgbww_template"
 CONF_EFFECT_ACTION = "set_effect"
 CONF_EFFECT_LIST_TEMPLATE = "effect_list_template"
 CONF_EFFECT_TEMPLATE = "effect_template"
@@ -67,8 +76,14 @@ LIGHT_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),
     vol.Schema(
         {
-            vol.Optional(CONF_COLOR_ACTION): cv.SCRIPT_SCHEMA,
-            vol.Optional(CONF_COLOR_TEMPLATE): cv.template,
+            vol.Optional(CONF_HS_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_HS_TEMPLATE): cv.template,
+            vol.Optional(CONF_RGB_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_RGB_TEMPLATE): cv.template,
+            vol.Optional(CONF_RGBW_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_RGBW_TEMPLATE): cv.template,
+            vol.Optional(CONF_RGBWW_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_RGBWW_TEMPLATE): cv.template,
             vol.Inclusive(CONF_EFFECT_ACTION, "effect"): cv.SCRIPT_SCHEMA,
             vol.Inclusive(CONF_EFFECT_LIST_TEMPLATE, "effect"): cv.template,
             vol.Inclusive(CONF_EFFECT_TEMPLATE, "effect"): cv.template,
@@ -162,10 +177,22 @@ class LightTemplate(TemplateEntity, LightEntity):
                 hass, temperature_action, friendly_name, DOMAIN
             )
         self._temperature_template = config.get(CONF_TEMPERATURE_TEMPLATE)
-        self._color_script = None
-        if (color_action := config.get(CONF_COLOR_ACTION)) is not None:
-            self._color_script = Script(hass, color_action, friendly_name, DOMAIN)
-        self._color_template = config.get(CONF_COLOR_TEMPLATE)
+        self._hs_script = None
+        if (hs_action := config.get(CONF_HS_ACTION)) is not None:
+            self._hs_script = Script(hass, hs_action, friendly_name, DOMAIN)
+        self._hs_template = config.get(CONF_HS_TEMPLATE)
+        self._rgb_script = None
+        if (rgb_action := config.get(CONF_RGB_ACTION)) is not None:
+            self._rgb_script = Script(hass, rgb_action, friendly_name, DOMAIN)
+        self._rgb_template = config.get(CONF_RGB_TEMPLATE)
+        self._rgbw_script = None
+        if (rgbw_action := config.get(CONF_RGBW_ACTION)) is not None:
+            self._rgbw_script = Script(hass, rgbw_action, friendly_name, DOMAIN)
+        self._rgbw_template = config.get(CONF_RGBW_TEMPLATE)
+        self._rgbww_script = None
+        if (rgbww_action := config.get(CONF_RGBWW_ACTION)) is not None:
+            self._rgbww_script = Script(hass, rgbww_action, friendly_name, DOMAIN)
+        self._rgbww_template = config.get(CONF_RGBWW_TEMPLATE)
         self._effect_script = None
         if (effect_action := config.get(CONF_EFFECT_ACTION)) is not None:
             self._effect_script = Script(hass, effect_action, friendly_name, DOMAIN)
@@ -178,24 +205,37 @@ class LightTemplate(TemplateEntity, LightEntity):
         self._state = False
         self._brightness = None
         self._temperature = None
-        self._color = None
+        self._hs_color = None
+        self._rgb_color = None
+        self._rgbw_color = None
+        self._rgbww_color = None
         self._effect = None
         self._effect_list = None
-        self._fixed_color_mode = None
+        self._color_mode = None
         self._max_mireds = None
         self._min_mireds = None
         self._supports_transition = False
+        self._supported_color_modes = None
 
         color_modes = {ColorMode.ONOFF}
         if self._level_script is not None:
             color_modes.add(ColorMode.BRIGHTNESS)
         if self._temperature_script is not None:
             color_modes.add(ColorMode.COLOR_TEMP)
-        if self._color_script is not None:
+        if self._hs_script is not None:
             color_modes.add(ColorMode.HS)
+        if self._rgb_script is not None:
+            color_modes.add(ColorMode.RGB)
+        if self._rgbw_script is not None:
+            color_modes.add(ColorMode.RGBW)
+        if self._rgbww_script is not None:
+            color_modes.add(ColorMode.RGBWW)
+
         self._supported_color_modes = filter_supported_color_modes(color_modes)
+        if len(self._supported_color_modes) > 1:
+            self._color_mode = ColorMode.UNKNOWN
         if len(self._supported_color_modes) == 1:
-            self._fixed_color_mode = next(iter(self._supported_color_modes))
+            self._color_mode = next(iter(self._supported_color_modes))
 
     @property
     def brightness(self) -> int | None:
@@ -226,7 +266,22 @@ class LightTemplate(TemplateEntity, LightEntity):
     @property
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hue and saturation color value [float, float]."""
-        return self._color
+        return self._hs_color
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the rgb color value."""
+        return self._rgb_color
+
+    @property
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the rgbw color value."""
+        return self._rgbw_color
+
+    @property
+    def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
+        """Return the rgbww color value."""
+        return self._rgbww_color
 
     @property
     def effect(self) -> str | None:
@@ -241,12 +296,8 @@ class LightTemplate(TemplateEntity, LightEntity):
     @property
     def color_mode(self):
         """Return current color mode."""
-        if self._fixed_color_mode:
-            return self._fixed_color_mode
-        # Support for ct + hs, prioritize hs
-        if self._color is not None:
-            return ColorMode.HS
-        return ColorMode.COLOR_TEMP
+        if self._color_mode:
+            return self._color_mode
 
     @property
     def supported_color_modes(self):
@@ -306,12 +357,36 @@ class LightTemplate(TemplateEntity, LightEntity):
                 self._update_temperature,
                 none_on_template_error=True,
             )
-        if self._color_template:
+        if self._hs_template:
             self.add_template_attribute(
-                "_color",
-                self._color_template,
+                "_hs_color",
+                self._hs_template,
                 None,
-                self._update_color,
+                self._update_hs,
+                none_on_template_error=True,
+            )
+        if self._rgb_template:
+            self.add_template_attribute(
+                "_rgb_color",
+                self._rgb_template,
+                None,
+                self._update_rgb,
+                none_on_template_error=True,
+            )
+        if self._rgbw_template:
+            self.add_template_attribute(
+                "_rgbw_color",
+                self._rgbw_template,
+                None,
+                self._update_rgbw,
+                none_on_template_error=True,
+            )
+        if self._rgbww_template:
+            self.add_template_attribute(
+                "_rgbww_color",
+                self._rgbww_template,
+                None,
+                self._update_rgbww,
                 none_on_template_error=True,
             )
         if self._effect_list_template:
@@ -340,7 +415,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             )
         await super().async_added_to_hass()
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:  # noqa: C901
         """Turn the light on."""
         optimistic_set = False
         # set optimistic states
@@ -361,18 +436,78 @@ class LightTemplate(TemplateEntity, LightEntity):
                 kwargs[ATTR_COLOR_TEMP],
             )
             self._temperature = kwargs[ATTR_COLOR_TEMP]
-            if self._color_template is None:
-                self._color = None
+            if self._hs_template is None:
+                self._hs_color = None
+            if self._rgb_template is None:
+                self._rgb_color = None
+            if self._rgbw_template is None:
+                self._rgbw_color = None
+            if self._rgbww_template is None:
+                self._rgbww_color = None
             optimistic_set = True
 
-        if self._color_template is None and ATTR_HS_COLOR in kwargs:
+        if self._hs_template is None and ATTR_HS_COLOR in kwargs:
             _LOGGER.debug(
-                "Optimistically setting color to %s",
+                "Optimistically setting hs color to %s",
                 kwargs[ATTR_HS_COLOR],
             )
-            self._color = kwargs[ATTR_HS_COLOR]
+            self._hs_color = kwargs[ATTR_HS_COLOR]
             if self._temperature_template is None:
                 self._temperature = None
+            if self._rgb_template is None:
+                self._rgb_color = None
+            if self._rgbw_template is None:
+                self._rgbw_color = None
+            if self._rgbww_template is None:
+                self._rgbww_color = None
+            optimistic_set = True
+
+        if self._rgb_template is None and ATTR_RGB_COLOR in kwargs:
+            _LOGGER.debug(
+                "Optimistically setting rgb color to %s",
+                kwargs[ATTR_RGB_COLOR],
+            )
+            self._rgb_color = kwargs[ATTR_RGB_COLOR]
+            if self._temperature_template is None:
+                self._temperature = None
+            if self._hs_template is None:
+                self._hs_color = None
+            if self._rgbw_template is None:
+                self._rgbw_color = None
+            if self._rgbww_template is None:
+                self._rgbww_color = None
+            optimistic_set = True
+
+        if self._rgbw_template is None and ATTR_RGBW_COLOR in kwargs:
+            _LOGGER.debug(
+                "Optimistically setting rgbw color to %s",
+                kwargs[ATTR_RGBW_COLOR],
+            )
+            self._rgbw_color = kwargs[ATTR_RGBW_COLOR]
+            if self._temperature_template is None:
+                self._temperature = None
+            if self._hs_template is None:
+                self._hs_color = None
+            if self._rgb_template is None:
+                self._rgb_color = None
+            if self._rgbww_template is None:
+                self._rgbww_color = None
+            optimistic_set = True
+
+        if self._rgbww_template is None and ATTR_RGBWW_COLOR in kwargs:
+            _LOGGER.debug(
+                "Optimistically setting rgbww color to %s",
+                kwargs[ATTR_RGBWW_COLOR],
+            )
+            self._rgbww_color = kwargs[ATTR_RGBWW_COLOR]
+            if self._temperature_template is None:
+                self._temperature = None
+            if self._hs_template is None:
+                self._hs_color = None
+            if self._rgb_template is None:
+                self._rgb_color = None
+            if self._rgbw_template is None:
+                self._rgbw_color = None
             optimistic_set = True
 
         common_params = {}
@@ -391,6 +526,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 run_variables=common_params,
                 context=self._context,
             )
+            self._color_mode = ColorMode.COLOR_TEMP
         elif ATTR_EFFECT in kwargs and self._effect_script:
             effect = kwargs[ATTR_EFFECT]
             if effect not in self._effect_list:
@@ -407,15 +543,62 @@ class LightTemplate(TemplateEntity, LightEntity):
             await self.async_run_script(
                 self._effect_script, run_variables=common_params, context=self._context
             )
-        elif ATTR_HS_COLOR in kwargs and self._color_script:
+        elif ATTR_HS_COLOR in kwargs and self._hs_script:
             hs_value = kwargs[ATTR_HS_COLOR]
             common_params["hs"] = hs_value
             common_params["h"] = int(hs_value[0])
             common_params["s"] = int(hs_value[1])
 
             await self.async_run_script(
-                self._color_script, run_variables=common_params, context=self._context
+                self._hs_script, run_variables=common_params, context=self._context
             )
+            self._color_mode = ColorMode.HS
+        elif ATTR_RGBWW_COLOR in kwargs and self._rgbww_script:
+            rgbww_value = kwargs[ATTR_RGBWW_COLOR]
+            common_params["rgbww"] = rgbww_value
+            common_params["rgb"] = (
+                int(rgbww_value[0]),
+                int(rgbww_value[1]),
+                int(rgbww_value[2]),
+            )
+            common_params["r"] = int(rgbww_value[0])
+            common_params["g"] = int(rgbww_value[1])
+            common_params["b"] = int(rgbww_value[2])
+            common_params["cw"] = int(rgbww_value[3])
+            common_params["ww"] = int(rgbww_value[4])
+
+            await self.async_run_script(
+                self._rgbww_script, run_variables=common_params, context=self._context
+            )
+            self._color_mode = ColorMode.RGBWW
+        elif ATTR_RGBW_COLOR in kwargs and self._rgbw_script:
+            rgbw_value = kwargs[ATTR_RGBW_COLOR]
+            common_params["rgbw"] = rgbw_value
+            common_params["rgb"] = (
+                int(rgbw_value[0]),
+                int(rgbw_value[1]),
+                int(rgbw_value[2]),
+            )
+            common_params["r"] = int(rgbw_value[0])
+            common_params["g"] = int(rgbw_value[1])
+            common_params["b"] = int(rgbw_value[2])
+            common_params["w"] = int(rgbw_value[3])
+
+            await self.async_run_script(
+                self._rgbw_script, run_variables=common_params, context=self._context
+            )
+            self._color_mode = ColorMode.RGBW
+        elif ATTR_RGB_COLOR in kwargs and self._rgb_script:
+            rgb_value = kwargs[ATTR_RGB_COLOR]
+            common_params["rgb"] = rgb_value
+            common_params["r"] = int(rgb_value[0])
+            common_params["g"] = int(rgb_value[1])
+            common_params["b"] = int(rgb_value[2])
+
+            await self.async_run_script(
+                self._rgb_script, run_variables=common_params, context=self._context
+            )
+            self._color_mode = ColorMode.RGB
         elif ATTR_BRIGHTNESS in kwargs and self._level_script:
             await self.async_run_script(
                 self._level_script, run_variables=common_params, context=self._context
@@ -567,18 +750,19 @@ class LightTemplate(TemplateEntity, LightEntity):
                 exc_info=True,
             )
             self._temperature = None
+        self._color_mode = ColorMode.COLOR_TEMP
 
     @callback
-    def _update_color(self, render):
-        """Update the hs_color from the template."""
+    def _update_hs(self, render):
+        """Update the color from the template."""
         if render is None:
-            self._color = None
+            self._hs_color = None
             return
 
         h_str = s_str = None
         if isinstance(render, str):
             if render in ("None", ""):
-                self._color = None
+                self._hs_color = None
                 return
             h_str, s_str = map(
                 float, render.replace("(", "").replace(")", "").split(",", 1)
@@ -592,7 +776,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             and 0 <= h_str <= 360
             and 0 <= s_str <= 100
         ):
-            self._color = (h_str, s_str)
+            self._hs_color = (h_str, s_str)
         elif h_str is not None and s_str is not None:
             _LOGGER.error(
                 (
@@ -603,12 +787,143 @@ class LightTemplate(TemplateEntity, LightEntity):
                 s_str,
                 self.entity_id,
             )
-            self._color = None
+            self._hs_color = None
         else:
             _LOGGER.error(
                 "Received invalid hs_color : (%s) for entity %s", render, self.entity_id
             )
-            self._color = None
+            self._hs_color = None
+        self._color_mode = ColorMode.HS
+
+    @callback
+    def _update_rgb(self, render):
+        """Update the color from the template."""
+        if render is None:
+            self._rgb_color = None
+            return
+
+        r_int = g_int = b_int = None
+        if isinstance(render, str):
+            if render in ("None", ""):
+                self._rgb_color = None
+                return
+            cleanup_char = ["(", ")", "[", "]", " "]
+            for char in cleanup_char:
+                render = render.replace(char, "")
+            r_int, g_int, b_int = map(int, render.split(",", 3))
+        elif isinstance(render, (list, tuple)) and len(render) == 3:
+            r_int, g_int, b_int = render
+
+        if all(
+            value is not None and 0 <= value <= 255 for value in (r_int, g_int, b_int)
+        ):
+            self._rgb_color = (r_int, g_int, b_int)
+        elif any(not 0 <= value <= 255 for value in (r_int, g_int, b_int)):
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255)",
+                r_int,
+                g_int,
+                b_int,
+                self.entity_id,
+            )
+            self._rgb_color = None
+        else:
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s) for entity %s",
+                render,
+                self.entity_id,
+            )
+            self._rgb_color = None
+        self._color_mode = ColorMode.RGB
+
+    @callback
+    def _update_rgbw(self, render):
+        """Update the color from the template."""
+        if render is None:
+            self._rgbw_color = None
+            return
+
+        r_int = g_int = b_int = w_int = None
+        if isinstance(render, str):
+            if render in ("None", ""):
+                self._rgb_color = None
+                return
+            cleanup_char = ["(", ")", "[", "]", " "]
+            for char in cleanup_char:
+                render = render.replace(char, "")
+            r_int, g_int, b_int, w_int = map(int, render.split(",", 4))
+        elif isinstance(render, (list, tuple)) and len(render) == 4:
+            r_int, g_int, b_int, w_int = render
+
+        if all(
+            value is not None and 0 <= value <= 255
+            for value in (r_int, g_int, b_int, w_int)
+        ):
+            self._rgbw_color = (r_int, g_int, b_int, w_int)
+        elif any(not 0 <= value <= 255 for value in (r_int, g_int, b_int, w_int)):
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s, %s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255, 0-255)",
+                r_int,
+                g_int,
+                b_int,
+                w_int,
+                self.entity_id,
+            )
+            self._rgbw_color = None
+        else:
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s) for entity %s",
+                render,
+                self.entity_id,
+            )
+            self._rgbw_color = None
+        self._color_mode = ColorMode.RGBW
+
+    @callback
+    def _update_rgbww(self, render):
+        """Update the color from the template."""
+        if render is None:
+            self._rgbww_color = None
+            return
+
+        r_int = g_int = b_int = cw_int = ww_int = None
+        if isinstance(render, str):
+            if render in ("None", ""):
+                self._rgb_color = None
+                return
+            cleanup_char = ["(", ")", "[", "]", " "]
+            for char in cleanup_char:
+                render = render.replace(char, "")
+            r_int, g_int, b_int, cw_int, ww_int = map(int, render.split(",", 5))
+        elif isinstance(render, (list, tuple)) and len(render) == 5:
+            r_int, g_int, b_int, cw_int, ww_int = render
+
+        if all(
+            value is not None and 0 <= value <= 255
+            for value in (r_int, g_int, b_int, cw_int, ww_int)
+        ):
+            self._rgbww_color = (r_int, g_int, b_int, cw_int, ww_int)
+        elif any(
+            not 0 <= value <= 255 for value in (r_int, g_int, b_int, cw_int, ww_int)
+        ):
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s, %s, %s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255, 0-255)",
+                r_int,
+                g_int,
+                b_int,
+                cw_int,
+                ww_int,
+                self.entity_id,
+            )
+            self._rgbww_color = None
+        else:
+            _LOGGER.error(
+                "Received invalid rgb_color : (%s) for entity %s",
+                render,
+                self.entity_id,
+            )
+            self._rgbww_color = None
+        self._color_mode = ColorMode.RGBWW
 
     @callback
     def _update_max_mireds(self, render):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -308,8 +308,7 @@ class LightTemplate(TemplateEntity, LightEntity):
     @property
     def color_mode(self):
         """Return current color mode."""
-        if self._color_mode:
-            return self._color_mode
+        return self._color_mode
 
     @property
     def supported_color_modes(self):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -807,6 +807,8 @@ class LightTemplate(TemplateEntity, LightEntity):
         if (
             h_str is not None
             and s_str is not None
+            and isinstance(h_str, (int, float))
+            and isinstance(s_str, (int, float))
             and 0 <= h_str <= 360
             and 0 <= s_str <= 100
         ):
@@ -849,10 +851,14 @@ class LightTemplate(TemplateEntity, LightEntity):
             r_int, g_int, b_int = render
 
         if all(
-            value is not None and 0 <= value <= 255 for value in (r_int, g_int, b_int)
+            value is not None and isinstance(value, (int, float)) and 0 <= value <= 255
+            for value in (r_int, g_int, b_int)
         ):
             self._rgb_color = (r_int, g_int, b_int)
-        elif any(not 0 <= value <= 255 for value in (r_int, g_int, b_int)):
+        elif any(
+            isinstance(value, (int, float)) and not 0 <= value <= 255
+            for value in (r_int, g_int, b_int)
+        ):
             _LOGGER.error(
                 "Received invalid rgb_color : (%s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255)",
                 r_int,
@@ -890,11 +896,14 @@ class LightTemplate(TemplateEntity, LightEntity):
             r_int, g_int, b_int, w_int = render
 
         if all(
-            value is not None and 0 <= value <= 255
+            value is not None and isinstance(value, (int, float)) and 0 <= value <= 255
             for value in (r_int, g_int, b_int, w_int)
         ):
             self._rgbw_color = (r_int, g_int, b_int, w_int)
-        elif any(not 0 <= value <= 255 for value in (r_int, g_int, b_int, w_int)):
+        elif any(
+            isinstance(value, (int, float)) and not 0 <= value <= 255
+            for value in (r_int, g_int, b_int, w_int)
+        ):
             _LOGGER.error(
                 "Received invalid rgb_color : (%s, %s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255, 0-255)",
                 r_int,
@@ -933,12 +942,13 @@ class LightTemplate(TemplateEntity, LightEntity):
             r_int, g_int, b_int, cw_int, ww_int = render
 
         if all(
-            value is not None and 0 <= value <= 255
+            value is not None and isinstance(value, (int, float)) and 0 <= value <= 255
             for value in (r_int, g_int, b_int, cw_int, ww_int)
         ):
             self._rgbww_color = (r_int, g_int, b_int, cw_int, ww_int)
         elif any(
-            not 0 <= value <= 255 for value in (r_int, g_int, b_int, cw_int, ww_int)
+            isinstance(value, (int, float)) and not 0 <= value <= 255
+            for value in (r_int, g_int, b_int, cw_int, ww_int)
         ):
             _LOGGER.error(
                 "Received invalid rgb_color : (%s, %s, %s, %s, %s) for entity %s. Expected: (0-255, 0-255, 0-255, 0-255)",

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1417,7 +1417,7 @@ async def test_all_colors_mode_no_template(
 
     state = hass.states.get("light.test_template_light")
     assert state.attributes["color_mode"] == ColorMode.RGB
-    assert "color_temp" not in state.attributes
+    assert state.attributes["color_temp"] is None
     assert state.attributes["rgb_color"] == (160, 78, 192)
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
@@ -1447,7 +1447,7 @@ async def test_all_colors_mode_no_template(
 
     state = hass.states.get("light.test_template_light")
     assert state.attributes["color_mode"] == ColorMode.RGBW
-    assert "color_temp" not in state.attributes
+    assert state.attributes["color_temp"] is None
     assert state.attributes["rgbw_color"] == (160, 78, 192, 25)
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
@@ -1478,7 +1478,7 @@ async def test_all_colors_mode_no_template(
 
     state = hass.states.get("light.test_template_light")
     assert state.attributes["color_mode"] == ColorMode.RGBWW
-    assert "color_temp" not in state.attributes
+    assert state.attributes["color_temp"] is None
     assert state.attributes["rgbww_color"] == (160, 78, 192, 25, 55)
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -672,6 +672,7 @@ async def test_level_action_no_template(
             "{{ state_attr('light.nolight', 'brightness') }}",
             ColorMode.BRIGHTNESS,
         ),
+        (None, "{{'one'}}", ColorMode.BRIGHTNESS),
     ],
 )
 async def test_level_template(
@@ -708,6 +709,7 @@ async def test_level_template(
         (None, "None", ColorMode.COLOR_TEMP),
         (None, "{{ none }}", ColorMode.COLOR_TEMP),
         (None, "", ColorMode.COLOR_TEMP),
+        (None, "{{ 'one' }}", ColorMode.COLOR_TEMP),
     ],
 )
 async def test_temperature_template(
@@ -1080,7 +1082,7 @@ async def test_rgbww_color_action_no_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "expected_hs,color_template,expected_color_mode",
+    ("expected_hs", "color_template", "expected_color_mode"),
     [
         ((360, 100), "{{(360, 100)}}", ColorMode.HS),
         ((359.9, 99.9), "{{(359.9, 99.9)}}", ColorMode.HS),
@@ -1090,6 +1092,7 @@ async def test_rgbww_color_action_no_template(
         (None, "{{x - 12}}", ColorMode.HS),
         (None, "", ColorMode.HS),
         (None, "{{ none }}", ColorMode.HS),
+        (None, "{{('one','two')}}", ColorMode.HS),
     ],
 )
 async def test_legacy_color_template(
@@ -1118,9 +1121,10 @@ async def test_legacy_color_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "expected_hs,hs_template,expected_color_mode",
+    ("expected_hs", "hs_template", "expected_color_mode"),
     [
         ((360, 100), "{{(360, 100)}}", ColorMode.HS),
+        ((360, 100), "(360, 100)", ColorMode.HS),
         ((359.9, 99.9), "{{(359.9, 99.9)}}", ColorMode.HS),
         (None, "{{(361, 100)}}", ColorMode.HS),
         (None, "{{(360, 101)}}", ColorMode.HS),
@@ -1128,6 +1132,7 @@ async def test_legacy_color_template(
         (None, "{{x - 12}}", ColorMode.HS),
         (None, "", ColorMode.HS),
         (None, "{{ none }}", ColorMode.HS),
+        (None, "{{('one','two')}}", ColorMode.HS),
     ],
 )
 async def test_hs_template(
@@ -1156,10 +1161,11 @@ async def test_hs_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "expected_rgb,rgb_template,expected_color_mode",
+    ("expected_rgb", "rgb_template", "expected_color_mode"),
     [
         ((160, 78, 192), "{{(160, 78, 192)}}", ColorMode.RGB),
         ((160, 78, 192), "{{[160, 78, 192]}}", ColorMode.RGB),
+        ((160, 78, 192), "(160, 78, 192)", ColorMode.RGB),
         ((159, 77, 191), "{{(159.9, 77.9, 191.9)}}", ColorMode.RGB),
         (None, "{{(256, 100, 100)}}", ColorMode.RGB),
         (None, "{{(100, 256, 100)}}", ColorMode.RGB),
@@ -1167,6 +1173,7 @@ async def test_hs_template(
         (None, "{{x - 12}}", ColorMode.RGB),
         (None, "", ColorMode.RGB),
         (None, "{{ none }}", ColorMode.RGB),
+        (None, "{{('one','two','tree')}}", ColorMode.RGB),
     ],
 )
 async def test_rgb_template(
@@ -1195,10 +1202,11 @@ async def test_rgb_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "expected_rgbw,rgbw_template,expected_color_mode",
+    ("expected_rgbw", "rgbw_template", "expected_color_mode"),
     [
         ((160, 78, 192, 25), "{{(160, 78, 192, 25)}}", ColorMode.RGBW),
         ((160, 78, 192, 25), "{{[160, 78, 192, 25]}}", ColorMode.RGBW),
+        ((160, 78, 192, 25), "(160, 78, 192, 25)", ColorMode.RGBW),
         ((159, 77, 191, 24), "{{(159.9, 77.9, 191.9, 24.9)}}", ColorMode.RGBW),
         (None, "{{(256, 100, 100, 100)}}", ColorMode.RGBW),
         (None, "{{(100, 256, 100, 100)}}", ColorMode.RGBW),
@@ -1207,6 +1215,7 @@ async def test_rgb_template(
         (None, "{{x - 12}}", ColorMode.RGBW),
         (None, "", ColorMode.RGBW),
         (None, "{{ none }}", ColorMode.RGBW),
+        (None, "{{('one','two','tree','four')}}", ColorMode.RGBW),
     ],
 )
 async def test_rgbw_template(
@@ -1235,9 +1244,10 @@ async def test_rgbw_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    "expected_rgbww,rgbww_template,expected_color_mode",
+    ("expected_rgbww", "rgbww_template", "expected_color_mode"),
     [
         ((160, 78, 192, 25, 55), "{{(160, 78, 192, 25, 55)}}", ColorMode.RGBWW),
+        ((160, 78, 192, 25, 55), "(160, 78, 192, 25, 55)", ColorMode.RGBWW),
         ((160, 78, 192, 25, 55), "{{[160, 78, 192, 25, 55]}}", ColorMode.RGBWW),
         (
             (159, 77, 191, 24, 54),
@@ -1252,6 +1262,7 @@ async def test_rgbw_template(
         (None, "{{x - 12}}", ColorMode.RGBWW),
         (None, "", ColorMode.RGBWW),
         (None, "{{ none }}", ColorMode.RGBWW),
+        (None, "{{('one','two','tree','four','five')}}", ColorMode.RGBWW),
     ],
 )
 async def test_rgbww_template(

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -856,53 +856,6 @@ async def test_entity_picture_template(hass: HomeAssistant, setup_light) -> None
     assert state.attributes["entity_picture"] == "/local/light.png"
 
 
-# TODO Cleanup or implement
-# @pytest.mark.parametrize("count", [1])
-# @pytest.mark.parametrize(
-#     "light_config",
-#     [
-#         {
-#             "test_template_light": {
-#                 **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
-#                 "value_template": "{{1 == 1}}",
-#                 "set_hs": {
-#                     "service": "test.automation",
-#                     "data_template": {
-#                         "entity_id": "test.test_state",
-#                         "h": "{{h}}",
-#                         "s": "{{s}}",
-#                     },
-#                 },
-#                 "set_color": {
-#                     "service": "test.automation",
-#                     "data_template": {
-#                         "caller": "{{ this.entity_id }}",
-#                         "s": "{{s}}",
-#                         "h": "{{h}}",
-#                     },
-#                 },
-#             }
-#         },
-#         {
-#             "test_template_light": {
-#                 **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
-#                 "value_template": "{{ 1 == 1 }}",
-#                 "hs_template": "{{(360, 100)}}",
-#                 "color_template": "{{(360, 100)}}",
-#             }
-#         },
-#     ],
-# )
-# async def test_exclusion_legacy_color_and_hs_colors(
-#     hass,
-#     setup_light,
-#     calls,
-# ):
-#     """Test that Invalid config is rejected"""
-#     with pytest.raises(Exception):
-#         hass.states.get("light.test_template_light")
-
-
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
     "light_config",

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -7,6 +7,9 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
     ColorMode,
     LightEntityFeature,
@@ -72,7 +75,7 @@ OPTIMISTIC_COLOR_TEMP_LIGHT_CONFIG = {
 }
 
 
-OPTIMISTIC_HS_COLOR_LIGHT_CONFIG = {
+OPTIMISTIC_HS_COLOR_RETRO_LIGHT_CONFIG = {
     **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
     "set_color": {
         "service": "test.automation",
@@ -81,6 +84,64 @@ OPTIMISTIC_HS_COLOR_LIGHT_CONFIG = {
             "caller": "{{ this.entity_id }}",
             "s": "{{s}}",
             "h": "{{h}}",
+        },
+    },
+}
+
+OPTIMISTIC_HS_COLOR_LIGHT_CONFIG = {
+    **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
+    "set_hs": {
+        "service": "test.automation",
+        "data_template": {
+            "action": "set_hs",
+            "caller": "{{ this.entity_id }}",
+            "s": "{{s}}",
+            "h": "{{h}}",
+        },
+    },
+}
+
+OPTIMISTIC_RGB_COLOR_LIGHT_CONFIG = {
+    **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
+    "set_rgb": {
+        "service": "test.automation",
+        "data_template": {
+            "action": "set_rgb",
+            "caller": "{{ this.entity_id }}",
+            "r": "{{r}}",
+            "g": "{{g}}",
+            "b": "{{b}}",
+        },
+    },
+}
+
+OPTIMISTIC_RGBW_COLOR_LIGHT_CONFIG = {
+    **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
+    "set_rgbw": {
+        "service": "test.automation",
+        "data_template": {
+            "action": "set_rgbw",
+            "caller": "{{ this.entity_id }}",
+            "r": "{{r}}",
+            "g": "{{g}}",
+            "b": "{{b}}",
+            "w": "{{w}}",
+        },
+    },
+}
+
+OPTIMISTIC_RGBWW_COLOR_LIGHT_CONFIG = {
+    **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
+    "set_rgbww": {
+        "service": "test.automation",
+        "data_template": {
+            "action": "set_rgbww",
+            "caller": "{{ this.entity_id }}",
+            "r": "{{r}}",
+            "g": "{{g}}",
+            "b": "{{b}}",
+            "cw": "{{cw}}",
+            "ww": "{{ww}}",
         },
     },
 }
@@ -803,12 +864,12 @@ async def test_entity_picture_template(hass: HomeAssistant, setup_light) -> None
         },
     ],
 )
-async def test_color_action_no_template(
+async def test_hs_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
     calls,
 ) -> None:
-    """Test setting color with optimistic template."""
+    """Test setting hs color with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
 
@@ -820,7 +881,7 @@ async def test_color_action_no_template(
     )
 
     assert len(calls) == 1
-    assert calls[-1].data["action"] == "set_color"
+    assert calls[-1].data["action"] == "set_hs"
     assert calls[-1].data["caller"] == "light.test_template_light"
     assert calls[-1].data["h"] == 40
     assert calls[-1].data["s"] == 50
@@ -835,7 +896,145 @@ async def test_color_action_no_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    ("expected_hs", "color_template", "expected_color_mode"),
+    "light_config",
+    [
+        {
+            "test_template_light": {
+                **OPTIMISTIC_RGB_COLOR_LIGHT_CONFIG,
+                "value_template": "{{1 == 1}}",
+            }
+        },
+    ],
+)
+async def test_rgb_color_action_no_template(
+    hass: HomeAssistant,
+    setup_light,
+    calls,
+) -> None:
+    """Test setting rgb color with optimistic template."""
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgb_color") is None
+
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.test_template_light", ATTR_RGB_COLOR: (160, 78, 192)},
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[-1].data["action"] == "set_rgb"
+    assert calls[-1].data["caller"] == "light.test_template_light"
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+
+    state = hass.states.get("light.test_template_light")
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == ColorMode.RGB
+    assert state.attributes.get("rgb_color") == (160, 78, 192)
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGB]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "light_config",
+    [
+        {
+            "test_template_light": {
+                **OPTIMISTIC_RGBW_COLOR_LIGHT_CONFIG,
+                "value_template": "{{1 == 1}}",
+            }
+        },
+    ],
+)
+async def test_rgbw_color_action_no_template(
+    hass: HomeAssistant,
+    setup_light,
+    calls,
+) -> None:
+    """Test setting rgbw color with optimistic template."""
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgbw_color") is None
+
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.test_template_light",
+            ATTR_RGBW_COLOR: (160, 78, 192, 25),
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[-1].data["action"] == "set_rgbw"
+    assert calls[-1].data["caller"] == "light.test_template_light"
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+    assert calls[-1].data["w"] == 25
+
+    state = hass.states.get("light.test_template_light")
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == ColorMode.RGBW
+    assert state.attributes.get("rgbw_color") == (160, 78, 192, 25)
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGBW]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "light_config",
+    [
+        {
+            "test_template_light": {
+                **OPTIMISTIC_RGBWW_COLOR_LIGHT_CONFIG,
+                "value_template": "{{1 == 1}}",
+            }
+        },
+    ],
+)
+async def test_rgbww_color_action_no_template(
+    hass: HomeAssistant,
+    setup_light,
+    calls,
+) -> None:
+    """Test setting rgbww color with optimistic template."""
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgbww_color") is None
+
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.test_template_light",
+            ATTR_RGBWW_COLOR: (160, 78, 192, 25, 55),
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[-1].data["action"] == "set_rgbww"
+    assert calls[-1].data["caller"] == "light.test_template_light"
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+    assert calls[-1].data["cw"] == 25
+    assert calls[-1].data["ww"] == 55
+
+    state = hass.states.get("light.test_template_light")
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == ColorMode.RGBWW
+    assert state.attributes.get("rgbww_color") == (160, 78, 192, 25, 55)
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGBWW]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "expected_hs,hs_template,expected_color_mode",
     [
         ((360, 100), "{{(360, 100)}}", ColorMode.HS),
         ((359.9, 99.9), "{{(359.9, 99.9)}}", ColorMode.HS),
@@ -847,19 +1046,19 @@ async def test_color_action_no_template(
         (None, "{{ none }}", ColorMode.HS),
     ],
 )
-async def test_color_template(
+async def test_hs_template(
     hass: HomeAssistant,
     expected_hs,
     expected_color_mode,
     count,
-    color_template,
+    hs_template,
 ) -> None:
     """Test the template for the color."""
     light_config = {
         "test_template_light": {
             **OPTIMISTIC_HS_COLOR_LIGHT_CONFIG,
             "value_template": "{{ 1 == 1 }}",
-            "color_template": color_template,
+            "hs_template": hs_template,
         }
     }
     await async_setup_light(hass, count, light_config)
@@ -873,22 +1072,144 @@ async def test_color_template(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
+    "expected_rgb,rgb_template,expected_color_mode",
+    [
+        ((160, 78, 192), "{{(160, 78, 192)}}", ColorMode.RGB),
+        ((160, 78, 192), "{{[160, 78, 192]}}", ColorMode.RGB),
+        ((159, 77, 191), "{{(159.9, 77.9, 191.9)}}", ColorMode.RGB),
+        (None, "{{(256, 100, 100)}}", ColorMode.RGB),
+        (None, "{{(100, 256, 100)}}", ColorMode.RGB),
+        (None, "{{(100, 100, 256)}}", ColorMode.RGB),
+        (None, "{{x - 12}}", ColorMode.RGB),
+        (None, "", ColorMode.RGB),
+        (None, "{{ none }}", ColorMode.RGB),
+    ],
+)
+async def test_rgb_template(
+    hass: HomeAssistant,
+    expected_rgb,
+    expected_color_mode,
+    count,
+    rgb_template,
+) -> None:
+    """Test the template for the color."""
+    light_config = {
+        "test_template_light": {
+            **OPTIMISTIC_RGB_COLOR_LIGHT_CONFIG,
+            "value_template": "{{ 1 == 1 }}",
+            "rgb_template": rgb_template,
+        }
+    }
+    await async_setup_light(hass, count, light_config)
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgb_color") == expected_rgb
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == expected_color_mode
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGB]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "expected_rgbw,rgbw_template,expected_color_mode",
+    [
+        ((160, 78, 192, 25), "{{(160, 78, 192, 25)}}", ColorMode.RGBW),
+        ((160, 78, 192, 25), "{{[160, 78, 192, 25]}}", ColorMode.RGBW),
+        ((159, 77, 191, 24), "{{(159.9, 77.9, 191.9, 24.9)}}", ColorMode.RGBW),
+        (None, "{{(256, 100, 100, 100)}}", ColorMode.RGBW),
+        (None, "{{(100, 256, 100, 100)}}", ColorMode.RGBW),
+        (None, "{{(100, 100, 256, 100)}}", ColorMode.RGBW),
+        (None, "{{(100, 100, 100, 256)}}", ColorMode.RGBW),
+        (None, "{{x - 12}}", ColorMode.RGBW),
+        (None, "", ColorMode.RGBW),
+        (None, "{{ none }}", ColorMode.RGBW),
+    ],
+)
+async def test_rgbw_template(
+    hass: HomeAssistant,
+    expected_rgbw,
+    expected_color_mode,
+    count,
+    rgbw_template,
+) -> None:
+    """Test the template for the color."""
+    light_config = {
+        "test_template_light": {
+            **OPTIMISTIC_RGBW_COLOR_LIGHT_CONFIG,
+            "value_template": "{{ 1 == 1 }}",
+            "rgbw_template": rgbw_template,
+        }
+    }
+    await async_setup_light(hass, count, light_config)
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgbw_color") == expected_rgbw
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == expected_color_mode
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGBW]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    "expected_rgbww,rgbww_template,expected_color_mode",
+    [
+        ((160, 78, 192, 25, 55), "{{(160, 78, 192, 25, 55)}}", ColorMode.RGBWW),
+        ((160, 78, 192, 25, 55), "{{[160, 78, 192, 25, 55]}}", ColorMode.RGBWW),
+        (
+            (159, 77, 191, 24, 54),
+            "{{(159.9, 77.9, 191.9, 24.9, 54.9)}}",
+            ColorMode.RGBWW,
+        ),
+        (None, "{{(256, 100, 100, 100, 100)}}", ColorMode.RGBWW),
+        (None, "{{(100, 256, 100, 100, 100)}}", ColorMode.RGBWW),
+        (None, "{{(100, 100, 256, 100, 100)}}", ColorMode.RGBWW),
+        (None, "{{(100, 100, 100, 256, 100)}}", ColorMode.RGBWW),
+        (None, "{{(100, 100, 100, 100, 256)}}", ColorMode.RGBWW),
+        (None, "{{x - 12}}", ColorMode.RGBWW),
+        (None, "", ColorMode.RGBWW),
+        (None, "{{ none }}", ColorMode.RGBWW),
+    ],
+)
+async def test_rgbww_template(
+    hass: HomeAssistant,
+    expected_rgbww,
+    expected_color_mode,
+    count,
+    rgbww_template,
+) -> None:
+    """Test the template for the color."""
+    light_config = {
+        "test_template_light": {
+            **OPTIMISTIC_RGBWW_COLOR_LIGHT_CONFIG,
+            "value_template": "{{ 1 == 1 }}",
+            "rgbww_template": rgbww_template,
+        }
+    }
+    await async_setup_light(hass, count, light_config)
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes.get("rgbww_color") == expected_rgbww
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == expected_color_mode
+    assert state.attributes["supported_color_modes"] == [ColorMode.RGBWW]
+    assert state.attributes["supported_features"] == 0
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
     "light_config",
     [
         {
             "test_template_light": {
                 **OPTIMISTIC_ON_OFF_LIGHT_CONFIG,
                 "value_template": "{{1 == 1}}",
-                "set_color": [
-                    {
-                        "service": "test.automation",
-                        "data_template": {
-                            "entity_id": "test.test_state",
-                            "h": "{{h}}",
-                            "s": "{{s}}",
-                        },
+                "set_hs": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "entity_id": "test.test_state",
+                        "h": "{{h}}",
+                        "s": "{{s}}",
                     },
-                ],
+                },
                 "set_temperature": {
                     "service": "test.automation",
                     "data_template": {
@@ -896,18 +1217,48 @@ async def test_color_template(
                         "color_temp": "{{color_temp}}",
                     },
                 },
+                "set_rgb": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "entity_id": "test.test_state",
+                        "r": "{{r}}",
+                        "g": "{{g}}",
+                        "b": "{{b}}",
+                    },
+                },
+                "set_rgbw": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "entity_id": "test.test_state",
+                        "r": "{{r}}",
+                        "g": "{{g}}",
+                        "b": "{{b}}",
+                        "w": "{{w}}",
+                    },
+                },
+                "set_rgbww": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "entity_id": "test.test_state",
+                        "r": "{{r}}",
+                        "g": "{{g}}",
+                        "b": "{{b}}",
+                        "cw": "{{cw}}",
+                        "ww": "{{ww}}",
+                    },
+                },
             }
         },
     ],
 )
-async def test_color_and_temperature_actions_no_template(
+async def test_all_colors_mode_no_template(
     hass: HomeAssistant, setup_light, calls
 ) -> None:
     """Test setting color and color temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
 
-    # Optimistically set color, light should be in hs_color mode
+    # Optimistically set hs color, light should be in hs_color mode
     await hass.services.async_call(
         light.DOMAIN,
         SERVICE_TURN_ON,
@@ -926,6 +1277,9 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
         ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
     ]
     assert state.attributes["supported_features"] == 0
 
@@ -947,10 +1301,100 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
         ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
     ]
     assert state.attributes["supported_features"] == 0
 
-    # Optimistically set color, light should again be in hs_color mode
+    # Optimistically set rgb color, light should be in rgb_color mode
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.test_template_light", ATTR_RGB_COLOR: (160, 78, 192)},
+        blocking=True,
+    )
+
+    assert len(calls) == 3
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes["color_mode"] == ColorMode.RGB
+    assert "color_temp" not in state.attributes
+    assert state.attributes["rgb_color"] == (160, 78, 192)
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
+    ]
+    assert state.attributes["supported_features"] == 0
+
+    # Optimistically set rgbw color, light should be in rgb_color mode
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.test_template_light",
+            ATTR_RGBW_COLOR: (160, 78, 192, 25),
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 4
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+    assert calls[-1].data["w"] == 25
+
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes["color_mode"] == ColorMode.RGBW
+    assert "color_temp" not in state.attributes
+    assert state.attributes["rgbw_color"] == (160, 78, 192, 25)
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
+    ]
+    assert state.attributes["supported_features"] == 0
+
+    # Optimistically set rgbww color, light should be in rgb_color mode
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.test_template_light",
+            ATTR_RGBWW_COLOR: (160, 78, 192, 25, 55),
+        },
+        blocking=True,
+    )
+
+    assert len(calls) == 5
+    assert calls[-1].data["r"] == 160
+    assert calls[-1].data["g"] == 78
+    assert calls[-1].data["b"] == 192
+    assert calls[-1].data["cw"] == 25
+    assert calls[-1].data["ww"] == 55
+
+    state = hass.states.get("light.test_template_light")
+    assert state.attributes["color_mode"] == ColorMode.RGBWW
+    assert "color_temp" not in state.attributes
+    assert state.attributes["rgbww_color"] == (160, 78, 192, 25, 55)
+    assert state.attributes["supported_color_modes"] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
+    ]
+    assert state.attributes["supported_features"] == 0
+
+    # Optimistically set hs color, light should again be in hs_color mode
     await hass.services.async_call(
         light.DOMAIN,
         SERVICE_TURN_ON,
@@ -958,7 +1402,7 @@ async def test_color_and_temperature_actions_no_template(
         blocking=True,
     )
 
-    assert len(calls) == 3
+    assert len(calls) == 6
     assert calls[-1].data["h"] == 10
     assert calls[-1].data["s"] == 20
 
@@ -969,6 +1413,9 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
         ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
     ]
     assert state.attributes["supported_features"] == 0
 
@@ -980,7 +1427,7 @@ async def test_color_and_temperature_actions_no_template(
         blocking=True,
     )
 
-    assert len(calls) == 4
+    assert len(calls) == 7
     assert calls[-1].data["color_temp"] == 234
 
     state = hass.states.get("light.test_template_light")
@@ -990,6 +1437,9 @@ async def test_color_and_temperature_actions_no_template(
     assert state.attributes["supported_color_modes"] == [
         ColorMode.COLOR_TEMP,
         ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
     ]
     assert state.attributes["supported_features"] == 0
 


### PR DESCRIPTION
Add the required unit test

Mute 'LightTemplate.async_turn_on' is too complex

Rename all HS color mode from a generic "Color" name to a specific "HS" name

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Template.light could nolonger be used to controle RGBW light since https://github.com/home-assistant/core/pull/76923 and the deprecation of a "white control" for light.
This bring full RGB, RGBW and RGBWW capability in addition the the already existing TEMPERATURE and HS capability.
It fix the previous regression and expend on it.

This can be used to template RGB(WW) light composed of multiple entity into a single one for exemple (like requested for WLED by OP)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80449
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25994

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
