### PR TITLE
Update Union typing (5) [Py310]

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -7,7 +7,7 @@ from enum import Enum
 from functools import wraps
 import logging
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, overload
 
 import voluptuous as vol
 import voluptuous_serialize
@@ -43,12 +43,13 @@ if TYPE_CHECKING:
     from .condition import DeviceAutomationConditionProtocol
     from .trigger import DeviceAutomationTriggerProtocol
 
-    DeviceAutomationPlatformType = Union[
-        ModuleType,
-        DeviceAutomationTriggerProtocol,
-        DeviceAutomationConditionProtocol,
-        DeviceAutomationActionProtocol,
-    ]
+    DeviceAutomationPlatformType: TypeAlias = (
+        ModuleType
+        | DeviceAutomationTriggerProtocol
+        | DeviceAutomationConditionProtocol
+        | DeviceAutomationActionProtocol
+    )
+
 
 DOMAIN = "device_automation"
 

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -1,7 +1,7 @@
 """Support for switch platform for Hue resources (V2 only)."""
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, TypeAlias
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -22,9 +22,9 @@ from .bridge import HueBridge
 from .const import DOMAIN
 from .v2.entity import HueBaseEntity
 
-ControllerType = Union[LightLevelController, MotionController]
+ControllerType: TypeAlias = LightLevelController | MotionController
 
-SensingService = Union[LightLevel, Motion]
+SensingService: TypeAlias = LightLevel | Motion
 
 
 async def async_setup_entry(

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Hue binary sensors."""
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, TypeAlias
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.config import (
@@ -25,8 +25,8 @@ from ..bridge import HueBridge
 from ..const import DOMAIN
 from .entity import HueBaseEntity
 
-SensorType = Union[Motion, EntertainmentConfiguration]
-ControllerType = Union[MotionController, EntertainmentConfigurationController]
+SensorType: TypeAlias = Motion | EntertainmentConfiguration
+ControllerType: TypeAlias = MotionController | EntertainmentConfigurationController
 
 
 async def async_setup_entry(

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -1,7 +1,7 @@
 """Generic Hue Entity Model."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, TypeAlias
 
 from aiohue.v2.controllers.base import BaseResourcesController
 from aiohue.v2.controllers.events import EventType
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from aiohue.v2.models.light_level import LightLevel
     from aiohue.v2.models.motion import Motion
 
-    HueResource = Union[Light, DevicePower, GroupedLight, LightLevel, Motion]
+    HueResource: TypeAlias = Light | DevicePower | GroupedLight | LightLevel | Motion
 
 
 RESOURCE_TYPE_NAMES = {

--- a/homeassistant/components/hue/v2/sensor.py
+++ b/homeassistant/components/hue/v2/sensor.py
@@ -1,7 +1,7 @@
 """Support for Hue sensors."""
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, TypeAlias
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -32,13 +32,13 @@ from ..bridge import HueBridge
 from ..const import DOMAIN
 from .entity import HueBaseEntity
 
-SensorType = Union[DevicePower, LightLevel, Temperature, ZigbeeConnectivity]
-ControllerType = Union[
-    DevicePowerController,
-    LightLevelController,
-    TemperatureController,
-    ZigbeeConnectivityController,
-]
+SensorType: TypeAlias = DevicePower | LightLevel | Temperature | ZigbeeConnectivity
+ControllerType: TypeAlias = (
+    DevicePowerController
+    | LightLevelController
+    | TemperatureController
+    | ZigbeeConnectivityController
+)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -5,7 +5,7 @@ import asyncio
 from copy import deepcopy
 from itertools import chain
 import re
-from typing import Union, cast
+from typing import TypeAlias, cast
 
 import pypck
 import voluptuous as vol
@@ -60,9 +60,10 @@ from .const import (
 
 # typing
 AddressType = tuple[int, int, bool]
-DeviceConnectionType = Union[
-    pypck.module.ModuleConnection, pypck.module.GroupConnection
-]
+DeviceConnectionType: TypeAlias = (
+    pypck.module.ModuleConnection | pypck.module.GroupConnection
+)
+
 InputType = type[pypck.inputs.Input]
 
 # Regex for address validation


### PR DESCRIPTION
## Proposed change
Update Union typing to use new syntax. Python 3.10 does support it at runtime.

Requires
* #86414

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
