### PR TITLE
Add ability to configure map icons for PurpleAir

### DIFF
--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,0 +1,2 @@
+[tools]
+python = { version="3.11", virtualenv=".venv" }

--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,2 +1,0 @@
-[tools]
-python = { version="3.11", virtualenv=".venv" }

--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -83,7 +83,7 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
         # Displaying the geography on the map relies upon putting the latitude/longitude
         # in the entity attributes with "latitude" and "longitude" as the keys.
         # Conversely, we can hide the location on the map by using other keys, like
-        # "lati" and "long".
+        # "lati" and "long":
         if self._entry.options.get(CONF_SHOW_ON_MAP):
             attrs[ATTR_LATITUDE] = self.sensor_data.latitude
             attrs[ATTR_LONGITUDE] = self.sensor_data.longitude

--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -58,6 +58,8 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
         """Initialize."""
         super().__init__(coordinator)
 
+        self._sensor_index = sensor_index
+
         self._attr_device_info = DeviceInfo(
             configuration_url=self.coordinator.async_get_map_url(sensor_index),
             hw_version=self.sensor_data.hardware,
@@ -68,7 +70,6 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
             sw_version=self.sensor_data.firmware_version,
         )
         self._entry = entry
-        self._sensor_index = sensor_index
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:

--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -58,22 +58,17 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
         """Initialize."""
         super().__init__(coordinator)
 
-        self._entry = entry
-        self._sensor_index = sensor_index
-
         self._attr_device_info = DeviceInfo(
             configuration_url=self.coordinator.async_get_map_url(sensor_index),
             hw_version=self.sensor_data.hardware,
-            identifiers={(DOMAIN, str(self._sensor_index))},
+            identifiers={(DOMAIN, str(sensor_index))},
             manufacturer="PurpleAir, Inc.",
             model=self.sensor_data.model,
             name=self.sensor_data.name,
             sw_version=self.sensor_data.firmware_version,
         )
-        self._attr_extra_state_attributes = {
-            ATTR_LATITUDE: self.sensor_data.latitude,
-            ATTR_LONGITUDE: self.sensor_data.longitude,
-        }
+        self._entry = entry
+        self._sensor_index = sensor_index
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:

--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_SENSOR_INDICES, DOMAIN, LOGGER
+from .const import CONF_SENSOR_INDICES, CONF_SHOW_ON_MAP, DOMAIN, LOGGER
 
 CONF_DISTANCE = "distance"
 CONF_NEARBY_SENSOR_OPTIONS = "nearby_sensor_options"
@@ -318,6 +318,22 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
         self._flow_data: dict[str, Any] = {}
         self.config_entry = config_entry
 
+    @property
+    def settings_schema(self) -> vol.Schema:
+        """Return the settings schema."""
+        return vol.Schema(
+            {
+                vol.Optional(
+                    CONF_SHOW_ON_MAP,
+                    description={
+                        "suggested_value": self.config_entry.options.get(
+                            CONF_SHOW_ON_MAP
+                        )
+                    },
+                ): bool
+            }
+        )
+
     async def async_step_add_sensor(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -352,7 +368,7 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_choose_sensor(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the selection of a sensor."""
+        """Choose a sensor."""
         if user_input is None:
             options = self._flow_data.pop(CONF_NEARBY_SENSOR_OPTIONS)
             return self.async_show_form(
@@ -375,13 +391,13 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["add_sensor", "remove_sensor"],
+            menu_options=["add_sensor", "remove_sensor", "settings"],
         )
 
     async def async_step_remove_sensor(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Add a sensor."""
+        """Remove a sensor."""
         if user_input is None:
             return self.async_show_form(
                 step_id="remove_sensor",
@@ -437,3 +453,15 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
         options[CONF_SENSOR_INDICES].remove(removed_sensor_index)
 
         return self.async_create_entry(data=options)
+
+    async def async_step_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage settings."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="settings", data_schema=self.settings_schema
+            )
+
+        options = deepcopy({**self.config_entry.options})
+        return self.async_create_entry(data=options | user_input)

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -7,3 +7,4 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_READ_KEY = "read_key"
 CONF_SENSOR_INDICES = "sensor_indices"
+CONF_SHOW_ON_MAP = "show_on_map"

--- a/homeassistant/components/purpleair/strings.json
+++ b/homeassistant/components/purpleair/strings.json
@@ -79,7 +79,8 @@
       "init": {
         "menu_options": {
           "add_sensor": "Add sensor",
-          "remove_sensor": "Remove sensor"
+          "remove_sensor": "Remove sensor",
+          "settings": "Settings"
         }
       },
       "remove_sensor": {
@@ -89,6 +90,12 @@
         },
         "data_description": {
           "sensor_device_id": "The sensor to remove"
+        }
+      },
+      "settings": {
+        "title": "Settings",
+        "data": {
+          "show_on_map": "Show configured sensor locations on the map"
         }
       }
     },

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -302,3 +302,29 @@ async def test_options_remove_sensor(
     # Unload to make sure the update does not run after the
     # mock is removed.
     await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_options_settings(
+    hass: HomeAssistant, config_entry, setup_config_entry
+) -> None:
+    """Test setting settings via the options flow."""
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.MENU
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "settings"}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "settings"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"show_on_map": True}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "sensor_indices": [TEST_SENSOR_INDEX1],
+        "show_on_map": True,
+    }
+
+    assert config_entry.options["show_on_map"] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `Settings` option to the PurpleAir options flow, and under it, an option to show or hide entities on the map.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25815

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
