### PR TITLE
Fix stray string literal in bluetooth test wrapper

### DIFF
--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -73,7 +73,7 @@ class BaseFakeBleakClient:
         self._address = address_or_ble_device.address
 
     async def disconnect(self, *args, **kwargs):
-        """Disconnect.""" ""
+        """Disconnect."""
 
     async def get_services(self, *args, **kwargs):
         """Get services."""


### PR DESCRIPTION
## Proposed change

Remove stray string literal (that RustPython parses as a syntax error).

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Split out from #86224

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
