### PR TITLE
Address Honeywell late review

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -94,10 +94,16 @@ async def async_setup_entry(
 class HoneywellUSThermostat(ClimateEntity):
     """Representation of a Honeywell US Thermostat."""
 
-    def __init__(self, data, device, cool_away_temp, heat_away_temp):
+    def __init__(
+        self,
+        data: HoneywellData,
+        device: AIOSomecomfort.device.Device,
+        cool_away_temp,
+        heat_away_temp,
+    ):
         """Initialize the thermostat."""
-        self._data: HoneywellData = data
-        self._device: AIOSomecomfort.device.Device = device
+        self._data = data
+        self._device = device
         self._cool_away_temp = cool_away_temp
         self._heat_away_temp = heat_away_temp
         self._away = False
@@ -111,8 +117,10 @@ class HoneywellUSThermostat(ClimateEntity):
         self._attr_is_aux_heat = device.system_mode == "emheat"
 
         # not all honeywell HVACs support all modes
-        mappings = [v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]]
-        self._hvac_mode_map = {k: v for d in mappings for k, v in d.items()}
+        mappings_hvac = [
+            v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]
+        ]
+        self._hvac_mode_map = {k: v for d in mappings_hvac for k, v in d.items()}
         self._attr_hvac_modes = list(self._hvac_mode_map)
 
         self._attr_supported_features = (
@@ -131,8 +139,8 @@ class HoneywellUSThermostat(ClimateEntity):
             return
 
         # not all honeywell fans support all modes
-        mappings = [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
-        self._fan_mode_map = {k: v for d in mappings for k, v in d.items()}
+        mappings_fan = [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
+        self._fan_mode_map = {k: v for d in mappings_fan for k, v in d.items()}
 
         self._attr_fan_modes = list(self._fan_mode_map)
 

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -98,8 +98,8 @@ class HoneywellUSThermostat(ClimateEntity):
         self,
         data: HoneywellData,
         device: AIOSomecomfort.device.Device,
-        cool_away_temp: str | Any,
-        heat_away_temp: str | Any,
+        cool_away_temp: str | None,
+        heat_away_temp: str | None,
     ) -> None:
         """Initialize the thermostat."""
         self._data = data

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -26,6 +26,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import HoneywellData
 from .const import (
     _LOGGER,
     CONF_COOL_AWAY_TEMPERATURE,
@@ -95,8 +96,8 @@ class HoneywellUSThermostat(ClimateEntity):
 
     def __init__(self, data, device, cool_away_temp, heat_away_temp):
         """Initialize the thermostat."""
-        self._data = data
-        self._device = device
+        self._data: HoneywellData = data
+        self._device: AIOSomecomfort.device.Device = device
         self._cool_away_temp = cool_away_temp
         self._heat_away_temp = heat_away_temp
         self._away = False
@@ -190,9 +191,9 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.hvac_mode == "cool":
+        if self.hvac_mode == HVACMode.COOL:
             return self._device.setpoint_cool
-        if self.hvac_mode == "heat":
+        if self.hvac_mode == HVACMode.HEAT:
             return self._device.setpoint_heat
         return None
 

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -119,11 +119,10 @@ class HoneywellUSThermostat(ClimateEntity):
         # not all honeywell HVACs support all modes
 
         self._hvac_mode_map = {
-            z: y
-            for x in [
-                v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]
-            ]
-            for z, y in x.items()
+            key2: value2
+            for key1, value1 in HVAC_MODE_TO_HW_MODE.items()
+            if device.raw_ui_data[key1]
+            for key2, value2 in value1.items()
         }
         self._attr_hvac_modes = list(self._hvac_mode_map)
 
@@ -144,9 +143,10 @@ class HoneywellUSThermostat(ClimateEntity):
 
         # not all honeywell fans support all modes
         self._fan_mode_map = {
-            z: y
-            for x in [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
-            for z, y in x.items()
+            key2: value2
+            for key1, value1 in FAN_MODE_TO_HW.items()
+            if device.raw_fan_data[key1]
+            for key2, value2 in value1.items()
         }
 
         self._attr_fan_modes = list(self._fan_mode_map)

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -70,7 +70,7 @@ HW_FAN_MODE_TO_HA = {
     "follow schedule": FAN_AUTO,
 }
 
-SCAN_INTERVAL = datetime.timedelta(seconds=10)
+SCAN_INTERVAL = datetime.timedelta(seconds=30)
 
 
 async def async_setup_entry(
@@ -190,9 +190,9 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.hvac_mode == HVACMode.COOL:
+        if self.hvac_mode == "cool":
             return self._device.setpoint_cool
-        if self.hvac_mode == HVACMode.HEAT:
+        if self.hvac_mode == "heat":
             return self._device.setpoint_heat
         return None
 
@@ -246,15 +246,15 @@ class HoneywellUSThermostat(ClimateEntity):
                 # Get next period time
                 hour, minute = divmod(next_period * 15, 60)
                 # Set hold time
-                if mode == HVACMode.COOL:
+                if mode == "cool":
                     await self._device.set_hold_cool(datetime.time(hour, minute))
-                elif mode == HVACMode.HEAT:
+                elif mode == "heat":
                     await self._device.set_hold_heat(datetime.time(hour, minute))
 
             # Set temperature
-            if mode == HVACMode.COOL:
+            if mode == "cool":
                 await self._device.set_setpoint_cool(temperature)
-            elif mode == HVACMode.HEAT:
+            elif mode == "heat":
                 await self._device.set_setpoint_heat(temperature)
 
         except AIOSomecomfort.SomeComfortError:
@@ -301,10 +301,10 @@ class HoneywellUSThermostat(ClimateEntity):
             # Set permanent hold
             # and Set temperature
             away_temp = getattr(self, f"_{mode}_away_temp")
-            if mode == HVACMode.COOL:
+            if mode == "cool":
                 self._device.set_hold_cool(True)
                 self._device.set_setpoint_cool(away_temp)
-            elif mode == HVACMode.HEAT:
+            elif mode == "heat":
                 self._device.set_hold_heat(True)
                 self._device.set_setpoint_heat(away_temp)
 
@@ -325,9 +325,9 @@ class HoneywellUSThermostat(ClimateEntity):
         if mode in HW_MODE_TO_HVAC_MODE:
             try:
                 # Set permanent hold
-                if mode == HVACMode.COOL:
+                if mode == "cool":
                     await self._device.set_hold_cool(True)
-                elif mode == HVACMode.HEAT:
+                elif mode == "heat":
                     await self._device.set_hold_heat(True)
 
             except AIOSomecomfort.SomeComfortError:

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -98,8 +98,8 @@ class HoneywellUSThermostat(ClimateEntity):
         self,
         data: HoneywellData,
         device: AIOSomecomfort.device.Device,
-        cool_away_temp: str | None,
-        heat_away_temp: str | None,
+        cool_away_temp: int | None,
+        heat_away_temp: int | None,
     ) -> None:
         """Initialize the thermostat."""
         self._data = data

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -98,9 +98,9 @@ class HoneywellUSThermostat(ClimateEntity):
         self,
         data: HoneywellData,
         device: AIOSomecomfort.device.Device,
-        cool_away_temp,
-        heat_away_temp,
-    ):
+        cool_away_temp: str | Any,
+        heat_away_temp: str | Any,
+    ) -> None:
         """Initialize the thermostat."""
         self._data = data
         self._device = device
@@ -117,10 +117,14 @@ class HoneywellUSThermostat(ClimateEntity):
         self._attr_is_aux_heat = device.system_mode == "emheat"
 
         # not all honeywell HVACs support all modes
-        mappings_hvac = [
-            v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]
-        ]
-        self._hvac_mode_map = {k: v for d in mappings_hvac for k, v in d.items()}
+
+        self._hvac_mode_map = {
+            z: y
+            for x in [
+                v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]
+            ]
+            for z, y in x.items()
+        }
         self._attr_hvac_modes = list(self._hvac_mode_map)
 
         self._attr_supported_features = (
@@ -139,8 +143,11 @@ class HoneywellUSThermostat(ClimateEntity):
             return
 
         # not all honeywell fans support all modes
-        mappings_fan = [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
-        self._fan_mode_map = {k: v for d in mappings_fan for k, v in d.items()}
+        self._fan_mode_map = {
+            z: y
+            for x in [v for k, v in FAN_MODE_TO_HW.items() if device.raw_fan_data[k]]
+            for z, y in x.items()
+        }
 
         self._attr_fan_modes = list(self._fan_mode_map)
 

--- a/homeassistant/components/honeywell/config_flow.py
+++ b/homeassistant/components/honeywell/config_flow.py
@@ -30,10 +30,8 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Create config entry. Show the setup form to the user."""
         errors = {}
         if user_input is not None:
-            valid = False
             try:
                 await self.is_valid(**user_input)
-                valid = True
             except AIOSomecomfort.AuthError:
                 errors["base"] = "invalid_auth"
             except (
@@ -43,7 +41,7 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ):
                 errors["base"] = "cannot_connect"
 
-            if valid:
+            if not errors:
                 return self.async_create_entry(
                     title=DOMAIN,
                     data=user_input,

--- a/homeassistant/components/honeywell/config_flow.py
+++ b/homeassistant/components/honeywell/config_flow.py
@@ -29,10 +29,11 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Create config entry. Show the setup form to the user."""
         errors = {}
-        valid = False
         if user_input is not None:
+            valid = False
             try:
-                valid = await self.is_valid(**user_input)
+                await self.is_valid(**user_input)
+                valid = True
             except AIOSomecomfort.AuthError:
                 errors["base"] = "invalid_auth"
             except (

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -40,26 +40,20 @@ async def test_show_authenticate_form(hass: HomeAssistant) -> None:
 async def test_connection_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on connection fail."""
     client.login.side_effect = AIOSomecomfort.ConnectionError
-    with patch(
-        "homeassistant.components.honeywell.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
-        )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
+    )
     assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_auth_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on login fail."""
     client.login.side_effect = AIOSomecomfort.AuthError
-    with patch(
-        "homeassistant.components.honeywell.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
-        )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
+    )
     assert result["errors"] == {"base": "invalid_auth"}
 
 

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -24,7 +24,7 @@ FAKE_CONFIG = {
 
 async def test_show_authenticate_form(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that the config form is shown."""
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):
@@ -40,7 +40,7 @@ async def test_show_authenticate_form(hass: HomeAssistant, client: MagicMock) ->
 async def test_connection_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on connection fail."""
     client.login.side_effect = AIOSomecomfort.ConnectionError
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):
@@ -63,9 +63,9 @@ async def test_auth_error(hass: HomeAssistant, client: MagicMock) -> None:
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_create_entry(hass: HomeAssistant, client: MagicMock) -> None:
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test that the config entry is created."""
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):
@@ -77,7 +77,7 @@ async def test_create_entry(hass: HomeAssistant, client: MagicMock) -> None:
 
 
 async def test_show_option_form(
-    hass: HomeAssistant, config_entry: MockConfigEntry, client: MagicMock
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test that the option form is shown."""
     config_entry.add_to_hass(hass)
@@ -86,7 +86,7 @@ async def test_show_option_form(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):
@@ -106,7 +106,7 @@ async def test_create_option_entry(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_connection_error(hass: HomeAssistant, client: MagicMock) -> None:
 async def test_auth_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on login fail."""
     client.login.side_effect = AIOSomecomfort.AuthError
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+    with patch(
         "homeassistant.components.honeywell.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -24,14 +24,10 @@ FAKE_CONFIG = {
 
 async def test_show_authenticate_form(hass: HomeAssistant) -> None:
     """Test that the config form is shown."""
-    with patch(
-        "homeassistant.components.honeywell.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -66,6 +62,8 @@ async def test_create_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
         )
+        await hass.async_block_till_done()
+
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == FAKE_CONFIG
 
@@ -111,6 +109,7 @@ async def test_create_option_entry(
             options_form["flow_id"],
             user_input={CONF_COOL_AWAY_TEMPERATURE: 1, CONF_HEAT_AWAY_TEMPERATURE: 2},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert config_entry.options == {

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -22,7 +22,7 @@ FAKE_CONFIG = {
 }
 
 
-async def test_show_authenticate_form(hass: HomeAssistant, client: MagicMock) -> None:
+async def test_show_authenticate_form(hass: HomeAssistant) -> None:
     """Test that the config form is shown."""
     with patch(
         "homeassistant.components.honeywell.async_setup_entry",
@@ -97,7 +97,7 @@ async def test_show_option_form(
 
 
 async def test_create_option_entry(
-    hass: HomeAssistant, config_entry: MockConfigEntry, client: MagicMock
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test that the config entry is created."""
     config_entry.add_to_hass(hass)

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -24,7 +24,10 @@ FAKE_CONFIG = {
 
 async def test_show_authenticate_form(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that the config form is shown."""
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -37,7 +40,10 @@ async def test_show_authenticate_form(hass: HomeAssistant, client: MagicMock) ->
 async def test_connection_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on connection fail."""
     client.login.side_effect = AIOSomecomfort.ConnectionError
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
         )
@@ -47,7 +53,10 @@ async def test_connection_error(hass: HomeAssistant, client: MagicMock) -> None:
 async def test_auth_error(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that an error message is shown on login fail."""
     client.login.side_effect = AIOSomecomfort.AuthError
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
         )
@@ -56,7 +65,10 @@ async def test_auth_error(hass: HomeAssistant, client: MagicMock) -> None:
 
 async def test_create_entry(hass: HomeAssistant, client: MagicMock) -> None:
     """Test that the config entry is created."""
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
         )
@@ -74,7 +86,10 @@ async def test_show_option_form(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -91,7 +106,10 @@ async def test_create_option_entry(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client):
+    with patch("AIOSomecomfort.AIOSomeComfort", return_value=client,), patch(
+        "homeassistant.components.honeywell.async_setup_entry",
+        return_value=True,
+    ):
         options_form = await hass.config_entries.options.async_init(
             config_entry.entry_id
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Various requested changes from PR#86102 by @MartinHjelmare 
remove incorrect Climate ENUM
config flow is_valid - remove "always true" return
Adjust poll to 30 seconds
Patch integration in config flow tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
