### PR TITLE
Rename fake kitchen_sink demo locks to more common name

### DIFF
--- a/homeassistant/components/kitchen_sink/lock.py
+++ b/homeassistant/components/kitchen_sink/lock.py
@@ -22,24 +22,24 @@ async def async_setup_platform(
         [
             DemoLock(
                 "kitchen_sink_lock_001",
-                "Openable kitchen sink lock",
+                "Openable lock",
                 STATE_LOCKED,
                 LockEntityFeature.OPEN,
             ),
             DemoLock(
                 "kitchen_sink_lock_002",
-                "Another kitchen sink openable lock",
+                "Another openable lock",
                 STATE_UNLOCKED,
                 LockEntityFeature.OPEN,
             ),
             DemoLock(
                 "kitchen_sink_lock_003",
-                "Basic kitchen sink lock",
+                "Basic lock",
                 STATE_LOCKED,
             ),
             DemoLock(
                 "kitchen_sink_lock_004",
-                "Another kitchen sink lock",
+                "Another basic lock",
                 STATE_UNLOCKED,
             ),
         ]

--- a/tests/components/group/test_lock.py
+++ b/tests/components/group/test_lock.py
@@ -183,8 +183,8 @@ async def test_service_calls_openable(hass: HomeAssistant) -> None:
                 {
                     "platform": DOMAIN,
                     "entities": [
-                        "lock.openable_kitchen_sink_lock",
-                        "lock.another_kitchen_sink_openable_lock",
+                        "lock.openable_lock",
+                        "lock.another_openable_lock",
                     ],
                 },
             ]
@@ -194,11 +194,8 @@ async def test_service_calls_openable(hass: HomeAssistant) -> None:
 
     group_state = hass.states.get("lock.lock_group")
     assert group_state.state == STATE_UNLOCKED
-    assert hass.states.get("lock.openable_kitchen_sink_lock").state == STATE_LOCKED
-    assert (
-        hass.states.get("lock.another_kitchen_sink_openable_lock").state
-        == STATE_UNLOCKED
-    )
+    assert hass.states.get("lock.openable_lock").state == STATE_LOCKED
+    assert hass.states.get("lock.another_openable_lock").state == STATE_UNLOCKED
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -206,11 +203,8 @@ async def test_service_calls_openable(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "lock.lock_group"},
         blocking=True,
     )
-    assert hass.states.get("lock.openable_kitchen_sink_lock").state == STATE_UNLOCKED
-    assert (
-        hass.states.get("lock.another_kitchen_sink_openable_lock").state
-        == STATE_UNLOCKED
-    )
+    assert hass.states.get("lock.openable_lock").state == STATE_UNLOCKED
+    assert hass.states.get("lock.another_openable_lock").state == STATE_UNLOCKED
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -218,10 +212,8 @@ async def test_service_calls_openable(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "lock.lock_group"},
         blocking=True,
     )
-    assert hass.states.get("lock.openable_kitchen_sink_lock").state == STATE_LOCKED
-    assert (
-        hass.states.get("lock.another_kitchen_sink_openable_lock").state == STATE_LOCKED
-    )
+    assert hass.states.get("lock.openable_lock").state == STATE_LOCKED
+    assert hass.states.get("lock.another_openable_lock").state == STATE_LOCKED
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -229,11 +221,8 @@ async def test_service_calls_openable(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "lock.lock_group"},
         blocking=True,
     )
-    assert hass.states.get("lock.openable_kitchen_sink_lock").state == STATE_UNLOCKED
-    assert (
-        hass.states.get("lock.another_kitchen_sink_openable_lock").state
-        == STATE_UNLOCKED
-    )
+    assert hass.states.get("lock.openable_lock").state == STATE_UNLOCKED
+    assert hass.states.get("lock.another_openable_lock").state == STATE_UNLOCKED
 
 
 async def test_service_calls_basic(hass: HomeAssistant) -> None:
@@ -247,8 +236,8 @@ async def test_service_calls_basic(hass: HomeAssistant) -> None:
                 {
                     "platform": DOMAIN,
                     "entities": [
-                        "lock.basic_kitchen_sink_lock",
-                        "lock.another_kitchen_sink_lock",
+                        "lock.basic_lock",
+                        "lock.another_basic_lock",
                     ],
                 },
             ]
@@ -258,8 +247,8 @@ async def test_service_calls_basic(hass: HomeAssistant) -> None:
 
     group_state = hass.states.get("lock.lock_group")
     assert group_state.state == STATE_UNLOCKED
-    assert hass.states.get("lock.basic_kitchen_sink_lock").state == STATE_LOCKED
-    assert hass.states.get("lock.another_kitchen_sink_lock").state == STATE_UNLOCKED
+    assert hass.states.get("lock.basic_lock").state == STATE_LOCKED
+    assert hass.states.get("lock.another_basic_lock").state == STATE_UNLOCKED
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -267,8 +256,8 @@ async def test_service_calls_basic(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "lock.lock_group"},
         blocking=True,
     )
-    assert hass.states.get("lock.basic_kitchen_sink_lock").state == STATE_LOCKED
-    assert hass.states.get("lock.another_kitchen_sink_lock").state == STATE_LOCKED
+    assert hass.states.get("lock.basic_lock").state == STATE_LOCKED
+    assert hass.states.get("lock.another_basic_lock").state == STATE_LOCKED
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -276,8 +265,8 @@ async def test_service_calls_basic(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "lock.lock_group"},
         blocking=True,
     )
-    assert hass.states.get("lock.basic_kitchen_sink_lock").state == STATE_UNLOCKED
-    assert hass.states.get("lock.another_kitchen_sink_lock").state == STATE_UNLOCKED
+    assert hass.states.get("lock.basic_lock").state == STATE_UNLOCKED
+    assert hass.states.get("lock.another_basic_lock").state == STATE_UNLOCKED
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up on #85842

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
