### PR TITLE
Add local_fulfillment_port option to Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -18,6 +18,7 @@ from .const import (  # noqa: F401
     CONF_EXPOSE,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
+    CONF_LOCAL_FULFILMENT_PORT,
     CONF_PRIVATE_KEY,
     CONF_PROJECT_ID,
     CONF_REPORT_STATE,
@@ -79,6 +80,7 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ENTITY_SCHEMA},
             # str on purpose, makes sure it is configured correctly.
             vol.Optional(CONF_SECURE_DEVICES_PIN): str,
+            vol.Optional(CONF_LOCAL_FULFILMENT_PORT): int,
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
             vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
             # deprecated configuration options

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -18,7 +18,7 @@ from .const import (  # noqa: F401
     CONF_EXPOSE,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
-    CONF_LOCAL_FULFILMENT_PORT,
+    CONF_LOCAL_FULFILLMENT_PORT,
     CONF_PRIVATE_KEY,
     CONF_PROJECT_ID,
     CONF_REPORT_STATE,
@@ -80,7 +80,7 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ENTITY_SCHEMA},
             # str on purpose, makes sure it is configured correctly.
             vol.Optional(CONF_SECURE_DEVICES_PIN): str,
-            vol.Optional(CONF_LOCAL_FULFILMENT_PORT): int,
+            vol.Optional(CONF_LOCAL_FULFILLMENT_PORT): int,
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
             vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
             # deprecated configuration options

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -38,7 +38,7 @@ CONF_PROJECT_ID = "project_id"
 CONF_REPORT_STATE = "report_state"
 CONF_ROOM_HINT = "room"
 CONF_SECURE_DEVICES_PIN = "secure_devices_pin"
-CONF_LOCAL_FULFILMENT_PORT = "local_fulfilment_port"
+CONF_LOCAL_FULFILLMENT_PORT = "local_fulfillment_port"
 CONF_SERVICE_ACCOUNT = "service_account"
 
 DATA_CONFIG = "config"

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -38,6 +38,7 @@ CONF_PROJECT_ID = "project_id"
 CONF_REPORT_STATE = "report_state"
 CONF_ROOM_HINT = "room"
 CONF_SECURE_DEVICES_PIN = "secure_devices_pin"
+CONF_LOCAL_FULFILMENT_PORT = "local_fulfilment_port"
 CONF_SERVICE_ACCOUNT = "service_account"
 
 DATA_CONFIG = "config"

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -127,7 +127,7 @@ class AbstractConfig(ABC):
         return None
 
     @property
-    def local_fulfilment_port(self):
+    def local_fulfillment_port(self):
         """Return manually-configured local SDK port."""
         return None
 
@@ -632,7 +632,7 @@ class GoogleEntity:
             device["otherDeviceIds"] = [{"deviceId": self.entity_id}]
             device["customData"] = {
                 "webhookId": self.config.get_local_webhook_id(agent_user_id),
-                "httpPort": self.config.local_fulfilment_port
+                "httpPort": self.config.local_fulfillment_port
                 or URL(get_url(self.hass, allow_external=False)).port,
                 "uuid": instance_uuid,
             }

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -127,6 +127,11 @@ class AbstractConfig(ABC):
         return None
 
     @property
+    def local_fulfilment_port(self):
+        """Return manually-configured local SDK port."""
+        return None
+
+    @property
     def is_reporting_state(self):
         """Return if we're actively reporting states."""
         return self._unsub_report_state is not None
@@ -627,7 +632,8 @@ class GoogleEntity:
             device["otherDeviceIds"] = [{"deviceId": self.entity_id}]
             device["customData"] = {
                 "webhookId": self.config.get_local_webhook_id(agent_user_id),
-                "httpPort": URL(get_url(self.hass, allow_external=False)).port,
+                "httpPort": self.config.local_fulfilment_port
+                or URL(get_url(self.hass, allow_external=False)).port,
                 "uuid": instance_uuid,
             }
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -27,7 +27,7 @@ from .const import (
     CONF_EXPOSE,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
-    CONF_LOCAL_FULFILMENT_PORT,
+    CONF_LOCAL_FULFILLMENT_PORT,
     CONF_PRIVATE_KEY,
     CONF_REPORT_STATE,
     CONF_SECURE_DEVICES_PIN,
@@ -108,9 +108,9 @@ class GoogleConfig(AbstractConfig):
         return self._config.get(CONF_SECURE_DEVICES_PIN)
 
     @property
-    def local_fulfilment_port(self):
+    def local_fulfillment_port(self):
         """Return manually-configured local SDK port."""
-        return self._config.get(CONF_LOCAL_FULFILMENT_PORT)
+        return self._config.get(CONF_LOCAL_FULFILLMENT_PORT)
 
     @property
     def should_report_state(self):

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_EXPOSE,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
+    CONF_LOCAL_FULFILMENT_PORT,
     CONF_PRIVATE_KEY,
     CONF_REPORT_STATE,
     CONF_SECURE_DEVICES_PIN,
@@ -105,6 +106,11 @@ class GoogleConfig(AbstractConfig):
     def secure_devices_pin(self):
         """Return entity config."""
         return self._config.get(CONF_SECURE_DEVICES_PIN)
+
+    @property
+    def local_fulfilment_port(self):
+        """Return manually-configured local SDK port."""
+        return self._config.get(CONF_LOCAL_FULFILMENT_PORT)
 
     @property
     def should_report_state(self):

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -24,7 +24,7 @@ class MockConfig(helpers.AbstractConfig):
         enabled=True,
         entity_config=None,
         hass=None,
-        local_fulfilment_port=None,
+        local_fulfillment_port=None,
         secure_devices_pin=None,
         should_2fa=None,
         should_expose=None,
@@ -34,7 +34,7 @@ class MockConfig(helpers.AbstractConfig):
         super().__init__(hass)
         self._enabled = enabled
         self._entity_config = entity_config or {}
-        self._local_fulfilment_port = local_fulfilment_port
+        self._local_fulfillment_port = local_fulfillment_port
         self._secure_devices_pin = secure_devices_pin
         self._should_2fa = should_2fa
         self._should_expose = should_expose
@@ -47,9 +47,9 @@ class MockConfig(helpers.AbstractConfig):
         return self._enabled
 
     @property
-    def local_fulfilment_port(self):
+    def local_fulfillment_port(self):
         """Return manually-configured local SDK port."""
-        return self._local_fulfilment_port
+        return self._local_fulfillment_port
 
     @property
     def secure_devices_pin(self):

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -24,6 +24,7 @@ class MockConfig(helpers.AbstractConfig):
         enabled=True,
         entity_config=None,
         hass=None,
+        local_fulfilment_port=None,
         secure_devices_pin=None,
         should_2fa=None,
         should_expose=None,
@@ -33,6 +34,7 @@ class MockConfig(helpers.AbstractConfig):
         super().__init__(hass)
         self._enabled = enabled
         self._entity_config = entity_config or {}
+        self._local_fulfilment_port = local_fulfilment_port
         self._secure_devices_pin = secure_devices_pin
         self._should_2fa = should_2fa
         self._should_expose = should_expose
@@ -43,6 +45,11 @@ class MockConfig(helpers.AbstractConfig):
     def enabled(self):
         """Return if Google is enabled."""
         return self._enabled
+
+    @property
+    def local_fulfilment_port(self):
+        """Return manually-configured local SDK port."""
+        return self._local_fulfilment_port
 
     @property
     def secure_devices_pin(self):

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -61,17 +61,17 @@ async def test_google_entity_sync_serialize_with_local_sdk(hass):
         "uuid": "abcdef",
     }
 
-    local_fulfilment_port = 5678
+    local_fulfillment_port = 5678
     port_config = MockConfig(
         hass=hass,
-        local_fulfilment_port=local_fulfilment_port,
+        local_fulfillment_port=local_fulfillment_port,
     )
     port_config.async_enable_local_sdk()
     port_entity = helpers.GoogleEntity(
         hass, port_config, hass.states.get("light.ceiling_lights")
     )
     port_serialized = port_entity.sync_serialize(None, None)
-    assert port_serialized["customData"]["httpPort"] == local_fulfilment_port
+    assert port_serialized["customData"]["httpPort"] == local_fulfillment_port
 
     for device_type in NOT_EXPOSE_LOCAL:
         with patch(

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -61,6 +61,18 @@ async def test_google_entity_sync_serialize_with_local_sdk(hass):
         "uuid": "abcdef",
     }
 
+    local_fulfilment_port = 5678
+    port_config = MockConfig(
+        hass=hass,
+        local_fulfilment_port=local_fulfilment_port,
+    )
+    port_config.async_enable_local_sdk()
+    port_entity = helpers.GoogleEntity(
+        hass, port_config, hass.states.get("light.ceiling_lights")
+    )
+    port_serialized = port_entity.sync_serialize(None, None)
+    assert port_serialized["customData"]["httpPort"] == local_fulfilment_port
+
     for device_type in NOT_EXPOSE_LOCAL:
         with patch(
             "homeassistant.components.google_assistant.helpers.get_google_type",

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -205,10 +205,10 @@ async def test_google_config_local_fulfillment(hass, aioclient_mock, hass_storag
     assert config.get_local_agent_user_id("INCORRECT") is None
 
 
-async def test_secure_device_pin_and_local_fulfilment_port_config(hass):
+async def test_secure_device_pin_and_local_fulfillment_port_config(hass):
     """Test the setting of the secure device pin configuration."""
     secure_pin = "TEST"
-    local_fulfilment_port = 5678
+    local_fulfillment_port = 5678
     secure_config = GOOGLE_ASSISTANT_SCHEMA(
         {
             "project_id": "1234",
@@ -217,13 +217,13 @@ async def test_secure_device_pin_and_local_fulfilment_port_config(hass):
                 "client_email": "dummy@dummy.iam.gserviceaccount.com",
             },
             "secure_devices_pin": secure_pin,
-            "local_fulfilment_port": local_fulfilment_port,
+            "local_fulfillment_port": local_fulfillment_port,
         }
     )
     config = GoogleConfig(hass, secure_config)
 
     assert config.secure_devices_pin == secure_pin
-    assert config.local_fulfilment_port == local_fulfilment_port
+    assert config.local_fulfillment_port == local_fulfillment_port
 
 
 async def test_should_expose(hass):

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -205,9 +205,10 @@ async def test_google_config_local_fulfillment(hass, aioclient_mock, hass_storag
     assert config.get_local_agent_user_id("INCORRECT") is None
 
 
-async def test_secure_device_pin_config(hass):
+async def test_secure_device_pin_and_local_fulfilment_port_config(hass):
     """Test the setting of the secure device pin configuration."""
     secure_pin = "TEST"
+    local_fulfilment_port = 5678
     secure_config = GOOGLE_ASSISTANT_SCHEMA(
         {
             "project_id": "1234",
@@ -216,11 +217,13 @@ async def test_secure_device_pin_config(hass):
                 "client_email": "dummy@dummy.iam.gserviceaccount.com",
             },
             "secure_devices_pin": secure_pin,
+            "local_fulfilment_port": local_fulfilment_port,
         }
     )
     config = GoogleConfig(hass, secure_config)
 
     assert config.secure_devices_pin == secure_pin
+    assert config.local_fulfilment_port == local_fulfilment_port
 
 
 async def test_should_expose(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per #80063, it was not possible to have an HTTPS Internal URL while using Google Assistant local fulfilment, as Google Assistant somewhat uniquely requires a plaintext HTTP connection.

This change adds the `local_fulfillment_port` option to the Google Assistant integration to override the port number provided to Google Assistant. The previous behaviour of taking the port number from the Internal URL remains the default if `local_fulfillment_port` is not set.

The configuration this allows is as follows:

- HA HTTP integration is configured for plaintext HTTP only
- NGINX or other reverse proxy provides TLS for remote and local access via HTTPS external and internal URLs
- `local_fulfillment_port` option can be set to the port number the HA HTTP integration is listening on to allow Google Assistant to connect over HTTP while still preferring HTTPS for other devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #80063
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25866

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
