### PR TITLE
Remove deprecated zamg YAML config

### DIFF
--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -5,13 +5,11 @@ from typing import Any
 
 import voluptuous as vol
 from zamg import ZamgData
-from zamg.exceptions import ZamgApiError, ZamgNoDataError, ZamgStationNotFoundError
+from zamg.exceptions import ZamgApiError, ZamgNoDataError
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import CONF_STATION_ID, DOMAIN, LOGGER
 
@@ -72,57 +70,4 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=self._client.get_station_name,
             data={CONF_STATION_ID: station_id},
-        )
-
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Handle ZAMG configuration import."""
-        station_id = config.get(CONF_STATION_ID)
-        # create issue every time after restart
-        # parameter is_persistent seems not working
-        async_create_issue(
-            self.hass,
-            DOMAIN,
-            "deprecated_yaml",
-            breaks_in_ha_version="2023.1.0",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_yaml",
-        )
-
-        if self._client is None:
-            self._client = ZamgData()
-            self._client.session = async_get_clientsession(self.hass)
-
-        try:
-            if station_id not in await self._client.zamg_stations():
-                LOGGER.warning(
-                    (
-                        "Configured station_id %s could not be found at zamg, trying to"
-                        " add nearest weather station instead"
-                    ),
-                    station_id,
-                )
-                latitude = config.get(CONF_LATITUDE) or self.hass.config.latitude
-                longitude = config.get(CONF_LONGITUDE) or self.hass.config.longitude
-                station_id = await self._client.closest_station(latitude, longitude)
-
-            # Check if already configured
-            await self.async_set_unique_id(station_id)
-            self._abort_if_unique_id_configured()
-
-            LOGGER.debug(
-                "importing zamg station from configuration.yaml: station_id = %s",
-                station_id,
-            )
-        except (ZamgApiError) as err:
-            LOGGER.error("Config_flow import: Received error from ZAMG: %s", err)
-            return self.async_abort(reason="cannot_connect")
-        except (ZamgStationNotFoundError) as err:
-            LOGGER.error("Config_flow import: Received error from ZAMG: %s", err)
-            return self.async_abort(reason="station_not_found")
-
-        return await self.async_step_user(
-            user_input={
-                CONF_STATION_ID: station_id,
-            }
         )

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -5,20 +5,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Union
 
-import voluptuous as vol
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_MONITORED_CONDITIONS,
-    CONF_NAME,
     DEGREE,
     PERCENTAGE,
     UnitOfPrecipitationDepth,
@@ -28,11 +22,10 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -40,7 +33,6 @@ from .const import (
     ATTR_UPDATED,
     ATTRIBUTION,
     CONF_STATION_ID,
-    DEFAULT_NAME,
     DOMAIN,
     MANUFACTURER_URL,
 )
@@ -191,39 +183,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
 SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 API_FIELDS: list[str] = [desc.para_name for desc in SENSOR_TYPES]
-
-PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_MONITORED_CONDITIONS, default=["temperature"]): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_KEYS)]
-        ),
-        vol.Optional(CONF_STATION_ID): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Inclusive(
-            CONF_LATITUDE, "coordinates", "Latitude and longitude must exist together"
-        ): cv.latitude,
-        vol.Inclusive(
-            CONF_LONGITUDE, "coordinates", "Latitude and longitude must exist together"
-        ): cv.longitude,
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the ZAMG sensor platform."""
-    # trigger import flow
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -1,59 +1,22 @@
 """Sensor for zamg the Austrian "Zentralanstalt für Meteorologie und Geodynamik" integration."""
 from __future__ import annotations
 
-import voluptuous as vol
-
-from homeassistant.components.weather import PLATFORM_SCHEMA, WeatherEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components.weather import WeatherEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_NAME,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN, MANUFACTURER_URL
 from .coordinator import ZamgDataUpdateCoordinator
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_STATION_ID): cv.string,
-        vol.Inclusive(
-            CONF_LATITUDE, "coordinates", "Latitude and longitude must exist together"
-        ): cv.latitude,
-        vol.Inclusive(
-            CONF_LONGITUDE, "coordinates", "Latitude and longitude must exist together"
-        ): cv.longitude,
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the ZAMG weather platform."""
-    # trigger import flow
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -1,15 +1,14 @@
 """Tests for the Zamg config flow."""
 from unittest.mock import MagicMock
 
-from zamg.exceptions import ZamgApiError, ZamgStationNotFoundError
+from zamg.exceptions import ZamgApiError
 
 from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN, LOGGER
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_NAME
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import TEST_STATION_ID, TEST_STATION_NAME
+from .conftest import TEST_STATION_ID
 
 
 async def test_full_user_flow_implementation(
@@ -75,21 +74,6 @@ async def test_error_update(
     assert result.get("reason") == "cannot_connect"
 
 
-async def test_full_import_flow_implementation(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test the full import flow from start to finish."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: TEST_STATION_ID, CONF_NAME: TEST_STATION_NAME},
-    )
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert result.get("data") == {CONF_STATION_ID: TEST_STATION_ID}
-
-
 async def test_user_flow_duplicate(
     hass: HomeAssistant,
     mock_zamg: MagicMock,
@@ -125,114 +109,3 @@ async def test_user_flow_duplicate(
     )
     assert result.get("type") == FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
-
-
-async def test_import_flow_duplicate(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test import flow with duplicate entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    assert result.get("step_id") == "user"
-    assert result.get("type") == FlowResultType.FORM
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_STATION_ID: TEST_STATION_ID},
-    )
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert "data" in result
-    assert result["data"][CONF_STATION_ID] == TEST_STATION_ID
-    assert "result" in result
-    assert result["result"].unique_id == TEST_STATION_ID
-    # try to add another instance
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: TEST_STATION_ID, CONF_NAME: TEST_STATION_NAME},
-    )
-    assert result.get("type") == FlowResultType.ABORT
-    assert result.get("reason") == "already_configured"
-
-
-async def test_import_flow_duplicate_after_position(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test import flow with duplicate entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    assert result.get("step_id") == "user"
-    assert result.get("type") == FlowResultType.FORM
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_STATION_ID: TEST_STATION_ID},
-    )
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert "data" in result
-    assert result["data"][CONF_STATION_ID] == TEST_STATION_ID
-    assert "result" in result
-    assert result["result"].unique_id == TEST_STATION_ID
-    # try to add another instance
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: "123", CONF_NAME: TEST_STATION_NAME},
-    )
-    assert result.get("type") == FlowResultType.ABORT
-    assert result.get("reason") == "already_configured"
-
-
-async def test_import_flow_no_name(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test import flow without any name."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: TEST_STATION_ID},
-    )
-    assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert result.get("data") == {CONF_STATION_ID: TEST_STATION_ID}
-
-
-async def test_import_flow_invalid_station(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test import flow with invalid station."""
-    mock_zamg.closest_station.side_effect = ZamgStationNotFoundError
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: ""},
-    )
-    assert result.get("type") == FlowResultType.ABORT
-    assert result.get("reason") == "station_not_found"
-
-
-async def test_import_flow_zamg_error(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test import flow with error on getting zamg stations."""
-    mock_zamg.zamg_stations.side_effect = ZamgApiError
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: ""},
-    )
-    assert result.get("type") == FlowResultType.ABORT
-    assert result.get("reason") == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the zamg integration has been removed.

Zamg is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
YAML configuration was deprecated with #66469

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
