### PR TITLE
Remove deprecated Renault service

### DIFF
--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -63,13 +63,7 @@ SERVICE_CHARGE_SET_SCHEDULES_SCHEMA = SERVICE_VEHICLE_SCHEMA.extend(
 SERVICE_AC_CANCEL = "ac_cancel"
 SERVICE_AC_START = "ac_start"
 SERVICE_CHARGE_SET_SCHEDULES = "charge_set_schedules"
-SERVICE_CHARGE_START = "charge_start"
-SERVICES = [
-    SERVICE_AC_CANCEL,
-    SERVICE_AC_START,
-    SERVICE_CHARGE_SET_SCHEDULES,
-    SERVICE_CHARGE_START,
-]
+SERVICES = [SERVICE_AC_CANCEL, SERVICE_AC_START, SERVICE_CHARGE_SET_SCHEDULES]
 
 
 def setup_services(hass: HomeAssistant) -> None:
@@ -110,22 +104,6 @@ def setup_services(hass: HomeAssistant) -> None:
             "It may take some time before these changes are reflected in your vehicle"
         )
 
-    async def charge_start(service_call: ServiceCall) -> None:
-        """Start charge."""
-        # The Renault start charge service has been replaced by a
-        # dedicated button entity and marked as deprecated
-        LOGGER.warning(
-            "The 'renault.charge_start' service is deprecated and "
-            "replaced by a dedicated start charge button entity; please "
-            "use that entity to start the charge instead"
-        )
-
-        proxy = get_vehicle_proxy(service_call.data)
-
-        LOGGER.debug("Charge start attempt")
-        result = await proxy.vehicle.set_charge_start()
-        LOGGER.debug("Charge start result: %s", result)
-
     def get_vehicle_proxy(service_call_data: Mapping) -> RenaultVehicleProxy:
         """Get vehicle from service_call data."""
         device_registry = dr.async_get(hass)
@@ -158,12 +136,6 @@ def setup_services(hass: HomeAssistant) -> None:
         SERVICE_CHARGE_SET_SCHEDULES,
         charge_set_schedules,
         schema=SERVICE_CHARGE_SET_SCHEDULES_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CHARGE_START,
-        charge_start,
-        schema=SERVICE_VEHICLE_SCHEMA,
     )
 
 

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -16,7 +16,6 @@ from homeassistant.components.renault.services import (
     SERVICE_AC_CANCEL,
     SERVICE_AC_START,
     SERVICE_CHARGE_SET_SCHEDULES,
-    SERVICE_CHARGE_START,
     SERVICES,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -240,33 +239,6 @@ async def test_service_set_charge_schedule_multi(
     assert len(mock_action.mock_calls) == 1
     mock_call_data: list[ChargeSchedule] = mock_action.mock_calls[0][1][0]
     assert mock_action.mock_calls[0][1] == (mock_call_data,)
-
-
-async def test_service_set_charge_start(
-    hass: HomeAssistant, config_entry: ConfigEntry, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test that service invokes renault_api with correct data."""
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    data = {
-        ATTR_VEHICLE: get_device_id(hass),
-    }
-
-    with patch(
-        "renault_api.renault_vehicle.RenaultVehicle.set_charge_start",
-        return_value=(
-            schemas.KamereonVehicleHvacStartActionDataSchema.loads(
-                load_fixture("renault/action.set_charge_start.json")
-            )
-        ),
-    ) as mock_action:
-        await hass.services.async_call(
-            DOMAIN, SERVICE_CHARGE_START, service_data=data, blocking=True
-        )
-    assert len(mock_action.mock_calls) == 1
-    assert mock_action.mock_calls[0][1] == ()
-    assert f"'{DOMAIN}.{SERVICE_CHARGE_START}' service is deprecated" in caplog.text
 
 
 async def test_service_invalid_device_id(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated `renault.charge_start` service has been removed.
Please use the dedicated start charge button entity to start the charge instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #59383

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25800

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
