### PR TITLE
Bump reolink-aio to 0.3.0

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .exceptions import UserNotAdmin
+from .exceptions import ReolinkException, UserNotAdmin
 from .host import ReolinkHost
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,12 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     host = ReolinkHost(hass, config_entry.data, config_entry.options)
 
     try:
-        if not await host.async_init():
-            await host.stop()
-            raise ConfigEntryNotReady(
-                f"Error while trying to setup {host.api.host}:{host.api.port}: "
-                "failed to obtain data from device."
-            )
+        await host.async_init()
     except UserNotAdmin as err:
         raise ConfigEntryAuthFailed(err) from UserNotAdmin
     except (
@@ -62,6 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         InvalidContentTypeError,
         LoginError,
         NoDataError,
+        ReolinkException,
         UnexpectedDataError,
     ) as err:
         await host.stop()

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -12,8 +12,10 @@ import async_timeout
 from reolink_aio.exceptions import (
     ApiError,
     InvalidContentTypeError,
+    LoginError,
     NoDataError,
     ReolinkError,
+    UnexpectedDataError,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -58,7 +60,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         asyncio.TimeoutError,
         ApiError,
         InvalidContentTypeError,
+        LoginError,
         NoDataError,
+        UnexpectedDataError,
     ) as err:
         await host.stop()
         raise ConfigEntryNotReady(

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -8,14 +8,14 @@ from typing import Any
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
 import voluptuous as vol
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DEFAULT_PROTOCOL, DOMAIN
-from .exceptions import UserNotAdmin
+from .exceptions import ReolinkException, UserNotAdmin
 from .host import ReolinkHost
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,25 +96,25 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = ReolinkHost(self.hass, user_input, DEFAULT_OPTIONS)
             try:
-                await async_obtain_host_settings(host)
+                await host.async_init()
             except UserNotAdmin:
                 errors[CONF_USERNAME] = "not_admin"
                 placeholders["username"] = host.api.username
                 placeholders["userlevel"] = host.api.user_level
-            except CannotConnect:
-                errors[CONF_HOST] = "cannot_connect"
             except CredentialsInvalidError:
                 errors[CONF_HOST] = "invalid_auth"
             except ApiError as err:
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "api_error"
-            except ReolinkError as err:
+            except (ReolinkError, ReolinkException) as err:
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "unknown"
+            finally:
+                await host.stop()
 
             if not errors:
                 user_input[CONF_PORT] = host.api.port
@@ -160,16 +160,3 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders=placeholders,
         )
-
-
-async def async_obtain_host_settings(host: ReolinkHost) -> None:
-    """Initialize the Reolink host and get the host information."""
-    try:
-        if not await host.async_init():
-            raise CannotConnect
-    finally:
-        await host.stop()
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""

--- a/homeassistant/components/reolink/exceptions.py
+++ b/homeassistant/components/reolink/exceptions.py
@@ -2,5 +2,13 @@
 from homeassistant.exceptions import HomeAssistantError
 
 
-class UserNotAdmin(HomeAssistantError):
+class ReolinkException(HomeAssistantError):
+    """BaseException for the Reolink integration."""
+
+
+class ReolinkSetupException(ReolinkException):
+    """Raised when setting up the Reolink host failed."""
+
+
+class UserNotAdmin(ReolinkException):
     """Raised when user is not admin."""

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DEFAULT_TIMEOUT
-from .exceptions import UserNotAdmin
+from .exceptions import ReolinkSetupException, UserNotAdmin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,14 +55,14 @@ class ReolinkHost:
         """Return the API object."""
         return self._api
 
-    async def async_init(self) -> bool:
+    async def async_init(self) -> None:
         """Connect to Reolink host."""
         self._api.expire_session()
 
         await self._api.get_host_data()
 
         if self._api.mac_address is None:
-            return False
+            raise ReolinkSetupException("Could not get mac address")
 
         if not self._api.is_admin:
             await self.stop()
@@ -117,8 +117,6 @@ class ReolinkHost:
                     )
 
         self._unique_id = format_mac(self._api.mac_address)
-
-        return True
 
     async def update_states(self) -> None:
         """Call the API of the camera device to update the internal states."""

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -9,7 +9,6 @@ from typing import Any
 import aiohttp
 from reolink_aio.api import Host
 from reolink_aio.exceptions import ReolinkError
-)
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -8,10 +8,7 @@ from typing import Any
 
 import aiohttp
 from reolink_aio.api import Host
-from reolink_aio.exceptions import (
-    ApiError,
-    CredentialsInvalidError,
-    InvalidContentTypeError,
+from reolink_aio.exceptions import ReolinkError
 )
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -96,11 +93,13 @@ class ReolinkHost:
             enable_rtsp = True
 
         if enable_onvif or enable_rtmp or enable_rtsp:
-            if not await self._api.set_net_port(
-                enable_onvif=enable_onvif,
-                enable_rtmp=enable_rtmp,
-                enable_rtsp=enable_rtsp,
-            ):
+            try:
+                await self._api.set_net_port(
+                    enable_onvif=enable_onvif,
+                    enable_rtmp=enable_rtmp,
+                    enable_rtsp=enable_rtsp,
+                )
+            except ReolinkError:
                 if enable_onvif:
                     _LOGGER.error(
                         "Failed to enable ONVIF on %s. Set it to ON to receive notifications",
@@ -145,22 +144,9 @@ class ReolinkHost:
                 self._api.host,
                 self._api.port,
             )
-        except ApiError as err:
+        except ReolinkError as err:
             _LOGGER.error(
-                "Reolink API error while logging out for host %s:%s: %s",
-                self._api.host,
-                self._api.port,
-                str(err),
-            )
-        except CredentialsInvalidError:
-            _LOGGER.error(
-                "Reolink credentials error while logging out for host %s:%s",
-                self._api.host,
-                self._api.port,
-            )
-        except InvalidContentTypeError as err:
-            _LOGGER.error(
-                "Reolink content type error while logging out for host %s:%s: %s",
+                "Reolink error while logging out for host %s:%s: %s",
                 self._api.host,
                 self._api.port,
                 str(err),

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Reolink IP NVR/camera",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/reolink",
-  "requirements": ["reolink-aio==0.2.3"],
+  "requirements": ["reolink-aio==0.3.0"],
   "codeowners": ["@starkillerOG"],
   "iot_class": "local_polling",
   "loggers": ["reolink_aio"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2221,7 +2221,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.11
 
 # homeassistant.components.reolink
-reolink-aio==0.2.3
+reolink-aio==0.3.0
 
 # homeassistant.components.python_script
 restrictedpython==6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1566,7 +1566,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.11
 
 # homeassistant.components.reolink
-reolink-aio==0.2.3
+reolink-aio==0.3.0
 
 # homeassistant.components.python_script
 restrictedpython==6.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.3.0 and make the nessesary adjustments because the move from boolean returns to raising exceptions has been made.

This is a extensive change to the upstream library and schould not be included in a patch release.

Reolink-aio 0.3.0:
https://github.com/starkillerOG/reolink_aio/compare/0.2.3...0.3.0
- Improve ONVIF event handeling
   - Compliance with latest beta NVR firmware which includes rich notifications for all channels
   - Log errors for unexpected/incompatible ONFIV notifications in order for users to report bugs
   - Only log ONVIF errors once
   - Info log per ONVIF notification
   - Simplify code and reduce code duplication
- raise errors instead of passing booleans and add new error types:
   - LoginError   
   - UnexpectedDataError
   - InvalidParameterError
   - NotSupportedError
- Add firmware commands
   - check_new_firmware
   - update_firmware
   - update_progress
- Add GetRtspUrl command, use that as primary for get_rtsp_stream_source
- Fall back to newest version of rtsp url when no Encoding available
- Split ai_detected and ai_detection_states, fix bool return type
- Full black compliance
   - Add workflow tests for black formatting
- Full mypy compliance
   - Add workflow tests for mypy type checking
- Countless small bugfixes for edge cases


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
