### PR TITLE
Add zha config entity for options on color cluster

### DIFF
--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .core import discovery
 from .core.const import (
     CHANNEL_BASIC,
+    CHANNEL_COLOR,
     CHANNEL_INOVELLI,
     CHANNEL_ON_OFF,
     DATA_ZHA,
@@ -273,6 +274,16 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
                 self._zcl_inverter_attribute, from_cache=False
             )
             self.debug("read value=%s, inverted=%s", value, self.inverted)
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names=CHANNEL_COLOR)
+class ColorOptionsConfigurationEntity(
+    ZHASwitchConfigurationEntity, id_suffix="options"
+):
+    """Representation of a ZHA color options configuration entity."""
+
+    _zcl_attribute: str = "options"
+    _attr_name = "Send color when off"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -45,6 +45,7 @@ def required_platform_only():
             Platform.DEVICE_TRACKER,
             Platform.NUMBER,
             Platform.SELECT,
+            Platform.SWITCH,
         ),
     ):
         yield

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -32,6 +32,7 @@ def light_platform_only():
             Platform.LIGHT,
             Platform.NUMBER,
             Platform.SELECT,
+            Platform.SWITCH,
         ),
     ):
         yield

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -99,6 +99,7 @@ def light_platform_only():
             Platform.SENSOR,
             Platform.NUMBER,
             Platform.SELECT,
+            Platform.SWITCH,
         ),
     ):
         yield

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -38,6 +38,7 @@ def number_platform_only():
             Platform.NUMBER,
             Platform.SELECT,
             Platform.SENSOR,
+            Platform.SWITCH,
         ),
     ):
         yield


### PR DESCRIPTION
Somewhat required PR merged:
- https://github.com/home-assistant/core/pull/84874

## Proposed change
This adds a config entity switch for the ZCL ``ExecuteIfOff`` option (for all compatible Zigbee lights).
That will allow users to write the ``options`` attribute using the UI to turn on/off the ``ExecuteIfOff`` function (and, with the [other PR](https://github.com/home-assistant/core/pull/84874), allow users to easily use the ``ExecuteIfOff`` function for compatible lights).

Screenshot of the config entity:
![image](https://user-images.githubusercontent.com/6409465/213308489-84496c31-b27e-43c1-8db2-5086cb3aa1f5.png)

### Notes:
The ``options`` attribute for compatible lights is a bitmap, but there's only one option available. If, in the future, there's another option added to ZCL that we also want to switch using the UI, a new switch might be needed and the code for this config entity needs to be changed to only alter the rightmost bit (instead of overwriting all others with ``0`` too).
At the moment, I wouldn't overcomplicate this, as ``options`` can only be ``0b00000000`` or ``0b00000001``, but I'm open for changes.

(I also thought of if this attribute should just be set on pairing/binding for every light, but I don't think that's the best idea.)

(Enabling this brings the benefit of having a proper transition from a different color when turning on the light from an off-state (without any intermediary states).)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to PR: https://github.com/home-assistant/core/pull/84874
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
