### PR TITLE
Add rainbird rain delay number entity, deprecating the sensor and service

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -126,11 +126,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN][entry_id]
 
         entity_registry = er.async_get(hass)
-        entity_ids = [
+        entity_ids = (
             entry.entity_id
             for entry in er.async_entries_for_config_entry(entity_registry, entry_id)
             if entry.unique_id == f"{coordinator.serial_number}-rain-delay"
-        ]
+        )
         async_create_issue(
             hass,
             DOMAIN,
@@ -141,7 +141,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_raindelay",
             translation_placeholders={
-                "alternate_target": next(iter(entity_ids), "unknown"),
+                "alternate_target": next(entity_ids, "unknown"),
             },
         )
 

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -87,6 +87,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_yaml",
     )
+
     return True
 
 
@@ -94,16 +95,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the config entry for Rain Bird."""
 
     hass.data.setdefault(DOMAIN, {})
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_raindelay",
-        breaks_in_ha_version="2023.4.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_raindelay",
-    )
 
     controller = AsyncRainbirdController(
         AsyncRainbirdClient(
@@ -126,6 +117,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def set_rain_delay(call: ServiceCall) -> None:
         """Service call to delay automatic irrigigation."""
+
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_raindelay",
+            breaks_in_ha_version="2023.4.0",
+            is_fixable=False,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_raindelay",
+            translation_placeholders={
+                "alternative_target": "number.rain_delay",
+            },
+        )
+
         entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
         duration = call.data[ATTR_DURATION]
         if entry_id not in hass.data[DOMAIN]:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 from .const import ATTR_CONFIG_ENTRY_ID, ATTR_DURATION, CONF_SERIAL_NUMBER, CONF_ZONES
 from .coordinator import RainbirdUpdateCoordinator
 
-PLATFORMS = [Platform.SWITCH, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.SWITCH, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +87,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_yaml",
     )
-
     return True
 
 
@@ -95,6 +94,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the config entry for Rain Bird."""
 
     hass.data.setdefault(DOMAIN, {})
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_raindelay",
+        breaks_in_ha_version="2023.4.0",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_raindelay",
+    )
 
     controller = AsyncRainbirdController(
         AsyncRainbirdClient(

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -1,0 +1,61 @@
+"""The number platform for rainbird."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import RainbirdUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up entry for a Rain Bird number platform."""
+    async_add_entities(
+        [
+            RainDelayNumber(
+                hass.data[DOMAIN][config_entry.entry_id],
+            )
+        ]
+    )
+
+
+class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity):
+    """A number implemnetaiton for the rain delay."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 14
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.DAYS
+    _attr_icon = "mdi:water-off"
+    _attr_name = "Rain delay"
+    _attr_use_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: RainbirdUpdateCoordinator,
+    ) -> None:
+        """Initialize the Rain Bird sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.serial_number}-rain-delay"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the value reported by the sensor."""
+        return self.coordinator.data.rain_delay
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        await self.coordinator.controller.set_rain_delay(value)

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -40,7 +40,7 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
     _attr_native_unit_of_measurement = UnitOfTime.DAYS
     _attr_icon = "mdi:water-off"
     _attr_name = "Rain delay"
-    _attr_use_entity_name = True
+    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/homeassistant/components/rainbird/strings.json
+++ b/homeassistant/components/rainbird/strings.json
@@ -36,7 +36,7 @@
         "step": {
           "confirm": {
             "title": "The Rain Bird Rain Delay Service is being removed",
-            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead."
+            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternate_target}` instead."
           }
         }
       }

--- a/homeassistant/components/rainbird/strings.json
+++ b/homeassistant/components/rainbird/strings.json
@@ -29,6 +29,10 @@
     "deprecated_yaml": {
       "title": "The Rain Bird YAML configuration is being removed",
       "description": "Configuring Rain Bird in configuration.yaml is being removed in Home Assistant 2023.4.\n\nYour configuration has been imported into the UI automatically, however default per-zone irrigation times are no longer supported. Remove the Rain Bird YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    },
+    "deprecated_raindelay": {
+      "title": "The Rain Bird Rain Delay Service is being removed",
+      "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` instead."
     }
   }
 }

--- a/homeassistant/components/rainbird/strings.json
+++ b/homeassistant/components/rainbird/strings.json
@@ -32,7 +32,7 @@
     },
     "deprecated_raindelay": {
       "title": "The Rain Bird Rain Delay Service is being removed",
-      "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` instead."
+      "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead."
     }
   }
 }

--- a/homeassistant/components/rainbird/strings.json
+++ b/homeassistant/components/rainbird/strings.json
@@ -32,7 +32,14 @@
     },
     "deprecated_raindelay": {
       "title": "The Rain Bird Rain Delay Service is being removed",
-      "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The Rain Bird Rain Delay Service is being removed",
+            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/rainbird/translations/en.json
+++ b/homeassistant/components/rainbird/translations/en.json
@@ -17,7 +17,7 @@
     },
     "issues": {
         "deprecated_raindelay": {
-            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` instead.",
+            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead.",
             "title": "The Rain Bird Rain Delay Service is being removed"
         },
         "deprecated_yaml": {

--- a/homeassistant/components/rainbird/translations/en.json
+++ b/homeassistant/components/rainbird/translations/en.json
@@ -17,7 +17,14 @@
     },
     "issues": {
         "deprecated_raindelay": {
-            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead.",
+                        "title": "The Rain Bird Rain Delay Service is being removed"
+                    }
+                }
+            },
             "title": "The Rain Bird Rain Delay Service is being removed"
         },
         "deprecated_yaml": {

--- a/homeassistant/components/rainbird/translations/en.json
+++ b/homeassistant/components/rainbird/translations/en.json
@@ -20,7 +20,7 @@
             "fix_flow": {
                 "step": {
                     "confirm": {
-                        "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternative_target}` instead.",
+                        "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` with a target of `{alternate_target}` instead.",
                         "title": "The Rain Bird Rain Delay Service is being removed"
                     }
                 }

--- a/homeassistant/components/rainbird/translations/en.json
+++ b/homeassistant/components/rainbird/translations/en.json
@@ -16,6 +16,10 @@
         }
     },
     "issues": {
+        "deprecated_raindelay": {
+            "description": "The Rain Bird service `rainbird.set_rain_delay` is being removed and replaced by a Number entity for managing the rain delay. Any existing automations or scripts will need to be updated to use `number.set_value` instead.",
+            "title": "The Rain Bird Rain Delay Service is being removed"
+        },
         "deprecated_yaml": {
             "description": "Configuring Rain Bird in configuration.yaml is being removed in Home Assistant 2023.4.\n\nYour configuration has been imported into the UI automatically, however default per-zone irrigation times are no longer supported. Remove the Rain Bird YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
             "title": "The Rain Bird YAML configuration is being removed"

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from .conftest import (
     ACK_ECHO,
@@ -102,7 +102,7 @@ async def test_communication_failure(
     ] == config_entry_states
 
 
-@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+@pytest.mark.parametrize("platforms", [[Platform.NUMBER, Platform.SENSOR]])
 async def test_rain_delay_service(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
@@ -130,6 +130,15 @@ async def test_rain_delay_service(
     )
 
     assert len(aioclient_mock.mock_calls) == 1
+
+    issue_registry: ir.IssueRegistry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(
+        domain=DOMAIN, issue_id="deprecated_raindelay"
+    )
+    assert issue
+    assert issue.translation_placeholders == {
+        "alternate_target": "number.rain_bird_controller_rain_delay"
+    }
 
 
 async def test_rain_delay_invalid_config_entry(

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -1,0 +1,84 @@
+"""Tests for rainbird number platform."""
+
+
+import pytest
+
+from homeassistant.components import number
+from homeassistant.components.rainbird import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .conftest import (
+    ACK_ECHO,
+    RAIN_DELAY,
+    RAIN_DELAY_OFF,
+    SERIAL_NUMBER,
+    ComponentSetup,
+    mock_response,
+)
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.NUMBER]
+
+
+@pytest.mark.parametrize(
+    "rain_delay_response,expected_state",
+    [(RAIN_DELAY, "16"), (RAIN_DELAY_OFF, "0")],
+)
+async def test_number_values(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    expected_state: str,
+) -> None:
+    """Test sensor platform."""
+
+    assert await setup_integration()
+
+    raindelay = hass.states.get("number.rain_delay")
+    assert raindelay is not None
+    assert raindelay.state == expected_state
+    assert raindelay.attributes == {
+        "friendly_name": "Rain delay",
+        "icon": "mdi:water-off",
+        "min": 0,
+        "max": 14,
+        "mode": "auto",
+        "step": 1,
+        "unit_of_measurement": "d",
+    }
+
+
+async def test_set_value(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[str],
+    config_entry: ConfigEntry,
+) -> None:
+    """Test setting the rain delay number."""
+
+    assert await setup_integration()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, SERIAL_NUMBER)})
+    assert device
+    assert device.name == "Rain Bird Controller"
+
+    aioclient_mock.mock_calls.clear()
+    responses.append(mock_response(ACK_ECHO))
+
+    await hass.services.async_call(
+        number.DOMAIN,
+        number.SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.rain_delay", number.ATTR_VALUE: 3},
+        blocking=True,
+    )
+
+    assert len(aioclient_mock.mock_calls) == 1

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -41,11 +41,11 @@ async def test_number_values(
 
     assert await setup_integration()
 
-    raindelay = hass.states.get("number.rain_delay")
+    raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
     assert raindelay is not None
     assert raindelay.state == expected_state
     assert raindelay.attributes == {
-        "friendly_name": "Rain delay",
+        "friendly_name": "Rain Bird Controller Rain delay",
         "icon": "mdi:water-off",
         "min": 0,
         "max": 14,
@@ -77,7 +77,10 @@ async def test_set_value(
     await hass.services.async_call(
         number.DOMAIN,
         number.SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: "number.rain_delay", number.ATTR_VALUE: 3},
+        {
+            ATTR_ENTITY_ID: "number.rain_bird_controller_rain_delay",
+            number.ATTR_VALUE: 3,
+        },
         blocking=True,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Rain Bird integration has changed the way the "Rain Delay" is managed. The Rain Delay, which pauses irrigation for a specified number of days, is now manage with a Number entity which can be controlled directly from the UI. The existing service call  is `rainbird.set_rain_delay` and the Raindelay sensor have been deprecated. Any existing automations or scripts  that make service calls to `rainbird.set_rain_delay` will need to be replaced with a call to `number.set_value`.  Additionally, the existing service call was updated to require a config entry parameter since it previously had undefined behavior, so it is recommend to move directly to the new number service call.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the rain delay number entity, deprecating the sensor and service, as discussed in https://github.com/home-assistant/core/pull/85271

This adds the Number entity, and creates an issue in the issue registry to remind users to switch services. The tests were borrowed from existing functionality of the sensor and service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25836

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
