### PR TITLE
Cast enum sensor value to str to compare options

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -501,7 +501,7 @@ class SensorEntity(Entity):
                     f"Sensor {self.entity_id} is providing enum options, but {reason}"
                 )
 
-            if (options := self.options) and value not in options:
+            if (options := self.options) and str(value) not in options:
                 raise ValueError(
                     f"Sensor {self.entity_id} provides state value '{value}', "
                     "which is not in the list of options provided"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A enum sensor is checked agains a list of strings. But the value can be `StateType | date | datetime | Decimal`. I think the value should be casted.

Why? For example:
```python

# Source: https://github.com/home-assistant/core/blob/566c0f63bdab2eddd36c9d72ff48ec3bf9f759e5/homeassistant/components/homewizard/sensor.py#L73-L78

HomeWizardSensorEntityDescription(
    key="active_tariff",
    name="Active tariff",
    icon="mdi:calendar-clock",
    value_fn=lambda data: data.active_tariff,
    device_class=SensorDeviceClass.ENUM,
    options=["1", "2", "3", "4"],
),
```

Triggers:
```
2023-01-17 10:27:49.134 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up homewizard platform for sensor
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 301, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 442, in async_add_entities
    await asyncio.gather(*tasks)
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 717, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 814, in add_to_platform_finish
    self.async_write_ha_state()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 566, in async_write_ha_state
    self._async_write_ha_state()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 607, in _async_write_ha_state
    state = self._stringify_state(available)
  File "/workspaces/core/homeassistant/helpers/entity.py", line 572, in _stringify_state
    if (state := self.state) is None:
  File "/workspaces/core/homeassistant/components/sensor/__init__.py", line 505, in state
    raise ValueError(
ValueError: Sensor sensor.p1_meter_active_tariff provides state value '2', which is not in the list of options provided
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
