### PR TITLE
Remove unnecessary try-else (3)

### DIFF
--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -145,8 +145,8 @@ class DataUpdateCoordinatorMixin:
             await client.set_setting_values(module_id, value)
         except ApiException:
             return False
-        else:
-            return True
+
+        return True
 
 
 class PlenticoreUpdateCoordinator(DataUpdateCoordinator[_DataT]):

--- a/homeassistant/components/media_extractor/__init__.py
+++ b/homeassistant/components/media_extractor/__init__.py
@@ -140,18 +140,16 @@ class MediaExtractor:
         except MEQueryException:
             _LOGGER.error("Wrong query format: %s", stream_query)
             return
-        else:
-            data = {k: v for k, v in self.call_data.items() if k != ATTR_ENTITY_ID}
-            data[ATTR_MEDIA_CONTENT_ID] = stream_url
 
-            if entity_id:
-                data[ATTR_ENTITY_ID] = entity_id
+        data = {k: v for k, v in self.call_data.items() if k != ATTR_ENTITY_ID}
+        data[ATTR_MEDIA_CONTENT_ID] = stream_url
 
-            self.hass.async_create_task(
-                self.hass.services.async_call(
-                    MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA, data
-                )
-            )
+        if entity_id:
+            data[ATTR_ENTITY_ID] = entity_id
+
+        self.hass.async_create_task(
+            self.hass.services.async_call(MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA, data)
+        )
 
     def get_stream_query_for_entity(self, entity_id):
         """Get stream format query for entity."""

--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -35,18 +35,18 @@ def fetch_data(connection: datapoint.Manager, site: Site, mode: str) -> MetOffic
     except (ValueError, datapoint.exceptions.APIException) as err:
         _LOGGER.error("Check Met Office connection: %s", err.args)
         raise UpdateFailed from err
-    else:
-        time_now = utcnow()
-        return MetOfficeData(
-            now=forecast.now(),
-            forecast=[
-                timestep
-                for day in forecast.days
-                for timestep in day.timesteps
-                if timestep.date > time_now
-                and (
-                    mode == MODE_3HOURLY or timestep.date.hour > 6
-                )  # ensures only one result per day in MODE_DAILY
-            ],
-            site=site,
-        )
+
+    time_now = utcnow()
+    return MetOfficeData(
+        now=forecast.now(),
+        forecast=[
+            timestep
+            for day in forecast.days
+            for timestep in day.timesteps
+            if timestep.date > time_now
+            and (
+                mode == MODE_3HOURLY or timestep.date.hour > 6
+            )  # ensures only one result per day in MODE_DAILY
+        ],
+        site=site,
+    )

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -371,10 +371,10 @@ class ModbusHub:
         except ModbusException as exception_error:
             self._log_error(str(exception_error), error_state=False)
             return False
-        else:
-            message = f"modbus {self.name} communication open"
-            _LOGGER.info(message)
-            return True
+
+        message = f"modbus {self.name} communication open"
+        _LOGGER.info(message)
+        return True
 
     def _pymodbus_call(
         self, unit: int | None, address: int, value: int | list[int], use_call: str

--- a/homeassistant/components/modem_callerid/config_flow.py
+++ b/homeassistant/components/modem_callerid/config_flow.py
@@ -111,5 +111,5 @@ class PhoneModemFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await api.test(dev_path)
         except EXCEPTIONS:
             return {"base": "cannot_connect"}
-        else:
-            return None
+
+        return None

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -71,8 +71,8 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         except (timeout, ParseException):
             # let the error be logged and handled by the motionblinds library
             return {ATTR_AVAILABLE: False}
-        else:
-            return {ATTR_AVAILABLE: True}
+
+        return {ATTR_AVAILABLE: True}
 
     def update_blind(self, blind):
         """Fetch data from a blind."""
@@ -84,8 +84,8 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         except (timeout, ParseException):
             # let the error be logged and handled by the motionblinds library
             return {ATTR_AVAILABLE: False}
-        else:
-            return {ATTR_AVAILABLE: True}
+
+        return {ATTR_AVAILABLE: True}
 
     async def _async_update_data(self):
         """Fetch the latest data from the gateway and blinds."""


### PR DESCRIPTION
## Proposed change
`try-else` is unnecessary if all `except` clauses either `return` or `raise`.
Especially if only one `except` clause is used and it's obvious that it returns / raises, the `else` can be removed and the code de-dented.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
