### PR TITLE
Clean up HomeWizard diagnostic tests

### DIFF
--- a/tests/components/homewizard/test_diagnostics.py
+++ b/tests/components/homewizard/test_diagnostics.py
@@ -14,7 +14,6 @@ async def test_diagnostics(
     init_integration: MockConfigEntry,
 ):
     """Test diagnostics."""
-    print(await get_diagnostics_for_config_entry(hass, hass_client, init_integration))
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration
     ) == {
@@ -28,11 +27,11 @@ async def test_diagnostics(
                 "firmware_version": "2.11",
             },
             "data": {
-                "wifi_ssid": "**REDACTED**",
+                "wifi_ssid": REDACTED,
                 "wifi_strength": 100,
                 "smr_version": 50,
                 "meter_model": "ISKRA  2M550T-101",
-                "unique_meter_id": "**REDACTED**",
+                "unique_meter_id": REDACTED,
                 "active_tariff": 2,
                 "total_power_import_kwh": 13779.338,
                 "total_power_import_t1_kwh": 10830.511,
@@ -68,7 +67,7 @@ async def test_diagnostics(
                 "montly_power_peak_timestamp": "2023-01-01T08:00:10",
                 "total_gas_m3": 1122.333,
                 "gas_timestamp": "2021-03-14T11:22:33",
-                "gas_unique_id": "**REDACTED**",
+                "gas_unique_id": REDACTED,
                 "active_liter_lpm": 12.345,
                 "total_liter_m3": 1234.567,
                 "external_devices": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleans up the diagnostic platform tests for HomeWizard

As per comment here: <https://github.com/home-assistant/core/pull/85198#pullrequestreview-1261027639>

Also replaces a couple of hardcoded strings for redacted values with the constant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
