### PR TITLE
Change meteoalarm binary sensor to not be 'Unsafe' when there is a future alert

### DIFF
--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -80,8 +80,9 @@ class MeteoAlertBinarySensor(BinarySensorEntity):
         self._attr_is_on = False
 
         if alert := self._api.get_alert():
+            onset_date = dt_util.parse_datetime(alert["onset"])
             expiration_date = dt_util.parse_datetime(alert["expires"])
 
-            if expiration_date is not None and expiration_date > dt_util.utcnow():
+            if onset_date is not None and expiration_date is not None and onset_date <= dt_util.utcnow() <= expiration_date:
                 self._attr_extra_state_attributes = alert
                 self._attr_is_on = True

--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -84,9 +84,9 @@ class MeteoAlertBinarySensor(BinarySensorEntity):
             expiration_date = dt_util.parse_datetime(alert["expires"])
 
             if (
-+                onset_date is not None
-+                and expiration_date is not None
-+                and onset_date <= dt_util.utcnow() <= expiration_date
-+            ):
+                onset_date is not None
+                and expiration_date is not None
+                and onset_date <= dt_util.utcnow() <= expiration_date
+            ):
                 self._attr_extra_state_attributes = alert
                 self._attr_is_on = True

--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -83,6 +83,10 @@ class MeteoAlertBinarySensor(BinarySensorEntity):
             onset_date = dt_util.parse_datetime(alert["onset"])
             expiration_date = dt_util.parse_datetime(alert["expires"])
 
-            if onset_date is not None and expiration_date is not None and onset_date <= dt_util.utcnow() <= expiration_date:
+            if (
++                onset_date is not None
++                and expiration_date is not None
++                and onset_date <= dt_util.utcnow() <= expiration_date
++            ):
                 self._attr_extra_state_attributes = alert
                 self._attr_is_on = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The state of the binary sensor will no longer be 'Unsafe' when there is a weather alert that is still in the future.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The state of the weather alert binary sensor is either 'Safe' or 'Unsafe'.  Currently when there is a weather alart with a starting date still in the future the state already turns to 'Unsafe'. I think that this sensor should represent the currently active weather alert?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I'm sorry to say that I don't have much experience in Python. Please check my code changes carefully!

Also I feel this integration could use some love, for example adding support to set it up from the UI.
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
