### PR TITLE
Add option to run only pylint or mypy tests [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,14 @@ on:
         description: "Skip pytest"
         default: false
         type: boolean
+      pylint-only:
+        description: "Only run pylint"
+        default: false
+        type: boolean
+      mypy-only:
+        description: "Only run mypy"
+        default: false
+        type: boolean
 
 env:
   CACHE_VERSION: 3
@@ -163,6 +171,9 @@ jobs:
   pre-commit:
     name: Prepare pre-commit base
     runs-on: ubuntu-20.04
+    if: |
+      github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
     needs:
       - info
     steps:
@@ -554,6 +565,9 @@ jobs:
   hassfest:
     name: Check hassfest
     runs-on: ubuntu-20.04
+    if: |
+      github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
     needs:
       - info
       - base
@@ -587,6 +601,9 @@ jobs:
   gen-requirements-all:
     name: Check all requirements
     runs-on: ubuntu-20.04
+    if: |
+      github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
     needs:
       - info
       - base
@@ -621,6 +638,9 @@ jobs:
     name: Check pylint
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    if: |
+      github.event.inputs.mypy-only != 'true'
+      || github.event.inputs.pylint-only == 'true'
     needs:
       - info
       - base
@@ -666,6 +686,9 @@ jobs:
   mypy:
     name: Check mypy
     runs-on: ubuntu-20.04
+    if: |
+      github.event.inputs.pylint-only != 'true'
+      || github.event.inputs.mypy-only == 'true'
     needs:
       - info
       - base
@@ -710,6 +733,9 @@ jobs:
 
   pip-check:
     runs-on: ubuntu-20.04
+    if: |
+      github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
     needs:
       - info
       - base
@@ -750,6 +776,8 @@ jobs:
     if: |
       (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
       && github.event.inputs.lint-only != 'true'
+      && github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
       && (needs.info.outputs.test_full_suite == 'true' || needs.info.outputs.tests_glob)
     needs:
       - info
@@ -873,6 +901,8 @@ jobs:
     if: |
       (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
       && github.event.inputs.lint-only != 'true'
+      && github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
       && needs.info.outputs.test_full_suite == 'true'
     needs:
       - info


### PR DESCRIPTION
## Proposed change
Add new options for the `workflow_dispatch` trigger to allow running only `pylint` and / or `mypy` for a selected branch.

> **Note**
> This one is personally motivated, so I would fully understand if it isn't implemented. Although obviously I would like it very much.

I frequently use Home Assistant to check the latest commits of both pylint and mypy to help those projects catch errors earlier and also improve the code quality of Home Assistant by applying updates to faster (if possible).

For that I usually use Github Actions in my fork together with the `lint-only` option. That helps a lot as I don't need to run the full test suite every time. However, the linters are still run every time and take up resources. It would help to be able to run only `pylint` or only `mypy` for that.

Although the usefulness for others might be limited, I hope the change is small enough to be acceptable.

<img width="303" alt="Screenshot 2023-01-20 at 00 37 09" src="https://user-images.githubusercontent.com/30130371/213585863-a8c2e8d9-b584-4914-94bf-b92b454a0bf2.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
