### PR TITLE
Update Union typing (zha) [Py310]

### DIFF
--- a/homeassistant/components/zha/core/decorators.py
+++ b/homeassistant/components/zha/core/decorators.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 _TypeT = TypeVar("_TypeT", bound=type[Any])
 
 
-class DictRegistry(dict[Union[int, str], _TypeT]):
+class DictRegistry(dict[int | str, _TypeT]):
     """Dict Registry of items."""
 
     def register(self, name: int | str) -> Callable[[_TypeT], _TypeT]:
@@ -21,7 +21,7 @@ class DictRegistry(dict[Union[int, str], _TypeT]):
         return decorator
 
 
-class SetRegistry(set[Union[int, str]]):
+class SetRegistry(set[int | str]):
     """Set Registry of items."""
 
     def register(self, name: int | str) -> Callable[[_TypeT], _TypeT]:

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 import traceback
-from typing import TYPE_CHECKING, Any, NamedTuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from zigpy.application import ControllerApplication
 from zigpy.config import CONF_DEVICE
@@ -91,7 +91,7 @@ if TYPE_CHECKING:
     from ..entity import ZhaEntity
     from .channels.base import ZigbeeChannel
 
-    _LogFilterType = Union[Filter, Callable[[LogRecord], int]]
+    _LogFilterType = Filter | Callable[[LogRecord], int]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -1,5 +1,6 @@
 """Test ZHA device switch."""
 from datetime import timedelta
+import logging
 import time
 from unittest import mock
 from unittest.mock import patch
@@ -224,6 +225,7 @@ async def test_check_available_no_basic_channel(
     hass, device_without_basic_channel, zha_device_restored, caplog
 ):
     """Check device availability for a device without basic cluster."""
+    caplog.set_level(logging.DEBUG, logger="homeassistant.components.zha")
 
     zha_device = await zha_device_restored(device_without_basic_channel)
     await async_enable_traffic(hass, [zha_device])


### PR DESCRIPTION
## Proposed change
Update Union typing to use new syntax. Python 3.10 does support it at runtime.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
