### PR TITLE
Enable strict typing for the otbr integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -223,6 +223,7 @@ homeassistant.components.onewire.*
 homeassistant.components.open_meteo.*
 homeassistant.components.openexchangerates.*
 homeassistant.components.openuv.*
+homeassistant.components.otbr.*
 homeassistant.components.overkiz.*
 homeassistant.components.peco.*
 homeassistant.components.persistent_notification.*

--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -1,8 +1,10 @@
 """The Open Thread Border Router integration."""
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 import dataclasses
 from functools import wraps
+from typing import Any, Concatenate, ParamSpec, TypeVar
 
 import python_otbr_api
 
@@ -15,12 +17,17 @@ from homeassistant.helpers.typing import ConfigType
 from . import websocket_api
 from .const import DOMAIN
 
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
-def _handle_otbr_error(func):
+
+def _handle_otbr_error(
+    func: Callable[Concatenate[OTBRData, _P], Coroutine[Any, Any, _R]]
+) -> Callable[Concatenate[OTBRData, _P], Coroutine[Any, Any, _R]]:
     """Handle OTBR errors."""
 
     @wraps(func)
-    async def _func(self, *args, **kwargs):
+    async def _func(self: OTBRData, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         try:
             return await func(self, *args, **kwargs)
         except python_otbr_api.OTBRError as exc:

--- a/homeassistant/components/otbr/manifest.json
+++ b/homeassistant/components/otbr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Open Thread Border Router",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/otbr",
-  "requirements": ["python-otbr-api==1.0.1"],
+  "requirements": ["python-otbr-api==1.0.2"],
   "after_dependencies": ["hassio"],
   "codeowners": ["@home-assistant/core"],
   "iot_class": "local_polling",

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @callback
-def async_setup(hass) -> None:
+def async_setup(hass: HomeAssistant) -> None:
     """Set up the OTBR Websocket API."""
     async_register_command(hass, websocket_info)
 
@@ -44,13 +44,10 @@ async def websocket_info(
         connection.send_error(msg["id"], "get_dataset_failed", str(exc))
         return
 
-    if dataset:
-        dataset = dataset.hex()
-
     connection.send_result(
         msg["id"],
         {
             "url": data.url,
-            "active_dataset_tlvs": dataset,
+            "active_dataset_tlvs": dataset.hex() if dataset else None,
         },
     )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1984,6 +1984,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.otbr.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.overkiz.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2081,7 +2081,7 @@ python-mystrom==1.1.2
 python-nest==4.2.0
 
 # homeassistant.components.otbr
-python-otbr-api==1.0.1
+python-otbr-api==1.0.2
 
 # homeassistant.components.picnic
 python-picnic-api==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1471,7 +1471,7 @@ python-miio==0.5.12
 python-nest==4.2.0
 
 # homeassistant.components.otbr
-python-otbr-api==1.0.1
+python-otbr-api==1.0.2
 
 # homeassistant.components.picnic
 python-picnic-api==1.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable strict typing for the `otbr` integration

This is a follow-up to https://github.com/home-assistant/core/pull/86107#discussion_r1080691721

https://github.com/home-assistant-libs/python-otbr-api/releases/tag/1.0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
