### PR TITLE
Fix docstring in esphome.bluetooth.client

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -583,11 +583,12 @@ class ESPHomeClient(BaseBleakClient):
                 print(f"{sender}: {data}")
             client.start_notify(char_uuid, callback)
         Args:
-            char_specifier (BleakGATTCharacteristic, int, str or UUID):
+            characteristic (BleakGATTCharacteristic):
                 The characteristic to activate notifications/indications on a
                 characteristic, specified by either integer handle, UUID or
                 directly by the BleakGATTCharacteristic object representing it.
             callback (function): The function to be called on notification.
+            kwargs: Unused.
         """
         ble_handle = characteristic.handle
         if ble_handle in self._notify_cancels:


### PR DESCRIPTION
## Proposed change

Add missing arguments to docstring.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Split out from #86224

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
