### PR TITLE
Only allow printable characters in payload, state or name of MQTT config options

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -48,7 +48,12 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +91,7 @@ REMOTE_CODE_TEXT = "REMOTE_CODE_TEXT"
 
 PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_CODE): cv.string,
+        vol.Optional(CONF_CODE): valid_printable_string,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DISARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_CODE_TRIGGER_REQUIRED, default=True): cv.boolean,
@@ -94,18 +99,28 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
             CONF_COMMAND_TEMPLATE, default=DEFAULT_COMMAND_TEMPLATE
         ): cv.template,
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY): cv.string,
-        vol.Optional(CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME): cv.string,
-        vol.Optional(CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_VACATION, default=DEFAULT_ARM_VACATION
-        ): cv.string,
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_CUSTOM_BYPASS, default=DEFAULT_ARM_CUSTOM_BYPASS
-        ): cv.string,
-        vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
-        vol.Optional(CONF_PAYLOAD_TRIGGER, default=DEFAULT_TRIGGER): cv.string,
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_TRIGGER, default=DEFAULT_TRIGGER
+        ): valid_printable_string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         vol.Required(CONF_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -48,12 +48,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,7 +86,7 @@ REMOTE_CODE_TEXT = "REMOTE_CODE_TEXT"
 
 PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_CODE): valid_printable_string,
+        vol.Optional(CONF_CODE): cv.printable_string,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DISARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_CODE_TRIGGER_REQUIRED, default=True): cv.boolean,
@@ -99,28 +94,26 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
             CONF_COMMAND_TEMPLATE, default=DEFAULT_COMMAND_TEMPLATE
         ): cv.template,
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_VACATION, default=DEFAULT_ARM_VACATION
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_ARM_CUSTOM_BYPASS, default=DEFAULT_ARM_CUSTOM_BYPASS
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM
-        ): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_TRIGGER, default=DEFAULT_TRIGGER
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         vol.Required(CONF_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -46,7 +46,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,10 +62,14 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
         vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_OFF_DELAY): cv.positive_int,
-        vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+        vol.Optional(
+            CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+        ): valid_printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -46,7 +46,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,14 +62,12 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
         vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_OFF_DELAY): cv.positive_int,
         vol.Optional(
             CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-        ): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/button.py
+++ b/homeassistant/components/mqtt/button.py
@@ -29,7 +29,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate
-from .util import valid_printable_string, valid_publish_topic
+from .util import valid_publish_topic
 
 CONF_PAYLOAD_PRESS = "payload_press"
 DEFAULT_NAME = "MQTT Button"
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_PAYLOAD_PRESS, default=DEFAULT_PAYLOAD_PRESS): cv.string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     }

--- a/homeassistant/components/mqtt/button.py
+++ b/homeassistant/components/mqtt/button.py
@@ -29,7 +29,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate
-from .util import valid_publish_topic
+from .util import valid_printable_string, valid_publish_topic
 
 CONF_PAYLOAD_PRESS = "payload_press"
 DEFAULT_NAME = "MQTT Button"
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_PAYLOAD_PRESS, default=DEFAULT_PAYLOAD_PRESS): cv.string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     }

--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -12,7 +12,6 @@ from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -27,7 +26,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import ReceiveMessage
-from .util import valid_subscribe_topic
+from .util import valid_printable_string, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +45,7 @@ MQTT_CAMERA_ATTRIBUTES_BLOCKED = frozenset(
 
 PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Required(CONF_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_IMAGE_ENCODING): "b64",
     }

--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -12,6 +12,7 @@ from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -26,7 +27,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import ReceiveMessage
-from .util import valid_printable_string, valid_subscribe_topic
+from .util import valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ MQTT_CAMERA_ATTRIBUTES_BLOCKED = frozenset(
 
 PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Required(CONF_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_IMAGE_ENCODING): "b64",
     }

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -71,12 +71,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -317,8 +312,8 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_MODE_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
-        vol.Optional(CONF_PAYLOAD_ON, default="ON"): valid_printable_string,
-        vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default="ON"): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): cv.printable_string,
         vol.Optional(CONF_POWER_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_POWER_STATE_TOPIC): valid_subscribe_topic,

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -71,7 +71,12 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -312,8 +317,8 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_MODE_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
-        vol.Optional(CONF_PAYLOAD_ON, default="ON"): cv.string,
-        vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): cv.string,
+        vol.Optional(CONF_PAYLOAD_ON, default="ON"): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): valid_printable_string,
         vol.Optional(CONF_POWER_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_POWER_STATE_TOPIC): valid_subscribe_topic,

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -52,12 +52,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -168,29 +163,29 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
         vol.Optional(CONF_GET_POSITION_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
         vol.Optional(CONF_PAYLOAD_CLOSE, default=DEFAULT_PAYLOAD_CLOSE): vol.Any(
-            valid_printable_string, None
+            cv.printable_string, None
         ),
         vol.Optional(CONF_PAYLOAD_OPEN, default=DEFAULT_PAYLOAD_OPEN): vol.Any(
-            valid_printable_string, None
+            cv.printable_string, None
         ),
         vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): vol.Any(
-            valid_printable_string, None
+            cv.printable_string, None
         ),
         vol.Optional(CONF_POSITION_CLOSED, default=DEFAULT_POSITION_CLOSED): int,
         vol.Optional(CONF_POSITION_OPEN, default=DEFAULT_POSITION_OPEN): int,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         vol.Optional(CONF_SET_POSITION_TEMPLATE): cv.template,
         vol.Optional(CONF_SET_POSITION_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): valid_printable_string,
-        vol.Optional(CONF_STATE_CLOSING, default=STATE_CLOSING): valid_printable_string,
-        vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): valid_printable_string,
-        vol.Optional(CONF_STATE_OPENING, default=STATE_OPENING): valid_printable_string,
+        vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.printable_string,
+        vol.Optional(CONF_STATE_CLOSING, default=STATE_CLOSING): cv.printable_string,
+        vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.printable_string,
+        vol.Optional(CONF_STATE_OPENING, default=STATE_OPENING): cv.printable_string,
         vol.Optional(
             CONF_STATE_STOPPED, default=DEFAULT_STATE_STOPPED
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(
             CONF_TILT_CLOSED_POSITION, default=DEFAULT_TILT_CLOSED_POSITION

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -52,7 +52,12 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -163,27 +168,29 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
         vol.Optional(CONF_GET_POSITION_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
         vol.Optional(CONF_PAYLOAD_CLOSE, default=DEFAULT_PAYLOAD_CLOSE): vol.Any(
-            cv.string, None
+            valid_printable_string, None
         ),
         vol.Optional(CONF_PAYLOAD_OPEN, default=DEFAULT_PAYLOAD_OPEN): vol.Any(
-            cv.string, None
+            valid_printable_string, None
         ),
         vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): vol.Any(
-            cv.string, None
+            valid_printable_string, None
         ),
         vol.Optional(CONF_POSITION_CLOSED, default=DEFAULT_POSITION_CLOSED): int,
         vol.Optional(CONF_POSITION_OPEN, default=DEFAULT_POSITION_OPEN): int,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         vol.Optional(CONF_SET_POSITION_TEMPLATE): cv.template,
         vol.Optional(CONF_SET_POSITION_TOPIC): valid_publish_topic,
-        vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
-        vol.Optional(CONF_STATE_CLOSING, default=STATE_CLOSING): cv.string,
-        vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
-        vol.Optional(CONF_STATE_OPENING, default=STATE_OPENING): cv.string,
-        vol.Optional(CONF_STATE_STOPPED, default=DEFAULT_STATE_STOPPED): cv.string,
+        vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): valid_printable_string,
+        vol.Optional(CONF_STATE_CLOSING, default=STATE_CLOSING): valid_printable_string,
+        vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): valid_printable_string,
+        vol.Optional(CONF_STATE_OPENING, default=STATE_OPENING): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_STOPPED, default=DEFAULT_STATE_STOPPED
+        ): valid_printable_string,
         vol.Optional(CONF_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(
             CONF_TILT_CLOSED_POSITION, default=DEFAULT_TILT_CLOSED_POSITION

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -38,7 +37,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage, ReceivePayloadType
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
@@ -49,10 +48,14 @@ DEFAULT_SOURCE_TYPE = SourceType.GPS
 
 PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
-        vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
-        vol.Optional(CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET): cv.string,
+        vol.Optional(CONF_NAME): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET
+        ): valid_printable_string,
         vol.Optional(CONF_SOURCE_TYPE, default=DEFAULT_SOURCE_TYPE): vol.In(
             SOURCE_TYPES
         ),

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.core import HomeAssistant, callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -37,7 +38,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage, ReceivePayloadType
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 CONF_PAYLOAD_HOME = "payload_home"
 CONF_PAYLOAD_NOT_HOME = "payload_not_home"
@@ -48,14 +49,14 @@ DEFAULT_SOURCE_TYPE = SourceType.GPS
 
 PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME): valid_printable_string,
-        vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): valid_printable_string,
+        vol.Optional(CONF_NAME): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_SOURCE_TYPE, default=DEFAULT_SOURCE_TYPE): vol.In(
             SOURCE_TYPES
         ),

--- a/homeassistant/components/mqtt/device_trigger.py
+++ b/homeassistant/components/mqtt/device_trigger.py
@@ -42,7 +42,7 @@ from .mixins import (
     send_discovery_done,
     update_device,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,8 +62,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): DEVICE,
         vol.Required(CONF_DOMAIN): DOMAIN,
-        vol.Required(CONF_DEVICE_ID): valid_printable_string,
-        vol.Required(CONF_DISCOVERY_ID): valid_printable_string,
+        vol.Required(CONF_DEVICE_ID): cv.printable_string,
+        vol.Required(CONF_DISCOVERY_ID): cv.printable_string,
         vol.Required(CONF_TYPE): cv.string,
         vol.Required(CONF_SUBTYPE): cv.string,
     }
@@ -73,7 +73,7 @@ TRIGGER_DISCOVERY_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_AUTOMATION_TYPE): str,
         vol.Required(CONF_DEVICE): MQTT_ENTITY_DEVICE_INFO_SCHEMA,
-        vol.Optional(CONF_PAYLOAD, default=None): vol.Any(None, valid_printable_string),
+        vol.Optional(CONF_PAYLOAD, default=None): vol.Any(None, cv.printable_string),
         vol.Required(CONF_SUBTYPE): cv.string,
         vol.Required(CONF_TOPIC): cv.string,
         vol.Required(CONF_TYPE): cv.string,

--- a/homeassistant/components/mqtt/device_trigger.py
+++ b/homeassistant/components/mqtt/device_trigger.py
@@ -42,7 +42,7 @@ from .mixins import (
     send_discovery_done,
     update_device,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,8 +62,8 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): DEVICE,
         vol.Required(CONF_DOMAIN): DOMAIN,
-        vol.Required(CONF_DEVICE_ID): str,
-        vol.Required(CONF_DISCOVERY_ID): str,
+        vol.Required(CONF_DEVICE_ID): valid_printable_string,
+        vol.Required(CONF_DISCOVERY_ID): valid_printable_string,
         vol.Required(CONF_TYPE): cv.string,
         vol.Required(CONF_SUBTYPE): cv.string,
     }
@@ -73,7 +73,7 @@ TRIGGER_DISCOVERY_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_AUTOMATION_TYPE): str,
         vol.Required(CONF_DEVICE): MQTT_ENTITY_DEVICE_INFO_SCHEMA,
-        vol.Optional(CONF_PAYLOAD, default=None): vol.Any(None, cv.string),
+        vol.Optional(CONF_PAYLOAD, default=None): vol.Any(None, valid_printable_string),
         vol.Required(CONF_SUBTYPE): cv.string,
         vol.Required(CONF_TOPIC): cv.string,
         vol.Required(CONF_TYPE): cv.string,

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -62,12 +62,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 CONF_PERCENTAGE_STATE_TOPIC = "percentage_state_topic"
 CONF_PERCENTAGE_COMMAND_TOPIC = "percentage_command_topic"
@@ -131,7 +126,7 @@ def valid_preset_mode_configuration(config: ConfigType) -> ConfigType:
 
 _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_OSCILLATION_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_OSCILLATION_COMMAND_TEMPLATE): cv.template,
@@ -160,22 +155,20 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         ): cv.positive_int,
         vol.Optional(
             CONF_PAYLOAD_RESET_PERCENTAGE, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_RESET_PRESET_MODE, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-        ): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OSCILLATION_OFF, default=OSCILLATE_OFF_PAYLOAD
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OSCILLATION_ON, default=OSCILLATE_ON_PAYLOAD
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -62,7 +62,12 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 CONF_PERCENTAGE_STATE_TOPIC = "percentage_state_topic"
 CONF_PERCENTAGE_COMMAND_TOPIC = "percentage_command_topic"
@@ -126,7 +131,7 @@ def valid_preset_mode_configuration(config: ConfigType) -> ConfigType:
 
 _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_OSCILLATION_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_OSCILLATION_COMMAND_TEMPLATE): cv.template,
@@ -155,18 +160,22 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         ): cv.positive_int,
         vol.Optional(
             CONF_PAYLOAD_RESET_PERCENTAGE, default=DEFAULT_PAYLOAD_RESET
-        ): cv.string,
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_RESET_PRESET_MODE, default=DEFAULT_PAYLOAD_RESET
-        ): cv.string,
-        vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_OSCILLATION_OFF, default=OSCILLATE_OFF_PAYLOAD
-        ): cv.string,
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_OSCILLATION_ON, default=OSCILLATE_ON_PAYLOAD
-        ): cv.string,
+        ): valid_printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -58,7 +58,12 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 CONF_AVAILABLE_MODES_LIST = "modes"
 CONF_DEVICE_CLASS = "device_class"
@@ -130,9 +135,13 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_MODE_STATE_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+        ): valid_printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         vol.Required(CONF_TARGET_HUMIDITY_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_TARGET_HUMIDITY_COMMAND_TEMPLATE): cv.template,
@@ -146,8 +155,10 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_TARGET_HUMIDITY_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(
             CONF_PAYLOAD_RESET_HUMIDITY, default=DEFAULT_PAYLOAD_RESET
-        ): cv.string,
-        vol.Optional(CONF_PAYLOAD_RESET_MODE, default=DEFAULT_PAYLOAD_RESET): cv.string,
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_RESET_MODE, default=DEFAULT_PAYLOAD_RESET
+        ): valid_printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -58,12 +58,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 CONF_AVAILABLE_MODES_LIST = "modes"
 CONF_DEVICE_CLASS = "device_class"
@@ -135,13 +130,11 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_MODE_STATE_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-        ): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         vol.Required(CONF_TARGET_HUMIDITY_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_TARGET_HUMIDITY_COMMAND_TEMPLATE): cv.template,
@@ -155,10 +148,10 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_TARGET_HUMIDITY_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(
             CONF_PAYLOAD_RESET_HUMIDITY, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_RESET_MODE, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -67,12 +67,7 @@ from ..models import (
     ReceivePayloadType,
     TemplateVarsType,
 )
-from ..util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from ..util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
@@ -192,7 +187,7 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_EFFECT_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_EFFECT_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_EFFECT_LIST): vol.All(
-                cv.ensure_list, [valid_printable_string]
+                cv.ensure_list, [cv.printable_string]
             ),
             vol.Optional(CONF_EFFECT_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_EFFECT_VALUE_TEMPLATE): cv.template,
@@ -202,16 +197,16 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_HS_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
             vol.Optional(CONF_ON_COMMAND_TYPE, default=DEFAULT_ON_COMMAND_TYPE): vol.In(
                 VALUES_ON_COMMAND_TYPE
             ),
             vol.Optional(
                 CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(CONF_RGB_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_RGB_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_RGB_STATE_TOPIC): valid_subscribe_topic,

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -67,7 +67,12 @@ from ..models import (
     ReceivePayloadType,
     TemplateVarsType,
 )
-from ..util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from ..util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
@@ -186,7 +191,9 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_COLOR_TEMP_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_EFFECT_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_EFFECT_COMMAND_TOPIC): valid_publish_topic,
-            vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_EFFECT_LIST): vol.All(
+                cv.ensure_list, [valid_printable_string]
+            ),
             vol.Optional(CONF_EFFECT_STATE_TOPIC): valid_subscribe_topic,
             vol.Optional(CONF_EFFECT_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_HS_COMMAND_TEMPLATE): cv.template,
@@ -195,12 +202,16 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_HS_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
             vol.Optional(CONF_ON_COMMAND_TYPE, default=DEFAULT_ON_COMMAND_TYPE): vol.In(
                 VALUES_ON_COMMAND_TYPE
             ),
-            vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-            vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+            vol.Optional(
+                CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+            ): valid_printable_string,
+            vol.Optional(
+                CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+            ): valid_printable_string,
             vol.Optional(CONF_RGB_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_RGB_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_RGB_STATE_TOPIC): valid_subscribe_topic,

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -64,7 +64,7 @@ from ..const import (
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity
 from ..models import ReceiveMessage
-from ..util import get_mqtt_data, valid_subscribe_topic
+from ..util import get_mqtt_data, valid_printable_string, valid_subscribe_topic
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import (
     CONF_BRIGHTNESS_SCALE,
@@ -133,7 +133,7 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_HS, default=DEFAULT_HS): cv.boolean,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
             vol.Optional(CONF_QOS, default=DEFAULT_QOS): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2])
             ),

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -64,7 +64,7 @@ from ..const import (
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity
 from ..models import ReceiveMessage
-from ..util import get_mqtt_data, valid_printable_string, valid_subscribe_topic
+from ..util import get_mqtt_data, valid_subscribe_topic
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import (
     CONF_BRIGHTNESS_SCALE,
@@ -133,7 +133,7 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_HS, default=DEFAULT_HS): cv.boolean,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
             vol.Optional(CONF_QOS, default=DEFAULT_QOS): vol.All(
                 vol.Coerce(int), vol.In([0, 1, 2])
             ),

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -54,7 +54,7 @@ from ..models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from ..util import get_mqtt_data, valid_printable_string
+from ..util import get_mqtt_data
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import MQTT_LIGHT_ATTRIBUTES_BLOCKED
 
@@ -97,13 +97,13 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Required(CONF_COMMAND_OFF_TEMPLATE): cv.template,
             vol.Required(CONF_COMMAND_ON_TEMPLATE): cv.template,
             vol.Optional(CONF_EFFECT_LIST): vol.All(
-                cv.ensure_list, [valid_printable_string]
+                cv.ensure_list, [cv.printable_string]
             ),
             vol.Optional(CONF_EFFECT_TEMPLATE): cv.template,
             vol.Optional(CONF_GREEN_TEMPLATE): cv.template,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
             vol.Optional(CONF_RED_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_TEMPLATE): cv.template,
         }

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -54,7 +54,7 @@ from ..models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from ..util import get_mqtt_data
+from ..util import get_mqtt_data, valid_printable_string
 from .schema import MQTT_LIGHT_SCHEMA_SCHEMA
 from .schema_basic import MQTT_LIGHT_ATTRIBUTES_BLOCKED
 
@@ -96,12 +96,14 @@ _PLATFORM_SCHEMA_BASE = (
             vol.Optional(CONF_COLOR_TEMP_TEMPLATE): cv.template,
             vol.Required(CONF_COMMAND_OFF_TEMPLATE): cv.template,
             vol.Required(CONF_COMMAND_ON_TEMPLATE): cv.template,
-            vol.Optional(CONF_EFFECT_LIST): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_EFFECT_LIST): vol.All(
+                cv.ensure_list, [valid_printable_string]
+            ),
             vol.Optional(CONF_EFFECT_TEMPLATE): cv.template,
             vol.Optional(CONF_GREEN_TEMPLATE): cv.template,
             vol.Optional(CONF_MAX_MIREDS): cv.positive_int,
             vol.Optional(CONF_MIN_MIREDS): cv.positive_int,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
             vol.Optional(CONF_RED_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_TEMPLATE): cv.template,
         }

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -46,7 +46,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 CONF_CODE_FORMAT = "code_format"
 
@@ -81,29 +81,29 @@ PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_CODE_FORMAT): cv.is_regex,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_LOCK, default=DEFAULT_PAYLOAD_LOCK
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_UNLOCK, default=DEFAULT_PAYLOAD_UNLOCK
-        ): valid_printable_string,
-        vol.Optional(CONF_PAYLOAD_OPEN): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_OPEN): cv.printable_string,
         vol.Optional(
             CONF_STATE_JAMMED, default=DEFAULT_STATE_JAMMED
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_STATE_LOCKING, default=DEFAULT_STATE_LOCKING
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_STATE_UNLOCKING, default=DEFAULT_STATE_UNLOCKING
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -46,7 +46,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 CONF_CODE_FORMAT = "code_format"
 
@@ -81,15 +81,29 @@ PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_CODE_FORMAT): cv.is_regex,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_LOCK, default=DEFAULT_PAYLOAD_LOCK): cv.string,
-        vol.Optional(CONF_PAYLOAD_UNLOCK, default=DEFAULT_PAYLOAD_UNLOCK): cv.string,
-        vol.Optional(CONF_PAYLOAD_OPEN): cv.string,
-        vol.Optional(CONF_STATE_JAMMED, default=DEFAULT_STATE_JAMMED): cv.string,
-        vol.Optional(CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED): cv.string,
-        vol.Optional(CONF_STATE_LOCKING, default=DEFAULT_STATE_LOCKING): cv.string,
-        vol.Optional(CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED): cv.string,
-        vol.Optional(CONF_STATE_UNLOCKING, default=DEFAULT_STATE_UNLOCKING): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_LOCK, default=DEFAULT_PAYLOAD_LOCK
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_UNLOCK, default=DEFAULT_PAYLOAD_UNLOCK
+        ): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_OPEN): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_JAMMED, default=DEFAULT_STATE_JAMMED
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_LOCKING, default=DEFAULT_STATE_LOCKING
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_STATE_UNLOCKING, default=DEFAULT_STATE_UNLOCKING
+        ): valid_printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -92,12 +92,7 @@ from .subscription import (
     async_subscribe_topics,
     async_unsubscribe_topics,
 )
-from .util import (
-    get_mqtt_data,
-    mqtt_config_entry_enabled,
-    valid_printable_string,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, mqtt_config_entry_enabled, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,10 +148,10 @@ MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
         vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_NOT_AVAILABLE, default=DEFAULT_PAYLOAD_NOT_AVAILABLE
-        ): valid_printable_string,
+        ): cv.printable_string,
     }
 )
 
@@ -172,11 +167,11 @@ MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
                     vol.Required(CONF_TOPIC): valid_subscribe_topic,
                     vol.Optional(
                         CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
-                    ): valid_printable_string,
+                    ): cv.printable_string,
                     vol.Optional(
                         CONF_PAYLOAD_NOT_AVAILABLE,
                         default=DEFAULT_PAYLOAD_NOT_AVAILABLE,
-                    ): valid_printable_string,
+                    ): cv.printable_string,
                     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
                 }
             ],
@@ -204,18 +199,18 @@ MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Optional(CONF_IDENTIFIERS, default=list): vol.All(
-                cv.ensure_list, [valid_printable_string]
+                cv.ensure_list, [cv.printable_string]
             ),
             vol.Optional(CONF_CONNECTIONS, default=list): vol.All(
-                cv.ensure_list, [vol.All(vol.Length(2), [valid_printable_string])]
+                cv.ensure_list, [vol.All(vol.Length(2), [cv.printable_string])]
             ),
-            vol.Optional(CONF_MANUFACTURER): valid_printable_string,
-            vol.Optional(CONF_MODEL): valid_printable_string,
-            vol.Optional(CONF_NAME): valid_printable_string,
-            vol.Optional(CONF_HW_VERSION): valid_printable_string,
-            vol.Optional(CONF_SW_VERSION): valid_printable_string,
-            vol.Optional(CONF_VIA_DEVICE): valid_printable_string,
-            vol.Optional(CONF_SUGGESTED_AREA): valid_printable_string,
+            vol.Optional(CONF_MANUFACTURER): cv.printable_string,
+            vol.Optional(CONF_MODEL): cv.printable_string,
+            vol.Optional(CONF_NAME): cv.printable_string,
+            vol.Optional(CONF_HW_VERSION): cv.printable_string,
+            vol.Optional(CONF_SW_VERSION): cv.printable_string,
+            vol.Optional(CONF_VIA_DEVICE): cv.printable_string,
+            vol.Optional(CONF_SUGGESTED_AREA): cv.printable_string,
             vol.Optional(CONF_CONFIGURATION_URL): cv.url,
         }
     ),
@@ -230,8 +225,8 @@ MQTT_ENTITY_COMMON_SCHEMA = MQTT_AVAILABILITY_SCHEMA.extend(
         vol.Optional(CONF_ICON): cv.icon,
         vol.Optional(CONF_JSON_ATTRS_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_JSON_ATTRS_TEMPLATE): cv.template,
-        vol.Optional(CONF_OBJECT_ID): valid_printable_string,
-        vol.Optional(CONF_UNIQUE_ID): valid_printable_string,
+        vol.Optional(CONF_OBJECT_ID): cv.printable_string,
+        vol.Optional(CONF_UNIQUE_ID): cv.printable_string,
     }
 )
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -92,7 +92,12 @@ from .subscription import (
     async_subscribe_topics,
     async_unsubscribe_topics,
 )
-from .util import get_mqtt_data, mqtt_config_entry_enabled, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    mqtt_config_entry_enabled,
+    valid_printable_string,
+    valid_subscribe_topic,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,10 +153,10 @@ MQTT_AVAILABILITY_SINGLE_SCHEMA = vol.Schema(
         vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
         vol.Optional(
             CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
-        ): cv.string,
+        ): valid_printable_string,
         vol.Optional(
             CONF_PAYLOAD_NOT_AVAILABLE, default=DEFAULT_PAYLOAD_NOT_AVAILABLE
-        ): cv.string,
+        ): valid_printable_string,
     }
 )
 
@@ -167,11 +172,11 @@ MQTT_AVAILABILITY_LIST_SCHEMA = vol.Schema(
                     vol.Required(CONF_TOPIC): valid_subscribe_topic,
                     vol.Optional(
                         CONF_PAYLOAD_AVAILABLE, default=DEFAULT_PAYLOAD_AVAILABLE
-                    ): cv.string,
+                    ): valid_printable_string,
                     vol.Optional(
                         CONF_PAYLOAD_NOT_AVAILABLE,
                         default=DEFAULT_PAYLOAD_NOT_AVAILABLE,
-                    ): cv.string,
+                    ): valid_printable_string,
                     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
                 }
             ],
@@ -199,18 +204,18 @@ MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Optional(CONF_IDENTIFIERS, default=list): vol.All(
-                cv.ensure_list, [cv.string]
+                cv.ensure_list, [valid_printable_string]
             ),
             vol.Optional(CONF_CONNECTIONS, default=list): vol.All(
-                cv.ensure_list, [vol.All(vol.Length(2), [cv.string])]
+                cv.ensure_list, [vol.All(vol.Length(2), [valid_printable_string])]
             ),
-            vol.Optional(CONF_MANUFACTURER): cv.string,
-            vol.Optional(CONF_MODEL): cv.string,
-            vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_HW_VERSION): cv.string,
-            vol.Optional(CONF_SW_VERSION): cv.string,
-            vol.Optional(CONF_VIA_DEVICE): cv.string,
-            vol.Optional(CONF_SUGGESTED_AREA): cv.string,
+            vol.Optional(CONF_MANUFACTURER): valid_printable_string,
+            vol.Optional(CONF_MODEL): valid_printable_string,
+            vol.Optional(CONF_NAME): valid_printable_string,
+            vol.Optional(CONF_HW_VERSION): valid_printable_string,
+            vol.Optional(CONF_SW_VERSION): valid_printable_string,
+            vol.Optional(CONF_VIA_DEVICE): valid_printable_string,
+            vol.Optional(CONF_SUGGESTED_AREA): valid_printable_string,
             vol.Optional(CONF_CONFIGURATION_URL): cv.url,
         }
     ),
@@ -225,8 +230,8 @@ MQTT_ENTITY_COMMON_SCHEMA = MQTT_AVAILABILITY_SCHEMA.extend(
         vol.Optional(CONF_ICON): cv.icon,
         vol.Optional(CONF_JSON_ATTRS_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_JSON_ATTRS_TEMPLATE): cv.template,
-        vol.Optional(CONF_OBJECT_ID): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_OBJECT_ID): valid_printable_string,
+        vol.Optional(CONF_UNIQUE_ID): valid_printable_string,
     }
 )
 

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -55,7 +55,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,12 +90,14 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_MAX, default=DEFAULT_MAX_VALUE): vol.Coerce(float),
         vol.Optional(CONF_MIN, default=DEFAULT_MIN_VALUE): vol.Coerce(float),
         vol.Optional(CONF_MODE, default=NumberMode.AUTO): vol.Coerce(NumberMode),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET
+        ): valid_printable_string,
         vol.Optional(CONF_STEP, default=DEFAULT_STEP): vol.All(
             vol.Coerce(float), vol.Range(min=1e-3)
         ),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): valid_printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -55,7 +55,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,14 +90,14 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_MAX, default=DEFAULT_MAX_VALUE): vol.Coerce(float),
         vol.Optional(CONF_MIN, default=DEFAULT_MIN_VALUE): vol.Coerce(float),
         vol.Optional(CONF_MODE, default=NumberMode.AUTO): vol.Coerce(NumberMode),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET
-        ): valid_printable_string,
+        ): cv.printable_string,
         vol.Optional(CONF_STEP, default=DEFAULT_STEP): vol.All(
             vol.Coerce(float), vol.Range(min=1e-3)
         ),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): valid_printable_string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)

--- a/homeassistant/components/mqtt/scene.py
+++ b/homeassistant/components/mqtt/scene.py
@@ -26,7 +26,7 @@ from .mixins import (
     async_setup_entry_helper,
     warn_for_legacy_schema,
 )
-from .util import valid_printable_string, valid_publish_topic
+from .util import valid_publish_topic
 
 DEFAULT_NAME = "MQTT Scene"
 DEFAULT_RETAIN = False
@@ -35,11 +35,11 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_ICON): cv.icon,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
-        vol.Optional(CONF_PAYLOAD_ON): valid_printable_string,
-        vol.Optional(CONF_UNIQUE_ID): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON): cv.printable_string,
+        vol.Optional(CONF_UNIQUE_ID): cv.printable_string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        vol.Optional(CONF_OBJECT_ID): valid_printable_string,
+        vol.Optional(CONF_OBJECT_ID): cv.printable_string,
         # CONF_ENABLED_BY_DEFAULT is not added by default because
         # we are not using the common schema here
         vol.Optional(CONF_ENABLED_BY_DEFAULT, default=True): cv.boolean,

--- a/homeassistant/components/mqtt/scene.py
+++ b/homeassistant/components/mqtt/scene.py
@@ -26,7 +26,7 @@ from .mixins import (
     async_setup_entry_helper,
     warn_for_legacy_schema,
 )
-from .util import valid_publish_topic
+from .util import valid_printable_string, valid_publish_topic
 
 DEFAULT_NAME = "MQTT Scene"
 DEFAULT_RETAIN = False
@@ -35,11 +35,11 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_ICON): cv.icon,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_ON): valid_printable_string,
+        vol.Optional(CONF_UNIQUE_ID): valid_printable_string,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        vol.Optional(CONF_OBJECT_ID): cv.string,
+        vol.Optional(CONF_OBJECT_ID): valid_printable_string,
         # CONF_ENABLED_BY_DEFAULT is not added by default because
         # we are not using the common schema here
         vol.Optional(CONF_ENABLED_BY_DEFAULT, default=True): cv.boolean,

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -41,7 +41,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ MQTT_SELECT_ATTRIBUTES_BLOCKED = frozenset(
 PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Required(CONF_OPTIONS): cv.ensure_list,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     },

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -41,7 +41,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ MQTT_SELECT_ATTRIBUTES_BLOCKED = frozenset(
 PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Required(CONF_OPTIONS): cv.ensure_list,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     },

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -53,7 +53,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_subscribe_topic
+from .util import get_mqtt_data, valid_printable_string, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,9 +103,9 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
         vol.Optional(CONF_LAST_RESET_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_STATE_CLASS): vol.Any(STATE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): valid_printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -53,7 +53,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string, valid_subscribe_topic
+from .util import get_mqtt_data, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,9 +103,9 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
         vol.Optional(CONF_LAST_RESET_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_STATE_CLASS): vol.Any(STATE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): valid_printable_string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.printable_string,
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/siren.py
+++ b/homeassistant/components/mqtt/siren.py
@@ -62,7 +62,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 DEFAULT_NAME = "MQTT Siren"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -84,11 +84,15 @@ PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_AVAILABLE_TONES): cv.ensure_list,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_COMMAND_OFF_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
-        vol.Optional(CONF_STATE_OFF): cv.string,
-        vol.Optional(CONF_STATE_ON): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+        ): valid_printable_string,
+        vol.Optional(CONF_STATE_OFF): valid_printable_string,
+        vol.Optional(CONF_STATE_ON): valid_printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_SUPPORT_DURATION, default=True): cv.boolean,
         vol.Optional(CONF_SUPPORT_VOLUME_SET, default=True): cv.boolean,

--- a/homeassistant/components/mqtt/siren.py
+++ b/homeassistant/components/mqtt/siren.py
@@ -62,7 +62,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 DEFAULT_NAME = "MQTT Siren"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -84,15 +84,13 @@ PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_AVAILABLE_TONES): cv.ensure_list,
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_COMMAND_OFF_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-        ): valid_printable_string,
-        vol.Optional(CONF_STATE_OFF): valid_printable_string,
-        vol.Optional(CONF_STATE_ON): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.printable_string,
+        vol.Optional(CONF_STATE_OFF): cv.printable_string,
+        vol.Optional(CONF_STATE_ON): cv.printable_string,
         vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_SUPPORT_DURATION, default=True): cv.boolean,
         vol.Optional(CONF_SUPPORT_VOLUME_SET, default=True): cv.boolean,

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -44,7 +44,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 DEFAULT_NAME = "MQTT Switch"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -54,11 +54,15 @@ CONF_STATE_OFF = "state_off"
 
 PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
-        vol.Optional(CONF_STATE_OFF): cv.string,
-        vol.Optional(CONF_STATE_ON): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
+        ): valid_printable_string,
+        vol.Optional(
+            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
+        ): valid_printable_string,
+        vol.Optional(CONF_STATE_OFF): valid_printable_string,
+        vol.Optional(CONF_STATE_ON): valid_printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
     }

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -44,7 +44,7 @@ from .mixins import (
     warn_for_legacy_schema,
 )
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 DEFAULT_NAME = "MQTT Switch"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -54,15 +54,13 @@ CONF_STATE_OFF = "state_off"
 
 PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(
             CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF
-        ): valid_printable_string,
-        vol.Optional(
-            CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON
-        ): valid_printable_string,
-        vol.Optional(CONF_STATE_OFF): valid_printable_string,
-        vol.Optional(CONF_STATE_ON): valid_printable_string,
+        ): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.printable_string,
+        vol.Optional(CONF_STATE_OFF): cv.printable_string,
+        vol.Optional(CONF_STATE_ON): cv.printable_string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
     }

--- a/homeassistant/components/mqtt/text.py
+++ b/homeassistant/components/mqtt/text.py
@@ -43,7 +43,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data
+from .util import get_mqtt_data, valid_printable_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def valid_text_size_configuration(config: ConfigType) -> ConfigType:
 _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
         vol.Optional(CONF_MAX, default=MAX_LENGTH_STATE_STATE): cv.positive_int,
         vol.Optional(CONF_MIN, default=0): cv.positive_int,
         vol.Optional(CONF_MODE, default=text.TextMode.TEXT): vol.In(

--- a/homeassistant/components/mqtt/text.py
+++ b/homeassistant/components/mqtt/text.py
@@ -43,7 +43,7 @@ from .models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from .util import get_mqtt_data, valid_printable_string
+from .util import get_mqtt_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def valid_text_size_configuration(config: ConfigType) -> ConfigType:
 _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
         vol.Optional(CONF_MAX, default=MAX_LENGTH_STATE_STATE): cv.positive_int,
         vol.Optional(CONF_MIN, default=0): cv.positive_int,
         vol.Optional(CONF_MODE, default=text.TextMode.TEXT): vol.In(

--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -36,12 +36,7 @@ from .const import (
 from .debug_info import log_messages
 from .mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import (
-    get_mqtt_data,
-    valid_printable_string,
-    valid_publish_topic,
-    valid_subscribe_topic,
-)
+from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,15 +55,15 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_ENTITY_PICTURE): valid_printable_string,
+        vol.Optional(CONF_ENTITY_PICTURE): cv.printable_string,
         vol.Optional(CONF_LATEST_VERSION_TEMPLATE): cv.template,
         vol.Optional(CONF_LATEST_VERSION_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
-        vol.Optional(CONF_PAYLOAD_INSTALL): valid_printable_string,
-        vol.Optional(CONF_RELEASE_SUMMARY): valid_printable_string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
+        vol.Optional(CONF_PAYLOAD_INSTALL): cv.printable_string,
+        vol.Optional(CONF_RELEASE_SUMMARY): cv.printable_string,
         vol.Optional(CONF_RELEASE_URL): cv.url,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        vol.Optional(CONF_TITLE): valid_printable_string,
+        vol.Optional(CONF_TITLE): cv.printable_string,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -36,7 +36,12 @@ from .const import (
 from .debug_info import log_messages
 from .mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 from .models import MqttValueTemplate, ReceiveMessage
-from .util import get_mqtt_data, valid_publish_topic, valid_subscribe_topic
+from .util import (
+    get_mqtt_data,
+    valid_printable_string,
+    valid_publish_topic,
+    valid_subscribe_topic,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,15 +60,15 @@ PLATFORM_SCHEMA_MODERN = MQTT_RO_SCHEMA.extend(
     {
         vol.Optional(CONF_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_DEVICE_CLASS): vol.Any(DEVICE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_ENTITY_PICTURE): cv.string,
+        vol.Optional(CONF_ENTITY_PICTURE): valid_printable_string,
         vol.Optional(CONF_LATEST_VERSION_TEMPLATE): cv.template,
         vol.Optional(CONF_LATEST_VERSION_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PAYLOAD_INSTALL): cv.string,
-        vol.Optional(CONF_RELEASE_SUMMARY): cv.string,
-        vol.Optional(CONF_RELEASE_URL): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+        vol.Optional(CONF_PAYLOAD_INSTALL): valid_printable_string,
+        vol.Optional(CONF_RELEASE_SUMMARY): valid_printable_string,
+        vol.Optional(CONF_RELEASE_URL): cv.url,
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-        vol.Optional(CONF_TITLE): cv.string,
+        vol.Optional(CONF_TITLE): valid_printable_string,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -41,6 +41,14 @@ def mqtt_config_entry_enabled(hass: HomeAssistant) -> bool | None:
     return not bool(hass.config_entries.async_entries(DOMAIN)[0].disabled_by)
 
 
+def valid_printable_string(name: Any) -> str:
+    """Validate the supplied string is a valid printble string."""
+    validated_string = cv.string(name)
+    if not validated_string.isprintable():
+        raise vol.Invalid("The string contains non printable characters.")
+    return validated_string
+
+
 def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter."""
     validated_topic = cv.string(topic)
@@ -121,7 +129,7 @@ def valid_qos_schema(qos: Any) -> int:
 _MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_TOPIC): valid_publish_topic,
-        vol.Required(ATTR_PAYLOAD): cv.string,
+        vol.Required(ATTR_PAYLOAD): valid_printable_string,
         vol.Optional(ATTR_QOS, default=DEFAULT_QOS): valid_qos_schema,
         vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     },

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -41,14 +41,6 @@ def mqtt_config_entry_enabled(hass: HomeAssistant) -> bool | None:
     return not bool(hass.config_entries.async_entries(DOMAIN)[0].disabled_by)
 
 
-def valid_printable_string(name: Any) -> str:
-    """Validate the supplied string is a valid printble string."""
-    validated_string = cv.string(name)
-    if not validated_string.isprintable():
-        raise vol.Invalid("The string contains non printable characters.")
-    return validated_string
-
-
 def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter."""
     validated_topic = cv.string(topic)
@@ -129,7 +121,7 @@ def valid_qos_schema(qos: Any) -> int:
 _MQTT_WILL_BIRTH_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_TOPIC): valid_publish_topic,
-        vol.Required(ATTR_PAYLOAD): valid_printable_string,
+        vol.Required(ATTR_PAYLOAD): cv.printable_string,
         vol.Optional(ATTR_QOS, default=DEFAULT_QOS): valid_qos_schema,
         vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
     },

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -33,7 +33,7 @@ from ..models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from ..util import get_mqtt_data, valid_publish_topic
+from ..util import get_mqtt_data, valid_printable_string, valid_publish_topic
 from .const import MQTT_VACUUM_ATTRIBUTES_BLOCKED
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 
@@ -123,30 +123,32 @@ PLATFORM_SCHEMA_LEGACY_MODERN = (
             vol.Inclusive(CONF_ERROR_TEMPLATE, "error"): cv.template,
             vol.Inclusive(CONF_ERROR_TOPIC, "error"): valid_publish_topic,
             vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
-                cv.ensure_list, [cv.string]
+                cv.ensure_list, [valid_printable_string]
             ),
             vol.Inclusive(CONF_FAN_SPEED_TEMPLATE, "fan_speed"): cv.template,
             vol.Inclusive(CONF_FAN_SPEED_TOPIC, "fan_speed"): valid_publish_topic,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_CLEAN_SPOT, default=DEFAULT_PAYLOAD_CLEAN_SPOT
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_LOCATE, default=DEFAULT_PAYLOAD_LOCATE
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_RETURN_TO_BASE, default=DEFAULT_PAYLOAD_RETURN_TO_BASE
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_START_PAUSE, default=DEFAULT_PAYLOAD_START_PAUSE
-            ): cv.string,
-            vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
+            ): valid_printable_string,
+            vol.Optional(
+                CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_TURN_OFF, default=DEFAULT_PAYLOAD_TURN_OFF
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_TURN_ON, default=DEFAULT_PAYLOAD_TURN_ON
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(CONF_SEND_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_SET_FAN_SPEED_TOPIC): valid_publish_topic,
             vol.Optional(

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -33,7 +33,7 @@ from ..models import (
     ReceiveMessage,
     ReceivePayloadType,
 )
-from ..util import get_mqtt_data, valid_printable_string, valid_publish_topic
+from ..util import get_mqtt_data, valid_publish_topic
 from .const import MQTT_VACUUM_ATTRIBUTES_BLOCKED
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 
@@ -123,32 +123,32 @@ PLATFORM_SCHEMA_LEGACY_MODERN = (
             vol.Inclusive(CONF_ERROR_TEMPLATE, "error"): cv.template,
             vol.Inclusive(CONF_ERROR_TOPIC, "error"): valid_publish_topic,
             vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
-                cv.ensure_list, [valid_printable_string]
+                cv.ensure_list, [cv.printable_string]
             ),
             vol.Inclusive(CONF_FAN_SPEED_TEMPLATE, "fan_speed"): cv.template,
             vol.Inclusive(CONF_FAN_SPEED_TOPIC, "fan_speed"): valid_publish_topic,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_CLEAN_SPOT, default=DEFAULT_PAYLOAD_CLEAN_SPOT
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_LOCATE, default=DEFAULT_PAYLOAD_LOCATE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_RETURN_TO_BASE, default=DEFAULT_PAYLOAD_RETURN_TO_BASE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_START_PAUSE, default=DEFAULT_PAYLOAD_START_PAUSE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_TURN_OFF, default=DEFAULT_PAYLOAD_TURN_OFF
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_TURN_ON, default=DEFAULT_PAYLOAD_TURN_ON
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(CONF_SEND_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_SET_FAN_SPEED_TOPIC): valid_publish_topic,
             vol.Optional(

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -40,7 +40,7 @@ from ..const import (
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, warn_for_legacy_schema
 from ..models import ReceiveMessage
-from ..util import get_mqtt_data, valid_publish_topic
+from ..util import get_mqtt_data, valid_printable_string, valid_publish_topic
 from .const import MQTT_VACUUM_ATTRIBUTES_BLOCKED
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 
@@ -125,21 +125,27 @@ PLATFORM_SCHEMA_STATE_MODERN = (
     MQTT_BASE_SCHEMA.extend(
         {
             vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
-                cv.ensure_list, [cv.string]
+                cv.ensure_list, [valid_printable_string]
             ),
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_CLEAN_SPOT, default=DEFAULT_PAYLOAD_CLEAN_SPOT
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_LOCATE, default=DEFAULT_PAYLOAD_LOCATE
-            ): cv.string,
+            ): valid_printable_string,
             vol.Optional(
                 CONF_PAYLOAD_RETURN_TO_BASE, default=DEFAULT_PAYLOAD_RETURN_TO_BASE
-            ): cv.string,
-            vol.Optional(CONF_PAYLOAD_START, default=DEFAULT_PAYLOAD_START): cv.string,
-            vol.Optional(CONF_PAYLOAD_PAUSE, default=DEFAULT_PAYLOAD_PAUSE): cv.string,
-            vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
+            ): valid_printable_string,
+            vol.Optional(
+                CONF_PAYLOAD_START, default=DEFAULT_PAYLOAD_START
+            ): valid_printable_string,
+            vol.Optional(
+                CONF_PAYLOAD_PAUSE, default=DEFAULT_PAYLOAD_PAUSE
+            ): valid_printable_string,
+            vol.Optional(
+                CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP
+            ): valid_printable_string,
             vol.Optional(CONF_SEND_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_SET_FAN_SPEED_TOPIC): valid_publish_topic,
             vol.Optional(CONF_STATE_TOPIC): valid_publish_topic,

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -40,7 +40,7 @@ from ..const import (
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, warn_for_legacy_schema
 from ..models import ReceiveMessage
-from ..util import get_mqtt_data, valid_printable_string, valid_publish_topic
+from ..util import get_mqtt_data, valid_publish_topic
 from .const import MQTT_VACUUM_ATTRIBUTES_BLOCKED
 from .schema import MQTT_VACUUM_SCHEMA, services_to_strings, strings_to_services
 
@@ -125,27 +125,27 @@ PLATFORM_SCHEMA_STATE_MODERN = (
     MQTT_BASE_SCHEMA.extend(
         {
             vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
-                cv.ensure_list, [valid_printable_string]
+                cv.ensure_list, [cv.printable_string]
             ),
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): valid_printable_string,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_CLEAN_SPOT, default=DEFAULT_PAYLOAD_CLEAN_SPOT
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_LOCATE, default=DEFAULT_PAYLOAD_LOCATE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_RETURN_TO_BASE, default=DEFAULT_PAYLOAD_RETURN_TO_BASE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_START, default=DEFAULT_PAYLOAD_START
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_PAUSE, default=DEFAULT_PAYLOAD_PAUSE
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(
                 CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP
-            ): valid_printable_string,
+            ): cv.printable_string,
             vol.Optional(CONF_SEND_COMMAND_TOPIC): valid_publish_topic,
             vol.Optional(CONF_SET_FAN_SPEED_TOPIC): valid_publish_topic,
             vol.Optional(CONF_STATE_TOPIC): valid_publish_topic,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -569,6 +569,14 @@ def string(value: Any) -> str:
     return str(value)
 
 
+def printable_string(value: Any) -> str:
+    """Validate the supplied value is a valid printable string."""
+    validated_string = string(value)
+    if not validated_string.isprintable():
+        raise vol.Invalid("The string contains non printable characters.")
+    return validated_string
+
+
 def string_with_no_html(value: Any) -> str:
     """Validate that the value is a string without HTML."""
     value = string(value)

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -4,6 +4,7 @@ from random import getrandbits
 from unittest.mock import patch
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components import mqtt
 
@@ -47,3 +48,13 @@ async def test_reading_non_exitisting_certificate_file():
     assert (
         mqtt.util.migrate_certificate_file_to_content("/home/file_not_exists") is None
     )
+
+
+async def test_printable_name():
+    """Test reading a non existing certificate file."""
+    assert mqtt.util.valid_printable_string("äll")
+    assert mqtt.util.valid_printable_string("äll!@#$%^&*")
+    with pytest.raises(vol.Invalid):
+        assert mqtt.util.valid_printable_string("Invalid device name\u0000")
+    with pytest.raises(vol.Invalid):
+        assert mqtt.util.valid_printable_string("Invalid device name\n")

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -4,7 +4,6 @@ from random import getrandbits
 from unittest.mock import patch
 
 import pytest
-import voluptuous as vol
 
 from homeassistant.components import mqtt
 
@@ -48,13 +47,3 @@ async def test_reading_non_exitisting_certificate_file():
     assert (
         mqtt.util.migrate_certificate_file_to_content("/home/file_not_exists") is None
     )
-
-
-async def test_printable_name():
-    """Test reading a non existing certificate file."""
-    assert mqtt.util.valid_printable_string("äll")
-    assert mqtt.util.valid_printable_string("äll!@#$%^&*")
-    with pytest.raises(vol.Invalid):
-        assert mqtt.util.valid_printable_string("Invalid device name\u0000")
-    with pytest.raises(vol.Invalid):
-        assert mqtt.util.valid_printable_string("Invalid device name\n")

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -517,6 +517,19 @@ def test_string(hass):
         assert schema(result) == text
 
 
+async def test_printable_string():
+    """Test printable string validation."""
+
+    schema = vol.Schema(cv.printable_string)
+
+    assert schema("äll") == "äll"
+    assert schema("ä2ll!@#$%^&*") == "ä2ll!@#$%^&*"
+    with pytest.raises(vol.Invalid):
+        assert schema("Invalid device name\u0000")
+    with pytest.raises(vol.Invalid):
+        assert schema("Invalid device name\n")
+
+
 def test_string_with_no_html():
     """Test string with no html validation."""
     schema = vol.Schema(cv.string_with_no_html)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR adds a `cv.printable_string` validator to use in MQTT configuration options for (device) name, payloads ans states do disallow not printable characters. This to avoid processing configs in logging and diagnostics.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Check MQTT config string options like names, payload and and state definitions for non printable characters. 
Configurations will no longer be valid if a `name` `payload` or `state` configuration options contains non printable characters.
 
TODO add some tests to test invalid configs,
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #85691
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
