### PR TITLE
Allow number entities to alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -23,6 +23,7 @@ from homeassistant.components import (
     light,
     lock,
     media_player,
+    number,
     scene,
     script,
     sensor,
@@ -853,6 +854,7 @@ class ImageProcessingCapabilities(AlexaEntity):
 
 
 @ENTITY_ADAPTERS.register(input_number.DOMAIN)
+@ENTITY_ADAPTERS.register(number.DOMAIN)
 class InputNumberCapabilities(AlexaEntity):
     """Class to represent input_number capabilities."""
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -3344,10 +3344,11 @@ async def test_cover_semantics_position_and_tilt(hass):
     } in tilt_state_mappings
 
 
-async def test_input_number(hass):
-    """Test input_number discovery."""
+@pytest.mark.parametrize("domain", ["input_number", "number"])
+async def test_input_number(hass, domain: str):
+    """Test input_number and number discovery."""
     device = (
-        "input_number.test_slider",
+        f"{domain}.test_slider",
         30,
         {
             "initial": 30,
@@ -3360,7 +3361,7 @@ async def test_input_number(hass):
     )
     appliance = await discovery_test(device, hass)
 
-    assert appliance["endpointId"] == "input_number#test_slider"
+    assert appliance["endpointId"] == f"{domain}#test_slider"
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test Slider"
 
@@ -3409,8 +3410,8 @@ async def test_input_number(hass):
     call, _ = await assert_request_calls_service(
         "Alexa.RangeController",
         "SetRangeValue",
-        "input_number#test_slider",
-        "input_number.set_value",
+        f"{domain}#test_slider",
+        f"{domain}.set_value",
         hass,
         payload={"rangeValue": 10},
         instance="input_number.value",
@@ -3422,17 +3423,18 @@ async def test_input_number(hass):
         [(25, -5, False), (35, 5, False), (-20, -100, False), (35, 100, False)],
         "Alexa.RangeController",
         "AdjustRangeValue",
-        "input_number#test_slider",
-        "input_number.set_value",
+        f"{domain}#test_slider",
+        f"{domain}.set_value",
         "value",
         instance="input_number.value",
     )
 
 
-async def test_input_number_float(hass):
-    """Test input_number discovery."""
+@pytest.mark.parametrize("domain", ["input_number", "number"])
+async def test_input_number_float(hass, domain: str):
+    """Test input_number and number discovery."""
     device = (
-        "input_number.test_slider_float",
+        f"{domain}.test_slider_float",
         0.5,
         {
             "initial": 0.5,
@@ -3445,7 +3447,7 @@ async def test_input_number_float(hass):
     )
     appliance = await discovery_test(device, hass)
 
-    assert appliance["endpointId"] == "input_number#test_slider_float"
+    assert appliance["endpointId"] == f"{domain}#test_slider_float"
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test Slider Float"
 
@@ -3494,8 +3496,8 @@ async def test_input_number_float(hass):
     call, _ = await assert_request_calls_service(
         "Alexa.RangeController",
         "SetRangeValue",
-        "input_number#test_slider_float",
-        "input_number.set_value",
+        f"{domain}#test_slider_float",
+        f"{domain}.set_value",
         hass,
         payload={"rangeValue": 0.333},
         instance="input_number.value",
@@ -3513,8 +3515,8 @@ async def test_input_number_float(hass):
         ],
         "Alexa.RangeController",
         "AdjustRangeValue",
-        "input_number#test_slider_float",
-        "input_number.set_value",
+        f"{domain}#test_slider_float",
+        f"{domain}.set_value",
         "value",
         instance="input_number.value",
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Allow numbers to be exposed to alexa like input numbers. From https://community.home-assistant.io/t/add-support-for-mqtt-number-to-alexa/521234


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
