### PR TITLE
Raise HomeAssistantError in Renault

### DIFF
--- a/homeassistant/components/renault/button.py
+++ b/homeassistant/components/renault/button.py
@@ -1,8 +1,9 @@
 """Support for Renault button entities."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -18,7 +19,7 @@ from .renault_hub import RenaultHub
 class RenaultButtonRequiredKeysMixin:
     """Mixin for required keys."""
 
-    async_press: Callable[[RenaultButtonEntity], Awaitable]
+    async_press: Callable[[RenaultButtonEntity], Coroutine[Any, Any, Any]]
 
 
 @dataclass
@@ -56,25 +57,15 @@ class RenaultButtonEntity(RenaultEntity, ButtonEntity):
         await self.entity_description.async_press(self)
 
 
-async def _start_charge(entity: RenaultButtonEntity) -> None:
-    """Start charge on the vehicle."""
-    await entity.vehicle.vehicle.set_charge_start()
-
-
-async def _start_air_conditioner(entity: RenaultButtonEntity) -> None:
-    """Start air conditioner on the vehicle."""
-    await entity.vehicle.vehicle.set_ac_start(21, None)
-
-
 BUTTON_TYPES: tuple[RenaultButtonEntityDescription, ...] = (
     RenaultButtonEntityDescription(
-        async_press=_start_air_conditioner,
+        async_press=lambda x: x.vehicle.set_ac_start(21, None),
         key="start_air_conditioner",
         icon="mdi:air-conditioner",
         name="Start air conditioner",
     ),
     RenaultButtonEntityDescription(
-        async_press=_start_charge,
+        async_press=lambda x: x.vehicle.set_charge_start(),
         key="start_charge",
         icon="mdi:ev-station",
         name="Start charge",

--- a/homeassistant/components/renault/renault_vehicle.py
+++ b/homeassistant/components/renault/renault_vehicle.py
@@ -37,7 +37,7 @@ def with_error_wrapping(
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> _T:
-        """Catch BraviaClient errors and log message."""
+        """Catch RenaultException errors and raise HomeAssistantError."""
         try:
             return await func(self, *args, **kwargs)
         except RenaultException as err:

--- a/homeassistant/components/renault/renault_vehicle.py
+++ b/homeassistant/components/renault/renault_vehicle.py
@@ -2,22 +2,48 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
+from functools import wraps
 import logging
-from typing import cast
+from typing import Any, TypeVar, cast
 
+from renault_api.exceptions import RenaultException
 from renault_api.kamereon import models
 from renault_api.renault_vehicle import RenaultVehicle
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
 from .renault_coordinator import RenaultDataUpdateCoordinator
 
 LOGGER = logging.getLogger(__name__)
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+def with_error_wrapping(
+    func: Callable[Concatenate[RenaultVehicleProxy, _P], Awaitable[_T]]
+) -> Callable[Concatenate[RenaultVehicleProxy, _P], Coroutine[Any, Any, _T]]:
+    """Catch Renault errors."""
+
+    @wraps(func)
+    async def wrapper(
+        self: RenaultVehicleProxy,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _T:
+        """Catch BraviaClient errors and log message."""
+        try:
+            return await func(self, *args, **kwargs)
+        except RenaultException as err:
+            raise HomeAssistantError(err) from err
+
+    return wrapper
 
 
 @dataclass
@@ -69,11 +95,6 @@ class RenaultVehicleProxy:
         """Return a device description for device registry."""
         return self._device_info
 
-    @property
-    def vehicle(self) -> RenaultVehicle:
-        """Return the underlying vehicle."""
-        return self._vehicle
-
     async def async_initialise(self) -> None:
         """Load available coordinators."""
         self.coordinators = {
@@ -118,6 +139,42 @@ class RenaultVehicleProxy:
                     coordinator.last_exception,
                 )
                 del self.coordinators[key]
+
+    @with_error_wrapping
+    async def set_charge_mode(
+        self, charge_mode: str
+    ) -> models.KamereonVehicleChargeModeActionData:
+        """Set vehicle charge mode."""
+        return await self._vehicle.set_charge_mode(charge_mode)
+
+    @with_error_wrapping
+    async def set_charge_start(self) -> models.KamereonVehicleChargingStartActionData:
+        """Start vehicle charge."""
+        return await self._vehicle.set_charge_start()
+
+    @with_error_wrapping
+    async def set_ac_stop(self) -> models.KamereonVehicleHvacStartActionData:
+        """Stop vehicle ac."""
+        return await self._vehicle.set_ac_stop()
+
+    @with_error_wrapping
+    async def set_ac_start(
+        self, temperature: float, when: datetime | None = None
+    ) -> models.KamereonVehicleHvacStartActionData:
+        """Start vehicle ac."""
+        return await self._vehicle.set_ac_start(temperature, when)
+
+    @with_error_wrapping
+    async def get_charging_settings(self) -> models.KamereonVehicleChargingSettingsData:
+        """Get vehicle charging settings."""
+        return await self._vehicle.get_charging_settings()
+
+    @with_error_wrapping
+    async def set_charge_schedules(
+        self, schedules: list[models.ChargeSchedule]
+    ) -> models.KamereonVehicleChargeScheduleActionData:
+        """Set vehicle charge schedules."""
+        return await self._vehicle.set_charge_schedules(schedules)
 
 
 COORDINATORS: tuple[RenaultCoordinatorDescription, ...] = (

--- a/homeassistant/components/renault/select.py
+++ b/homeassistant/components/renault/select.py
@@ -75,7 +75,7 @@ class RenaultSelectEntity(
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.vehicle.vehicle.set_charge_mode(option)
+        await self.vehicle.set_charge_mode(option)
 
 
 def _get_charge_mode_icon(entity: RenaultSelectEntity) -> str:

--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -74,7 +74,7 @@ def setup_services(hass: HomeAssistant) -> None:
         proxy = get_vehicle_proxy(service_call.data)
 
         LOGGER.debug("A/C cancel attempt")
-        result = await proxy.vehicle.set_ac_stop()
+        result = await proxy.set_ac_stop()
         LOGGER.debug("A/C cancel result: %s", result)
 
     async def ac_start(service_call: ServiceCall) -> None:
@@ -84,21 +84,22 @@ def setup_services(hass: HomeAssistant) -> None:
         proxy = get_vehicle_proxy(service_call.data)
 
         LOGGER.debug("A/C start attempt: %s / %s", temperature, when)
-        result = await proxy.vehicle.set_ac_start(temperature, when)
+        result = await proxy.set_ac_start(temperature, when)
         LOGGER.debug("A/C start result: %s", result.raw_data)
 
     async def charge_set_schedules(service_call: ServiceCall) -> None:
         """Set charge schedules."""
         schedules: list[dict[str, Any]] = service_call.data[ATTR_SCHEDULES]
         proxy = get_vehicle_proxy(service_call.data)
-        charge_schedules = await proxy.vehicle.get_charging_settings()
+        charge_schedules = await proxy.get_charging_settings()
         for schedule in schedules:
             charge_schedules.update(schedule)
 
         if TYPE_CHECKING:
             assert charge_schedules.schedules is not None
         LOGGER.debug("Charge set schedules attempt: %s", schedules)
-        result = await proxy.vehicle.set_charge_schedules(charge_schedules.schedules)
+        result = await proxy.set_charge_schedules(charge_schedules.schedules)
+
         LOGGER.debug("Charge set schedules result: %s", result)
         LOGGER.debug(
             "It may take some time before these changes are reflected in your vehicle"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use a decorator to handle `RenaultException` and raise `HomeAssistantError`
As requested by @frenck in https://github.com/home-assistant/core/pull/85753#discussion_r1071576063
Needs #86070

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
