### PR TITLE
Remove unnecessary try-else (2)

### DIFF
--- a/homeassistant/components/enphase_envoy/__init__.py
+++ b/homeassistant/components/enphase_envoy/__init__.py
@@ -78,8 +78,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryNotReady(
                 f"Could not obtain serial number from envoy: {ex}"
             ) from ex
-        else:
-            hass.config_entries.async_update_entry(entry, unique_id=serial)
+
+        hass.config_entries.async_update_entry(entry, unique_id=serial)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         COORDINATOR: coordinator,

--- a/homeassistant/components/everlights/light.py
+++ b/homeassistant/components/everlights/light.py
@@ -65,9 +65,8 @@ async def async_setup_platform(
         except pyeverlights.ConnectionError as err:
             raise PlatformNotReady from err
 
-        else:
-            lights.append(EverLightsLight(api, pyeverlights.ZONE_1, status, effects))
-            lights.append(EverLightsLight(api, pyeverlights.ZONE_2, status, effects))
+        lights.append(EverLightsLight(api, pyeverlights.ZONE_1, status, effects))
+        lights.append(EverLightsLight(api, pyeverlights.ZONE_2, status, effects))
 
     async_add_entities(lights)
 

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -155,16 +155,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device = await self._async_try_connect(host, device)
             except FLUX_LED_EXCEPTIONS:
                 return self.async_abort(reason="cannot_connect")
-            else:
-                discovered_mac = device[ATTR_ID]
-                if device[ATTR_MODEL_DESCRIPTION] or (
-                    discovered_mac is not None
-                    and (formatted_discovered_mac := dr.format_mac(discovered_mac))
-                    and formatted_discovered_mac != mac
-                    and mac_matches_by_one(discovered_mac, mac)
-                ):
-                    self._discovered_device = device
-                    await self._async_set_discovered_mac(device, True)
+
+            discovered_mac = device[ATTR_ID]
+            if device[ATTR_MODEL_DESCRIPTION] or (
+                discovered_mac is not None
+                and (formatted_discovered_mac := dr.format_mac(discovered_mac))
+                and formatted_discovered_mac != mac
+                and mac_matches_by_one(discovered_mac, mac)
+            ):
+                self._discovered_device = device
+                await self._async_set_discovered_mac(device, True)
         return await self.async_step_discovery_confirm()
 
     async def async_step_discovery_confirm(

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -275,5 +275,5 @@ class HarmonyData(HarmonySubscriberMixin):
         except aioexc.TimeOut:
             _LOGGER.error("%s: Syncing hub with Harmony cloud timed-out", self.name)
             return False
-        else:
-            return True
+
+        return True

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -167,8 +167,8 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
             await async_update_addon(self.hass, slug=self._addon_slug, backup=backup)
         except HassioAPIError as err:
             raise HomeAssistantError(f"Error updating {self.title}: {err}") from err
-        else:
-            await self.coordinator.force_info_update_supervisor()
+
+        await self.coordinator.force_info_update_supervisor()
 
 
 class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):

--- a/homeassistant/components/hlk_sw16/config_flow.py
+++ b/homeassistant/components/hlk_sw16/config_flow.py
@@ -44,6 +44,7 @@ async def validate_input(hass: HomeAssistant, user_input):
         client = await connect_client(hass, user_input)
     except asyncio.TimeoutError as err:
         raise CannotConnect from err
+
     try:
 
         def disconnect_callback():
@@ -56,9 +57,9 @@ async def validate_input(hass: HomeAssistant, user_input):
         client.disconnect_callback = None
         client.stop()
         raise
-    else:
-        client.disconnect_callback = None
-        client.stop()
+
+    client.disconnect_callback = None
+    client.stop()
 
 
 class SW16FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -580,8 +580,8 @@ class KNXModule:
                 raise HomeAssistantError(
                     f"Could not find exposure for '{group_address}' to remove."
                 ) from err
-            else:
-                removed_exposure.shutdown()
+
+            removed_exposure.shutdown()
             return
 
         if group_address in self.service_exposures:

--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -191,11 +191,11 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.data[CONF_ID] = status.get("chipId", status["mac"].replace(":", ""))
         except (CannotConnect, KeyError) as err:
             raise CannotConnect from err
-        else:
-            self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
-            self.data[CONF_ACCESS_TOKEN] = "".join(
-                random.choices(f"{string.ascii_uppercase}{string.digits}", k=20)
-            )
+
+        self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
+        self.data[CONF_ACCESS_TOKEN] = "".join(
+            random.choices(f"{string.ascii_uppercase}{string.digits}", k=20)
+        )
 
     async def async_step_import(self, device_config):
         """Import a configuration.yaml config.
@@ -282,19 +282,17 @@ class KonnectedFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 status = await get_status(self.hass, netloc[0], int(netloc[1]))
             except CannotConnect:
                 return self.async_abort(reason="cannot_connect")
-            else:
-                self.data[CONF_HOST] = netloc[0]
-                self.data[CONF_PORT] = int(netloc[1])
-                self.data[CONF_ID] = status.get(
-                    "chipId", status["mac"].replace(":", "")
-                )
-                self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
 
-                KonnectedFlowHandler.discovered_hosts[self.data[CONF_ID]] = {
-                    CONF_HOST: self.data[CONF_HOST],
-                    CONF_PORT: self.data[CONF_PORT],
-                }
-                return await self.async_step_confirm()
+            self.data[CONF_HOST] = netloc[0]
+            self.data[CONF_PORT] = int(netloc[1])
+            self.data[CONF_ID] = status.get("chipId", status["mac"].replace(":", ""))
+            self.data[CONF_MODEL] = status.get("model", KONN_MODEL)
+
+            KonnectedFlowHandler.discovered_hosts[self.data[CONF_ID]] = {
+                CONF_HOST: self.data[CONF_HOST],
+                CONF_PORT: self.data[CONF_PORT],
+            }
+            return await self.async_step_confirm()
 
         return self.async_abort(reason="unknown")
 


### PR DESCRIPTION
## Proposed change
`try-else` is unnecessary if all `except` clauses either `return` or `raise`.
Especially if only one `except` clause is used and it's obvious that it returns / raises, the `else` can be removed and the code de-dented.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
