### PR TITLE
Ensure all unit converters are tested

### DIFF
--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1,9 +1,15 @@
 """Test Home Assistant eneergy utility functions."""
+from __future__ import annotations
+
+import inspect
+
 import pytest
 
 from homeassistant.const import (
+    PERCENTAGE,
     UnitOfDataRate,
     UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfInformation,
     UnitOfLength,
@@ -16,11 +22,13 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import unit_conversion
 from homeassistant.util.unit_conversion import (
     BaseUnitConverter,
     DataRateConverter,
     DistanceConverter,
     ElectricCurrentConverter,
+    ElectricPotentialConverter,
     EnergyConverter,
     InformationConverter,
     MassConverter,
@@ -28,122 +36,139 @@ from homeassistant.util.unit_conversion import (
     PressureConverter,
     SpeedConverter,
     TemperatureConverter,
+    UnitlessRatioConverter,
     VolumeConverter,
 )
 
-INVALID_SYMBOL = "bob"
+_ALL_CONVERTERS: list[type[BaseUnitConverter]] = [
+    obj
+    for _, obj in inspect.getmembers(unit_conversion)
+    if inspect.isclass(obj)
+    and issubclass(obj, BaseUnitConverter)
+    and obj != BaseUnitConverter
+]
+_INVALID_SYMBOL = "bob"
 
 
-@pytest.mark.parametrize(
-    "converter,valid_unit",
-    [
-        (DataRateConverter, UnitOfDataRate.GIBIBYTES_PER_SECOND),
-        (DistanceConverter, UnitOfLength.KILOMETERS),
-        (DistanceConverter, UnitOfLength.METERS),
-        (DistanceConverter, UnitOfLength.CENTIMETERS),
-        (DistanceConverter, UnitOfLength.MILLIMETERS),
-        (DistanceConverter, UnitOfLength.MILES),
-        (DistanceConverter, UnitOfLength.YARDS),
-        (DistanceConverter, UnitOfLength.FEET),
-        (DistanceConverter, UnitOfLength.INCHES),
-        (ElectricCurrentConverter, UnitOfElectricCurrent.AMPERE),
-        (ElectricCurrentConverter, UnitOfElectricCurrent.MILLIAMPERE),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.MEGA_WATT_HOUR),
-        (EnergyConverter, UnitOfEnergy.GIGA_JOULE),
-        (InformationConverter, UnitOfInformation.GIGABYTES),
-        (MassConverter, UnitOfMass.GRAMS),
-        (MassConverter, UnitOfMass.KILOGRAMS),
-        (MassConverter, UnitOfMass.MICROGRAMS),
-        (MassConverter, UnitOfMass.MILLIGRAMS),
-        (MassConverter, UnitOfMass.OUNCES),
-        (MassConverter, UnitOfMass.POUNDS),
-        (PowerConverter, UnitOfPower.WATT),
-        (PowerConverter, UnitOfPower.KILO_WATT),
-        (PressureConverter, UnitOfPressure.PA),
-        (PressureConverter, UnitOfPressure.HPA),
-        (PressureConverter, UnitOfPressure.MBAR),
-        (PressureConverter, UnitOfPressure.INHG),
-        (PressureConverter, UnitOfPressure.KPA),
-        (PressureConverter, UnitOfPressure.CBAR),
-        (PressureConverter, UnitOfPressure.MMHG),
-        (PressureConverter, UnitOfPressure.PSI),
-        (SpeedConverter, UnitOfVolumetricFlux.INCHES_PER_DAY),
-        (SpeedConverter, UnitOfVolumetricFlux.INCHES_PER_HOUR),
-        (SpeedConverter, UnitOfVolumetricFlux.MILLIMETERS_PER_DAY),
-        (SpeedConverter, UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR),
-        (SpeedConverter, UnitOfSpeed.FEET_PER_SECOND),
-        (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR),
-        (SpeedConverter, UnitOfSpeed.KNOTS),
-        (SpeedConverter, UnitOfSpeed.METERS_PER_SECOND),
-        (SpeedConverter, UnitOfSpeed.MILES_PER_HOUR),
-        (TemperatureConverter, UnitOfTemperature.CELSIUS),
-        (TemperatureConverter, UnitOfTemperature.FAHRENHEIT),
-        (TemperatureConverter, UnitOfTemperature.KELVIN),
-        (VolumeConverter, UnitOfVolume.LITERS),
-        (VolumeConverter, UnitOfVolume.MILLILITERS),
-        (VolumeConverter, UnitOfVolume.GALLONS),
-        (VolumeConverter, UnitOfVolume.FLUID_OUNCES),
-    ],
-)
+_PARAMS_SAME_UNIT: list[tuple[type[BaseUnitConverter], str]] = [
+    (DataRateConverter, UnitOfDataRate.GIBIBYTES_PER_SECOND),
+    (DistanceConverter, UnitOfLength.KILOMETERS),
+    (DistanceConverter, UnitOfLength.METERS),
+    (DistanceConverter, UnitOfLength.CENTIMETERS),
+    (DistanceConverter, UnitOfLength.MILLIMETERS),
+    (DistanceConverter, UnitOfLength.MILES),
+    (DistanceConverter, UnitOfLength.YARDS),
+    (DistanceConverter, UnitOfLength.FEET),
+    (DistanceConverter, UnitOfLength.INCHES),
+    (ElectricCurrentConverter, UnitOfElectricCurrent.AMPERE),
+    (ElectricPotentialConverter, UnitOfElectricPotential.MILLIVOLT),
+    (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
+    (EnergyConverter, UnitOfEnergy.MEGA_WATT_HOUR),
+    (EnergyConverter, UnitOfEnergy.GIGA_JOULE),
+    (InformationConverter, UnitOfInformation.GIGABYTES),
+    (MassConverter, UnitOfMass.GRAMS),
+    (MassConverter, UnitOfMass.KILOGRAMS),
+    (MassConverter, UnitOfMass.MICROGRAMS),
+    (MassConverter, UnitOfMass.MILLIGRAMS),
+    (MassConverter, UnitOfMass.OUNCES),
+    (MassConverter, UnitOfMass.POUNDS),
+    (PowerConverter, UnitOfPower.WATT),
+    (PowerConverter, UnitOfPower.KILO_WATT),
+    (PressureConverter, UnitOfPressure.PA),
+    (PressureConverter, UnitOfPressure.HPA),
+    (PressureConverter, UnitOfPressure.MBAR),
+    (PressureConverter, UnitOfPressure.INHG),
+    (PressureConverter, UnitOfPressure.KPA),
+    (PressureConverter, UnitOfPressure.CBAR),
+    (PressureConverter, UnitOfPressure.MMHG),
+    (PressureConverter, UnitOfPressure.PSI),
+    (SpeedConverter, UnitOfVolumetricFlux.INCHES_PER_DAY),
+    (SpeedConverter, UnitOfVolumetricFlux.INCHES_PER_HOUR),
+    (SpeedConverter, UnitOfVolumetricFlux.MILLIMETERS_PER_DAY),
+    (SpeedConverter, UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR),
+    (SpeedConverter, UnitOfSpeed.FEET_PER_SECOND),
+    (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR),
+    (SpeedConverter, UnitOfSpeed.KNOTS),
+    (SpeedConverter, UnitOfSpeed.METERS_PER_SECOND),
+    (SpeedConverter, UnitOfSpeed.MILES_PER_HOUR),
+    (TemperatureConverter, UnitOfTemperature.CELSIUS),
+    (TemperatureConverter, UnitOfTemperature.FAHRENHEIT),
+    (TemperatureConverter, UnitOfTemperature.KELVIN),
+    (UnitlessRatioConverter, PERCENTAGE),
+    (VolumeConverter, UnitOfVolume.LITERS),
+    (VolumeConverter, UnitOfVolume.MILLILITERS),
+    (VolumeConverter, UnitOfVolume.GALLONS),
+    (VolumeConverter, UnitOfVolume.FLUID_OUNCES),
+]
+
+
+@pytest.mark.parametrize("converter,valid_unit", _PARAMS_SAME_UNIT)
 def test_convert_same_unit(converter: type[BaseUnitConverter], valid_unit: str) -> None:
     """Test conversion from any valid unit to same unit."""
     assert converter.convert(2, valid_unit, valid_unit) == 2
 
 
-@pytest.mark.parametrize(
-    "converter,valid_unit",
-    [
-        (DataRateConverter, UnitOfDataRate.GIBIBYTES_PER_SECOND),
-        (DistanceConverter, UnitOfLength.KILOMETERS),
-        (ElectricCurrentConverter, UnitOfElectricCurrent.AMPERE),
-        (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
-        (InformationConverter, UnitOfInformation.GIBIBYTES),
-        (MassConverter, UnitOfMass.GRAMS),
-        (PowerConverter, UnitOfPower.WATT),
-        (PressureConverter, UnitOfPressure.PA),
-        (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR),
-        (TemperatureConverter, UnitOfTemperature.CELSIUS),
-        (TemperatureConverter, UnitOfTemperature.FAHRENHEIT),
-        (TemperatureConverter, UnitOfTemperature.KELVIN),
-        (VolumeConverter, UnitOfVolume.LITERS),
-    ],
-)
+_PARAMS_INVALID_UNIT: list[tuple[type[BaseUnitConverter], str]] = [
+    (DataRateConverter, UnitOfDataRate.GIBIBYTES_PER_SECOND),
+    (DistanceConverter, UnitOfLength.KILOMETERS),
+    (ElectricCurrentConverter, UnitOfElectricCurrent.AMPERE),
+    (ElectricPotentialConverter, UnitOfElectricPotential.MILLIVOLT),
+    (EnergyConverter, UnitOfEnergy.KILO_WATT_HOUR),
+    (InformationConverter, UnitOfInformation.GIBIBYTES),
+    (MassConverter, UnitOfMass.GRAMS),
+    (PowerConverter, UnitOfPower.WATT),
+    (PressureConverter, UnitOfPressure.PA),
+    (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR),
+    (TemperatureConverter, UnitOfTemperature.CELSIUS),
+    (TemperatureConverter, UnitOfTemperature.FAHRENHEIT),
+    (TemperatureConverter, UnitOfTemperature.KELVIN),
+    (UnitlessRatioConverter, PERCENTAGE),
+    (VolumeConverter, UnitOfVolume.LITERS),
+]
+
+
+@pytest.mark.parametrize("converter,valid_unit", _PARAMS_INVALID_UNIT)
 def test_convert_invalid_unit(
     converter: type[BaseUnitConverter], valid_unit: str
 ) -> None:
     """Test exception is thrown for invalid units."""
     with pytest.raises(HomeAssistantError, match="is not a recognized .* unit"):
-        converter.convert(5, INVALID_SYMBOL, valid_unit)
+        converter.convert(5, _INVALID_SYMBOL, valid_unit)
 
     with pytest.raises(HomeAssistantError, match="is not a recognized .* unit"):
-        converter.convert(5, valid_unit, INVALID_SYMBOL)
+        converter.convert(5, valid_unit, _INVALID_SYMBOL)
 
 
-@pytest.mark.parametrize(
-    "converter,from_unit,to_unit",
-    [
-        (
-            DataRateConverter,
-            UnitOfDataRate.BYTES_PER_SECOND,
-            UnitOfDataRate.BITS_PER_SECOND,
-        ),
-        (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR),
-        (
-            InformationConverter,
-            UnitOfInformation.GIBIBYTES,
-            UnitOfInformation.GIGABYTES,
-        ),
-        (MassConverter, UnitOfMass.GRAMS, UnitOfMass.KILOGRAMS),
-        (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT),
-        (PressureConverter, UnitOfPressure.HPA, UnitOfPressure.INHG),
-        (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR, UnitOfSpeed.MILES_PER_HOUR),
-        (TemperatureConverter, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT),
-        (VolumeConverter, UnitOfVolume.GALLONS, UnitOfVolume.LITERS),
-    ],
-)
+_PARAMS_NONNUMERIC: list[tuple[type[BaseUnitConverter], str, str | None]] = [
+    (
+        DataRateConverter,
+        UnitOfDataRate.BYTES_PER_SECOND,
+        UnitOfDataRate.BITS_PER_SECOND,
+    ),
+    (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS),
+    (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR),
+    (
+        ElectricCurrentConverter,
+        UnitOfElectricCurrent.AMPERE,
+        UnitOfElectricCurrent.MILLIAMPERE,
+    ),
+    (
+        ElectricPotentialConverter,
+        UnitOfElectricPotential.VOLT,
+        UnitOfElectricPotential.MILLIVOLT,
+    ),
+    (InformationConverter, UnitOfInformation.GIBIBYTES, UnitOfInformation.GIGABYTES),
+    (MassConverter, UnitOfMass.GRAMS, UnitOfMass.KILOGRAMS),
+    (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT),
+    (PressureConverter, UnitOfPressure.HPA, UnitOfPressure.INHG),
+    (SpeedConverter, UnitOfSpeed.KILOMETERS_PER_HOUR, UnitOfSpeed.MILES_PER_HOUR),
+    (TemperatureConverter, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT),
+    (UnitlessRatioConverter, PERCENTAGE, None),
+    (VolumeConverter, UnitOfVolume.GALLONS, UnitOfVolume.LITERS),
+]
+
+
+@pytest.mark.parametrize("converter,from_unit,to_unit", _PARAMS_NONNUMERIC)
 def test_convert_nonnumeric_value(
     converter: type[BaseUnitConverter], from_unit: str, to_unit: str
 ) -> None:
@@ -152,51 +177,59 @@ def test_convert_nonnumeric_value(
         converter.convert("a", from_unit, to_unit)
 
 
-@pytest.mark.parametrize(
-    "converter,from_unit,to_unit,expected",
-    [
-        (
-            DataRateConverter,
-            UnitOfDataRate.BITS_PER_SECOND,
-            UnitOfDataRate.BYTES_PER_SECOND,
-            8,
-        ),
-        (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS, 1 / 1000),
-        (
-            ElectricCurrentConverter,
-            UnitOfElectricCurrent.AMPERE,
-            UnitOfElectricCurrent.MILLIAMPERE,
-            1 / 1000,
-        ),
-        (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR, 1000),
-        (InformationConverter, UnitOfInformation.BITS, UnitOfInformation.BYTES, 8),
-        (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT, 1000),
-        (
-            PressureConverter,
-            UnitOfPressure.HPA,
-            UnitOfPressure.INHG,
-            pytest.approx(33.86389),
-        ),
-        (
-            SpeedConverter,
-            UnitOfSpeed.KILOMETERS_PER_HOUR,
-            UnitOfSpeed.MILES_PER_HOUR,
-            pytest.approx(1.609343),
-        ),
-        (
-            TemperatureConverter,
-            UnitOfTemperature.CELSIUS,
-            UnitOfTemperature.FAHRENHEIT,
-            1 / 1.8,
-        ),
-        (
-            VolumeConverter,
-            UnitOfVolume.GALLONS,
-            UnitOfVolume.LITERS,
-            pytest.approx(0.264172),
-        ),
-    ],
-)
+_PARAMS_UNIT_RATIO: list[tuple[type[BaseUnitConverter], str, str, float]] = [
+    (
+        DataRateConverter,
+        UnitOfDataRate.BITS_PER_SECOND,
+        UnitOfDataRate.BYTES_PER_SECOND,
+        8,
+    ),
+    (DistanceConverter, UnitOfLength.KILOMETERS, UnitOfLength.METERS, 1 / 1000),
+    (
+        ElectricCurrentConverter,
+        UnitOfElectricCurrent.AMPERE,
+        UnitOfElectricCurrent.MILLIAMPERE,
+        1 / 1000,
+    ),
+    (
+        ElectricPotentialConverter,
+        UnitOfElectricPotential.MILLIVOLT,
+        UnitOfElectricPotential.VOLT,
+        1000,
+    ),
+    (EnergyConverter, UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR, 1000),
+    (InformationConverter, UnitOfInformation.BITS, UnitOfInformation.BYTES, 8),
+    (MassConverter, UnitOfMass.KILOGRAMS, UnitOfMass.STONES, pytest.approx(6.35029)),
+    (PowerConverter, UnitOfPower.WATT, UnitOfPower.KILO_WATT, 1000),
+    (
+        PressureConverter,
+        UnitOfPressure.HPA,
+        UnitOfPressure.INHG,
+        pytest.approx(33.86389),
+    ),
+    (
+        SpeedConverter,
+        UnitOfSpeed.KILOMETERS_PER_HOUR,
+        UnitOfSpeed.MILES_PER_HOUR,
+        pytest.approx(1.609343),
+    ),
+    (
+        TemperatureConverter,
+        UnitOfTemperature.CELSIUS,
+        UnitOfTemperature.FAHRENHEIT,
+        1 / 1.8,
+    ),
+    (UnitlessRatioConverter, PERCENTAGE, None, 100),
+    (
+        VolumeConverter,
+        UnitOfVolume.GALLONS,
+        UnitOfVolume.LITERS,
+        pytest.approx(0.264172),
+    ),
+]
+
+
+@pytest.mark.parametrize("converter,from_unit,to_unit,expected", _PARAMS_UNIT_RATIO)
 def test_get_unit_ratio(
     converter: type[BaseUnitConverter], from_unit: str, to_unit: str, expected: float
 ) -> None:
@@ -658,3 +691,28 @@ def test_volume_convert(
 ) -> None:
     """Test conversion to other units."""
     assert VolumeConverter.convert(value, from_unit, to_unit) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("converter", _ALL_CONVERTERS)
+def test_all_converters(converter: type[BaseUnitConverter]) -> None:
+    """Ensure all unit converters are tested."""
+    # The converter should exist in _PARAMS_SAME_UNIT
+    item = next((pair for pair in _PARAMS_SAME_UNIT if pair[0] == converter), None)
+    assert item, "converter is not present in _PARAMS_SAME_UNIT"
+    assert item[1] in item[0].VALID_UNITS
+    # The converter should exist in _PARAMS_INVALID_UNIT
+    item = next((pair for pair in _PARAMS_INVALID_UNIT if pair[0] == converter), None)
+    assert item, "converter is not present in _PARAMS_OTHER_UNIT"
+    assert item[1] in item[0].VALID_UNITS
+    # The converter should exist in _PARAMS_NONNUMERIC
+    item = next((pair for pair in _PARAMS_NONNUMERIC if pair[0] == converter), None)
+    assert item, "converter is not present in _PARAMS_NONNUMERIC"
+    assert item[1] in item[0].VALID_UNITS
+    assert item[2] in item[0].VALID_UNITS
+    assert item[1] != item[2]
+    # The converter should exist in _PARAMS_UNIT_RATIO
+    item = next((pair for pair in _PARAMS_UNIT_RATIO if pair[0] == converter), None)
+    assert item, "converter is not present in _PARAMS_UNIT_RATIO"
+    assert item[1] in item[0].VALID_UNITS
+    assert item[2] in item[0].VALID_UNITS
+    assert item[1] != item[2]

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -40,13 +40,6 @@ from homeassistant.util.unit_conversion import (
     VolumeConverter,
 )
 
-_ALL_CONVERTERS: list[type[BaseUnitConverter]] = [
-    obj
-    for _, obj in inspect.getmembers(unit_conversion)
-    if inspect.isclass(obj)
-    and issubclass(obj, BaseUnitConverter)
-    and obj != BaseUnitConverter
-]
 _INVALID_SYMBOL = "bob"
 
 
@@ -693,7 +686,19 @@ def test_volume_convert(
     assert VolumeConverter.convert(value, from_unit, to_unit) == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("converter", _ALL_CONVERTERS)
+@pytest.mark.parametrize(
+    "converter",
+    [
+        # Generate list of all converters available in
+        # `homeassistant.util.unit_conversion` to ensure
+        # that we don't miss on in the tests.
+        obj
+        for _, obj in inspect.getmembers(unit_conversion)
+        if inspect.isclass(obj)
+        and issubclass(obj, BaseUnitConverter)
+        and obj != BaseUnitConverter
+    ],
+)
 def test_all_converters(converter: type[BaseUnitConverter]) -> None:
     """Ensure all unit converters are tested."""
     # The converter should exist in _PARAMS_SAME_UNIT

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1,4 +1,4 @@
-"""Test Home Assistant eneergy utility functions."""
+"""Test Home Assistant unit conversion utility functions."""
 from __future__ import annotations
 
 import inspect

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -38,7 +38,7 @@ from homeassistant.util.unit_conversion import (
     VolumeConverter,
 )
 
-_INVALID_SYMBOL = "bob"
+INVALID_SYMBOL = "bob"
 
 
 # Dict containing all converters that need to be tested.
@@ -110,10 +110,10 @@ def test_convert_invalid_unit(
 ) -> None:
     """Test exception is thrown for invalid units."""
     with pytest.raises(HomeAssistantError, match="is not a recognized .* unit"):
-        converter.convert(5, _INVALID_SYMBOL, valid_unit)
+        converter.convert(5, INVALID_SYMBOL, valid_unit)
 
     with pytest.raises(HomeAssistantError, match="is not a recognized .* unit"):
-        converter.convert(5, valid_unit, _INVALID_SYMBOL)
+        converter.convert(5, valid_unit, INVALID_SYMBOL)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust parametrization, and ensure that all unit converters are tested.

Alternative to #84808

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
