### PR TITLE
Add Enum device class for HomeWizard active tariff

### DIFF
--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -74,7 +74,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="active_tariff",
         name="Active tariff",
         icon="mdi:calendar-clock",
-        value_fn=lambda data: data.active_tariff,
+        value_fn=lambda data: str(data.active_tariff),
+        device_class=SensorDeviceClass.ENUM,
+        options=["1", "2", "3", "4"],
     ),
     HomeWizardSensorEntityDescription(
         key="wifi_strength",

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -74,9 +74,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="active_tariff",
         name="Active tariff",
         icon="mdi:calendar-clock",
-        value_fn=lambda data: str(data.active_tariff)
-        if data.active_tariff is not None
-        else None,
+        value_fn=lambda data: (
+            None if data.active_tariff is None else str(data.active_tariff)
+        ),
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -74,7 +74,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="active_tariff",
         name="Active tariff",
         icon="mdi:calendar-clock",
-        value_fn=lambda data: str(data.active_tariff),
+        value_fn=lambda data: str(data.active_tariff)
+        if data.active_tariff is not None
+        else None,
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -145,6 +145,44 @@ async def test_sensor_entity_wifi_ssid(hass, mock_config_entry_data, mock_config
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
 
 
+async def test_sensor_entity_active_tariff(
+    hass, mock_config_entry_data, mock_config_entry
+):
+    """Test entity loads active_tariff."""
+
+    api = get_mock_device()
+    api.data = AsyncMock(return_value=Data.from_dict({"active_tariff": 2}))
+
+    with patch(
+        "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("sensor.product_name_aabbccddeeff_active_tariff")
+    entry = entity_registry.async_get("sensor.product_name_aabbccddeeff_active_tariff")
+    assert entry
+    assert state
+    assert entry.unique_id == "aabbccddeeff_active_tariff"
+    assert not entry.disabled
+    assert state.state == "2"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Product Name (aabbccddeeff) Active tariff"
+    )
+    assert ATTR_STATE_CLASS not in state.attributes
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
+    assert state.attributes.get(ATTR_ICON) == "mdi:calendar-clock"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
+
+
 async def test_sensor_entity_wifi_strength(
     hass, mock_config_entry_data, mock_config_entry
 ):

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    ATTR_OPTIONS,
     ATTR_UNIT_OF_MEASUREMENT,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -181,6 +182,7 @@ async def test_sensor_entity_active_tariff(
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
     assert state.attributes.get(ATTR_ICON) == "mdi:calendar-clock"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
+    assert state.attributes.get(ATTR_OPTIONS) == ["1", "2", "3", "4"]
 
 
 async def test_sensor_entity_wifi_strength(

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -7,6 +7,7 @@ from homewizard_energy.errors import DisabledError, RequestError
 from homewizard_energy.models import Data
 
 from homeassistant.components.sensor import (
+    ATTR_OPTIONS,
     ATTR_STATE_CLASS,
     SensorDeviceClass,
     SensorStateClass,
@@ -15,7 +16,6 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
-    ATTR_OPTIONS,
     ATTR_UNIT_OF_MEASUREMENT,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-→
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Enum device class for HomeWizard active_tariff sensor.

Also adds a test for this sensor, which was missing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
