### PR TITLE
Update Optional typing (2) [Py310]

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -1,8 +1,6 @@
 """Support for Aranet sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from aranet4.client import Aranet4Advertisement
 from bleak.backends.device import BLEDevice
 
@@ -145,9 +143,7 @@ async def async_setup_entry(
 
 
 class Aranet4BluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of an Aranet sensor."""

--- a/homeassistant/components/bluemaestro/sensor.py
+++ b/homeassistant/components/bluemaestro/sensor.py
@@ -1,8 +1,6 @@
 """Support for BlueMaestro sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from bluemaestro_ble import (
     SensorDeviceClass as BlueMaestroSensorDeviceClass,
     SensorUpdate,
@@ -137,9 +135,7 @@ async def async_setup_entry(
 
 
 class BlueMaestroBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a BlueMaestro sensor."""

--- a/homeassistant/components/bthome/sensor.py
+++ b/homeassistant/components/bthome/sensor.py
@@ -1,8 +1,6 @@
 """Support for BTHome sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from bthome_ble import SensorDeviceClass as BTHomeSensorDeviceClass, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -332,9 +330,7 @@ async def async_setup_entry(
 
 
 class BTHomeBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a BTHome BLE sensor."""

--- a/homeassistant/components/dlna_dmr/config_flow.py
+++ b/homeassistant/components/dlna_dmr/config_flow.py
@@ -6,7 +6,7 @@ from functools import partial
 from ipaddress import IPv6Address, ip_address
 import logging
 from pprint import pformat
-from typing import Any, Optional, cast
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from async_upnp_client.client import UpnpError
@@ -36,7 +36,7 @@ from .data import get_domain_data
 
 LOGGER = logging.getLogger(__name__)
 
-FlowInput = Optional[Mapping[str, Any]]
+FlowInput = Mapping[str, Any] | None
 
 
 class ConnectError(IntegrationError):

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for govee ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from govee_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 from govee_ble.parser import ERROR
 
@@ -117,7 +115,7 @@ async def async_setup_entry(
 
 class GoveeBluetoothSensorEntity(
     PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int, str]]]
+        PassiveBluetoothDataProcessor[float | int | str | None]
     ],
     SensorEntity,
 ):

--- a/homeassistant/components/inkbird/sensor.py
+++ b/homeassistant/components/inkbird/sensor.py
@@ -1,8 +1,6 @@
 """Support for inkbird ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from inkbird_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -115,9 +113,7 @@ async def async_setup_entry(
 
 
 class INKBIRDBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a inkbird ble sensor."""

--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -1,8 +1,6 @@
 """Support for Kegtron sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from kegtron_ble import (
     SensorDeviceClass as KegtronSensorDeviceClass,
     SensorUpdate,
@@ -126,9 +124,7 @@ async def async_setup_entry(
 
 
 class KegtronBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a Kegtron sensor."""

--- a/homeassistant/components/moat/sensor.py
+++ b/homeassistant/components/moat/sensor.py
@@ -1,8 +1,6 @@
 """Support for moat ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from moat_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -122,9 +120,7 @@ async def async_setup_entry(
 
 
 class MoatBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a moat ble sensor."""

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import (
@@ -123,7 +123,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
 
 
 class SlaveSensor(
-    CoordinatorEntity[DataUpdateCoordinator[Optional[list[int]]]],
+    CoordinatorEntity[DataUpdateCoordinator[list[int] | None]],
     RestoreEntity,
     BinarySensorEntity,
 ):

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.components.sensor import CONF_STATE_CLASS, SensorEntity
 from homeassistant.const import (
@@ -134,7 +134,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
 
 
 class SlaveSensor(
-    CoordinatorEntity[DataUpdateCoordinator[Optional[list[int]]]],
+    CoordinatorEntity[DataUpdateCoordinator[list[int] | None]],
     RestoreEntity,
     SensorEntity,
 ):

--- a/homeassistant/components/oralb/sensor.py
+++ b/homeassistant/components/oralb/sensor.py
@@ -1,8 +1,6 @@
 """Support for OralB sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from oralb_ble import OralBSensor, SensorUpdate
 
 from homeassistant import config_entries
@@ -117,9 +115,7 @@ async def async_setup_entry(
 
 
 class OralBBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[str, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[str | int | None]],
     SensorEntity,
 ):
     """Representation of a OralB sensor."""

--- a/homeassistant/components/qingping/sensor.py
+++ b/homeassistant/components/qingping/sensor.py
@@ -1,8 +1,6 @@
 """Support for Qingping sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from qingping_ble import (
     SensorDeviceClass as QingpingSensorDeviceClass,
     SensorUpdate,
@@ -161,9 +159,7 @@ async def async_setup_entry(
 
 
 class QingpingBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a Qingping sensor."""

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for RuuviTag sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from sensor_state_data import (
     DeviceKey,
     SensorDescription,
@@ -143,9 +141,7 @@ async def async_setup_entry(
 
 
 class RuuvitagBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a Ruuvitag BLE sensor."""

--- a/homeassistant/components/sensirion_ble/sensor.py
+++ b/homeassistant/components/sensirion_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for Sensirion sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from sensor_state_data import (
     DeviceKey,
     SensorDescription,
@@ -123,9 +121,7 @@ async def async_setup_entry(
 
 
 class SensirionBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a Sensirion BLE sensor."""

--- a/homeassistant/components/sensorpro/sensor.py
+++ b/homeassistant/components/sensorpro/sensor.py
@@ -1,8 +1,6 @@
 """Support for SensorPro sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from sensorpro_ble import (
     SensorDeviceClass as SensorProSensorDeviceClass,
     SensorUpdate,
@@ -128,9 +126,7 @@ async def async_setup_entry(
 
 
 class SensorProBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a SensorPro sensor."""

--- a/homeassistant/components/sensorpush/sensor.py
+++ b/homeassistant/components/sensorpush/sensor.py
@@ -1,8 +1,6 @@
 """Support for sensorpush ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from sensorpush_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -116,9 +114,7 @@ async def async_setup_entry(
 
 
 class SensorPushBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a sensorpush ble sensor."""

--- a/homeassistant/components/thermobeacon/sensor.py
+++ b/homeassistant/components/thermobeacon/sensor.py
@@ -1,8 +1,6 @@
 """Support for ThermoBeacon sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from thermobeacon_ble import (
     SensorDeviceClass as ThermoBeaconSensorDeviceClass,
     SensorUpdate,
@@ -128,9 +126,7 @@ async def async_setup_entry(
 
 
 class ThermoBeaconBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a ThermoBeacon sensor."""

--- a/homeassistant/components/thermopro/sensor.py
+++ b/homeassistant/components/thermopro/sensor.py
@@ -1,8 +1,6 @@
 """Support for thermopro ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from thermopro_ble import (
     DeviceKey,
     SensorDeviceClass as ThermoProSensorDeviceClass,
@@ -117,9 +115,7 @@ async def async_setup_entry(
 
 
 class ThermoProBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a thermopro ble sensor."""

--- a/homeassistant/components/tilt_ble/sensor.py
+++ b/homeassistant/components/tilt_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for Tilt Hydrometers."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from tilt_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -103,9 +101,7 @@ async def async_setup_entry(
 
 
 class TiltBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a Tilt Hydrometer BLE sensor."""

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for xiaomi ble sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from xiaomi_ble import DeviceClass, SensorUpdate, Units
 
 from homeassistant import config_entries
@@ -162,9 +160,7 @@ async def async_setup_entry(
 
 
 class XiaomiBluetoothSensorEntity(
-    PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
-    ],
+    PassiveBluetoothProcessorEntity[PassiveBluetoothDataProcessor[float | int | None]],
     SensorEntity,
 ):
     """Representation of a xiaomi ble sensor."""

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,7 +1,7 @@
 """Typing Helpers for Home Assistant."""
 from collections.abc import Mapping
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import homeassistant.core
 
@@ -12,7 +12,7 @@ DiscoveryInfoType = dict[str, Any]
 EventType = homeassistant.core.Event
 ServiceDataType = dict[str, Any]
 StateType = Union[None, str, int, float]
-TemplateVarsType = Optional[Mapping[str, Any]]
+TemplateVarsType = Mapping[str, Any] | None
 
 # Custom type for recorder Queries
 QueryType = Any

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,7 +1,7 @@
 """Typing Helpers for Home Assistant."""
 from collections.abc import Mapping
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 import homeassistant.core
 
@@ -11,7 +11,7 @@ ContextType = homeassistant.core.Context
 DiscoveryInfoType = dict[str, Any]
 EventType = homeassistant.core.Event
 ServiceDataType = dict[str, Any]
-StateType = Union[None, str, int, float]
+StateType = str | int | float | None
 TemplateVarsType = Mapping[str, Any] | None
 
 # Custom type for recorder Queries


### PR DESCRIPTION
## Proposed change
Update Optional typing to use new union syntax. Python 3.10 does support it at runtime.

Requires
* #86414

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
