### PR TITLE
Delete caches after PR is closed [ci]

### DIFF
--- a/.github/workflows/cache_pr.yml
+++ b/.github/workflows/cache_pr.yml
@@ -1,0 +1,54 @@
+name: Delete Caches (PR)
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Closed PR number"
+        type: string
+        required: true
+
+jobs:
+  delete:
+    name: Delete caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Delete caches
+        run: |
+          ref="refs/pull/${{ github.event.inputs.pr-number || github.event.number }}/merge"
+          sort="last_accessed_at"
+          del_count=0
+
+          res=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/actions/caches?sort=$sort)
+
+          res_count=$(echo "$res" | jq '.actions_caches | length')
+          if [[ "$res_count" -eq 0 ]]; then exit; fi
+
+          targets=$(echo "$res" | jq \
+            --arg ref "$ref" \
+            '.actions_caches[] | select(.ref == $ref)
+              | del(.created_at, .size_in_bytes, .version)')
+          targets_count=$(echo "$targets" | jq -s 'length')
+          if [[ "$targets_count" -eq 0 ]]; then exit; fi
+          echo "Found $targets_count caches"
+          echo "$targets"
+
+          for id in $(echo "$targets" | jq '.id'); do
+            echo "Delete cache with id: $id ..."
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/actions/caches/$id
+            (( del_count += 1 ))
+          done
+
+          echo "Deleted $del_count caches"


### PR DESCRIPTION
## Proposed change
Add workflow to delete caches after a PR is closed. This will help cleanup old caches and can improve the cache hit rate, requiring fewer cache rebuilds.

Due to scoping rules, a cache is only reused from (a) the default branch, (b) the base branch for the PR, or (c) the current feature branch. For Home Assistant, almost all development is based on the default `dev` branch, so it isn't necessary to keep caches around after a PR is closed. In the few other cases, it's still easily rebuild for a new PR.
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

A version of this was initially implemented in #80898 but reverted due to hitting the rate limit when combined with other actions. Now that Python 3.9 was dropped, we could give it another go. If we end up hitting the limit again, it's also possible to temporarily disable the workflow for the Github actions web interface. That would still allow forks to use it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
