### PR TITLE
Add type hints to Filter integration tests

### DIFF
--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config as hass_config
+from homeassistant.components import recorder
 from homeassistant.components.filter.sensor import (
     DOMAIN,
     LowPassFilter,
@@ -27,7 +28,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -35,19 +36,19 @@ import homeassistant.util.dt as dt_util
 from tests.common import assert_setup_component, get_fixture_path
 
 
-@pytest.fixture
-def values():
+@pytest.fixture(name="values")
+def values_fixture() -> list[State]:
     """Fixture for a list of test States."""
     values = []
-    raw_values = [20, 19, 18, 21, 22, 0]
+    raw_values = ["20", "19", "18", "21", "22", "0"]
     timestamp = dt_util.utcnow()
     for val in raw_values:
-        values.append(ha.State("sensor.test_monitored", val, last_updated=timestamp))
+        values.append(State("sensor.test_monitored", val, last_updated=timestamp))
         timestamp += timedelta(minutes=1)
     return values
 
 
-async def test_setup_fail(hass):
+async def test_setup_fail(hass: HomeAssistant) -> None:
     """Test if filter doesn't exist."""
     config = {
         "sensor": {
@@ -61,7 +62,9 @@ async def test_setup_fail(hass):
         await hass.async_block_till_done()
 
 
-async def test_chain(recorder_mock, hass, values):
+async def test_chain(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, values: list[State]
+) -> None:
     """Test if filter chaining works."""
     config = {
         "sensor": {
@@ -89,7 +92,12 @@ async def test_chain(recorder_mock, hass, values):
 
 
 @pytest.mark.parametrize("missing", (True, False))
-async def test_chain_history(recorder_mock, hass, values, missing):
+async def test_chain_history(
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    values: list[State],
+    missing: bool,
+) -> None:
     """Test if filter chaining works, when a source is and isn't recorded."""
     config = {
         "sensor": {
@@ -114,10 +122,10 @@ async def test_chain_history(recorder_mock, hass, values, missing):
     else:
         fake_states = {
             "sensor.test_monitored": [
-                ha.State("sensor.test_monitored", 18.0, last_changed=t_0),
-                ha.State("sensor.test_monitored", "unknown", last_changed=t_1),
-                ha.State("sensor.test_monitored", 19.0, last_changed=t_2),
-                ha.State("sensor.test_monitored", 18.2, last_changed=t_3),
+                State("sensor.test_monitored", "18.0", last_changed=t_0),
+                State("sensor.test_monitored", "unknown", last_changed=t_1),
+                State("sensor.test_monitored", "19.0", last_changed=t_2),
+                State("sensor.test_monitored", "18.2", last_changed=t_3),
             ]
         }
 
@@ -143,7 +151,9 @@ async def test_chain_history(recorder_mock, hass, values, missing):
             assert state.state == "17.05"
 
 
-async def test_source_state_none(recorder_mock, hass, values):
+async def test_source_state_none(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test is source sensor state is null and sets state to STATE_UNKNOWN."""
 
     config = {
@@ -203,7 +213,9 @@ async def test_source_state_none(recorder_mock, hass, values):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_history_time(recorder_mock, hass):
+async def test_history_time(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test loading from history based on a time window."""
     config = {
         "sensor": {
@@ -220,9 +232,9 @@ async def test_history_time(recorder_mock, hass):
 
     fake_states = {
         "sensor.test_monitored": [
-            ha.State("sensor.test_monitored", 18.0, last_changed=t_0),
-            ha.State("sensor.test_monitored", 19.0, last_changed=t_1),
-            ha.State("sensor.test_monitored", 18.2, last_changed=t_2),
+            State("sensor.test_monitored", 18.0, last_changed=t_0),
+            State("sensor.test_monitored", 19.0, last_changed=t_1),
+            State("sensor.test_monitored", 18.2, last_changed=t_2),
         ]
     }
     with patch(
@@ -241,7 +253,7 @@ async def test_history_time(recorder_mock, hass):
         assert state.state == "18.0"
 
 
-async def test_setup(recorder_mock, hass):
+async def test_setup(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -283,7 +295,9 @@ async def test_setup(recorder_mock, hass):
         assert entity_id == "sensor.test"
 
 
-async def test_invalid_state(recorder_mock, hass):
+async def test_invalid_state(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -313,7 +327,9 @@ async def test_invalid_state(recorder_mock, hass):
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_timestamp_state(recorder_mock, hass):
+async def test_timestamp_state(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test if filter state is a datetime."""
     config = {
         "sensor": {
@@ -342,7 +358,7 @@ async def test_timestamp_state(recorder_mock, hass):
         assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
 
 
-async def test_outlier(values):
+async def test_outlier(values: list[State]) -> None:
     """Test if outlier filter works."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
     for state in values:
@@ -350,7 +366,7 @@ async def test_outlier(values):
     assert filtered.state == 21
 
 
-def test_outlier_step(values):
+def test_outlier_step(values: list[State]) -> None:
     """
     Test step-change handling in outlier.
 
@@ -365,19 +381,19 @@ def test_outlier_step(values):
     assert filtered.state == 22
 
 
-def test_initial_outlier(values):
+def test_initial_outlier(values: list[State]) -> None:
     """Test issue #13363."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
-    out = ha.State("sensor.test_monitored", 4000)
+    out = State("sensor.test_monitored", 4000)
     for state in [out] + values:
         filtered = filt.filter_state(state)
     assert filtered.state == 21
 
 
-def test_unknown_state_outlier(values):
+def test_unknown_state_outlier(values: list[State]) -> None:
     """Test issue #32395."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
-    out = ha.State("sensor.test_monitored", "unknown")
+    out = State("sensor.test_monitored", "unknown")
     for state in [out] + values + [out]:
         try:
             filtered = filt.filter_state(state)
@@ -386,7 +402,7 @@ def test_unknown_state_outlier(values):
     assert filtered.state == 21
 
 
-def test_precision_zero(values):
+def test_precision_zero(values: list[State]) -> None:
     """Test if precision of zero returns an integer."""
     filt = LowPassFilter(window_size=10, precision=0, entity=None, time_constant=10)
     for state in values:
@@ -394,10 +410,10 @@ def test_precision_zero(values):
     assert isinstance(filtered.state, int)
 
 
-def test_lowpass(values):
+def test_lowpass(values: list[State]) -> None:
     """Test if lowpass filter works."""
     filt = LowPassFilter(window_size=10, precision=2, entity=None, time_constant=10)
-    out = ha.State("sensor.test_monitored", "unknown")
+    out = State("sensor.test_monitored", "unknown")
     for state in [out] + values + [out]:
         try:
             filtered = filt.filter_state(state)
@@ -406,7 +422,7 @@ def test_lowpass(values):
     assert filtered.state == 18.05
 
 
-def test_range(values):
+def test_range(values: list[State]) -> None:
     """Test if range filter works."""
     lower = 10
     upper = 20
@@ -422,7 +438,7 @@ def test_range(values):
             assert unf == filtered.state
 
 
-def test_range_zero(values):
+def test_range_zero(values: list[State]) -> None:
     """Test if range filter works with zeroes as bounds."""
     lower = 0
     upper = 0
@@ -438,7 +454,7 @@ def test_range_zero(values):
             assert unf == filtered.state
 
 
-def test_throttle(values):
+def test_throttle(values: list[State]) -> None:
     """Test if lowpass filter works."""
     filt = ThrottleFilter(window_size=3, precision=2, entity=None)
     filtered = []
@@ -449,7 +465,7 @@ def test_throttle(values):
     assert [20, 21] == [f.state for f in filtered]
 
 
-def test_time_throttle(values):
+def test_time_throttle(values: list[State]) -> None:
     """Test if lowpass filter works."""
     filt = TimeThrottleFilter(
         window_size=timedelta(minutes=2), precision=2, entity=None
@@ -462,7 +478,7 @@ def test_time_throttle(values):
     assert [20, 18, 22] == [f.state for f in filtered]
 
 
-def test_time_sma(values):
+def test_time_sma(values: list[State]) -> None:
     """Test if time_sma filter works."""
     filt = TimeSMAFilter(
         window_size=timedelta(minutes=2), precision=2, entity=None, type="last"
@@ -472,7 +488,7 @@ def test_time_sma(values):
     assert filtered.state == 21.5
 
 
-async def test_reload(recorder_mock, hass):
+async def test_reload(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload filter sensors."""
     hass.states.async_set("sensor.test_monitored", 12345)
     await async_setup_component(

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config as hass_config
-from homeassistant.components import recorder
 from homeassistant.components.filter.sensor import (
     DOMAIN,
     LowPassFilter,
@@ -15,6 +14,7 @@ from homeassistant.components.filter.sensor import (
     TimeSMAFilter,
     TimeThrottleFilter,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -63,7 +63,7 @@ async def test_setup_fail(hass: HomeAssistant) -> None:
 
 
 async def test_chain(
-    recorder_mock: recorder.Recorder, hass: HomeAssistant, values: list[State]
+    recorder_mock: Recorder, hass: HomeAssistant, values: list[State]
 ) -> None:
     """Test if filter chaining works."""
     config = {
@@ -93,7 +93,7 @@ async def test_chain(
 
 @pytest.mark.parametrize("missing", (True, False))
 async def test_chain_history(
-    recorder_mock: recorder.Recorder,
+    recorder_mock: Recorder,
     hass: HomeAssistant,
     values: list[State],
     missing: bool,
@@ -151,9 +151,7 @@ async def test_chain_history(
             assert state.state == "17.05"
 
 
-async def test_source_state_none(
-    recorder_mock: recorder.Recorder, hass: HomeAssistant
-) -> None:
+async def test_source_state_none(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test is source sensor state is null and sets state to STATE_UNKNOWN."""
 
     config = {
@@ -213,9 +211,7 @@ async def test_source_state_none(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_history_time(
-    recorder_mock: recorder.Recorder, hass: HomeAssistant
-) -> None:
+async def test_history_time(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test loading from history based on a time window."""
     config = {
         "sensor": {
@@ -253,7 +249,7 @@ async def test_history_time(
         assert state.state == "18.0"
 
 
-async def test_setup(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
+async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -295,9 +291,7 @@ async def test_setup(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> N
         assert entity_id == "sensor.test"
 
 
-async def test_invalid_state(
-    recorder_mock: recorder.Recorder, hass: HomeAssistant
-) -> None:
+async def test_invalid_state(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -327,9 +321,7 @@ async def test_invalid_state(
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_timestamp_state(
-    recorder_mock: recorder.Recorder, hass: HomeAssistant
-) -> None:
+async def test_timestamp_state(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test if filter state is a datetime."""
     config = {
         "sensor": {
@@ -488,7 +480,7 @@ def test_time_sma(values: list[State]) -> None:
     assert filtered.state == 21.5
 
 
-async def test_reload(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
+async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload filter sensors."""
     hass.states.async_set("sensor.test_monitored", 12345)
     await async_setup_component(

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -40,10 +40,10 @@ from tests.common import assert_setup_component, get_fixture_path
 def values_fixture() -> list[State]:
     """Fixture for a list of test States."""
     values = []
-    raw_values = ["20", "19", "18", "21", "22", "0"]
+    raw_values = [20, 19, 18, 21, 22, 0]
     timestamp = dt_util.utcnow()
     for val in raw_values:
-        values.append(State("sensor.test_monitored", val, last_updated=timestamp))
+        values.append(State("sensor.test_monitored", str(val), last_updated=timestamp))
         timestamp += timedelta(minutes=1)
     return values
 

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -232,9 +232,9 @@ async def test_history_time(
 
     fake_states = {
         "sensor.test_monitored": [
-            State("sensor.test_monitored", 18.0, last_changed=t_0),
-            State("sensor.test_monitored", 19.0, last_changed=t_1),
-            State("sensor.test_monitored", 18.2, last_changed=t_2),
+            State("sensor.test_monitored", "18.0", last_changed=t_0),
+            State("sensor.test_monitored", "19.0", last_changed=t_1),
+            State("sensor.test_monitored", "18.2", last_changed=t_2),
         ]
     }
     with patch(
@@ -384,7 +384,7 @@ def test_outlier_step(values: list[State]) -> None:
 def test_initial_outlier(values: list[State]) -> None:
     """Test issue #13363."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
-    out = State("sensor.test_monitored", 4000)
+    out = State("sensor.test_monitored", "4000")
     for state in [out] + values:
         filtered = filt.filter_state(state)
     assert filtered.state == 21


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to Filter integration tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
