### PR TITLE
modbus slave unique ids

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -138,6 +139,9 @@ class SlaveSensor(
         idx += 1
         self._attr_name = f"{entry[CONF_NAME]} {idx}"
         self._attr_device_class = entry.get(CONF_DEVICE_CLASS)
+        self._attr_unique_id = entry.get(CONF_UNIQUE_ID)
+        if self._attr_unique_id:
+            self._attr_unique_id = f"{self._attr_unique_id}_{idx}"
         self._attr_available = False
         self._result_inx = idx
         super().__init__(coordinator)

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -6,7 +6,12 @@ import logging
 from typing import Any, Optional
 
 from homeassistant.components.sensor import CONF_STATE_CLASS, SensorEntity
-from homeassistant.const import CONF_NAME, CONF_SENSORS, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_SENSORS,
+    CONF_UNIQUE_ID,
+    CONF_UNIT_OF_MEASUREMENT,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -143,6 +148,9 @@ class SlaveSensor(
         idx += 1
         self._idx = idx
         self._attr_name = f"{entry[CONF_NAME]} {idx}"
+        self._attr_unique_id = entry.get(CONF_UNIQUE_ID)
+        if self._attr_unique_id:
+            self._attr_unique_id = f"{self._attr_unique_id}_{idx}"
         self._attr_available = False
         super().__init__(coordinator)
 

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -32,6 +32,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
 ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+SLAVE_UNIQUE_ID = "ground_floor_sensor"
 
 
 @pytest.mark.parametrize(
@@ -343,31 +344,31 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
     "config_addon,register_words,expected, slaves",
     [
         (
-            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [False] * 8,
             STATE_OFF,
             [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [True] + [False] * 7,
             STATE_ON,
             [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [False, True] + [False] * 6,
             STATE_OFF,
             [STATE_ON],
         ),
         (
-            {CONF_SLAVE_COUNT: 7, CONF_UNIQUE_ID: "ground_floor_sensor"},
+            {CONF_SLAVE_COUNT: 7, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [True, False] * 4,
             STATE_ON,
             [STATE_OFF, STATE_ON] * 3 + [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 31, CONF_UNIQUE_ID: "ground_floor_sensor"},
+            {CONF_SLAVE_COUNT: 31, CONF_UNIQUE_ID: SLAVE_UNIQUE_ID},
             [True, False] * 16,
             STATE_ON,
             [STATE_OFF, STATE_ON] * 15 + [STATE_OFF],
@@ -382,7 +383,7 @@ async def test_slave_binary_sensor(hass, expected, slaves, mock_do_cycle):
     for i, slave in enumerate(slaves):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}".replace(" ", "_")
         assert hass.states.get(entity_id).state == slave
-        unique_id = f"ground_floor_sensor_{i+1}"
+        unique_id = f"{SLAVE_UNIQUE_ID}_{i+1}"
         entry = entity_registry.async_get(entity_id)
         assert entry.unique_id == unique_id
 

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -19,12 +19,14 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    CONF_UNIQUE_ID,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
@@ -341,31 +343,31 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
     "config_addon,register_words,expected, slaves",
     [
         (
-            {CONF_SLAVE_COUNT: 1},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
             [False] * 8,
             STATE_OFF,
             [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 1},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
             [True] + [False] * 7,
             STATE_ON,
             [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 1},
+            {CONF_SLAVE_COUNT: 1, CONF_UNIQUE_ID: "ground_floor_sensor"},
             [False, True] + [False] * 6,
             STATE_OFF,
             [STATE_ON],
         ),
         (
-            {CONF_SLAVE_COUNT: 7},
+            {CONF_SLAVE_COUNT: 7, CONF_UNIQUE_ID: "ground_floor_sensor"},
             [True, False] * 4,
             STATE_ON,
             [STATE_OFF, STATE_ON] * 3 + [STATE_OFF],
         ),
         (
-            {CONF_SLAVE_COUNT: 31},
+            {CONF_SLAVE_COUNT: 31, CONF_UNIQUE_ID: "ground_floor_sensor"},
             [True, False] * 16,
             STATE_ON,
             [STATE_OFF, STATE_ON] * 15 + [STATE_OFF],
@@ -375,10 +377,14 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
 async def test_slave_binary_sensor(hass, expected, slaves, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
+    entity_registry = er.async_get(hass)
 
-    for i in range(len(slaves)):
+    for i, slave in enumerate(slaves):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}".replace(" ", "_")
-        assert hass.states.get(entity_id).state == slaves[i]
+        assert hass.states.get(entity_id).state == slave
+        unique_id = f"ground_floor_sensor_{i+1}"
+        entry = entity_registry.async_get(entity_id)
+        assert entry.unique_id == unique_id
 
 
 async def test_no_discovery_info_binary_sensor(hass, caplog):

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -33,10 +33,12 @@ from homeassistant.const import (
     CONF_SENSORS,
     CONF_SLAVE,
     CONF_STRUCTURE,
+    CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
@@ -573,6 +575,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 0,
+                CONF_UNIQUE_ID: "ground_floor_sensor",
             },
             [0x0102, 0x0304],
             False,
@@ -581,6 +584,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: "ground_floor_sensor",
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
             False,
@@ -589,6 +593,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 3,
+                CONF_UNIQUE_ID: "ground_floor_sensor",
             },
             [
                 0x0102,
@@ -611,6 +616,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: "ground_floor_sensor",
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
             True,
@@ -619,6 +625,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: "ground_floor_sensor",
             },
             [],
             False,
@@ -629,10 +636,14 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
 async def test_slave_sensor(hass, mock_do_cycle, expected):
     """Run test for sensor."""
     assert hass.states.get(ENTITY_ID).state == expected[0]
+    entity_registry = er.async_get(hass)
 
     for i in range(1, len(expected)):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i}".replace(" ", "_")
         assert hass.states.get(entity_id).state == expected[i]
+        unique_id = f"ground_floor_sensor_{i}"
+        entry = entity_registry.async_get(entity_id)
+        assert entry.unique_id == unique_id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -44,6 +44,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
 ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+SLAVE_UNIQUE_ID = "ground_floor_sensor"
 
 
 @pytest.mark.parametrize(
@@ -575,7 +576,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 0,
-                CONF_UNIQUE_ID: "ground_floor_sensor",
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [0x0102, 0x0304],
             False,
@@ -584,7 +585,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
-                CONF_UNIQUE_ID: "ground_floor_sensor",
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
             False,
@@ -593,7 +594,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 3,
-                CONF_UNIQUE_ID: "ground_floor_sensor",
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [
                 0x0102,
@@ -616,7 +617,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
-                CONF_UNIQUE_ID: "ground_floor_sensor",
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [0x0102, 0x0304, 0x0403, 0x0201],
             True,
@@ -625,7 +626,7 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
         (
             {
                 CONF_SLAVE_COUNT: 1,
-                CONF_UNIQUE_ID: "ground_floor_sensor",
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
             },
             [],
             False,
@@ -641,7 +642,7 @@ async def test_slave_sensor(hass, mock_do_cycle, expected):
     for i in range(1, len(expected)):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i}".replace(" ", "_")
         assert hass.states.get(entity_id).state == expected[i]
-        unique_id = f"ground_floor_sensor_{i}"
+        unique_id = f"{SLAVE_UNIQUE_ID}_{i}"
         entry = entity_registry.async_get(entity_id)
         assert entry.unique_id == unique_id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
If parent unique-id is overridden by user, slaves unique-ids should follow parent (with unique per-slave suffix)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
See unique_id. This never worked for slaves.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
