### PR TITLE
Add reauth flow to webOS TV integration

### DIFF
--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -148,10 +148,10 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="error_pairing")
             except WEBOSTV_EXCEPTIONS:
                 return self.async_abort(reason="reauth_unsuccessful")
-            else:
-                update_client_key(self.hass, self._entry, client)
-                await self.hass.config_entries.async_reload(self._entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
+
+            update_client_key(self.hass, self._entry, client)
+            await self.hass.config_entries.async_reload(self._entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
 
         return self.async_show_form(step_id="reauth_confirm")
 

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure webostv component."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -8,14 +9,14 @@ from urllib.parse import urlparse
 from aiowebostv import WebOsTvPairError
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ssdp
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_NAME
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
 
-from . import async_control_connect
+from . import async_control_connect, update_client_key
 from .const import CONF_SOURCES, DEFAULT_NAME, DOMAIN, WEBOSTV_EXCEPTIONS
 from .helpers import async_get_sources
 
@@ -30,7 +31,7 @@ DATA_SCHEMA = vol.Schema(
 _LOGGER = logging.getLogger(__name__)
 
 
-class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+class FlowHandler(ConfigFlow, domain=DOMAIN):
     """WebosTV configuration flow."""
 
     VERSION = 1
@@ -40,12 +41,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._host: str = ""
         self._name: str = ""
         self._uuid: str | None = None
+        self._entry: ConfigEntry | None = None
 
     @staticmethod
     @callback
-    def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
-    ) -> OptionsFlowHandler:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
@@ -78,7 +78,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 self.hass.config_entries.async_update_entry(entry, unique_id=self._uuid)
 
-            raise data_entry_flow.AbortFlow("already_configured")
+            raise AbortFlow("already_configured")
 
     async def async_step_pairing(
         self, user_input: dict[str, Any] | None = None
@@ -129,11 +129,37 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._uuid = uuid
         return await self.async_step_pairing()
 
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Perform reauth upon an WebOsTvPairError."""
+        self._host = entry_data[CONF_HOST]
+        self._entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
 
-class OptionsFlowHandler(config_entries.OptionsFlow):
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        assert self._entry is not None
+
+        if user_input is not None:
+            try:
+                client = await async_control_connect(self._host, None)
+            except WebOsTvPairError:
+                return self.async_abort(reason="error_pairing")
+            except WEBOSTV_EXCEPTIONS:
+                return self.async_abort(reason="reauth_unsuccessful")
+            else:
+                update_client_key(self.hass, self._entry, client)
+                await self.hass.config_entries.async_reload(self._entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(step_id="reauth_confirm")
+
+
+class OptionsFlowHandler(OptionsFlow):
     """Handle options."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
         self.options = config_entry.options

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.trigger import PluggableAction
 
+from . import update_client_key
 from .const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
@@ -73,18 +74,11 @@ SCAN_INTERVAL = timedelta(seconds=10)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LG webOS Smart TV platform."""
-    unique_id = config_entry.unique_id
-    assert unique_id
-    name = config_entry.title
-    sources = config_entry.options.get(CONF_SOURCES)
-    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
-
-    async_add_entities([LgWebOSMediaPlayerEntity(client, name, sources, unique_id)])
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
+    async_add_entities([LgWebOSMediaPlayerEntity(entry, client)])
 
 
 _T = TypeVar("_T", bound="LgWebOSMediaPlayerEntity")
@@ -123,19 +117,14 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
     _attr_device_class = MediaPlayerDeviceClass.TV
 
-    def __init__(
-        self,
-        client: WebOsClient,
-        name: str,
-        sources: list[str] | None,
-        unique_id: str,
-    ) -> None:
+    def __init__(self, entry: ConfigEntry, client: WebOsClient) -> None:
         """Initialize the webos device."""
+        self._entry = entry
         self._client = client
         self._attr_assumed_state = True
-        self._attr_name = name
-        self._attr_unique_id = unique_id
-        self._sources = sources
+        self._attr_name = entry.title
+        self._attr_unique_id = entry.unique_id
+        self._sources = entry.options.get(CONF_SOURCES)
 
         # Assume that the TV is not paused
         self._paused = False
@@ -326,7 +315,12 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
             return
 
         with suppress(*WEBOSTV_EXCEPTIONS, WebOsTvPairError):
-            await self._client.connect()
+            try:
+                await self._client.connect()
+            except WebOsTvPairError:
+                self._entry.async_start_reauth(self.hass)
+            else:
+                update_client_key(self.hass, self._entry, self._client)
 
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -13,6 +13,10 @@
       "pairing": {
         "title": "webOS TV Pairing",
         "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)"
+      },
+      "reauth_confirm": {
+        "title": "webOS TV Pairing",
+        "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)"
       }
     },
     "error": {
@@ -21,7 +25,9 @@
     "abort": {
       "error_pairing": "Connected to LG webOS TV but not paired",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reauth_unsuccessful": "Re-authentication was unsuccessful, please turn on your TV and try again."
     }
   },
   "options": {

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -3,7 +3,9 @@
         "abort": {
             "already_configured": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
-            "error_pairing": "Connected to LG webOS TV but not paired"
+            "error_pairing": "Connected to LG webOS TV but not paired",
+			"reauth_successful": "Re-authentication was successful",
+			"reauth_unsuccessful": "Re-authentication was unsuccessful, please turn on your TV and try again."
         },
         "error": {
             "cannot_connect": "Failed to connect, please turn on your TV or check ip address"
@@ -11,6 +13,10 @@
         "flow_title": "LG webOS Smart TV",
         "step": {
             "pairing": {
+                "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)",
+                "title": "webOS TV Pairing"
+            },
+            "reauth_confirm": {
                 "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)",
                 "title": "webOS TV Pairing"
             },

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -9,11 +9,11 @@ from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.components.webostv.const import CONF_SOURCES, DOMAIN, LIVE_TV_APP_ID
 from homeassistant.config_entries import SOURCE_SSDP
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SOURCE
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_NAME, CONF_SOURCE
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import setup_webostv
-from .const import FAKE_UUID, HOST, MOCK_APPS, MOCK_INPUTS, TV_NAME
+from .const import CLIENT_KEY, FAKE_UUID, HOST, MOCK_APPS, MOCK_INPUTS, TV_NAME
 
 MOCK_USER_CONFIG = {
     CONF_HOST: HOST,
@@ -289,3 +289,64 @@ async def test_form_abort_uuid_configured(hass, client):
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == "new_host"
+
+
+async def test_reauth_successful(hass, client, monkeypatch):
+    """Test that the reauthorization is successful."""
+    entry = await setup_webostv(hass)
+    assert client
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert entry.data[CONF_CLIENT_SECRET] == CLIENT_KEY
+
+    monkeypatch.setattr(client, "client_key", "new_key")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_CLIENT_SECRET] == "new_key"
+
+
+@pytest.mark.parametrize(
+    "side_effect,reason",
+    [
+        (WebOsTvPairError, "error_pairing"),
+        (ConnectionRefusedError, "reauth_unsuccessful"),
+    ],
+)
+async def test_reauth_errors(hass, client, monkeypatch, side_effect, reason):
+    """Test reauthorization errors."""
+    entry = await setup_webostv(hass)
+    assert client
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    monkeypatch.setattr(client, "connect", Mock(side_effect=side_effect))
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == reason

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -1,0 +1,39 @@
+"""The tests for the LG webOS TV platform."""
+from unittest.mock import Mock
+
+from aiowebostv import WebOsTvPairError
+
+from homeassistant.components.webostv.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_CLIENT_SECRET
+
+from . import setup_webostv
+
+
+async def test_reauth_setup_entry(hass, client, monkeypatch):
+    """Test reauth flow triggered by setup entry."""
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
+    monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
+    entry = await setup_webostv(hass)
+
+    assert entry.state == ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow.get("step_id") == "reauth_confirm"
+    assert flow.get("handler") == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == entry.entry_id
+
+
+async def test_key_update_setup_entry(hass, client, monkeypatch):
+    """Test key update from setup entry."""
+    monkeypatch.setattr(client, "client_key", "new_key")
+    entry = await setup_webostv(hass)
+
+    assert entry.state == ConfigEntryState.LOADED
+    assert entry.data[CONF_CLIENT_SECRET] == "new_key"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add reauth flow support, this can happen if `LG Connect Apps` is disabled and enabled again so the TV forgets the pairing.
Handle two scenarios:
- User accepted pairing request during loading/connecting, silently store the new key
- TV rejects the pairing (or user declined pairing prompt) - trigger reauth flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/82524
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
