### PR TITLE
Adjust device registry for Matter devices

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, ID_TYPE_DEVICE_ID, ID_TYPE_SERIAL, LOGGER
 from .device_platform import DEVICE_PLATFORM
 from .helpers import get_device_id
 
@@ -106,11 +106,11 @@ class MatterAdapter:
             server_info,
             node_device,
         )
-        identifiers = {(DOMAIN, node_device_id)}
+        identifiers = {(DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")}
         # if available, we also add the serialnumber as identifier
         if basic_info.serialNumber and "test" not in basic_info.serialNumber.lower():
             # prefix identifier with 'serial_' to be able to filter it
-            identifiers.add((DOMAIN, f"serial_{basic_info.serialNumber}"))
+            identifiers.add((DOMAIN, f"{ID_TYPE_SERIAL}_{basic_info.serialNumber}"))
 
         dr.async_get(self.hass).async_get_or_create(
             name=name,

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -102,16 +102,15 @@ class MatterAdapter:
         elif not name and device_type_instances:
             # use the productName if no node label is present
             name = basic_info.productName
-        node_unique_id = get_device_id(
+        node_device_id = get_device_id(
             server_info,
             node_device,
         )
-        identifiers = {(DOMAIN, node_unique_id)}
-        # if available, we also add the uniqueID or serialnumber as identifier
-        if basic_info.uniqueID:
-            identifiers.add((DOMAIN, basic_info.uniqueID))
+        identifiers = {(DOMAIN, node_device_id)}
+        # if available, we also add the serialnumber as identifier
         if basic_info.serialNumber and "test" not in basic_info.serialNumber.lower():
-            identifiers.add((DOMAIN, basic_info.serialNumber))
+            # prefix identifier with 'serial_' to be able to filter it
+            identifiers.add((DOMAIN, f"serial_{basic_info.serialNumber}"))
 
         dr.async_get(self.hass).async_get_or_create(
             name=name,

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -108,10 +108,9 @@ class MatterAdapter:
         )
         identifiers = {(DOMAIN, node_unique_id)}
         # if available, we also add the uniqueID or serialnumber as identifier
-        # prefer uniqueID here because test devices may have "test" as serial number
         if basic_info.uniqueID:
             identifiers.add((DOMAIN, basic_info.uniqueID))
-        elif basic_info.serialNumber:
+        if basic_info.serialNumber and "test" not in basic_info.serialNumber.lower():
             identifiers.add((DOMAIN, basic_info.serialNumber))
 
         dr.async_get(self.hass).async_get_or_create(

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -102,6 +102,7 @@ class MatterAdapter:
         elif not name and device_type_instances:
             # use the productName if no node label is present
             name = basic_info.productName
+
         node_device_id = get_device_id(
             server_info,
             node_device,

--- a/homeassistant/components/matter/const.py
+++ b/homeassistant/components/matter/const.py
@@ -10,5 +10,5 @@ DOMAIN = "matter"
 LOGGER = logging.getLogger(__package__)
 
 # prefixes to identify device identifier id types
-ID_TYPE_DEVICE_ID = "device_id"
+ID_TYPE_DEVICE_ID = "deviceid"
 ID_TYPE_SERIAL = "serial"

--- a/homeassistant/components/matter/const.py
+++ b/homeassistant/components/matter/const.py
@@ -8,3 +8,7 @@ CONF_USE_ADDON = "use_addon"
 
 DOMAIN = "matter"
 LOGGER = logging.getLogger(__package__)
+
+# prefixes to identify device identifier id types
+ID_TYPE_DEVICE_ID = "device_id"
+ID_TYPE_SERIAL = "serial"

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -15,7 +15,7 @@ from matter_server.common.models.server_information import ServerInfo
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 
-from .const import DOMAIN
+from .const import DOMAIN, ID_TYPE_DEVICE_ID
 from .helpers import get_device_id, get_operational_instance_id
 
 if TYPE_CHECKING:
@@ -68,8 +68,9 @@ class MatterEntity(Entity):
             f"{device_type_instance.endpoint}-"
             f"{device_type_instance.device_type.device_type}"
         )
+        node_device_id = get_device_id(server_info, node_device)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, get_device_id(server_info, node_device))}
+            identifiers={(DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")}
         )
 
     async def async_added_to_hass(self) -> None:

--- a/tests/components/matter/fixtures/nodes/on-off-plugin-unit.json
+++ b/tests/components/matter/fixtures/nodes/on-off-plugin-unit.json
@@ -175,7 +175,7 @@
       "attribute_id": 5,
       "attribute_type": "chip.clusters.Objects.Basic.Attributes.NodeLabel",
       "attribute_name": "NodeLabel",
-      "value": "Mock OnOff Plugin Unit"
+      "value": ""
     },
     "0/40/6": {
       "node_id": 1,

--- a/tests/components/matter/fixtures/nodes/onoff-light.json
+++ b/tests/components/matter/fixtures/nodes/onoff-light.json
@@ -469,7 +469,7 @@
       "attribute_id": 15,
       "attribute_type": "chip.clusters.Objects.Basic.Attributes.SerialNumber",
       "attribute_name": "SerialNumber",
-      "value": "TEST_SN"
+      "value": "12345678"
     },
     "0/40/16": {
       "node_id": 1,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -32,10 +32,8 @@ async def test_device_registry_single_node_device(
     )
     assert entry is not None
 
-    # test unique id present as additional identifier
-    assert (DOMAIN, "mock-onoff-light") in entry.identifiers
-    # test serial NOT added as additional identifier
-    assert (DOMAIN, "TEST_SN") not in entry.identifiers
+    # test serial id present as additional identifier
+    assert (DOMAIN, "serial_12345678") in entry.identifiers
 
     assert entry.name == "Mock OnOff Light"
     assert entry.manufacturer == "Nabu Casa"

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -28,7 +28,7 @@ async def test_device_registry_single_node_device(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "00000000000004D2-0000000000000001-MatterNodeDevice")}
+        {(DOMAIN, "device_id_00000000000004D2-0000000000000001-MatterNodeDevice")}
     )
     assert entry is not None
 
@@ -55,7 +55,7 @@ async def test_device_registry_single_node_device_alt(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "00000000000004D2-0000000000000001-MatterNodeDevice")}
+        {(DOMAIN, "device_id_00000000000004D2-0000000000000001-MatterNodeDevice")}
     )
     assert entry is not None
 

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -32,6 +32,11 @@ async def test_device_registry_single_node_device(
     )
     assert entry is not None
 
+    # test unique id present as additional identifier
+    assert (DOMAIN, "mock-onoff-light") in entry.identifiers
+    # test serial NOT added as additional identifier
+    assert (DOMAIN, "TEST_SN") not in entry.identifiers
+
     assert entry.name == "Mock OnOff Light"
     assert entry.manufacturer == "Nabu Casa"
     assert entry.model == "Mock Light"

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -42,6 +42,30 @@ async def test_device_registry_single_node_device(
     assert entry.sw_version == "v1.0"
 
 
+async def test_device_registry_single_node_device_alt(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Test additional device with different attribute values."""
+    await setup_integration_with_node_fixture(
+        hass,
+        "on-off-plugin-unit",
+        matter_client,
+    )
+
+    dev_reg = dr.async_get(hass)
+    entry = dev_reg.async_get_device(
+        {(DOMAIN, "00000000000004D2-0000000000000001-MatterNodeDevice")}
+    )
+    assert entry is not None
+
+    # test name is derived from productName (because nodeLabel is absent)
+    assert entry.name == "Mock OnOffPluginUnit (powerplug/switch)"
+
+    # test serial id NOT present as additional identifier
+    assert (DOMAIN, "serial_TEST_SN") not in entry.identifiers
+
+
 @pytest.mark.skip("Waiting for a new test fixture")
 async def test_device_registry_bridge(
     hass: HomeAssistant,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -28,7 +28,7 @@ async def test_device_registry_single_node_device(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "device_id_00000000000004D2-0000000000000001-MatterNodeDevice")}
+        {(DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")}
     )
     assert entry is not None
 
@@ -55,7 +55,7 @@ async def test_device_registry_single_node_device_alt(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "device_id_00000000000004D2-0000000000000001-MatterNodeDevice")}
+        {(DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")}
     )
     assert entry is not None
 

--- a/tests/components/matter/test_switch.py
+++ b/tests/components/matter/test_switch.py
@@ -30,7 +30,7 @@ async def test_turn_on(
     switch_node: MatterNode,
 ) -> None:
     """Test turning on a switch."""
-    state = hass.states.get("switch.mock_onoff_plugin_unit")
+    state = hass.states.get("switch.mock_onoffpluginunit_powerplug_switch")
     assert state
     assert state.state == "off"
 
@@ -38,7 +38,7 @@ async def test_turn_on(
         "switch",
         "turn_on",
         {
-            "entity_id": "switch.mock_onoff_plugin_unit",
+            "entity_id": "switch.mock_onoffpluginunit_powerplug_switch",
         },
         blocking=True,
     )
@@ -53,7 +53,7 @@ async def test_turn_on(
     set_node_attribute(switch_node, 1, 6, 0, True)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("switch.mock_onoff_plugin_unit")
+    state = hass.states.get("switch.mock_onoffpluginunit_powerplug_switch")
     assert state
     assert state.state == "on"
 
@@ -64,7 +64,7 @@ async def test_turn_off(
     switch_node: MatterNode,
 ) -> None:
     """Test turning off a switch."""
-    state = hass.states.get("switch.mock_onoff_plugin_unit")
+    state = hass.states.get("switch.mock_onoffpluginunit_powerplug_switch")
     assert state
     assert state.state == "off"
 
@@ -72,7 +72,7 @@ async def test_turn_off(
         "switch",
         "turn_off",
         {
-            "entity_id": "switch.mock_onoff_plugin_unit",
+            "entity_id": "switch.mock_onoffpluginunit_powerplug_switch",
         },
         blocking=True,
     )


### PR DESCRIPTION
## Proposed change
Small follow-up to improve device registry creation for Matter devices:

- Use productname as fallback default name if no node label present
- Use serialNumber as additional identifier if present

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
