### PR TITLE
Drop unused dtype

### DIFF
--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TypeAlias
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -38,15 +37,12 @@ from .const import (
 )
 from .coordinator import ZamgDataUpdateCoordinator
 
-_DType: TypeAlias = "type[int] | type[float] | type[str]"
-
 
 @dataclass
 class ZamgRequiredKeysMixin:
     """Mixin for required keys."""
 
     para_name: str
-    dtype: _DType
 
 
 @dataclass
@@ -62,7 +58,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="P",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="pressure_sealevel",
@@ -71,7 +66,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="PRED",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="humidity",
@@ -80,7 +74,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="RFAM",
-        dtype=int,
     ),
     ZamgSensorEntityDescription(
         key="wind_speed",
@@ -89,7 +82,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.WIND_SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="FFAM",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="wind_bearing",
@@ -97,7 +89,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         native_unit_of_measurement=DEGREE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="DD",
-        dtype=int,
     ),
     ZamgSensorEntityDescription(
         key="wind_max_speed",
@@ -106,7 +97,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.WIND_SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="FFX",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="wind_max_bearing",
@@ -114,7 +104,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         native_unit_of_measurement=DEGREE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="DDX",
-        dtype=int,
     ),
     ZamgSensorEntityDescription(
         key="sun_last_10min",
@@ -122,7 +111,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="SO",
-        dtype=int,
     ),
     ZamgSensorEntityDescription(
         key="temperature",
@@ -131,7 +119,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="TL",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="temperature_average",
@@ -140,7 +127,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="TLAM",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="precipitation",
@@ -149,7 +135,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PRECIPITATION,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="RR",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="snow",
@@ -158,7 +143,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PRECIPITATION,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="SCHNEE",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="dewpoint",
@@ -167,7 +151,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="TP",
-        dtype=float,
     ),
     ZamgSensorEntityDescription(
         key="dewpoint_average",
@@ -176,7 +159,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         para_name="TPAM",
-        dtype=float,
     ),
 )
 


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/86454#discussion_r1084083695

`dtype` doesn't seem to be used anywhere.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
