### PR TITLE
Revert "Add SSHd and GH CLI to devcontainer to support `gh net`"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,13 +45,5 @@
       "!include_dir_merge_list scalar",
       "!include_dir_merge_named scalar"
     ]
-  },
-  "features": {
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "latest"
-    }
   }
 }


### PR DESCRIPTION
Reverts home-assistant/core#81623 as it breaks building the container.
After this change rebuilding the container fails with `No authentication credentials found for registry 'ghcr.io'`
I hope it is acceptable to revert it until we find an solution to this.

CC @iMicknl @frenck 
