### PR TITLE
Add zeroconf discovery to Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from ipaddress import ip_address
 import logging
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from synology_dsm import SynologyDSM
@@ -18,7 +18,7 @@ from synology_dsm.exceptions import (
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.components import ssdp
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
     CONF_DISKS,
@@ -56,6 +56,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 CONF_OTP_CODE = "otp_code"
+
+HTTP_SUFFIX = "._http._tcp.local."
 
 
 def _discovery_schema_with_defaults(discovery_info: DiscoveryInfoType) -> vol.Schema:
@@ -103,6 +105,11 @@ def _is_valid_ip(text: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def format_synology_mac(mac: str) -> str:
+    """Format a mac address to the format used by Synology DSM."""
+    return mac.replace(":", "").replace("-", "").upper()
 
 
 class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -239,21 +246,46 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             return self._show_form(step)
         return await self.async_validate_input_create_entry(user_input, step_id=step)
 
-    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
-        """Handle a discovered synology_dsm."""
-        parsed_url = urlparse(discovery_info.ssdp_location)
-        friendly_name = (
-            discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME].split("(", 1)[0].strip()
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle a discovered synology_dsm via zeroconf."""
+        discovered_macs = [
+            format_synology_mac(mac)
+            for mac in discovery_info.properties.get("mac_address", "").split("|")
+            if mac
+        ]
+        if not discovered_macs:
+            return self.async_abort(reason="no_mac_address")
+        host = discovery_info.host
+        friendly_name = discovery_info.name.removesuffix(HTTP_SUFFIX)
+        return await self._async_step_from_discovery(
+            host, friendly_name, discovered_macs
         )
 
-        discovered_mac = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL].upper()
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
+        """Handle a discovered synology_dsm via ssdp."""
+        parsed_url = urlparse(discovery_info.ssdp_location)
+        upnp_friendly_name: str = discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME]
+        friendly_name = upnp_friendly_name.split("(", 1)[0].strip()
+        mac_address = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+        discovered_macs = [format_synology_mac(mac_address)]
         # Synology NAS can broadcast on multiple IP addresses, since they can be connected to multiple ethernets.
         # The serial of the NAS is actually its MAC address.
+        host = cast(str, parsed_url.hostname)
+        return await self._async_step_from_discovery(
+            host, friendly_name, discovered_macs
+        )
 
-        await self.async_set_unique_id(discovered_mac)
-        existing_entry = self._async_get_existing_entry(discovered_mac)
-
-        if not existing_entry:
+    async def _async_step_from_discovery(
+        self, host: str, friendly_name: str, discovered_macs: list[str]
+    ) -> FlowResult:
+        """Handle a discovered synology_dsm via zeroconf or ssdp."""
+        existing_entry = None
+        for discovered_mac in discovered_macs:
+            await self.async_set_unique_id(discovered_mac)
+            if existing_entry := self._async_get_existing_entry(discovered_mac):
+                break
             self._abort_if_unique_id_configured()
 
         fqdn_with_ssl_verification = (
@@ -264,18 +296,18 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if (
             existing_entry
-            and existing_entry.data[CONF_HOST] != parsed_url.hostname
+            and existing_entry.data[CONF_HOST] != host
             and not fqdn_with_ssl_verification
         ):
             _LOGGER.info(
-                "Update host from '%s' to '%s' for NAS '%s' via SSDP discovery",
+                "Update host from '%s' to '%s' for NAS '%s' via discovery",
                 existing_entry.data[CONF_HOST],
-                parsed_url.hostname,
+                host,
                 existing_entry.unique_id,
             )
             self.hass.config_entries.async_update_entry(
                 existing_entry,
-                data={**existing_entry.data, CONF_HOST: parsed_url.hostname},
+                data={**existing_entry.data, CONF_HOST: host},
             )
             return self.async_abort(reason="reconfigure_successful")
 
@@ -284,7 +316,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self.discovered_conf = {
             CONF_NAME: friendly_name,
-            CONF_HOST: parsed_url.hostname,
+            CONF_HOST: host,
         }
         self.context["title_placeholders"] = self.discovered_conf
         return await self.async_step_link()
@@ -339,7 +371,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         """See if we already have a configured NAS with this MAC address."""
         for entry in self._async_current_entries():
             if discovered_mac in [
-                mac.replace("-", "") for mac in entry.data.get(CONF_MAC, [])
+                format_synology_mac(mac) for mac in entry.data.get(CONF_MAC, [])
             ]:
                 return entry
         return None

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -259,9 +259,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_mac_address")
         host = discovery_info.host
         friendly_name = discovery_info.name.removesuffix(HTTP_SUFFIX)
-        return await self._async_step_from_discovery(
-            host, friendly_name, discovered_macs
-        )
+        return await self._async_from_discovery(host, friendly_name, discovered_macs)
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered synology_dsm via ssdp."""
@@ -273,11 +271,9 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         # Synology NAS can broadcast on multiple IP addresses, since they can be connected to multiple ethernets.
         # The serial of the NAS is actually its MAC address.
         host = cast(str, parsed_url.hostname)
-        return await self._async_step_from_discovery(
-            host, friendly_name, discovered_macs
-        )
+        return await self._async_from_discovery(host, friendly_name, discovered_macs)
 
-    async def _async_step_from_discovery(
+    async def _async_from_discovery(
         self, host: str, friendly_name: str, discovered_macs: list[str]
     ) -> FlowResult:
         """Handle a discovered synology_dsm via zeroconf or ssdp."""

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -11,6 +11,9 @@
       "deviceType": "urn:schemas-upnp-org:device:Basic:1"
     }
   ],
+  "zeroconf": [
+    { "type": "_http._tcp.local.", "properties": { "vendor": "synology*" } }
+  ],
   "iot_class": "local_polling",
   "loggers": ["synology_dsm"]
 }

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -44,7 +44,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "no_mac_address": "No MAC address is missing from the zeroconf record",
+      "no_mac_address": "The MAC address is missing from the zeroconf record",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "Re-configuration was successful"

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -44,6 +44,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "no_mac_address": "No MAC address is missing from the zeroconf record",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "Re-configuration was successful"

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -2,8 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "invalid_host": "The host is not valid",
-            "no_mac_address": "No MAC address found",
+            "no_mac_address": "No MAC address is missing from the zeroconf record",
             "reauth_successful": "Re-authentication was successful",
             "reconfigure_successful": "Re-configuration was successful"
         },

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -2,6 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
+            "invalid_host": "The host is not valid",
+            "no_mac_address": "No MAC address found",
             "reauth_successful": "Re-authentication was successful",
             "reconfigure_successful": "Re-configuration was successful"
         },

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "no_mac_address": "No MAC address is missing from the zeroconf record",
+            "no_mac_address": "The MAC address is missing from the zeroconf record",
             "reauth_successful": "Re-authentication was successful",
             "reconfigure_successful": "Re-configuration was successful"
         },

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -282,6 +282,12 @@ ZEROCONF = {
             "domain": "shelly",
             "name": "shelly*",
         },
+        {
+            "domain": "synology_dsm",
+            "properties": {
+                "vendor": "synology*",
+            },
+        },
     ],
     "_hue._tcp.local.": [
         {


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zeroconf discovery to synology_dsm

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
