### PR TITLE
Remove unnecessary ZHA AnalogInput sensors for Xiaomi plugs

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -187,12 +187,6 @@ class Sensor(ZhaEntity, SensorEntity):
 
 @MULTI_MATCH(
     channel_names=CHANNEL_ANALOG_INPUT,
-    manufacturers="LUMI",
-    models={"lumi.plug", "lumi.plug.maus01", "lumi.plug.mmeu01"},
-    stop_on_match_group=CHANNEL_ANALOG_INPUT,
-)
-@MULTI_MATCH(
-    channel_names=CHANNEL_ANALOG_INPUT,
     manufacturers="Digi",
     stop_on_match_group=CHANNEL_ANALOG_INPUT,
 )

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -2245,8 +2245,6 @@ DEVICES = [
             "sensor.lumi_lumi_plug_maus01_rms_voltage",
             "sensor.lumi_lumi_plug_maus01_ac_frequency",
             "sensor.lumi_lumi_plug_maus01_power_factor",
-            "sensor.lumi_lumi_plug_maus01_analoginput",
-            "sensor.lumi_lumi_plug_maus01_analoginput_2",
             "binary_sensor.lumi_lumi_plug_maus01_binaryinput",
             "switch.lumi_lumi_plug_maus01_switch",
             "sensor.lumi_lumi_plug_maus01_rssi",
@@ -2308,16 +2306,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "LQISensor",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_lqi",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-2-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_analoginput",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_analoginput_2",
             },
             ("binary_sensor", "00:11:22:33:44:55:66:77-100-15"): {
                 DEV_SIG_CHANNELS: ["binary_input"],


### PR DESCRIPTION
Depends on:
- https://github.com/zigpy/zha-device-handlers/pull/2116
- https://github.com/home-assistant/core/pull/86590

## Breaking change
The `AnalogInput` sensor entities for certain Xiaomi plugs have been removed from ZHA.
Properly working "Active power" and "Summation delivered" sensors are available to replace the older entities.
These newer sensor entities can also be used in Home Assistant Energy dashboard.


## Proposed change
The sensor entities for the AnalogInput clusters were only ever added as a workaround: https://github.com/home-assistant/core/pull/43817 ("stop-gap solution")
There are proper quirks available for all models now, so these outdated sensors can be removed.

The "total consumption" sensor equivalent for the InputCluster also never updated properly (at least on the `lumi.plug` model), as that cluster attribute doesn't even support attribute reporting on those plugs.
These AnalogInput sensors also don't integrate in the Home Assistant Energy dashboard at all and don't show a graph when clicked on due to how they are implemented.

Obviously these changes can also be argued against, as they might break automations, but removing them seems like the proper solution (now that they all have proper entities).

The proper entities for both EU plug models have been available for multiple months already: https://github.com/zigpy/zha-device-handlers/pull/1656
For the US plugs, the one missing entity was implemented last HA release: https://github.com/zigpy/zha-device-handlers/pull/2057
And the Chinese/Australian(?) plugs also have a ready PR: https://github.com/zigpy/zha-device-handlers/pull/2116

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
