### PR TITLE
Influxdb fullquery

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -135,7 +135,7 @@ def validate_version_specific_config(conf: dict) -> dict:
     if conf[CONF_API_VERSION] == API_VERSION_2:
         if CONF_TOKEN not in conf:
             raise vol.Invalid(
-                f"{CONF_TOKEN} and {CONF_BUCKET} are required when {CONF_API_VERSION} is {API_VERSION_2}"
+                f"{CONF_TOKEN} is required when {CONF_API_VERSION} is {API_VERSION_2}"
             )
 
         if CONF_USERNAME in conf:
@@ -146,7 +146,7 @@ def validate_version_specific_config(conf: dict) -> dict:
     else:
         if CONF_TOKEN in conf:
             raise vol.Invalid(
-                f"{CONF_TOKEN} and {CONF_BUCKET} are only allowed when {CONF_API_VERSION} is {API_VERSION_2}"
+                f"{CONF_TOKEN} is only allowed when {CONF_API_VERSION} is {API_VERSION_2}"
             )
 
     return conf

--- a/homeassistant/components/influxdb/const.py
+++ b/homeassistant/components/influxdb/const.py
@@ -50,7 +50,6 @@ CONF_IMPORTS = "imports"
 DEFAULT_DATABASE = "home_assistant"
 DEFAULT_HOST_V2 = "us-west-2-1.aws.cloud2.influxdata.com"
 DEFAULT_SSL_V2 = True
-DEFAULT_BUCKET = "Home Assistant"
 DEFAULT_VERIFY_SSL = True
 DEFAULT_API_VERSION = "1"
 DEFAULT_GROUP_FUNCTION = "mean"
@@ -104,10 +103,6 @@ CLIENT_ERROR_V1 = (
     "Please check that the database, username and password are correct and "
     "that the specified user has the correct permissions set."
 )
-NO_BUCKET_ERROR = (
-    "InfluxDB bucket '%s' cannot be found. "
-    "Check the name is correct and the token has access to it."
-)
 NO_DATABASE_ERROR = (
     "InfluxDB database '%s' cannot be found. "
     "Check the name is correct and the user has access to it."
@@ -150,5 +145,5 @@ COMPONENT_CONFIG_SCHEMA_CONNECTION = {
     # Connection config for V2 API only.
     vol.Inclusive(CONF_TOKEN, "v2_authentication"): cv.string,
     vol.Inclusive(CONF_ORG, "v2_authentication"): cv.string,
-    vol.Optional(CONF_BUCKET, default=DEFAULT_BUCKET): cv.string,
+    vol.Optional(CONF_BUCKET): cv.string,
 }

--- a/homeassistant/components/influxdb/sensor.py
+++ b/homeassistant/components/influxdb/sensor.py
@@ -55,7 +55,6 @@ from .const import (
     LANGUAGE_FLUX,
     LANGUAGE_INFLUXQL,
     MIN_TIME_BETWEEN_UPDATES,
-    NO_BUCKET_ERROR,
     NO_DATABASE_ERROR,
     QUERY_MULTIPLE_RESULTS_MESSAGE,
     QUERY_NO_RESULTS_MESSAGE,
@@ -90,7 +89,8 @@ def validate_query_format_for_version(conf: dict) -> dict:
             _merge_connection_config_into_query(conf, query)
             query[CONF_LANGUAGE] = LANGUAGE_FLUX
 
-        del conf[CONF_BUCKET]
+        if CONF_BUCKET in conf:
+            del conf[CONF_BUCKET]
 
     else:
         if CONF_QUERIES not in conf:
@@ -169,10 +169,7 @@ def setup_platform(
     entities = []
     if CONF_QUERIES_FLUX in config:
         for query in config[CONF_QUERIES_FLUX]:
-            if query[CONF_BUCKET] in influx.data_repositories:
-                entities.append(InfluxSensor(hass, influx, query))
-            else:
-                _LOGGER.error(NO_BUCKET_ERROR, query[CONF_BUCKET])
+            entities.append(InfluxSensor(hass, influx, query))
     else:
         for query in config[CONF_QUERIES]:
             if query[CONF_DB_NAME] in influx.data_repositories:
@@ -270,15 +267,19 @@ class InfluxFluxSensorData:
         self.value = None
         self.full_query = None
 
-        self.query_prefix = f'from(bucket:"{bucket}") |> range(start: {range_start}, stop: {range_stop}) |>'
-        if imports is not None:
-            for i in imports:
-                self.query_prefix = f'import "{i}" {self.query_prefix}'
-
-        if group is None:
-            self.query_postfix = DEFAULT_FUNCTION_FLUX
+        if bucket is None:
+            self.query_prefix = ""
+            self.query_postfix = ""
         else:
-            self.query_postfix = f'|> {group}(column: "{INFLUX_CONF_VALUE_V2}")'
+            self.query_prefix = f'from(bucket:"{bucket}") |> range(start: {range_start}, stop: {range_stop}) |>'
+            if imports is not None:
+                for i in imports:
+                    self.query_prefix = f'import "{i}" {self.query_prefix}'
+
+            if group is None:
+                self.query_postfix = DEFAULT_FUNCTION_FLUX
+            else:
+                self.query_postfix = f'|> {group}(column: "{INFLUX_CONF_VALUE_V2}")'
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 
 import homeassistant.components.influxdb as influxdb
-from homeassistant.components.influxdb.const import DEFAULT_BUCKET
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     PERCENTAGE,
@@ -20,11 +19,13 @@ from homeassistant.setup import async_setup_component
 
 INFLUX_PATH = "homeassistant.components.influxdb"
 INFLUX_CLIENT_PATH = f"{INFLUX_PATH}.InfluxDBClient"
+
 BASE_V1_CONFIG = {}
 BASE_V2_CONFIG = {
     "api_version": influxdb.API_VERSION_2,
     "organization": "org",
     "token": "token",
+    "bucket": "Home Assistant",
 }
 
 
@@ -63,7 +64,7 @@ def get_mock_call_fixture(request):
     """Get version specific lambda to make write API call mock."""
 
     def v2_call(body, precision):
-        data = {"bucket": DEFAULT_BUCKET, "record": body}
+        data = {"bucket": "Home Assistant", "record": body}
 
         if precision is not None:
             data["write_precision"] = precision


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change allows the user to specify the full Flux query (APIv2, queries_flux:) in sensors with platform type 'influxdb'.

Current influxdb sensor implementation rewrites the query specified under 'queries_flux: query' by pre- and postfixing things as bucket ('from(bucket: "{DEFAULT_BUCKET}") ...') and (' ... |> limit(n: 1)').

The change is not a breaking change and is made backward compatible by making the 'bucket' config optional. 
If 'bucket' is not specified, then the rewriting logic is bypassed and the query is sent to the db as written. 
If 'bucket' is specified on sensor-level (as is currently common), then all queries in queries_flux will be rewritten. No change required.
The 'bucket' can be specified on queries_flux-level if the user wants mix full-queries and rewritten ones.

The main advantage of the change is that the user can specify more complex queries including data variables.
For example:
```yaml
sensor:
  - platform: influxdb
    api_version: 2
    # ....
    queries_flux:
      - name: "Joined data"
        # ...
        query: >
          import "date"
          import "timezone"
          option location = timezone.location(name: "Europe/Helsinki")
          bucket = "home_assistant"
          a = from(bucket: bucket)
            |> range(start: date.truncate(t:-1h, unit: 1h))
            # ...
            |> keep(columns: ["_value","_time"])
          b = from(bucket: bucket)
            |> range(start: -1h)
            # ...
            |> keep(columns: ["_value","_time"])
          joined = join(tables: {a: a, b: b}, on: ["_time"])
            |> map(fn: (r) => ({r with _value: ((r._value_a * r._value_b) / 100.0) }))
            |> keep(columns: ["_value"])
            |> last()
            |> yield(name: "joined")
```
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Here's an example sensor configuration:
```yaml
sensor:
  - platform: influxdb
    api_version: 2
    # bucket: home_assistant  # bucket-specification is moved below 
    # ...
    queries_flux:
      - name: "Current spot price"
        bucket: home_assistant  # old-style, rewrite will occur
        range_start: "-1h"
        unit_of_measurement: €/kWh
        unique_id: current_spot_price
        value_template: "{{ (value|float(default=0) / 100.0)|round(5) }}"
        query: >
          filter(fn: (r) => r["_measurement"] == "nordpool-fi-spot" and r["_field"] == "pricePerMwhExclVAT")
          |> last(column: "_value")
          |> keep(columns: ["_value","_time"])
          |> map(fn: (r) => ({r with _value: r._value * 0.1  }))
      - name: "Current spot price (New)" # new-style, no rewrite, possible to f.e. add variables inside query
        unit_of_measurement: €/kWh
        unique_id: current_spot_price_new
        value_template: "{{ (value|float(default=0) / 100.0)|round(5) }}"
        query: >
          from(bucket: "home_assistant")
            |> range(start: -1h)
            |> filter(fn: (r) => r["_measurement"] == "nordpool-fi-spot" and r["_field"] == "pricePerMwhExclVAT")
            |> last(column: "_value")
            |> keep(columns: ["_value","_time"])
            |> map(fn: (r) => ({r with _value: r._value * 0.1  }))
```
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: [(https://github.com/home-assistant/home-assistant.io/pull/25274)]

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
