### PR TITLE
Add a `contains` jinja filter and test

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -13,7 +13,7 @@ from functools import cache, lru_cache, partial, wraps
 import json
 import logging
 import math
-from operator import attrgetter
+from operator import attrgetter, contains
 import random
 import re
 import statistics
@@ -1774,11 +1774,6 @@ def regex_match(value, find="", ignorecase=False):
         value = str(value)
     flags = re.I if ignorecase else 0
     return bool(_regex_cache(find, flags).match(value))
-
-
-def contains(seq, value):
-    """Opposite of the ``in`` test, allowing use as a test in filters like ``selectattr``."""
-    return value in seq
 
 
 @lru_cache(maxsize=128)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1776,6 +1776,11 @@ def regex_match(value, find="", ignorecase=False):
     return bool(_regex_cache(find, flags).match(value))
 
 
+def contains(seq, value):
+    """Opposite of the ``in`` test, allowing use as a test in filters like ``selectattr``."""
+    return value in seq
+
+
 @lru_cache(maxsize=128)
 def _regex_cache(find: str, flags: int) -> re.Pattern:
     """Cache compiled regex."""
@@ -2077,6 +2082,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["iif"] = iif
         self.filters["bool"] = forgiving_boolean
         self.filters["version"] = version
+        self.filters["contains"] = contains
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -2113,6 +2119,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.tests["is_number"] = is_number
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
+        self.tests["contains"] = contains
 
         if hass is None:
             return

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4078,3 +4078,33 @@ async def test_template_states_can_serialize(hass: HomeAssistant) -> None:
     template_state = template.TemplateState(hass, state, True)
     assert template_state.as_dict() is template_state.as_dict()
     assert json_dumps(template_state) == json_dumps(template_state)
+
+
+@pytest.mark.parametrize(
+    "seq, value, expected",
+    [
+        ([0], 0, True),
+        ([1], 0, False),
+        ([False], 0, True),
+        ([True], 0, False),
+        ([0], [0], False),
+        (["toto", 1], "toto", True),
+        (["toto", 1], "tata", False),
+        ([], 0, False),
+        ([], None, False),
+    ],
+)
+def test_contains(hass, seq, value, expected):
+    """Test contains."""
+    assert (
+        template.Template("{{ seq | contains(value) }}", hass).async_render(
+            {"seq": seq, "value": value}
+        )
+        == expected
+    )
+    assert (
+        template.Template("{{ seq is contains(value) }}", hass).async_render(
+            {"seq": seq, "value": value}
+        )
+        == expected
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR add a new jinja test and a new jinja filter called `contains`
This very basic filter is from Ansible custom filter : https://github.com/ansible/ansible/blob/4f5ed249727dc0c271e07b045e514cc31e25c2de/lib/ansible/plugins/test/mathstuff.py#L39

It work as an exact reverse to the `in` filter, allowing the user to test if a list have a specific value in it. It both make is simple  and more readable for case when you could swap the value from one side to the other of the `in` filter, but more importantly allow some previously impossible test with select and selectattr.

Example:
```jinja
{{ expand('light.office') | selectattr("attributes.supported_color_modes", 'contains', 'color_temp') | list }}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25890

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
