### PR TITLE
Add per-file-ignore to pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ runtime-typing = false
 max-line-length-suggestions = 72
 
 [tool.pylint-per-file-ignores]
-"/tests/"="protected-access"
+"/tests/"="protected-access,redefined-outer-name"
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ load-plugins = [
     "hass_enforce_type_hints",
     "hass_imports",
     "hass_logger",
+    "pylint_per_file_ignores",
 ]
 persistent = false
 extension-pkg-allow-list = [
@@ -218,6 +219,9 @@ runtime-typing = false
 
 [tool.pylint.CODE_STYLE]
 max-line-length-suggestions = 72
+
+[tool.pylint-per-file-ignores]
+"/tests/"="protected-access"
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,6 +15,7 @@ mock-open==1.4.0
 mypy==0.991
 pre-commit==2.21.0
 pylint==2.15.10
+pylint-per-file-ignores==1.1.0
 pipdeptree==2.3.1
 pytest-asyncio==0.20.2
 pytest-aiohttp==1.0.4

--- a/tests/common.py
+++ b/tests/common.py
@@ -166,7 +166,6 @@ def get_test_home_assistant():
     return hass
 
 
-# pylint: disable=protected-access
 async def async_test_home_assistant(event_loop, load_registries=True):
     """Return a Home Assistant object pointing at test config dir."""
     hass = HomeAssistant()

--- a/tests/common.py
+++ b/tests/common.py
@@ -140,7 +140,7 @@ def get_test_home_assistant():
 
     def run_loop():
         """Run event loop."""
-        # pylint: disable-next=protected-access
+
         loop._thread_ident = threading.get_ident()
         loop.run_forever()
         loop_stop_event.set()

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Alert component."""
-# pylint: disable=protected-access
+
 from copy import deepcopy
 
 import pytest

--- a/tests/components/alexa/test_flash_briefings.py
+++ b/tests/components/alexa/test_flash_briefings.py
@@ -1,5 +1,5 @@
 """The tests for the Alexa component."""
-# pylint: disable=protected-access
+
 import datetime
 from http import HTTPStatus
 

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -1,5 +1,5 @@
 """The tests for the Alexa component."""
-# pylint: disable=protected-access
+
 from http import HTTPStatus
 import json
 

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Home Assistant API component."""
-# pylint: disable=protected-access
+
 from http import HTTPStatus
 import json
 from unittest.mock import patch

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -10,8 +10,6 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
-# pylint: disable=redefined-outer-name
-
 DEVICE_DATA = {"name": "Private Calendar", "device_id": "Private Calendar"}
 
 EVENTS = [

--- a/tests/components/cast/conftest.py
+++ b/tests/components/cast/conftest.py
@@ -1,5 +1,5 @@
 """Test fixtures for the cast integration."""
-# pylint: disable=protected-access
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pychromecast

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -1,5 +1,5 @@
 """The tests for the Cast Media player platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -312,7 +312,6 @@ async def test_ws_api(hass, hass_ws_client, payload):
     }
 
 
-# pylint: disable=protected-access
 async def test_ws_prepare(hass, hass_ws_client):
     """Test the Websocket prepare conversation API."""
     assert await async_setup_component(hass, "conversation", {})
@@ -429,7 +428,6 @@ async def test_custom_sentences_config(hass, hass_client, hass_admin_user):
     }
 
 
-# pylint: disable=protected-access
 async def test_prepare_reload(hass):
     """Test calling the reload service."""
     language = hass.config.language
@@ -451,7 +449,6 @@ async def test_prepare_reload(hass):
     assert not agent._lang_intents.get(language)
 
 
-# pylint: disable=protected-access
 async def test_prepare_fail(hass):
     """Test calling prepare with a non-existent language."""
     assert await async_setup_component(hass, "conversation", {})

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the counter component."""
-# pylint: disable=protected-access
+
 import logging
 
 import pytest

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 """Tests for the Daikin config flow."""
 import asyncio
 from unittest.mock import PropertyMock, patch

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -1,5 +1,5 @@
 """The tests device sun light trigger component."""
-# pylint: disable=protected-access
+
 from datetime import datetime
 from unittest.mock import patch
 

--- a/tests/components/directv/test_init.py
+++ b/tests/components/directv/test_init.py
@@ -7,8 +7,6 @@ from . import setup_integration
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-# pylint: disable=redefined-outer-name
-
 
 async def test_config_entry_not_ready(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -61,8 +61,6 @@ RESTRICTED_ENTITY_ID = f"{MP_DOMAIN}.restricted_client"
 STANDBY_ENTITY_ID = f"{MP_DOMAIN}.standby_client"
 UNAVAILABLE_ENTITY_ID = f"{MP_DOMAIN}.unavailable_client"
 
-# pylint: disable=redefined-outer-name
-
 
 @fixture
 def mock_now() -> datetime:

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -19,8 +19,6 @@ CLIENT_ENTITY_ID = f"{REMOTE_DOMAIN}.client"
 MAIN_ENTITY_ID = f"{REMOTE_DOMAIN}.host"
 UNAVAILABLE_ENTITY_ID = f"{REMOTE_DOMAIN}.unavailable_client"
 
-# pylint: disable=redefined-outer-name
-
 
 async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with basic config."""

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -86,7 +86,7 @@ async def test_token_request_succeeds(hass):
         mock_ecobee.request_tokens.return_value = True
         mock_ecobee.api_key = "test-api-key"
         mock_ecobee.refresh_token = "test-token"
-        # pylint: disable-next=protected-access
+
         flow._ecobee = mock_ecobee
 
         result = await flow.async_step_authorize(user_input={})
@@ -109,7 +109,7 @@ async def test_token_request_fails(hass):
         mock_ecobee = mock_ecobee.return_value
         mock_ecobee.request_tokens.return_value = False
         mock_ecobee.pin = "test-pin"
-        # pylint: disable-next=protected-access
+
         flow._ecobee = mock_ecobee
 
         result = await flow.async_step_authorize(user_input={})

--- a/tests/components/geocaching/test_config_flow.py
+++ b/tests/components/geocaching/test_config_flow.py
@@ -53,7 +53,6 @@ async def test_full_flow(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -109,7 +108,7 @@ async def test_existing_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    # pylint: disable-next=protected-access
+
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -150,7 +149,6 @@ async def test_oauth_error(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -207,7 +205,6 @@ async def test_reauthentication(
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -1,7 +1,5 @@
 """The tests for the Geofency device tracker platform."""
 from http import HTTPStatus
-
-# pylint: disable=redefined-outer-name
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -1,7 +1,5 @@
 """The tests for the Google Assistant component."""
 from http import HTTPStatus
-
-# pylint: disable=protected-access
 import json
 
 from aiohttp.hdrs import AUTHORIZATION

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -125,9 +125,6 @@ def hass_fixture(event_loop, hass):
     return hass
 
 
-# pylint: disable=redefined-outer-name
-
-
 async def test_sync_request(hass_fixture, assistant_client, auth_header):
     """Test a sync request."""
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -228,7 +228,6 @@ async def test_sync_message(hass, registries):
     assert events[0].data == {"request_id": REQ_ID, "source": "cloud"}
 
 
-# pylint: disable=redefined-outer-name
 @pytest.mark.parametrize("area_on_device", [True, False])
 async def test_sync_in_area(area_on_device, hass, registries):
     """Test a sync message where room hint comes from area."""

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -921,7 +921,7 @@ async def test_unavailable_state_does_sync(hass):
     )
     light.hass = hass
     light.entity_id = "light.demo_light"
-    light._available = False  # pylint: disable=protected-access
+    light._available = False
     await light.async_update_ha_state()
 
     events = async_capture_events(hass, EVENT_SYNC_RECEIVED)

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -17,8 +17,6 @@ from homeassistant.setup import async_setup_component
 HOME_LATITUDE = 37.239622
 HOME_LONGITUDE = -115.815811
 
-# pylint: disable=redefined-outer-name
-
 
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Group components."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -1,5 +1,5 @@
 """The tests the History component."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from datetime import timedelta
 from http import HTTPStatus
 import json

--- a/tests/components/history/test_init_db_schema_30.py
+++ b/tests/components/history/test_init_db_schema_30.py
@@ -1,7 +1,7 @@
 """The tests the History component."""
 from __future__ import annotations
 
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from datetime import timedelta
 from http import HTTPStatus
 import importlib

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1,5 +1,5 @@
 """The test for the History Statistics sensor platform."""
-# pylint: disable=protected-access
+
 from datetime import timedelta
 import unittest
 from unittest.mock import patch

--- a/tests/components/home_plus_control/test_config_flow.py
+++ b/tests/components/home_plus_control/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_full_flow(
         "home_plus_control", context={"source": config_entries.SOURCE_USER}
     )
 
-    state = config_entry_oauth2_flow._encode_jwt(  # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
             "flow_id": result["flow_id"],
@@ -154,7 +154,7 @@ async def test_abort_if_invalid_token(
         "home_plus_control", context={"source": config_entries.SOURCE_USER}
     )
 
-    state = config_entry_oauth2_flow._encode_jwt(  # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
             "flow_id": result["flow_id"],

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -1,5 +1,5 @@
 """The tests for Core components."""
-# pylint: disable=protected-access
+
 import asyncio
 import unittest
 from unittest.mock import Mock, patch

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -20,7 +20,6 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-# pylint: disable=redefined-outer-name
 @pytest.fixture
 def calls(hass):
     """Track calls to a mock service."""

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -37,9 +37,7 @@ def mock_connection_fixture() -> AsyncConnection:
     def _rest_call_side_effect(path, body=None):
         return path, body
 
-    connection._restCall.side_effect = (  # pylint: disable=protected-access
-        _rest_call_side_effect
-    )
+    connection._restCall.side_effect = _rest_call_side_effect
     connection.api_call = AsyncMock(return_value=True)
     connection.init = AsyncMock(side_effect=True)
 

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -62,9 +62,7 @@ async def async_manipulate_test_data(
     fire_target = hmip_device if fire_device is None else fire_device
 
     if isinstance(fire_target, AsyncHome):
-        fire_target.fire_update_event(
-            fire_target._rawJSONData  # pylint: disable=protected-access
-        )
+        fire_target.fire_update_event(fire_target._rawJSONData)
     else:
         fire_target.fire_update_event()
 
@@ -206,9 +204,7 @@ class HomeTemplate(Home):
 def _get_mock(instance):
     """Create a mock and copy instance attributes over mock."""
     if isinstance(instance, Mock):
-        instance.__dict__.update(
-            instance._mock_wraps.__dict__  # pylint: disable=protected-access
-        )
+        instance.__dict__.update(instance._mock_wraps.__dict__)
         return instance
 
     mock = Mock(spec=instance, wraps=instance)

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -18,7 +18,7 @@ async def _async_manipulate_security_zones(
     hass, home, internal_active=False, external_active=False, alarm_triggered=False
 ):
     """Set new values on hmip security zones."""
-    json = home._rawJSONData  # pylint: disable=protected-access
+    json = home._rawJSONData
     json["functionalHomes"]["SECURITY_AND_ALARM"]["alarmActive"] = alarm_triggered
     external_zone_id = json["functionalHomes"]["SECURITY_AND_ALARM"]["securityZones"][
         "EXTERNAL"

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -408,7 +408,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_absence_with_duration"
     assert home.mock_calls[-1][1] == (60,)
-    assert len(home._connection.mock_calls) == 1  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 1
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -418,7 +418,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_absence_with_duration"
     assert home.mock_calls[-1][1] == (60,)
-    assert len(home._connection.mock_calls) == 2  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 2
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -428,7 +428,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_absence_with_period"
     assert home.mock_calls[-1][1] == (datetime.datetime(2019, 2, 17, 14, 0),)
-    assert len(home._connection.mock_calls) == 3  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 3
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -438,7 +438,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_absence_with_period"
     assert home.mock_calls[-1][1] == (datetime.datetime(2019, 2, 17, 14, 0),)
-    assert len(home._connection.mock_calls) == 4  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 4
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -448,7 +448,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_vacation"
     assert home.mock_calls[-1][1] == (datetime.datetime(2019, 2, 17, 14, 0), 18.5)
-    assert len(home._connection.mock_calls) == 5  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 5
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -458,7 +458,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "activate_vacation"
     assert home.mock_calls[-1][1] == (datetime.datetime(2019, 2, 17, 14, 0), 18.5)
-    assert len(home._connection.mock_calls) == 6  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 6
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -468,14 +468,14 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "deactivate_absence"
     assert home.mock_calls[-1][1] == ()
-    assert len(home._connection.mock_calls) == 7  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 7
 
     await hass.services.async_call(
         "homematicip_cloud", "deactivate_eco_mode", blocking=True
     )
     assert home.mock_calls[-1][0] == "deactivate_absence"
     assert home.mock_calls[-1][1] == ()
-    assert len(home._connection.mock_calls) == 8  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 8
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -485,14 +485,14 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     )
     assert home.mock_calls[-1][0] == "deactivate_vacation"
     assert home.mock_calls[-1][1] == ()
-    assert len(home._connection.mock_calls) == 9  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 9
 
     await hass.services.async_call(
         "homematicip_cloud", "deactivate_vacation", blocking=True
     )
     assert home.mock_calls[-1][0] == "deactivate_vacation"
     assert home.mock_calls[-1][1] == ()
-    assert len(home._connection.mock_calls) == 10  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 10
 
     not_existing_hap_id = "5555F7110000000000000001"
     await hass.services.async_call(
@@ -504,7 +504,7 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     assert home.mock_calls[-1][0] == "deactivate_vacation"
     assert home.mock_calls[-1][1] == ()
     # There is no further call on connection.
-    assert len(home._connection.mock_calls) == 10  # pylint: disable=protected-access
+    assert len(home._connection.mock_calls) == 10
 
 
 async def test_hmip_heating_group_services(hass, default_mock_hap_factory):
@@ -529,9 +529,7 @@ async def test_hmip_heating_group_services(hass, default_mock_hap_factory):
     )
     assert hmip_device.mock_calls[-1][0] == "set_active_profile"
     assert hmip_device.mock_calls[-1][1] == (1,)
-    assert (
-        len(hmip_device._connection.mock_calls) == 2  # pylint: disable=protected-access
-    )
+    assert len(hmip_device._connection.mock_calls) == 2
 
     await hass.services.async_call(
         "homematicip_cloud",
@@ -541,6 +539,4 @@ async def test_hmip_heating_group_services(hass, default_mock_hap_factory):
     )
     assert hmip_device.mock_calls[-1][0] == "set_active_profile"
     assert hmip_device.mock_calls[-1][1] == (1,)
-    assert (
-        len(hmip_device._connection.mock_calls) == 4  # pylint: disable=protected-access
-    )
+    assert len(hmip_device._connection.mock_calls) == 4

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -183,7 +183,7 @@ async def test_hap_reconnected(hass, default_mock_hap_factory):
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_UNAVAILABLE
 
-    mock_hap._accesspoint_connected = False  # pylint: disable=protected-access
+    mock_hap._accesspoint_connected = False
     await async_manipulate_test_data(hass, mock_hap.home, "connected", True)
     await hass.async_block_till_done()
     ha_state = hass.states.get(entity_id)

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -1,7 +1,5 @@
 """The tests for the Home Assistant HTTP component."""
 from http import HTTPStatus
-
-# pylint: disable=protected-access
 from ipaddress import ip_address
 import os
 from unittest.mock import Mock, mock_open, patch

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the input_boolean component."""
-# pylint: disable=protected-access
+
 import logging
 from unittest.mock import patch
 

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -1,5 +1,5 @@
 """Tests for the Input slider component."""
-# pylint: disable=protected-access
+
 import datetime
 from unittest.mock import patch
 

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Input number component."""
-# pylint: disable=protected-access
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Input select component."""
-# pylint: disable=protected-access
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Input text component."""
-# pylint: disable=protected-access
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -66,7 +66,6 @@ async def test_full_cloud_import_flow_multiple_devices(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -147,7 +146,6 @@ async def test_full_cloud_import_flow_single_device(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -267,7 +265,6 @@ async def test_full_ssdp_with_cloud_import(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -411,7 +408,6 @@ async def test_cloud_import_updates_existing_entry(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -518,7 +514,6 @@ async def test_cloud_abort_no_devices(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -637,7 +632,6 @@ async def test_cloud_errors(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -769,7 +763,6 @@ async def test_reauth_cloud_import(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -835,7 +828,6 @@ async def test_reauth_cloud_abort_device_not_found(
         flow_id, user_input={"next_step_id": "pick_implementation"}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -62,9 +62,7 @@ async def test_on_off_commands(
     for service, new_state, new_value in services:
         count += 1
         await hass.services.async_call(PLATFORM_DOMAIN, service, data, blocking=True)
-        robot._update_data(  # pylint:disable=protected-access
-            {updated_field: new_value}, partial=True
-        )
+        robot._update_data({updated_field: new_value}, partial=True)
 
         assert getattr(robot, robot_command).call_count == count
         assert (state := hass.states.get(entity_id))

--- a/tests/components/litterrobot/test_update.py
+++ b/tests/components/litterrobot/test_update.py
@@ -93,9 +93,7 @@ async def test_robot_with_update_already_in_progress(
 ):
     """Tests the update entity was set up."""
     robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
-    robot._update_data(  # pylint:disable=protected-access
-        {"isFirmwareUpdateTriggered": True}, partial=True
-    )
+    robot._update_data({"isFirmwareUpdateTriggered": True}, partial=True)
 
     entry = await setup_integration(
         hass, mock_account_with_litterrobot_4, PLATFORM_DOMAIN

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -12,8 +12,6 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
-# pylint: disable=redefined-outer-name
-
 
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the logbook component."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 import asyncio
 import collections
 from datetime import datetime, timedelta

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -57,9 +57,7 @@ def mock_logi_circle():
         yield LogiCircle
 
 
-async def test_step_import(
-    hass, mock_logi_circle  # pylint: disable=redefined-outer-name
-):
+async def test_step_import(hass, mock_logi_circle):
     """Test that we trigger import when configuring with client."""
     flow = init_config_flow(hass)
 
@@ -68,9 +66,7 @@ async def test_step_import(
     assert result["step_id"] == "auth"
 
 
-async def test_full_flow_implementation(
-    hass, mock_logi_circle  # pylint: disable=redefined-outer-name
-):
+async def test_full_flow_implementation(hass, mock_logi_circle):
     """Test registering an implementation and finishing flow works."""
     config_flow.register_flow_implementation(
         hass,
@@ -151,9 +147,7 @@ async def test_abort_if_already_setup(hass):
         (AuthorizationFailed, "invalid_auth"),
     ],
 )
-async def test_abort_if_authorize_fails(
-    hass, mock_logi_circle, side_effect, error
-):  # pylint: disable=redefined-outer-name
+async def test_abort_if_authorize_fails(hass, mock_logi_circle, side_effect, error):
     """Test we abort if authorizing fails."""
     flow = init_config_flow(hass)
     mock_logi_circle.authorize.side_effect = side_effect
@@ -175,9 +169,7 @@ async def test_not_pick_implementation_if_only_one(hass):
     assert result["step_id"] == "auth"
 
 
-async def test_gen_auth_url(
-    hass, mock_logi_circle
-):  # pylint: disable=redefined-outer-name
+async def test_gen_auth_url(hass, mock_logi_circle):
     """Test generating authorize URL from Logi Circle API."""
     config_flow.register_flow_implementation(
         hass,
@@ -205,9 +197,7 @@ async def test_callback_view_rejects_missing_code(hass):
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_callback_view_accepts_code(
-    hass, mock_logi_circle
-):  # pylint: disable=redefined-outer-name
+async def test_callback_view_accepts_code(hass, mock_logi_circle):
     """Test the auth callback view handles requests with auth code."""
     init_config_flow(hass)
     view = LogiCircleAuthCallbackView()

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -38,9 +38,7 @@ def init_config_flow(hass):
         sensors=None,
     )
     flow = config_flow.LogiCircleFlowHandler()
-    flow._get_authorization_url = Mock(  # pylint: disable=protected-access
-        return_value="http://example.com"
-    )
+    flow._get_authorization_url = Mock(return_value="http://example.com")
     flow.hass = hass
     return flow
 
@@ -195,7 +193,7 @@ async def test_gen_auth_url(
     flow.flow_impl = "test-auth-url"
     await async_setup_component(hass, "http", {})
 
-    result = flow._get_authorization_url()  # pylint: disable=protected-access
+    result = flow._get_authorization_url()
     assert result == "http://authorize.url"
 
 

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -120,7 +120,6 @@ async def test_reauthentication_flow(
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/melnor/test_sensor.py
+++ b/tests/components/melnor/test_sensor.py
@@ -47,7 +47,7 @@ async def test_minutes_remaining_sensor(hass):
     end_time = now + dt_util.dt.timedelta(minutes=10)
 
     # we control this mock
-    # pylint: disable-next=protected-access
+
     device.zone1._end_time = (end_time).timestamp()
 
     with freeze_time(now), patch_async_ble_device_from_address(), patch_melnor_device(

--- a/tests/components/mfi/test_switch.py
+++ b/tests/components/mfi/test_switch.py
@@ -74,13 +74,13 @@ async def test_update(port, switch):
 
 async def test_update_with_target_state(port, switch):
     """Test update with target state."""
-    # pylint: disable-next=protected-access
+
     switch._target_state = True
     port.data = {}
     port.data["output"] = "stale"
     switch.update()
     assert port.data["output"] == 1.0
-    # pylint: disable-next=protected-access
+
     assert switch._target_state is None
     port.data["output"] = "untouched"
     switch.update()
@@ -92,7 +92,7 @@ async def test_turn_on(port, switch):
     switch.turn_on()
     assert port.control.call_count == 1
     assert port.control.call_args == mock.call(True)
-    # pylint: disable-next=protected-access
+
     assert switch._target_state
 
 
@@ -101,5 +101,5 @@ async def test_turn_off(port, switch):
     switch.turn_off()
     assert port.control.call_count == 1
     assert port.control.call_args == mock.call(False)
-    # pylint: disable-next=protected-access
+
     assert not switch._target_state

--- a/tests/components/mobile_app/conftest.py
+++ b/tests/components/mobile_app/conftest.py
@@ -1,7 +1,7 @@
 """Tests for mobile_app component."""
 from http import HTTPStatus
 
-# pylint: disable=redefined-outer-name,unused-import
+# pylint: disable=unused-import
 import pytest
 
 from homeassistant.components.mobile_app.const import DOMAIN

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -277,7 +277,7 @@ BAD_MESSAGE = {"_type": "unsupported", "tst": 1}
 BAD_JSON_PREFIX = "--$this is bad json#--"
 BAD_JSON_SUFFIX = "** and it ends here ^^"
 
-# pylint: disable=invalid-name, len-as-condition, redefined-outer-name
+# pylint: disable=invalid-name, len-as-condition
 
 
 @pytest.fixture

--- a/tests/components/point/test_config_flow.py
+++ b/tests/components/point/test_config_flow.py
@@ -13,7 +13,7 @@ def init_config_flow(hass, side_effect=None):
     """Init a configuration flow."""
     config_flow.register_flow_implementation(hass, DOMAIN, "id", "secret")
     flow = config_flow.PointFlowHandler()
-    flow._get_authorization_url = AsyncMock(  # pylint: disable=protected-access
+    flow._get_authorization_url = AsyncMock(
         return_value="https://example.com", side_effect=side_effect
     )
     flow.hass = hass

--- a/tests/components/point/test_config_flow.py
+++ b/tests/components/point/test_config_flow.py
@@ -27,7 +27,7 @@ def is_authorized():
 
 
 @pytest.fixture
-def mock_pypoint(is_authorized):  # pylint: disable=redefined-outer-name
+def mock_pypoint(is_authorized):
     """Mock pypoint."""
     with patch(
         "homeassistant.components.point.config_flow.PointSession"
@@ -67,9 +67,7 @@ async def test_abort_if_already_setup(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow_implementation(
-    hass, mock_pypoint  # pylint: disable=redefined-outer-name
-):
+async def test_full_flow_implementation(hass, mock_pypoint):
     """Test registering an implementation and finishing flow works."""
     config_flow.register_flow_implementation(hass, "test-other", None, None)
     flow = init_config_flow(hass)
@@ -95,7 +93,7 @@ async def test_full_flow_implementation(
     assert result["data"]["token"] == {"access_token": "boo"}
 
 
-async def test_step_import(hass, mock_pypoint):  # pylint: disable=redefined-outer-name
+async def test_step_import(hass, mock_pypoint):
     """Test that we trigger import when configuring with client."""
     flow = init_config_flow(hass)
 
@@ -105,9 +103,7 @@ async def test_step_import(hass, mock_pypoint):  # pylint: disable=redefined-out
 
 
 @pytest.mark.parametrize("is_authorized", [False])
-async def test_wrong_code_flow_implementation(
-    hass, mock_pypoint
-):  # pylint: disable=redefined-outer-name
+async def test_wrong_code_flow_implementation(hass, mock_pypoint):
     """Test wrong code."""
     flow = init_config_flow(hass)
 

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -1,7 +1,7 @@
 """The tests the History component."""
 from __future__ import annotations
 
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from copy import copy
 from datetime import datetime, timedelta
 import json

--- a/tests/components/recorder/test_history_db_schema_30.py
+++ b/tests/components/recorder/test_history_db_schema_30.py
@@ -1,7 +1,7 @@
 """The tests the History component."""
 from __future__ import annotations
 
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from copy import copy
 from datetime import datetime, timedelta
 import importlib

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,7 +1,6 @@
 """The tests for the Recorder component."""
 from __future__ import annotations
 
-# pylint: disable=protected-access
 import asyncio
 from datetime import datetime, timedelta
 import sqlite3

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -504,7 +504,7 @@ def test_setup_without_migration(hass_recorder):
     assert recorder.get_instance(hass).schema_version == SCHEMA_VERSION
 
 
-# pylint: disable=redefined-outer-name,invalid-name
+# pylint: disable=invalid-name
 def test_saving_state_include_domains(hass_recorder):
     """Test saving and restoring a state."""
     hass = hass_recorder({"include": {"domains": "test2"}})

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -1,5 +1,5 @@
 """The tests for the Recorder component."""
-# pylint: disable=protected-access
+
 import datetime
 import importlib
 import sqlite3

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -1,5 +1,5 @@
 """The tests for sensor recorder platform."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from datetime import datetime, timedelta
 import importlib
 import sys

--- a/tests/components/recorder/test_statistics_v23_migration.py
+++ b/tests/components/recorder/test_statistics_v23_migration.py
@@ -3,7 +3,7 @@
 The v23 schema used for these tests has been slightly modified to add the
 EventData table to allow the recorder to startup successfully.
 """
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 import importlib
 import json
 import sys

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -1,5 +1,5 @@
 """The tests for recorder platform migrating data from v30."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from datetime import timedelta
 import importlib
 import sys

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1,5 +1,5 @@
 """The tests for sensor recorder platform."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 import datetime
 from datetime import timedelta
 from statistics import fmean

--- a/tests/components/roku/test_remote.py
+++ b/tests/components/roku/test_remote.py
@@ -16,8 +16,6 @@ from tests.common import MockConfigEntry
 
 MAIN_ENTITY_ID = f"{REMOTE_DOMAIN}.my_roku_3"
 
-# pylint: disable=redefined-outer-name
-
 
 async def test_setup(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
     """Test setup with basic config."""

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the Script component."""
-# pylint: disable=protected-access
+
 import asyncio
 from datetime import timedelta
 from unittest.mock import Mock, patch

--- a/tests/components/sensibo/conftest.py
+++ b/tests/components/sensibo/conftest.py
@@ -58,7 +58,7 @@ async def get_data_from_library(
     client = SensiboClient("123467890", aioclient_mock.create_session(hass.loop))
     with patch("pysensibo.SensiboClient.async_get_devices", return_value=load_json):
         output = await client.async_get_devices_data()
-    await client._session.close()  # pylint: disable=protected-access
+    await client._session.close()
     return output
 
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -1,5 +1,5 @@
 """The tests for sensor recorder platform."""
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=invalid-name
 from datetime import datetime, timedelta
 import math
 from statistics import mean

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -83,7 +83,7 @@ class MockAyla(AylaApi):
         """Get the list of devices."""
         shark = MockShark(self, SHARK_DEVICE_DICT)
         shark.properties_full = deepcopy(SHARK_PROPERTIES_DICT)
-        shark._update_metadata(SHARK_METADATA_DICT)  # pylint: disable=protected-access
+        shark._update_metadata(SHARK_METADATA_DICT)
         return [shark]
 
     async def async_request(self, http_method: str, url: str, **kwargs):

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -124,7 +124,7 @@ async def test_set_cover_position(hass, device_factory):
     assert state.attributes[ATTR_BATTERY_LEVEL] == 95
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
     # Ensure API called
-    # pylint: disable-next=protected-access
+
     assert device._api.post_device_command.call_count == 1  # type: ignore
 
 
@@ -147,7 +147,7 @@ async def test_set_cover_position_unsupported(hass, device_factory):
     assert ATTR_CURRENT_POSITION not in state.attributes
 
     # Ensure API was not called
-    # pylint: disable-next=protected-access
+
     assert device._api.post_device_command.call_count == 0  # type: ignore
 
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -451,7 +451,6 @@ async def test_event_handler_dispatches_updated_devices(
     broker = smartthings.DeviceBroker(hass, config_entry, Mock(), Mock(), devices, [])
     broker.connect()
 
-    # pylint:disable=protected-access
     await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 
@@ -478,7 +477,6 @@ async def test_event_handler_ignores_other_installed_app(
     broker = smartthings.DeviceBroker(hass, config_entry, Mock(), Mock(), [device], [])
     broker.connect()
 
-    # pylint:disable=protected-access
     await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 
@@ -516,7 +514,6 @@ async def test_event_handler_fires_button_events(
     broker = smartthings.DeviceBroker(hass, config_entry, Mock(), Mock(), [device], [])
     broker.connect()
 
-    # pylint:disable=protected-access
     await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 

--- a/tests/components/soundtouch/conftest.py
+++ b/tests/components/soundtouch/conftest.py
@@ -20,9 +20,6 @@ DEVICE_1_ENTITY_ID = f"{MEDIA_PLAYER_DOMAIN}.my_soundtouch_1"
 DEVICE_2_ENTITY_ID = f"{MEDIA_PLAYER_DOMAIN}.my_soundtouch_2"
 
 
-# pylint: disable=redefined-outer-name
-
-
 @pytest.fixture
 def device1_config() -> MockConfigEntry:
     """Mock SoundTouch device 1 config entry."""

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -1,7 +1,5 @@
 """The tests for the Home Assistant SpaceAPI component."""
 from http import HTTPStatus
-
-# pylint: disable=protected-access
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -84,7 +84,6 @@ async def test_full_flow(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -151,7 +150,6 @@ async def test_abort_if_spotify_error(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -213,7 +211,6 @@ async def test_reauthentication(
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -279,7 +276,6 @@ async def test_reauth_account_mismatch(
     flows = hass.config_entries.flow.async_progress()
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,5 +1,5 @@
 """Test the SSDP integration."""
-# pylint: disable=protected-access
+
 
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Subaru component config flow."""
-# pylint: disable=redefined-outer-name
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import PropertyMock, patch

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -5,7 +5,6 @@ import homeassistant.components.time_date.sensor as time_date
 import homeassistant.util.dt as dt_util
 
 
-# pylint: disable=protected-access
 async def test_intervals(hass):
     """Test timing intervals of sensors."""
     device = time_date.TimeDateSensor(hass, "time")

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the timer component."""
-# pylint: disable=protected-access
+
 from datetime import timedelta
 import logging
 from unittest.mock import patch

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -54,7 +54,6 @@ async def test_full_flow_implementation(
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "pick_implementation"
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -114,7 +113,6 @@ async def test_no_agreements(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -154,7 +152,6 @@ async def test_multiple_agreements(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -205,7 +202,6 @@ async def test_agreement_already_set_up(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -244,7 +240,7 @@ async def test_toon_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    # pylint: disable-next=protected-access
+
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {
@@ -306,7 +302,6 @@ async def test_import_migration(
     assert len(flows) == 1
     assert flows[0]["context"][CONF_MIGRATE] == old_entry.entry_id
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -5,8 +5,6 @@ import pytest
 
 from . import GATEWAY_ID, TRADFRI_PATH
 
-# pylint: disable=protected-access
-
 
 @pytest.fixture
 def mock_gateway_info():

--- a/tests/components/unifi_direct/test_device_tracker.py
+++ b/tests/components/unifi_direct/test_device_tracker.py
@@ -126,7 +126,7 @@ async def test_to_get_update(mock_sendline, mock_prompt, mock_login, mock_logout
     scanner = get_scanner(hass, conf_dict)
     # mock_sendline.side_effect = AssertionError("Test")
     mock_prompt.side_effect = AssertionError("Test")
-    devices = scanner._get_update()  # pylint: disable=protected-access
+    devices = scanner._get_update()
     assert devices is None
 
 

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures and test data for UniFi Protect methods."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect binary_sensor platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect button platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect camera platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect setup flow."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect light platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect lock platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect media_player platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock, patch

--- a/tests/components/unifiprotect/test_migrate.py
+++ b/tests/components/unifiprotect/test_migrate.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect setup flow."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect number platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect select platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from copy import copy

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect sensor platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect global services."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect switch platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -1,5 +1,5 @@
 """Test the UniFi Protect text platform."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -1,5 +1,5 @@
 """Test helpers for UniFi Protect."""
-# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -198,7 +198,7 @@ class ComponentFactory:
             const.DOMAIN, context={"source": SOURCE_USER}
         )
         assert result
-        # pylint: disable-next=protected-access
+
         state = config_entry_oauth2_flow._encode_jwt(
             self._hass,
             {

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -163,7 +163,6 @@ async def test_data_manager_webhook_subscription(
         WebhookConfig(id="1234", url="http://localhost/api/webhook/1234", enabled=True),
     )
 
-    # pylint: disable=protected-access
     data_manager._notify_subscribe_delay = datetime.timedelta(seconds=0)
     data_manager._notify_unsubscribe_delay = datetime.timedelta(seconds=0)
     # pylint: enable=protected-access

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -165,7 +165,6 @@ async def test_data_manager_webhook_subscription(
 
     data_manager._notify_subscribe_delay = datetime.timedelta(seconds=0)
     data_manager._notify_unsubscribe_delay = datetime.timedelta(seconds=0)
-    # pylint: enable=protected-access
 
     api.notify_list.return_value = NotifyListResponse(
         profiles=(

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -80,7 +80,6 @@ async def test_config_reauth_profile(
         {},
     )
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -172,7 +172,6 @@ async def test_reauthentication(
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
 
-    # pylint: disable-next=protected-access
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,7 @@ def verify_cleanup(event_loop: asyncio.AbstractEventLoop):
     if tasks:
         event_loop.run_until_complete(asyncio.wait(tasks))
 
-    for handle in event_loop._scheduled:  # pylint: disable=protected-access
+    for handle in event_loop._scheduled:
         if not handle.cancelled():
             _LOGGER.warning("Lingering timer after test %r", handle)
             handle.cancel()

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,5 +1,5 @@
 """Test the entity helper."""
-# pylint: disable=protected-access
+
 import asyncio
 import dataclasses
 from datetime import timedelta

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -1,5 +1,5 @@
 """The tests for the Entity component helper."""
-# pylint: disable=protected-access
+
 from collections import OrderedDict
 from datetime import timedelta
 import logging

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1,5 +1,5 @@
 """Test event helpers."""
-# pylint: disable=protected-access
+
 import asyncio
 from datetime import date, datetime, timedelta
 from unittest.mock import patch

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -1,5 +1,5 @@
 """Test the frame helper."""
-# pylint: disable=protected-access
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/helpers/test_init.py
+++ b/tests/helpers/test_init.py
@@ -1,5 +1,5 @@
 """Test component helpers."""
-# pylint: disable=protected-access
+
 from collections import OrderedDict
 
 from homeassistant import helpers

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,5 +1,5 @@
 """The tests for the Script component."""
-# pylint: disable=protected-access
+
 import asyncio
 from contextlib import contextmanager
 from datetime import timedelta

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -1,5 +1,5 @@
 """The tests for the Sun helpers."""
-# pylint: disable=protected-access
+
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3672,26 +3672,18 @@ async def test_cache_garbage_collection() -> None:
         (template_string),
     )
     tpl.ensure_valid()
-    assert template._NO_HASS_ENV.template_cache.get(
-        template_string
-    )  # pylint: disable=protected-access
+    assert template._NO_HASS_ENV.template_cache.get(template_string)
 
     tpl2 = template.Template(
         (template_string),
     )
     tpl2.ensure_valid()
-    assert template._NO_HASS_ENV.template_cache.get(
-        template_string
-    )  # pylint: disable=protected-access
+    assert template._NO_HASS_ENV.template_cache.get(template_string)
 
     del tpl
-    assert template._NO_HASS_ENV.template_cache.get(
-        template_string
-    )  # pylint: disable=protected-access
+    assert template._NO_HASS_ENV.template_cache.get(template_string)
     del tpl2
-    assert not template._NO_HASS_ENV.template_cache.get(
-        template_string
-    )  # pylint: disable=protected-access
+    assert not template._NO_HASS_ENV.template_cache.get(template_string)
 
 
 def test_is_template_string() -> None:

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -1,5 +1,5 @@
 """Tests for pylint hass_enforce_type_hints plugin."""
-# pylint:disable=protected-access
+
 from __future__ import annotations
 
 import re

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -1,5 +1,5 @@
 """Tests for pylint hass_imports plugin."""
-# pylint:disable=protected-access
+
 from __future__ import annotations
 
 import astroid

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,5 @@
 """Test the bootstrapping."""
-# pylint: disable=protected-access
+
 import asyncio
 import glob
 import os

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 """Test config utils."""
-# pylint: disable=protected-access
+
 from collections import OrderedDict
 import contextlib
 import copy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -754,7 +754,6 @@ async def test_async_hass_config_yaml_merge(merge_log_err, hass):
     assert len(conf["light"]) == 1
 
 
-# pylint: disable=redefined-outer-name
 @pytest.fixture
 def merge_log_err(hass):
     """Patch _merge_log_error from packages."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,6 @@
 """Test to verify that Home Assistant core works."""
 from __future__ import annotations
 
-# pylint: disable=protected-access
 import array
 import asyncio
 from datetime import datetime, timedelta

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,5 +1,5 @@
 """Test component/platform setup."""
-# pylint: disable=protected-access
+
 import asyncio
 import datetime
 import threading

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -324,7 +324,7 @@ def load_yaml(fname, string, secrets=None):
 class TestSecrets(unittest.TestCase):
     """Test the secrets parameter in the yaml utility."""
 
-    # pylint: disable=protected-access,invalid-name
+    # pylint: disable=invalid-name
 
     def setUp(self):
         """Create & load secrets file."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add per-file-ignore to pylint

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
