### PR TITLE
Remove unnecessary try-else (1)

### DIFF
--- a/homeassistant/components/airzone/entity.py
+++ b/homeassistant/components/airzone/entity.py
@@ -152,5 +152,5 @@ class AirzoneZoneEntity(AirzoneEntity):
             raise HomeAssistantError(
                 f"Failed to set zone {self.name}: {error}"
             ) from error
-        else:
-            self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
+
+        self.coordinator.async_set_updated_data(self.coordinator.airzone.data())

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -76,17 +76,16 @@ class BroadlinkUpdateManager(ABC):
                 )
             raise UpdateFailed(err) from err
 
-        else:
-            if self.available is False:
-                _LOGGER.warning(
-                    "Connected to %s (%s at %s)",
-                    self.device.name,
-                    self.device.api.model,
-                    self.device.api.host[0],
-                )
-            self.available = True
-            self.last_update = dt.utcnow()
-            return data
+        if self.available is False:
+            _LOGGER.warning(
+                "Connected to %s (%s at %s)",
+                self.device.name,
+                self.device.api.model,
+                self.device.api.host[0],
+            )
+        self.available = True
+        self.last_update = dt.utcnow()
+        return data
 
     @abstractmethod
     async def async_fetch_data(self):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -747,8 +747,8 @@ class CameraImageView(CameraView):
             )
         except (HomeAssistantError, ValueError) as ex:
             raise web.HTTPInternalServerError() from ex
-        else:
-            return web.Response(body=image.content, content_type=image.content_type)
+
+        return web.Response(body=image.content, content_type=image.content_type)
 
 
 class CameraMjpegStream(CameraView):

--- a/homeassistant/components/co2signal/__init__.py
+++ b/homeassistant/components/co2signal/__init__.py
@@ -131,12 +131,11 @@ def get_data(hass: HomeAssistant, config: Mapping[str, Any]) -> CO2SignalRespons
         _LOGGER.exception("Unexpected exception")
         raise UnknownError from err
 
-    else:
-        if "error" in data:
-            raise UnknownError(data["error"])
+    if "error" in data:
+        raise UnknownError(data["error"])
 
-        if data.get("status") != "ok":
-            _LOGGER.exception("Unexpected response: %s", data)
-            raise UnknownError
+    if data.get("status") != "ok":
+        _LOGGER.exception("Unexpected response: %s", data)
+        raise UnknownError
 
     return cast(CO2SignalResponse, data)

--- a/homeassistant/components/emoncms/sensor.py
+++ b/homeassistant/components/emoncms/sensor.py
@@ -285,15 +285,15 @@ class EmonCmsData:
         except requests.exceptions.RequestException as exception:
             _LOGGER.error(exception)
             return
+
+        if req.status_code == HTTPStatus.OK:
+            self.data = req.json()
         else:
-            if req.status_code == HTTPStatus.OK:
-                self.data = req.json()
-            else:
-                _LOGGER.error(
-                    (
-                        "Please verify if the specified configuration value "
-                        "'%s' is correct! (HTTP Status_code = %d)"
-                    ),
-                    CONF_URL,
-                    req.status_code,
-                )
+            _LOGGER.error(
+                (
+                    "Please verify if the specified configuration value "
+                    "'%s' is correct! (HTTP Status_code = %d)"
+                ),
+                CONF_URL,
+                req.status_code,
+            )


### PR DESCRIPTION
## Proposed change
`try-else` is unnecessary if all `except` clauses either `return` or `raise`.
Especially if only one `except` clause is used and it's obvious that it returns / raises, the `else` can be removed and the code de-dented.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
