### PR TITLE
Add state attributes for lock component

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -40,7 +40,7 @@ ATTR_CHANGED_BY = "changed_by"
 ATTR_IS_JAMMED = "is_jammed"
 ATTR_IS_LOCKED = "is_locked"
 ATTR_IS_LOCKING = "is_locking"
-ATTR_UNLOCKING = "is_unlocking"
+ATTR_IS_UNLOCKING = "is_unlocking"
 
 DOMAIN = "lock"
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -68,6 +68,7 @@ PROP_TO_ATTR = {
     "is_jammed": ATTR_IS_JAMMED,
     "is_locked": ATTR_IS_LOCKED,
     "is_locking": ATTR_IS_LOCKING,
+    "is_unlocking": ATTR_IS_UNLOCKING,
 }
 
 # mypy: disallow-any-generics
@@ -182,11 +183,7 @@ class LockEntity(Entity):
     @property
     def state_attributes(self) -> dict[str, StateType]:
         """Return the state attributes."""
-        state_attr = {}
-        for prop, attr in PROP_TO_ATTR.items():
-            if (value := getattr(self, prop)) is not None:
-                state_attr[attr] = value
-        return state_attr
+        return {attr: getattr(self, prop) for prop, attr in PROP_TO_ATTR.items()}
 
     @final
     @property

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -37,6 +37,10 @@ from homeassistant.helpers.typing import ConfigType, StateType
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANGED_BY = "changed_by"
+ATTR_IS_JAMMED = "is_jammed"
+ATTR_IS_LOCKED = "is_locked"
+ATTR_IS_LOCKING = "is_locking"
+ATTR_UNLOCKING = "is_unlocking"
 
 DOMAIN = "lock"
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -58,7 +62,13 @@ class LockEntityFeature(IntFlag):
 # Please use the LockEntityFeature enum instead.
 SUPPORT_OPEN = 1
 
-PROP_TO_ATTR = {"changed_by": ATTR_CHANGED_BY, "code_format": ATTR_CODE_FORMAT}
+PROP_TO_ATTR = {
+    "changed_by": ATTR_CHANGED_BY,
+    "code_format": ATTR_CODE_FORMAT,
+    "is_jammed": ATTR_IS_JAMMED,
+    "is_locked": ATTR_IS_LOCKED,
+    "is_locking": ATTR_IS_LOCKING,
+}
 
 # mypy: disallow-any-generics
 

--- a/tests/components/demo/test_lock.py
+++ b/tests/components/demo/test_lock.py
@@ -113,9 +113,12 @@ async def test_opening(hass):
     state = hass.states.get(OPENABLE_LOCK)
     assert state.state == STATE_UNLOCKED
     assert state.attributes == {
+        "changed_by": None,
+        "code_format": None,
         "is_jammed": False,
         "is_locked": False,
         "is_locking": False,
+        "is_unlocking": False,
         "friendly_name": "Openable Lock",
         "supported_features": LockEntityFeature.OPEN,
     }

--- a/tests/components/demo/test_lock.py
+++ b/tests/components/demo/test_lock.py
@@ -14,6 +14,7 @@ from homeassistant.components.lock import (
     STATE_LOCKING,
     STATE_UNLOCKED,
     STATE_UNLOCKING,
+    LockEntityFeature,
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED
 from homeassistant.setup import async_setup_component
@@ -111,3 +112,10 @@ async def test_opening(hass):
     )
     state = hass.states.get(OPENABLE_LOCK)
     assert state.state == STATE_UNLOCKED
+    assert state.attributes == {
+        "is_jammed": False,
+        "is_locked": False,
+        "is_locking": False,
+        "friendly_name": "Openable Lock",
+        "supported_features": LockEntityFeature.OPEN,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `is_locked`, `is_locking`, `is_unlocking` and `is_jammed` state attributes for lock component. When a lock is `jammed` we want to `know` in what state this happened, if only the state is available, we do not know of the lock is `locked` or not when it gets jammed. Also this information is not logged at the moment.

With this PR all lock state attributes will become always available, which is not the current case.

Architecture discussion:
https://github.com/home-assistant/architecture/discussions/860

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
