### PR TITLE
Allow customizing sensor state precision

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -459,7 +459,7 @@ class SensorEntity(Entity):
 
     @final
     @property
-    def state(self) -> Any:
+    def state(self) -> Any:  # noqa: C901
         """Return the state of the sensor and perform unit conversions, if needed."""
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
@@ -570,12 +570,18 @@ class SensorEntity(Entity):
 
         numerical_value: int | float | Decimal | None = None
         numerical_conversion_failed = None
-        if not isinstance(value, (int, float, Decimal)):
-            try:
-                numerical_value = float(value)  # type:ignore[arg-type]
-            except (TypeError, ValueError):
-                numerical_conversion_failed = True
-        else:
+        if isinstance(value, str):
+            if "." in value:
+                try:
+                    numerical_value = float(value)
+                except (TypeError, ValueError):
+                    numerical_conversion_failed = True
+            else:
+                try:
+                    numerical_value = int(value)
+                except (TypeError, ValueError):
+                    numerical_conversion_failed = True
+        elif isinstance(value, (int, float, Decimal)):
             numerical_value = value
 
         if (

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -565,6 +565,11 @@ class SensorEntity(Entity):
                 )
             return value
 
+        # If the sensor has neither a device class, a state class nor
+        # a unit_of measurement then there are no further checks or conversions
+        if not device_class and not state_class and not unit_of_measurement:
+            return value
+
         numerical_value: int | float | Decimal | None = None
         numerical_conversion_failed = None
         if not isinstance(value, (int, float, Decimal)):
@@ -588,11 +593,6 @@ class SensorEntity(Entity):
             )
         ):
             value = f"{numerical_value:.{prec}f}"
-
-        # If the sensor has neither a device class, a state class nor
-        # a unit_of measurement then there are no further checks or conversions
-        if not device_class and not state_class and not unit_of_measurement:
-            return value
 
         if not self._invalid_numeric_value_reported and numerical_conversion_failed:
             # This should raise in Home Assistant Core 2023.4

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -585,10 +585,16 @@ class SensorEntity(Entity):
                     numerical_value = int(value)
                 else:
                     numerical_value = float(value)  # type:ignore[arg-type]
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as err:
                 # Raise if precision is not None, for other cases log a warning
                 if precision is not None:
-                    raise
+                    raise ValueError(
+                        f"Sensor {self.entity_id} has device class {device_class}, "
+                        f"state class {state_class} unit {unit_of_measurement} and "
+                        f"precision {precision} thus indicating it has a numeric value;"
+                        f" however, it has the non-numeric value: {value} "
+                        f"({type(value)})"
+                    ) from err
                 # This should raise in Home Assistant Core 2023.4
                 self._invalid_numeric_value_reported = True
                 report_issue = self._suggest_report_issue()

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -459,7 +459,7 @@ class SensorEntity(Entity):
 
     @final
     @property
-    def state(self) -> Any:  # noqa: C901
+    def state(self) -> Any:
         """Return the state of the sensor and perform unit conversions, if needed."""
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
@@ -570,18 +570,15 @@ class SensorEntity(Entity):
 
         numerical_value: int | float | Decimal | None = None
         numerical_conversion_failed = None
-        if isinstance(value, str):
-            if "." in value:
-                try:
-                    numerical_value = float(value)
-                except (TypeError, ValueError):
-                    numerical_conversion_failed = True
-            else:
-                try:
+        if not isinstance(value, (int, float, Decimal)):
+            try:
+                if isinstance(value, str) and "." in value:
                     numerical_value = int(value)
-                except (TypeError, ValueError):
-                    numerical_conversion_failed = True
-        elif isinstance(value, (int, float, Decimal)):
+                else:
+                    numerical_value = float(value)  # type:ignore[arg-type]
+            except (TypeError, ValueError):
+                numerical_conversion_failed = True
+        else:
             numerical_value = value
 
         if (

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation as DecimalInvalidOperation
 import logging
-from math import floor, log10
+from math import ceil, floor, log10
 from typing import Any, Final, cast, final
 
 from homeassistant.config_entries import ConfigEntry
@@ -369,11 +369,11 @@ class SensorEntity(Entity):
             return self._sensor_option_precision
 
         # Second priority, native precision
+        if self.native_precision is None:
+            return None
         device_class = self.device_class
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
-        if self.native_precision is None:
-            return None
         precision = self.native_precision
 
         if (
@@ -389,6 +389,7 @@ class SensorEntity(Entity):
                     native_unit_of_measurement, unit_of_measurement
                 )
             )
+            ratio_log = floor(ratio_log) if ratio_log > 0 else ceil(ratio_log)
             precision = max(0, precision + floor(ratio_log))
 
         return precision

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -369,13 +369,12 @@ class SensorEntity(Entity):
             return self._sensor_option_precision
 
         # Second priority, native precision
-        if self.native_precision is None:
+        if (precision := self.native_precision) is None:
             return None
 
         device_class = self.device_class
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
-        precision = self.native_precision
 
         if (
             native_unit_of_measurement != unit_of_measurement

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -436,6 +436,19 @@ UNIT_CONVERTERS: dict[SensorDeviceClass | str | None, type[BaseUnitConverter]] =
     SensorDeviceClass.WIND_SPEED: SpeedConverter,
 }
 
+DEVICE_CLASS_PRECISION: dict[
+    tuple[SensorDeviceClass | None, StrEnum | str | None], int
+] = {
+    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.HPA): 0,
+    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.INHG): 0,
+    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.MMHG): 0,
+    (SensorDeviceClass.BATTERY, PERCENTAGE): 0,
+    (SensorDeviceClass.HUMIDITY, PERCENTAGE): 0,
+    (SensorDeviceClass.MOISTURE, PERCENTAGE): 0,
+    (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS): 1,
+    (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.FAHRENHEIT): 1,
+}
+
 DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.APPARENT_POWER: set(UnitOfApparentPower),
     SensorDeviceClass.AQI: {None},

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -436,19 +436,6 @@ UNIT_CONVERTERS: dict[SensorDeviceClass | str | None, type[BaseUnitConverter]] =
     SensorDeviceClass.WIND_SPEED: SpeedConverter,
 }
 
-DEVICE_CLASS_PRECISION: dict[
-    tuple[SensorDeviceClass | None, StrEnum | str | None], int
-] = {
-    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.HPA): 0,
-    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.INHG): 0,
-    (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.MMHG): 0,
-    (SensorDeviceClass.BATTERY, PERCENTAGE): 0,
-    (SensorDeviceClass.HUMIDITY, PERCENTAGE): 0,
-    (SensorDeviceClass.MOISTURE, PERCENTAGE): 0,
-    (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS): 1,
-    (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.FAHRENHEIT): 1,
-}
-
 DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.APPARENT_POWER: set(UnitOfApparentPower),
     SensorDeviceClass.AQI: {None},

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -20,7 +20,7 @@ async def test_airzone_create_sensors(
 
     # Zones
     state = hass.states.get("sensor.despacho_temperature")
-    assert state.state == "21.2"
+    assert state.state == "21.20"
 
     state = hass.states.get("sensor.despacho_humidity")
     assert state.state == "36"

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -41,23 +41,29 @@ from tests.common import mock_restore_cache_with_extra_data
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.FAHRENHEIT,
             100,
-            100,
+            "100.0",
         ),
         (
             US_CUSTOMARY_SYSTEM,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.FAHRENHEIT,
             38,
-            100,
+            "100",
         ),
         (
             METRIC_SYSTEM,
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.CELSIUS,
             100,
-            38,
+            "37.8",
         ),
-        (METRIC_SYSTEM, UnitOfTemperature.CELSIUS, UnitOfTemperature.CELSIUS, 38, 38),
+        (
+            METRIC_SYSTEM,
+            UnitOfTemperature.CELSIUS,
+            UnitOfTemperature.CELSIUS,
+            38,
+            "38.0",
+        ),
     ],
 )
 async def test_temperature_conversion(
@@ -85,7 +91,7 @@ async def test_temperature_conversion(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(state_value))
+    assert state.state == state_value
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == state_unit
 
 
@@ -109,7 +115,7 @@ async def test_temperature_conversion_wrong_device_class(
 
     # Check temperature is not converted
     state = hass.states.get(entity0.entity_id)
-    assert state.state == "0.0"
+    assert state.state == "0.00"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.FAHRENHEIT
 
 
@@ -407,7 +413,7 @@ async def test_restore_sensor_restore_state(
 
 
 @pytest.mark.parametrize(
-    "device_class,native_unit,custom_unit,state_unit,native_value,custom_value",
+    "device_class, native_unit, custom_unit, state_unit, native_value, custom_state",
     [
         # Smaller to larger unit, InHg is ~33x larger than hPa -> 1 more decimal
         (
@@ -415,24 +421,32 @@ async def test_restore_sensor_restore_state(
             UnitOfPressure.HPA,
             UnitOfPressure.INHG,
             UnitOfPressure.INHG,
-            1000.0,
-            29.53,
+            1000.0,  # Will be treated as precision 2
+            "29.530",  # Precision 2 + 1 = 3
         ),
         (
             SensorDeviceClass.PRESSURE,
             UnitOfPressure.KPA,
             UnitOfPressure.HPA,
             UnitOfPressure.HPA,
-            1.234,
-            12.34,
+            1.234,  # Will be treated as precision 2
+            "12.3",  # Precision 2 - 1 = 1
+        ),
+        (
+            SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+            UnitOfPressure.HPA,
+            UnitOfPressure.MMHG,
+            UnitOfPressure.MMHG,
+            1000,  # Will be treated as precision 0
+            "750",  # Precision 0 + 0 = 0
         ),
         (
             SensorDeviceClass.PRESSURE,
             UnitOfPressure.HPA,
             UnitOfPressure.MMHG,
             UnitOfPressure.MMHG,
-            1000,
-            750,
+            1000,  # Will be treated as precision 2
+            "750.06",  # Precision 2 + 0 = 2
         ),
         # Not a supported pressure unit
         (
@@ -440,24 +454,24 @@ async def test_restore_sensor_restore_state(
             UnitOfPressure.HPA,
             "peer_pressure",
             UnitOfPressure.HPA,
-            1000,
-            1000,
+            1000,  # Will be treated as precision 2
+            "1000.00",
         ),
         (
             SensorDeviceClass.TEMPERATURE,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.FAHRENHEIT,
-            37.5,
-            99.5,
+            37.5,  # Will be treated as precision 1
+            "100",  # Precision 1 - 1 = 0
         ),
         (
             SensorDeviceClass.TEMPERATURE,
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.CELSIUS,
-            100,
-            38.0,
+            100,  # Will be treated as precision 1
+            "37.8",
         ),
     ],
 )
@@ -469,7 +483,7 @@ async def test_custom_unit(
     custom_unit,
     state_unit,
     native_value,
-    custom_value,
+    custom_state,
 ):
     """Test custom unit."""
     entity_registry = er.async_get(hass)
@@ -495,12 +509,68 @@ async def test_custom_unit(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(custom_value))
+    assert state.state == custom_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == state_unit
 
 
 @pytest.mark.parametrize(
-    "native_unit,custom_unit,state_unit,native_value,custom_value,device_class",
+    "device_class,native_unit,custom_precision,native_value,custom_state",
+    [
+        (
+            SensorDeviceClass.ATMOSPHERIC_PRESSURE,  # Defaults to 0 decimals
+            UnitOfPressure.HPA,
+            4,
+            1000.0,
+            "1000.0000",
+        ),
+        (
+            SensorDeviceClass.PRESSURE,  # Defaults to 2 decimals
+            UnitOfPressure.HPA,
+            4,
+            1000.0,
+            "1000.0000",
+        ),
+    ],
+)
+async def test_custom_precision(
+    hass,
+    enable_custom_integrations,
+    device_class,
+    native_unit,
+    custom_precision,
+    native_value,
+    custom_state,
+):
+    """Test custom precision."""
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get_or_create("sensor", "test", "very_unique")
+    entity_registry.async_update_entity_options(
+        entry.entity_id, "sensor", {"precision": custom_precision}
+    )
+    await hass.async_block_till_done()
+
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=str(native_value),
+        native_unit_of_measurement=native_unit,
+        device_class=device_class,
+        unique_id="very_unique",
+    )
+
+    entity0 = platform.ENTITIES["0"]
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.state == custom_state
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == native_unit
+
+
+@pytest.mark.parametrize(
+    "native_unit, custom_unit, state_unit, native_value, native_state, custom_state, device_class",
     [
         # Distance
         (
@@ -508,7 +578,8 @@ async def test_custom_unit(
             UnitOfLength.MILES,
             UnitOfLength.MILES,
             1000,
-            621,
+            "1000.00",
+            "621.37",
             SensorDeviceClass.DISTANCE,
         ),
         (
@@ -516,7 +587,8 @@ async def test_custom_unit(
             UnitOfLength.INCHES,
             UnitOfLength.INCHES,
             7.24,
-            2.85,
+            "7.24",
+            "2.85",
             SensorDeviceClass.DISTANCE,
         ),
         (
@@ -524,7 +596,8 @@ async def test_custom_unit(
             "peer_distance",
             UnitOfLength.KILOMETERS,
             1000,
-            1000,
+            "1000.00",
+            "1000.00",
             SensorDeviceClass.DISTANCE,
         ),
         # Energy
@@ -533,7 +606,8 @@ async def test_custom_unit(
             UnitOfEnergy.MEGA_WATT_HOUR,
             UnitOfEnergy.MEGA_WATT_HOUR,
             1000,
-            1.0,
+            "1000.00",
+            "1.00000",
             SensorDeviceClass.ENERGY,
         ),
         (
@@ -541,7 +615,8 @@ async def test_custom_unit(
             UnitOfEnergy.MEGA_WATT_HOUR,
             UnitOfEnergy.MEGA_WATT_HOUR,
             1000,
-            278,
+            "1000.00",
+            "277.78",
             SensorDeviceClass.ENERGY,
         ),
         (
@@ -549,7 +624,8 @@ async def test_custom_unit(
             "BTU",
             UnitOfEnergy.KILO_WATT_HOUR,
             1000,
-            1000,
+            "1000.00",
+            "1000.00",
             SensorDeviceClass.ENERGY,
         ),
         # Power factor
@@ -558,7 +634,8 @@ async def test_custom_unit(
             PERCENTAGE,
             PERCENTAGE,
             1.0,
-            100,
+            "1.00",
+            "100",
             SensorDeviceClass.POWER_FACTOR,
         ),
         (
@@ -566,7 +643,8 @@ async def test_custom_unit(
             None,
             None,
             100,
-            1,
+            "100.00",
+            "1.0000",
             SensorDeviceClass.POWER_FACTOR,
         ),
         (
@@ -574,7 +652,8 @@ async def test_custom_unit(
             None,
             "Cos φ",
             1.0,
-            1.0,
+            "1.00",
+            "1.00",
             SensorDeviceClass.POWER_FACTOR,
         ),
         # Pressure
@@ -584,7 +663,8 @@ async def test_custom_unit(
             UnitOfPressure.INHG,
             UnitOfPressure.INHG,
             1000.0,
-            29.53,
+            "1000.00",
+            "29.530",
             SensorDeviceClass.PRESSURE,
         ),
         (
@@ -592,7 +672,8 @@ async def test_custom_unit(
             UnitOfPressure.HPA,
             UnitOfPressure.HPA,
             1.234,
-            12.34,
+            "1.23",
+            "12.3",
             SensorDeviceClass.PRESSURE,
         ),
         (
@@ -600,7 +681,8 @@ async def test_custom_unit(
             UnitOfPressure.MMHG,
             UnitOfPressure.MMHG,
             1000,
-            750,
+            "1000.00",
+            "750.06",
             SensorDeviceClass.PRESSURE,
         ),
         # Not a supported pressure unit
@@ -609,7 +691,8 @@ async def test_custom_unit(
             "peer_pressure",
             UnitOfPressure.HPA,
             1000,
-            1000,
+            "1000.00",
+            "1000.00",
             SensorDeviceClass.PRESSURE,
         ),
         # Speed
@@ -618,7 +701,8 @@ async def test_custom_unit(
             UnitOfSpeed.MILES_PER_HOUR,
             UnitOfSpeed.MILES_PER_HOUR,
             100,
-            62,
+            "100.00",
+            "62.14",
             SensorDeviceClass.SPEED,
         ),
         (
@@ -626,7 +710,8 @@ async def test_custom_unit(
             UnitOfVolumetricFlux.INCHES_PER_HOUR,
             UnitOfVolumetricFlux.INCHES_PER_HOUR,
             78,
-            0.13,
+            "78.00",
+            "0.1280",
             SensorDeviceClass.SPEED,
         ),
         (
@@ -634,7 +719,8 @@ async def test_custom_unit(
             "peer_distance",
             UnitOfSpeed.KILOMETERS_PER_HOUR,
             100,
-            100,
+            "100.00",
+            "100.00",
             SensorDeviceClass.SPEED,
         ),
         # Volume
@@ -643,7 +729,8 @@ async def test_custom_unit(
             UnitOfVolume.CUBIC_FEET,
             UnitOfVolume.CUBIC_FEET,
             100,
-            3531,
+            "100.00",
+            "3531",
             SensorDeviceClass.VOLUME,
         ),
         (
@@ -651,7 +738,8 @@ async def test_custom_unit(
             UnitOfVolume.FLUID_OUNCES,
             UnitOfVolume.FLUID_OUNCES,
             2.3,
-            77.8,
+            "2.30",
+            "78",
             SensorDeviceClass.VOLUME,
         ),
         (
@@ -659,7 +747,8 @@ async def test_custom_unit(
             "peer_distance",
             UnitOfVolume.CUBIC_METERS,
             100,
-            100,
+            "100.00",
+            "100.00",
             SensorDeviceClass.VOLUME,
         ),
         # Weight
@@ -668,7 +757,8 @@ async def test_custom_unit(
             UnitOfMass.OUNCES,
             UnitOfMass.OUNCES,
             100,
-            3.5,
+            "100.00",
+            "3.527",
             SensorDeviceClass.WEIGHT,
         ),
         (
@@ -676,7 +766,8 @@ async def test_custom_unit(
             UnitOfMass.GRAMS,
             UnitOfMass.GRAMS,
             78,
-            2211,
+            "78.00",
+            "2211",
             SensorDeviceClass.WEIGHT,
         ),
         (
@@ -684,7 +775,8 @@ async def test_custom_unit(
             "peer_distance",
             UnitOfMass.GRAMS,
             100,
-            100,
+            "100.00",
+            "100.00",
             SensorDeviceClass.WEIGHT,
         ),
     ],
@@ -696,7 +788,8 @@ async def test_custom_unit_change(
     custom_unit,
     state_unit,
     native_value,
-    custom_value,
+    native_state,
+    custom_state,
     device_class,
 ):
     """Test custom unit changes are picked up."""
@@ -716,7 +809,7 @@ async def test_custom_unit_change(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(native_value))
+    assert state.state == native_state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == native_unit
 
     entity_registry.async_update_entity_options(
@@ -725,7 +818,7 @@ async def test_custom_unit_change(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(custom_value))
+    assert state.state == custom_state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == state_unit
 
     entity_registry.async_update_entity_options(
@@ -734,19 +827,19 @@ async def test_custom_unit_change(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(native_value))
+    assert state.state == native_state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == native_unit
 
     entity_registry.async_update_entity_options("sensor.test", "sensor", None)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(native_value))
+    assert state.state == native_state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == native_unit
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, automatic_unit, suggested_unit, custom_unit, native_value, automatic_value, suggested_value, custom_value, device_class",
+    "unit_system, native_unit, automatic_unit, suggested_unit, custom_unit, native_value, native_state, automatic_state, suggested_state, custom_state, device_class",
     [
         # Distance
         (
@@ -756,9 +849,10 @@ async def test_custom_unit_change(
             UnitOfLength.METERS,
             UnitOfLength.YARDS,
             1000,
-            621,
-            1000000,
-            1093613,
+            "1000.00",
+            "621.37",
+            "1000000",
+            "1093613",
             SensorDeviceClass.DISTANCE,
         ),
     ],
@@ -772,9 +866,10 @@ async def test_unit_conversion_priority(
     suggested_unit,
     custom_unit,
     native_value,
-    automatic_value,
-    suggested_value,
-    custom_value,
+    native_state,
+    automatic_state,
+    suggested_state,
+    custom_state,
     device_class,
 ):
     """Test priority of unit conversion."""
@@ -826,7 +921,7 @@ async def test_unit_conversion_priority(
 
     # Registered entity -> Follow automatic unit conversion
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(automatic_value))
+    assert state.state == automatic_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == automatic_unit
     # Assert the automatic unit conversion is stored in the registry
     entry = entity_registry.async_get(entity0.entity_id)
@@ -836,12 +931,12 @@ async def test_unit_conversion_priority(
 
     # Unregistered entity -> Follow native unit
     state = hass.states.get(entity1.entity_id)
-    assert float(state.state) == approx(float(native_value))
+    assert state.state == native_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == native_unit
 
     # Registered entity with suggested unit
     state = hass.states.get(entity2.entity_id)
-    assert float(state.state) == approx(float(suggested_value))
+    assert state.state == suggested_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == suggested_unit
     # Assert the suggested unit is stored in the registry
     entry = entity_registry.async_get(entity2.entity_id)
@@ -851,7 +946,7 @@ async def test_unit_conversion_priority(
 
     # Unregistered entity with suggested unit
     state = hass.states.get(entity3.entity_id)
-    assert float(state.state) == approx(float(suggested_value))
+    assert state.state == suggested_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == suggested_unit
 
     # Set a custom unit, this should have priority over the automatic unit conversion
@@ -861,7 +956,7 @@ async def test_unit_conversion_priority(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert float(state.state) == approx(float(custom_value))
+    assert state.state == custom_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == custom_unit
 
     entity_registry.async_update_entity_options(
@@ -870,7 +965,7 @@ async def test_unit_conversion_priority(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity2.entity_id)
-    assert float(state.state) == approx(float(custom_value))
+    assert state.state == custom_state
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == custom_unit
 
 
@@ -964,7 +1059,7 @@ async def test_unit_conversion_priority_suggested_unit_change(
             UnitOfLength.KILOMETERS,
             UnitOfLength.MILES,
             1000,
-            621,
+            621.37,
             SensorDeviceClass.DISTANCE,
         ),
         (
@@ -1265,8 +1360,8 @@ async def test_non_numeric_validation(
     "native_value,expected",
     [
         (13, "13"),
-        (17.50, "17.5"),
-        (Decimal(18.50), "18.5"),
+        (17.50, "17.50"),
+        (Decimal(18.50), "18.50"),
         ("19.70", "19.70"),
         (None, STATE_UNKNOWN),
     ],

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -41,7 +41,7 @@ from tests.common import mock_restore_cache_with_extra_data
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.FAHRENHEIT,
             100,
-            "100.0",
+            "100",
         ),
         (
             US_CUSTOMARY_SYSTEM,
@@ -55,14 +55,14 @@ from tests.common import mock_restore_cache_with_extra_data
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.CELSIUS,
             100,
-            "37.8",
+            "38",
         ),
         (
             METRIC_SYSTEM,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.CELSIUS,
             38,
-            "38.0",
+            "38",
         ),
     ],
 )
@@ -115,7 +115,7 @@ async def test_temperature_conversion_wrong_device_class(
 
     # Check temperature is not converted
     state = hass.states.get(entity0.entity_id)
-    assert state.state == "0.00"
+    assert state.state == "0.0"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.FAHRENHEIT
 
 
@@ -421,32 +421,32 @@ async def test_restore_sensor_restore_state(
             UnitOfPressure.HPA,
             UnitOfPressure.INHG,
             UnitOfPressure.INHG,
-            1000.0,  # Will be treated as precision 2
-            "29.530",  # Precision 2 + 1 = 3
+            1000.0,
+            "29.53",
         ),
         (
             SensorDeviceClass.PRESSURE,
             UnitOfPressure.KPA,
             UnitOfPressure.HPA,
             UnitOfPressure.HPA,
-            1.234,  # Will be treated as precision 2
-            "12.3",  # Precision 2 - 1 = 1
+            1.234,
+            "12.340",
         ),
         (
             SensorDeviceClass.ATMOSPHERIC_PRESSURE,
             UnitOfPressure.HPA,
             UnitOfPressure.MMHG,
             UnitOfPressure.MMHG,
-            1000,  # Will be treated as precision 0
-            "750",  # Precision 0 + 0 = 0
+            1000,
+            "750",
         ),
         (
             SensorDeviceClass.PRESSURE,
             UnitOfPressure.HPA,
             UnitOfPressure.MMHG,
             UnitOfPressure.MMHG,
-            1000,  # Will be treated as precision 2
-            "750.06",  # Precision 2 + 0 = 2
+            1000,
+            "750",
         ),
         # Not a supported pressure unit
         (
@@ -454,24 +454,24 @@ async def test_restore_sensor_restore_state(
             UnitOfPressure.HPA,
             "peer_pressure",
             UnitOfPressure.HPA,
-            1000,  # Will be treated as precision 2
-            "1000.00",
+            1000,
+            "1000",
         ),
         (
             SensorDeviceClass.TEMPERATURE,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.FAHRENHEIT,
-            37.5,  # Will be treated as precision 1
-            "100",  # Precision 1 - 1 = 0
+            37.5,
+            "99.5",
         ),
         (
             SensorDeviceClass.TEMPERATURE,
             UnitOfTemperature.FAHRENHEIT,
             UnitOfTemperature.CELSIUS,
             UnitOfTemperature.CELSIUS,
-            100,  # Will be treated as precision 1
-            "37.8",
+            100,
+            "38",
         ),
     ],
 )
@@ -578,8 +578,8 @@ async def test_custom_precision(
             UnitOfLength.MILES,
             UnitOfLength.MILES,
             1000,
-            "1000.00",
-            "621.37",
+            "1000",
+            "621",
             SensorDeviceClass.DISTANCE,
         ),
         (
@@ -596,8 +596,8 @@ async def test_custom_precision(
             "peer_distance",
             UnitOfLength.KILOMETERS,
             1000,
-            "1000.00",
-            "1000.00",
+            "1000",
+            "1000",
             SensorDeviceClass.DISTANCE,
         ),
         # Energy
@@ -606,8 +606,8 @@ async def test_custom_precision(
             UnitOfEnergy.MEGA_WATT_HOUR,
             UnitOfEnergy.MEGA_WATT_HOUR,
             1000,
-            "1000.00",
-            "1.00000",
+            "1000",
+            "1.000",
             SensorDeviceClass.ENERGY,
         ),
         (
@@ -615,8 +615,8 @@ async def test_custom_precision(
             UnitOfEnergy.MEGA_WATT_HOUR,
             UnitOfEnergy.MEGA_WATT_HOUR,
             1000,
-            "1000.00",
-            "277.78",
+            "1000",
+            "278",
             SensorDeviceClass.ENERGY,
         ),
         (
@@ -624,8 +624,8 @@ async def test_custom_precision(
             "BTU",
             UnitOfEnergy.KILO_WATT_HOUR,
             1000,
-            "1000.00",
-            "1000.00",
+            "1000",
+            "1000",
             SensorDeviceClass.ENERGY,
         ),
         # Power factor
@@ -634,8 +634,8 @@ async def test_custom_precision(
             PERCENTAGE,
             PERCENTAGE,
             1.0,
-            "1.00",
-            "100",
+            "1.0",
+            "100.0",
             SensorDeviceClass.POWER_FACTOR,
         ),
         (
@@ -643,8 +643,8 @@ async def test_custom_precision(
             None,
             None,
             100,
-            "100.00",
-            "1.0000",
+            "100",
+            "1.00",
             SensorDeviceClass.POWER_FACTOR,
         ),
         (
@@ -652,8 +652,8 @@ async def test_custom_precision(
             None,
             "Cos φ",
             1.0,
-            "1.00",
-            "1.00",
+            "1.0",
+            "1.0",
             SensorDeviceClass.POWER_FACTOR,
         ),
         # Pressure
@@ -663,8 +663,8 @@ async def test_custom_precision(
             UnitOfPressure.INHG,
             UnitOfPressure.INHG,
             1000.0,
-            "1000.00",
-            "29.530",
+            "1000.0",
+            "29.53",
             SensorDeviceClass.PRESSURE,
         ),
         (
@@ -672,8 +672,8 @@ async def test_custom_precision(
             UnitOfPressure.HPA,
             UnitOfPressure.HPA,
             1.234,
-            "1.23",
-            "12.3",
+            "1.234",
+            "12.340",
             SensorDeviceClass.PRESSURE,
         ),
         (
@@ -681,8 +681,8 @@ async def test_custom_precision(
             UnitOfPressure.MMHG,
             UnitOfPressure.MMHG,
             1000,
-            "1000.00",
-            "750.06",
+            "1000",
+            "750",
             SensorDeviceClass.PRESSURE,
         ),
         # Not a supported pressure unit
@@ -691,8 +691,8 @@ async def test_custom_precision(
             "peer_pressure",
             UnitOfPressure.HPA,
             1000,
-            "1000.00",
-            "1000.00",
+            "1000",
+            "1000",
             SensorDeviceClass.PRESSURE,
         ),
         # Speed
@@ -701,8 +701,8 @@ async def test_custom_precision(
             UnitOfSpeed.MILES_PER_HOUR,
             UnitOfSpeed.MILES_PER_HOUR,
             100,
-            "100.00",
-            "62.14",
+            "100",
+            "62",
             SensorDeviceClass.SPEED,
         ),
         (
@@ -710,8 +710,8 @@ async def test_custom_precision(
             UnitOfVolumetricFlux.INCHES_PER_HOUR,
             UnitOfVolumetricFlux.INCHES_PER_HOUR,
             78,
-            "78.00",
-            "0.1280",
+            "78",
+            "0.13",
             SensorDeviceClass.SPEED,
         ),
         (
@@ -719,8 +719,8 @@ async def test_custom_precision(
             "peer_distance",
             UnitOfSpeed.KILOMETERS_PER_HOUR,
             100,
-            "100.00",
-            "100.00",
+            "100",
+            "100",
             SensorDeviceClass.SPEED,
         ),
         # Volume
@@ -729,7 +729,7 @@ async def test_custom_precision(
             UnitOfVolume.CUBIC_FEET,
             UnitOfVolume.CUBIC_FEET,
             100,
-            "100.00",
+            "100",
             "3531",
             SensorDeviceClass.VOLUME,
         ),
@@ -738,8 +738,8 @@ async def test_custom_precision(
             UnitOfVolume.FLUID_OUNCES,
             UnitOfVolume.FLUID_OUNCES,
             2.3,
-            "2.30",
-            "78",
+            "2.3",
+            "77.8",
             SensorDeviceClass.VOLUME,
         ),
         (
@@ -747,8 +747,8 @@ async def test_custom_precision(
             "peer_distance",
             UnitOfVolume.CUBIC_METERS,
             100,
-            "100.00",
-            "100.00",
+            "100",
+            "100",
             SensorDeviceClass.VOLUME,
         ),
         # Weight
@@ -757,8 +757,8 @@ async def test_custom_precision(
             UnitOfMass.OUNCES,
             UnitOfMass.OUNCES,
             100,
-            "100.00",
-            "3.527",
+            "100",
+            "3.5",
             SensorDeviceClass.WEIGHT,
         ),
         (
@@ -766,7 +766,7 @@ async def test_custom_precision(
             UnitOfMass.GRAMS,
             UnitOfMass.GRAMS,
             78,
-            "78.00",
+            "78",
             "2211",
             SensorDeviceClass.WEIGHT,
         ),
@@ -775,8 +775,8 @@ async def test_custom_precision(
             "peer_distance",
             UnitOfMass.GRAMS,
             100,
-            "100.00",
-            "100.00",
+            "100",
+            "100",
             SensorDeviceClass.WEIGHT,
         ),
     ],
@@ -849,8 +849,8 @@ async def test_custom_unit_change(
             UnitOfLength.METERS,
             UnitOfLength.YARDS,
             1000,
-            "1000.00",
-            "621.37",
+            "1000",
+            "621",
             "1000000",
             "1093613",
             SensorDeviceClass.DISTANCE,
@@ -1059,7 +1059,7 @@ async def test_unit_conversion_priority_suggested_unit_change(
             UnitOfLength.KILOMETERS,
             UnitOfLength.MILES,
             1000,
-            621.37,
+            621.0,
             SensorDeviceClass.DISTANCE,
         ),
         (
@@ -1360,8 +1360,8 @@ async def test_non_numeric_validation(
     "native_value,expected",
     [
         (13, "13"),
-        (17.50, "17.50"),
-        (Decimal(18.50), "18.50"),
+        (17.50, "17.5"),
+        (Decimal(18.50), "18.5"),
         ("19.70", "19.70"),
         (None, STATE_UNKNOWN),
     ],

--- a/tests/testing_config/custom_components/test/sensor.py
+++ b/tests/testing_config/custom_components/test/sensor.py
@@ -99,6 +99,11 @@ class MockSensor(MockEntity, SensorEntity):
         return self._handle("last_reset")
 
     @property
+    def native_precision(self):
+        """Return the number of digits after the decimal point."""
+        return self._handle("native_precision")
+
+    @property
     def native_unit_of_measurement(self):
         """Return the native unit_of_measurement of this sensor."""
         return self._handle("native_unit_of_measurement")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow customizing sensor state precision:
- By default, no rounding is done
  - Integrations can influence the state precision by setting a new property `native_precision`
- The state precision is influenced by unit conversion
  - Converting from a smaller to a larger unit increases the display precision
  - Converting from a larger to a smaller unit decreases the display precision if the integration has set `native_precision`
  - Minimum precision when converting from a larger to a smaller unit is 0, i.e. there's no rounding to tens, hundreds etc.
- User can override the display precision from the frontend
  - There's no minimum precision, i.e. rounding to tens, hundreds, etc. is possible by setting a negative precision
- Integrations are encouraged to drop rounding for display and instead set property `native_precision`
- Trailing zeroes are added to the sensor state's string representation to match the precision if:
  - The precision is set by user
  - The `native_precision` property is not `None`
  - Unit conversion is done

Frontend:
- https://github.com/home-assistant/frontend/pull/15176

Documentation:
- Developer documentation update: https://github.com/home-assistant/developers.home-assistant/pull/1648
- Developer blog: https://github.com/home-assistant/developers.home-assistant/pull/1649

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
