### PR TITLE
Update python version used for pylint [Py310]

### DIFF
--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -2,11 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import logging
-
-# Issue with Python 3.9.0 and 3.9.1 with collections.abc.Callable
-# https://bugs.python.org/issue42965
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -153,7 +153,7 @@ class KNXCommonFlow(ABC, FlowHandler):
         # keep a reference to the generator to scan in background until user selects a connection type
         self._async_scan_gen = self._gatewayscanner.async_scan()
         try:
-            await self._async_scan_gen.__anext__()
+            await anext(self._async_scan_gen)
         except StopAsyncIteration:
             pass  # scan finished, no interfaces discovered
         else:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1,11 +1,8 @@
 """Support for MQTT message handling."""
-# pylint: disable=deprecated-typing-alias
-#   In Python 3.9.0 and 3.9.1 collections.abc.Callable
-#   can't be used inside typing.Union or typing.Optional
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine, Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from functools import lru_cache, partial, wraps
 import inspect
 from itertools import groupby
@@ -13,7 +10,7 @@ import logging
 from operator import attrgetter
 import ssl
 import time
-from typing import TYPE_CHECKING, Any, Callable, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 import uuid
 
 import attr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ forced_separate = [
 combine_as_imports = true
 
 [tool.pylint.MAIN]
-py-version = "3.9"
+py-version = "3.10"
 ignore = [
     "tests",
 ]
@@ -164,6 +164,9 @@ good-names = [
 # Enable once current issues are fixed:
 # consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
 # consider-using-assignment-expr (Pylint CodeStyle extension)
+# ---
+# Temporary for the Python 3.10 update
+# consider-alternative-union-syntax
 disable = [
     "format",
     "abstract-method",
@@ -188,6 +191,7 @@ disable = [
     "consider-using-f-string",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
+    "consider-alternative-union-syntax",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/tests/components/anthemav/conftest.py
+++ b/tests/components/anthemav/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for anthemav integration tests."""
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/components/anthemav/test_init.py
+++ b/tests/components/anthemav/test_init.py
@@ -1,5 +1,5 @@
 """Test the Anthem A/V Receivers config flow."""
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import ANY, AsyncMock, patch
 
 from anthemav.device_error import DeviceError

--- a/tests/components/anthemav/test_media_player.py
+++ b/tests/components/anthemav/test_media_player.py
@@ -1,5 +1,5 @@
 """Test the Anthem A/V Receivers config flow."""
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import AsyncMock
 
 import pytest

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -2,10 +2,10 @@
 # pylint: disable=invalid-name
 import asyncio
 import collections
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
-from typing import Callable
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -1,6 +1,5 @@
 """Test pushbullet integration."""
-from collections.abc import Awaitable
-from typing import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 import aiohttp

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import Mock
 
 from pyunifiprotect import ProtectApiClient

--- a/tests/components/wiz/__init__.py
+++ b/tests/components/wiz/__init__.py
@@ -1,9 +1,9 @@
 """Tests for the WiZ Platform integration."""
 
+from collections.abc import Callable
 from contextlib import contextmanager
 from copy import deepcopy
 import json
-from typing import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pywizlight import SCENES, BulbType, PilotParser, wizlight


### PR DESCRIPTION
## Proposed change
Update `py-version` setting for pylint.
* `Callable` can now safely be imported from `collections.abc` the issue with Python 3.9.0 isn't relevant anymore.
* `anext` is a builtin in Python 3.10
* Temporarily disabled `consider-alternative-union-syntax` to resolve a race condition and not have to do all changes in one PR, keeping it reviewable. Once `Optional` and `Union` are updated, I'll enable it again.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
