### PR TITLE
Add filters to climate and light service descriptions

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -25,7 +25,7 @@ rules:
   comments:
     level: error
     require-starting-space: true
-    min-spaces-from-content: 2
+    min-spaces-from-content: 1
   comments-indentation:
     level: error
   document-end:

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -7,7 +7,7 @@ set_aux_heat:
     entity:
       domain: climate
       supported_features:
-        - 64 # ClimateEntityFeature.AUX_HEAT
+        - climate.ClimateEntityFeature.AUX_HEAT
   fields:
     aux_heat:
       name: Auxiliary heating
@@ -23,7 +23,7 @@ set_preset_mode:
     entity:
       domain: climate
       supported_features:
-        - 16 # ClimateEntityFeature.PRESET_MODE
+        - climate.ClimateEntityFeature.PRESET_MODE
   fields:
     preset_mode:
       name: Preset mode
@@ -40,15 +40,15 @@ set_temperature:
     entity:
       domain: climate
       supported_features:
-        - 1 # ClimateEntityFeature.TARGET_TEMPERATURE
-        - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        - climate.ClimateEntityFeature.TARGET_TEMPERATURE
+        - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
   fields:
     temperature:
       name: Temperature
       description: New target temperature for HVAC.
       filter:
         supported_features:
-          - 1 # ClimateEntityFeature.TARGET_TEMPERATURE
+          - climate.ClimateEntityFeature.TARGET_TEMPERATURE
       selector:
         number:
           min: 0
@@ -60,7 +60,7 @@ set_temperature:
       description: New target high temperature for HVAC.
       filter:
         supported_features:
-          - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+          - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
       advanced: true
       selector:
         number:
@@ -73,7 +73,7 @@ set_temperature:
       description: New target low temperature for HVAC.
       filter:
         supported_features:
-          - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+          - climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
       advanced: true
       selector:
         number:
@@ -109,7 +109,7 @@ set_humidity:
     entity:
       domain: climate
       supported_features:
-        - 4 # ClimateEntityFeature.TARGET_HUMIDITY
+        - climate.ClimateEntityFeature.TARGET_HUMIDITY
   fields:
     humidity:
       name: Humidity
@@ -128,7 +128,7 @@ set_fan_mode:
     entity:
       domain: climate
       supported_features:
-        - 8 # ClimateEntityFeature.FAN_MODE
+        - climate.ClimateEntityFeature.FAN_MODE
   fields:
     fan_mode:
       name: Fan mode
@@ -173,7 +173,7 @@ set_swing_mode:
     entity:
       domain: climate
       supported_features:
-        - 32 # ClimateEntityFeature.SWING_MODE
+        - climate.ClimateEntityFeature.SWING_MODE
   fields:
     swing_mode:
       name: Swing mode

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -6,6 +6,8 @@ set_aux_heat:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 64 # ClimateEntityFeature.AUX_HEAT
   fields:
     aux_heat:
       name: Auxiliary heating
@@ -20,6 +22,8 @@ set_preset_mode:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 16 # ClimateEntityFeature.PRESET_MODE
   fields:
     preset_mode:
       name: Preset mode
@@ -35,10 +39,16 @@ set_temperature:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 1 # ClimateEntityFeature.TARGET_TEMPERATURE
+        - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
   fields:
     temperature:
       name: Temperature
       description: New target temperature for HVAC.
+      filter:
+        supported_features:
+          - 1 # ClimateEntityFeature.TARGET_TEMPERATURE
       selector:
         number:
           min: 0
@@ -48,6 +58,9 @@ set_temperature:
     target_temp_high:
       name: Target temperature high
       description: New target high temperature for HVAC.
+      filter:
+        supported_features:
+          - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
       advanced: true
       selector:
         number:
@@ -58,6 +71,9 @@ set_temperature:
     target_temp_low:
       name: Target temperature low
       description: New target low temperature for HVAC.
+      filter:
+        supported_features:
+          - 2 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
       advanced: true
       selector:
         number:
@@ -92,6 +108,8 @@ set_humidity:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 4 # ClimateEntityFeature.TARGET_HUMIDITY
   fields:
     humidity:
       name: Humidity
@@ -109,6 +127,8 @@ set_fan_mode:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 8 # ClimateEntityFeature.FAN_MODE
   fields:
     fan_mode:
       name: Fan mode
@@ -152,6 +172,8 @@ set_swing_mode:
   target:
     entity:
       domain: climate
+      supported_features:
+        - 32 # ClimateEntityFeature.SWING_MODE
   fields:
     swing_mode:
       name: Swing mode

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -12,6 +12,9 @@ turn_on:
     transition:
       name: Transition
       description: Duration it takes to get to next state.
+      filter:
+        supported_features:
+          - 32 # LightEntityFeature.TRANSITION
       selector:
         number:
           min: 0
@@ -20,11 +23,25 @@ turn_on:
     rgb_color:
       name: Color
       description: The color for the light (based on RGB - red, green, blue).
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       selector:
         color_rgb:
     rgbw_color:
       name: RGBW-color
       description: A list containing four integers between 0 and 255 representing the RGBW (red, green, blue, white) color for the light.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[255, 100, 100, 50]"
       selector:
@@ -32,6 +49,13 @@ turn_on:
     rgbww_color:
       name: RGBWW-color
       description: A list containing five integers between 0 and 255 representing the RGBWW (red, green, blue, cold white, warm white) color for the light.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[255, 100, 100, 50, 70]"
       selector:
@@ -39,6 +63,13 @@ turn_on:
     color_name:
       name: Color name
       description: A human readable color name.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         select:
@@ -195,6 +226,13 @@ turn_on:
     hs_color:
       name: Hue/Sat color
       description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[300, 70]"
       selector:
@@ -202,6 +240,13 @@ turn_on:
     xy_color:
       name: XY-color
       description: Color for the light in XY-format.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[0.52, 0.43]"
       selector:
@@ -209,6 +254,14 @@ turn_on:
     color_temp:
       name: Color temperature
       description: Color temperature for the light in mireds.
+      filter:
+        supported_color_modes:
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       selector:
         color_temp:
           min_mireds: 153
@@ -216,6 +269,14 @@ turn_on:
     kelvin:
       name: Color temperature (Kelvin)
       description: Color temperature for the light in Kelvin.
+      filter:
+        supported_color_modes:
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         number:
@@ -228,6 +289,15 @@ turn_on:
       description: Number indicating brightness, where 0 turns the light
         off, 1 is the minimum brightness and 255 is the maximum brightness
         supported by the light.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         number:
@@ -238,6 +308,15 @@ turn_on:
       description: Number indicating percentage of full brightness, where 0
         turns the light off, 1 is the minimum brightness and 100 is the maximum
         brightness supported by the light.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       selector:
         number:
           min: 0
@@ -246,6 +325,15 @@ turn_on:
     brightness_step:
       name: Brightness step value
       description: Change brightness by an amount.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         number:
@@ -254,6 +342,15 @@ turn_on:
     brightness_step_pct:
       name: Brightness step
       description: Change brightness by a percentage.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       selector:
         number:
           min: -100
@@ -265,6 +362,9 @@ turn_on:
         Set the light to white mode and change its brightness, where 0 turns
         the light off, 1 is the minimum brightness and 255 is the maximum
         brightness supported by the light.
+      filter:
+        supported_color_modes:
+          - white
       advanced: true
       selector:
         number:
@@ -280,6 +380,9 @@ turn_on:
     flash:
       name: Flash
       description: If the light should flash.
+      filter:
+        supported_features:
+          - 8 # LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -291,6 +394,9 @@ turn_on:
     effect:
       name: Effect
       description: Light effect.
+      filter:
+        supported_features:
+          - 4 # LightEntityFeature.EFFECT
       selector:
         text:
 
@@ -304,6 +410,9 @@ turn_off:
     transition:
       name: Transition
       description: Duration it takes to get to next state.
+      filter:
+        supported_color_modes:
+          - white
       selector:
         number:
           min: 0
@@ -312,6 +421,9 @@ turn_off:
     flash:
       name: Flash
       description: If the light should flash.
+      filter:
+        supported_features:
+          - 8 # LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -333,6 +445,9 @@ toggle:
     transition:
       name: Transition
       description: Duration it takes to get to next state.
+      filter:
+        supported_features:
+          - 32 # LightEntityFeature.TRANSITION
       selector:
         number:
           min: 0
@@ -341,6 +456,13 @@ toggle:
     rgb_color:
       name: RGB-color
       description: Color for the light in RGB-format.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[255, 100, 100]"
       selector:
@@ -348,6 +470,13 @@ toggle:
     color_name:
       name: Color name
       description: A human readable color name.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         select:
@@ -504,6 +633,13 @@ toggle:
     hs_color:
       name: Hue/Sat color
       description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[300, 70]"
       selector:
@@ -511,6 +647,13 @@ toggle:
     xy_color:
       name: XY-color
       description: Color for the light in XY-format.
+      filter:
+        supported_color_modes:
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       example: "[0.52, 0.43]"
       selector:
@@ -518,12 +661,28 @@ toggle:
     color_temp:
       name: Color temperature (mireds)
       description: Color temperature for the light in mireds.
+      filter:
+        supported_color_modes:
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         color_temp:
     kelvin:
       name: Color temperature (Kelvin)
       description: Color temperature for the light in Kelvin.
+      filter:
+        supported_color_modes:
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         number:
@@ -536,6 +695,15 @@ toggle:
       description: Number indicating brightness, where 0 turns the light
         off, 1 is the minimum brightness and 255 is the maximum brightness
         supported by the light.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       advanced: true
       selector:
         number:
@@ -546,6 +714,15 @@ toggle:
       description: Number indicating percentage of full brightness, where 0
         turns the light off, 1 is the minimum brightness and 100 is the maximum
         brightness supported by the light.
+      filter:
+        supported_color_modes:
+          - brightness
+          - ct
+          - hs
+          - xy
+          - rgb
+          - rgbw
+          - rgbww
       selector:
         number:
           min: 0
@@ -561,6 +738,9 @@ toggle:
     flash:
       name: Flash
       description: If the light should flash.
+      filter:
+        supported_features:
+          - 8 # LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -572,5 +752,8 @@ toggle:
     effect:
       name: Effect
       description: Light effect.
+      filter:
+        supported_features:
+          - 4 # LightEntityFeature.EFFECT
       selector:
         text:

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -14,7 +14,7 @@ turn_on:
       description: Duration it takes to get to next state.
       filter:
         supported_features:
-          - 32 # LightEntityFeature.TRANSITION
+          - light.LightEntityFeature.TRANSITION
       selector:
         number:
           min: 0
@@ -24,24 +24,26 @@ turn_on:
       name: Color
       description: The color for the light (based on RGB - red, green, blue).
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       selector:
         color_rgb:
     rgbw_color:
       name: RGBW-color
       description: A list containing four integers between 0 and 255 representing the RGBW (red, green, blue, white) color for the light.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[255, 100, 100, 50]"
       selector:
@@ -50,12 +52,13 @@ turn_on:
       name: RGBWW-color
       description: A list containing five integers between 0 and 255 representing the RGBWW (red, green, blue, cold white, warm white) color for the light.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[255, 100, 100, 50, 70]"
       selector:
@@ -64,12 +67,13 @@ turn_on:
       name: Color name
       description: A human readable color name.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         select:
@@ -227,12 +231,13 @@ turn_on:
       name: Hue/Sat color
       description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[300, 70]"
       selector:
@@ -241,12 +246,13 @@ turn_on:
       name: XY-color
       description: Color for the light in XY-format.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[0.52, 0.43]"
       selector:
@@ -255,13 +261,14 @@ turn_on:
       name: Color temperature
       description: Color temperature for the light in mireds.
       filter:
-        supported_color_modes:
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       selector:
         color_temp:
           min_mireds: 153
@@ -270,13 +277,14 @@ turn_on:
       name: Color temperature (Kelvin)
       description: Color temperature for the light in Kelvin.
       filter:
-        supported_color_modes:
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         number:
@@ -290,14 +298,15 @@ turn_on:
         off, 1 is the minimum brightness and 255 is the maximum brightness
         supported by the light.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         number:
@@ -309,14 +318,15 @@ turn_on:
         turns the light off, 1 is the minimum brightness and 100 is the maximum
         brightness supported by the light.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       selector:
         number:
           min: 0
@@ -326,14 +336,15 @@ turn_on:
       name: Brightness step value
       description: Change brightness by an amount.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         number:
@@ -343,14 +354,15 @@ turn_on:
       name: Brightness step
       description: Change brightness by a percentage.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       selector:
         number:
           min: -100
@@ -363,8 +375,9 @@ turn_on:
         the light off, 1 is the minimum brightness and 255 is the maximum
         brightness supported by the light.
       filter:
-        supported_color_modes:
-          - white
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.WHITE
       advanced: true
       selector:
         number:
@@ -382,7 +395,7 @@ turn_on:
       description: If the light should flash.
       filter:
         supported_features:
-          - 8 # LightEntityFeature.FLASH
+          - light.LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -396,7 +409,7 @@ turn_on:
       description: Light effect.
       filter:
         supported_features:
-          - 4 # LightEntityFeature.EFFECT
+          - light.LightEntityFeature.EFFECT
       selector:
         text:
 
@@ -411,8 +424,8 @@ turn_off:
       name: Transition
       description: Duration it takes to get to next state.
       filter:
-        supported_color_modes:
-          - white
+        supported_features:
+          - light.LightEntityFeature.TRANSITION
       selector:
         number:
           min: 0
@@ -423,7 +436,7 @@ turn_off:
       description: If the light should flash.
       filter:
         supported_features:
-          - 8 # LightEntityFeature.FLASH
+          - light.LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -447,7 +460,7 @@ toggle:
       description: Duration it takes to get to next state.
       filter:
         supported_features:
-          - 32 # LightEntityFeature.TRANSITION
+          - light.LightEntityFeature.TRANSITION
       selector:
         number:
           min: 0
@@ -457,12 +470,13 @@ toggle:
       name: RGB-color
       description: Color for the light in RGB-format.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[255, 100, 100]"
       selector:
@@ -471,12 +485,13 @@ toggle:
       name: Color name
       description: A human readable color name.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         select:
@@ -634,12 +649,13 @@ toggle:
       name: Hue/Sat color
       description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[300, 70]"
       selector:
@@ -648,12 +664,13 @@ toggle:
       name: XY-color
       description: Color for the light in XY-format.
       filter:
-        supported_color_modes:
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       example: "[0.52, 0.43]"
       selector:
@@ -662,13 +679,14 @@ toggle:
       name: Color temperature (mireds)
       description: Color temperature for the light in mireds.
       filter:
-        supported_color_modes:
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         color_temp:
@@ -676,13 +694,14 @@ toggle:
       name: Color temperature (Kelvin)
       description: Color temperature for the light in Kelvin.
       filter:
-        supported_color_modes:
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         number:
@@ -696,14 +715,15 @@ toggle:
         off, 1 is the minimum brightness and 255 is the maximum brightness
         supported by the light.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       advanced: true
       selector:
         number:
@@ -715,14 +735,15 @@ toggle:
         turns the light off, 1 is the minimum brightness and 100 is the maximum
         brightness supported by the light.
       filter:
-        supported_color_modes:
-          - brightness
-          - ct
-          - hs
-          - xy
-          - rgb
-          - rgbw
-          - rgbww
+        attribute:
+          supported_color_modes:
+            - light.ColorMode.BRIGHTNESS
+            - light.ColorMode.COLOR_TEMP
+            - light.ColorMode.HS
+            - light.ColorMode.XY
+            - light.ColorMode.RGB
+            - light.ColorMode.RGBW
+            - light.ColorMode.RGBWW
       selector:
         number:
           min: 0
@@ -740,7 +761,7 @@ toggle:
       description: If the light should flash.
       filter:
         supported_features:
-          - 8 # LightEntityFeature.FLASH
+          - light.LightEntityFeature.FLASH
       advanced: true
       selector:
         select:
@@ -754,6 +775,6 @@ toggle:
       description: Light effect.
       filter:
         supported_features:
-          - 4 # LightEntityFeature.EFFECT
+          - light.LightEntityFeature.EFFECT
       selector:
         text:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -153,9 +153,7 @@ ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Device class of the entity
         vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
         # Features supported by the entity
-        vol.Optional("supported_features"): [
-            vol.All(vol.Any(int, str), _validate_supported_feature)
-        ],
+        vol.Optional("supported_features"): [vol.All(str, _validate_supported_feature)],
     }
 )
 
@@ -166,7 +164,7 @@ class EntityFilterSelectorConfig(TypedDict, total=False):
     integration: str
     domain: str | list[str]
     device_class: str | list[str]
-    supported_features: list[int | str]
+    supported_features: list[str]
 
 
 DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -130,12 +130,18 @@ def _validate_supported_feature(supported_feature: int | str) -> int:
 
     known_entity_features = _entity_features()
 
-    _, enum, feature = supported_feature.split(".", 2)
+    try:
+        _, enum, feature = supported_feature.split(".", 2)
+    except ValueError as exc:
+        raise vol.Invalid(
+            f"Invalid supported feature '{supported_feature}', expected "
+            "<domain>.<enum>.<member>"
+        ) from exc
 
     try:
         return cast(int, getattr(known_entity_features[enum], feature).value)
     except (AttributeError, KeyError) as exc:
-        raise vol.Invalid(f"Unknown supported feature {supported_feature}") from exc
+        raise vol.Invalid(f"Unknown supported feature '{supported_feature}'") from exc
 
 
 ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from enum import IntFlag
 from functools import cache
-from typing import Any, Generic, Literal, Type, TypedDict, TypeVar, cast
+from typing import Any, Generic, Literal, TypedDict, TypeVar, cast
 from uuid import UUID
 
 from typing_extensions import Required
@@ -82,7 +82,7 @@ class Selector(Generic[_T]):
 
 
 @cache
-def _entity_features() -> dict[str, Type[IntFlag]]:
+def _entity_features() -> dict[str, type[IntFlag]]:
     """Return a cached lookup of entity feature enums."""
     # pylint: disable=import-outside-toplevel
     from homeassistant.components.alarm_control_panel import (

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -87,6 +87,8 @@ ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("domain"): vol.All(cv.ensure_list, [str]),
         # Device class of the entity
         vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
+        # Features supported by the entity
+        vol.Optional("supported_features"): [int],
     }
 )
 
@@ -97,6 +99,7 @@ class EntityFilterSelectorConfig(TypedDict, total=False):
     integration: str
     domain: str | list[str]
     device_class: str | list[str]
+    supported_features: list[int]
 
 
 DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -33,6 +33,10 @@ FIELD_SCHEMA = vol.Schema(
         vol.Optional("required"): bool,
         vol.Optional("advanced"): bool,
         vol.Optional(CONF_SELECTOR): selector.validate_selector,
+        vol.Optional("filter"): {
+            vol.Optional("supported_features"): [int],
+            vol.Optional("supported_color_modes"): [str],
+        },
     }
 )
 

--- a/script/hassfest/services.py
+++ b/script/hassfest/services.py
@@ -10,7 +10,7 @@ from voluptuous.humanize import humanize_error
 
 from homeassistant.const import CONF_SELECTOR
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers import config_validation as cv, selector, service
 from homeassistant.util.yaml import load_yaml
 
 from .model import Config, Integration
@@ -34,8 +34,12 @@ FIELD_SCHEMA = vol.Schema(
         vol.Optional("advanced"): bool,
         vol.Optional(CONF_SELECTOR): selector.validate_selector,
         vol.Optional("filter"): {
-            vol.Optional("supported_features"): [int],
-            vol.Optional("supported_color_modes"): [str],
+            vol.Optional("attribute"): {
+                vol.Required(str): [vol.All(str, service.validate_attribute_option)],
+            },
+            vol.Optional("supported_features"): [
+                vol.All(str, service.validate_supported_feature)
+            ],
         },
     }
 )
@@ -44,9 +48,7 @@ SERVICE_SCHEMA = vol.Schema(
     {
         vol.Required("description"): str,
         vol.Optional("name"): str,
-        vol.Optional("target"): vol.Any(
-            selector.TargetSelector.CONFIG_SCHEMA, None  # pylint: disable=no-member
-        ),
+        vol.Optional("target"): vol.Any(selector.TargetSelector.CONFIG_SCHEMA, None),
         vol.Optional("fields"): vol.Schema({str: FIELD_SCHEMA}),
     }
 )

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -227,11 +227,46 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
             ("light.abc123", "binary_sensor.abc123", FAKE_UUID),
             (None,),
         ),
+        (
+            {
+                "filter": [
+                    {"supported_features": ["LightEntityFeature.EFFECT"]},
+                ]
+            },
+            ("light.abc123", "blah.blah", FAKE_UUID),
+            (None,),
+        ),
+        (
+            {
+                "filter": [
+                    {"supported_features": [8]},
+                ]
+            },
+            ("light.abc123", "blah.blah", FAKE_UUID),
+            (None,),
+        ),
     ),
 )
 def test_entity_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test entity selector."""
     _test_selector("entity", schema, valid_selections, invalid_selections)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    (
+        # Invalid feature
+        {"filter": [{"supported_features": ["blah"]}]},
+        # Unknown feature enum
+        {"filter": [{"supported_features": ["FooEntityFeature.blah"]}]},
+        # Unknown feature enum member
+        {"filter": [{"supported_features": ["LightEntityFeature.blah"]}]},
+    ),
+)
+def test_entity_selector_schema_error(schema) -> None:
+    """Test number selector."""
+    with pytest.raises(vol.Invalid):
+        selector.validate_selector({"entity": schema})
 
 
 @pytest.mark.parametrize(
@@ -359,7 +394,7 @@ def test_addon_selector_schema(schema, valid_selections, invalid_selections) -> 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, (1, "one", None), ()),),  # Everything can be coarced to bool
+    (({}, (1, "one", None), ()),),  # Everything can be coerced to bool
 )
 def test_boolean_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test boolean selector."""

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -230,7 +230,7 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
         (
             {
                 "filter": [
-                    {"supported_features": ["LightEntityFeature.EFFECT"]},
+                    {"supported_features": ["light.LightEntityFeature.EFFECT"]},
                 ]
             },
             ("light.abc123", "blah.blah", FAKE_UUID),
@@ -258,9 +258,9 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
         # Invalid feature
         {"filter": [{"supported_features": ["blah"]}]},
         # Unknown feature enum
-        {"filter": [{"supported_features": ["FooEntityFeature.blah"]}]},
+        {"filter": [{"supported_features": ["blah.FooEntityFeature.blah"]}]},
         # Unknown feature enum member
-        {"filter": [{"supported_features": ["LightEntityFeature.blah"]}]},
+        {"filter": [{"supported_features": ["light.LightEntityFeature.blah"]}]},
     ),
 )
 def test_entity_selector_schema_error(schema) -> None:

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -69,10 +69,9 @@ def _test_selector(
 
     # Serialize selector
     selector_instance = selector.selector({selector_type: schema})
-    assert (
-        selector.selector(selector_instance.serialize()["selector"]).config
-        == selector_instance.config
-    )
+    assert selector_instance.serialize() == {
+        "selector": {selector_type: selector_instance.config}
+    }
     # Test serialized selector can be dumped to YAML
     yaml.dump(selector_instance.serialize())
 
@@ -239,7 +238,12 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
         (
             {
                 "filter": [
-                    {"supported_features": [8]},
+                    {
+                        "supported_features": [
+                            "light.LightEntityFeature.EFFECT",
+                            "light.LightEntityFeature.TRANSITION",
+                        ]
+                    },
                 ]
             },
             ("light.abc123", "blah.blah", FAKE_UUID),
@@ -255,6 +259,8 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
 @pytest.mark.parametrize(
     "schema",
     (
+        # Feature should be string specifying an enum member, not an int
+        {"filter": [{"supported_features": [1]}]},
         # Invalid feature
         {"filter": [{"supported_features": ["blah"]}]},
         # Unknown feature enum


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add filters to `climate` and `light` service descriptions

This PR makes it possible for service descriptions to add filters both to a service and a service parameters based on the capabilities of the service call target:
- `entity` target selector has a new configuration parameter `supported_features`
  - `supported_features` filter lists supported features needed for the service field, the target entity must support at least one of the supported features
- service fields has a new parameter `filter`
  - A service field `filter` can be either `supported_features` or `attributes`
    - A `supported_features` filter lists supported features needed for the service field, the target entity must support at least one of the supported features
    - An `attribute` filter names an attribute and lists possible attribute states needed for the service field


`climate` and `light` are chosen as targets because they both have services which should be hidden depending on the target, or where service call parameters should be hidden depending on the target.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
