### PR TITLE
Store Shelly climate `last_target_temp` value in restore extra data

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import asdict, dataclass
 from typing import Any, cast
 
 from aioshelly.block_device import Block
@@ -27,7 +28,7 @@ from homeassistant.helpers.entity_registry import (
     async_entries_for_config_entry,
     async_get as er_async_get,
 )
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.unit_conversion import TemperatureConverter
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -100,6 +101,17 @@ def async_restore_climate_entities(
         break
 
 
+@dataclass
+class ShellyClimateExtraStoredData(ExtraStoredData):
+    """Object to hold extra stored data."""
+
+    last_target_temp: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the text data."""
+        return asdict(self)
+
+
 class BlockSleepingClimate(
     CoordinatorEntity[ShellyBlockCoordinator], RestoreEntity, ClimateEntity
 ):
@@ -131,14 +143,7 @@ class BlockSleepingClimate(
         self.last_state: State | None = None
         self.last_state_attributes: Mapping[str, Any]
         self._preset_modes: list[str] = []
-        if coordinator.hass.config.units is US_CUSTOMARY_SYSTEM:
-            self._last_target_temp = TemperatureConverter.convert(
-                SHTRV_01_TEMPERATURE_SETTINGS["default"],
-                UnitOfTemperature.CELSIUS,
-                UnitOfTemperature.FAHRENHEIT,
-            )
-        else:
-            self._last_target_temp = SHTRV_01_TEMPERATURE_SETTINGS["default"]
+        self._last_target_temp = SHTRV_01_TEMPERATURE_SETTINGS["default"]
 
         if self.block is not None and self.device_block is not None:
             self._unique_id = f"{self.coordinator.mac}-{self.block.description}"
@@ -153,6 +158,11 @@ class BlockSleepingClimate(
             self._unique_id = entry.unique_id
 
         self._channel = cast(int, self._unique_id.split("_")[1])
+
+    @property
+    def extra_restore_state_data(self) -> ShellyClimateExtraStoredData:
+        """Return text specific state data to be restored."""
+        return ShellyClimateExtraStoredData(self._last_target_temp)
 
     @property
     def unique_id(self) -> str:
@@ -308,6 +318,9 @@ class BlockSleepingClimate(
         LOGGER.info("Restoring entity %s", self.name)
 
         last_state = await self.async_get_last_state()
+        last_extra_data = await self.async_get_last_extra_data()
+        if last_extra_data is not None:
+            self._last_target_temp = last_extra_data.as_dict()["last_target_temp"]
 
         if last_state is not None:
             self.last_state = last_state

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -318,16 +318,16 @@ class BlockSleepingClimate(
         LOGGER.info("Restoring entity %s", self.name)
 
         last_state = await self.async_get_last_state()
-        last_extra_data = await self.async_get_last_extra_data()
-        if last_extra_data is not None:
-            self._last_target_temp = last_extra_data.as_dict()["last_target_temp"]
-
         if last_state is not None:
             self.last_state = last_state
             self.last_state_attributes = self.last_state.attributes
             self._preset_modes = cast(
                 list, self.last_state.attributes.get("preset_modes")
             )
+
+        last_extra_data = await self.async_get_last_extra_data()
+        if last_extra_data is not None:
+            self._last_target_temp = last_extra_data.as_dict()["last_target_temp"]
 
         await super().async_added_to_hass()
 

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -25,7 +25,7 @@ from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import init_integration, register_device, register_entity
 
-from tests.common import mock_restore_cache
+from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
 
 SENSOR_BLOCK_ID = 3
 DEVICE_BLOCK_ID = 4
@@ -191,19 +191,25 @@ async def test_block_restored_climate(hass, mock_block_device, device_reg, monke
         "sensor_0",
         entry,
     )
-    mock_restore_cache(hass, [State(entity_id, HVACMode.HEAT)])
+    attrs = {"current_temperature": 20.5, "temperature": 4.0}
+    extra_data = {"last_target_temp": 22.0}
+    mock_restore_cache_with_extra_data(
+        hass, ((State(entity_id, HVACMode.OFF, attributes=attrs), extra_data),)
+    )
 
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == HVACMode.HEAT
+    assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 4.0
 
     # Partial update, should not change state
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == HVACMode.HEAT
+    assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 4.0
 
     # Make device online
     monkeypatch.setattr(mock_block_device, "initialized", True)
@@ -211,6 +217,24 @@ async def test_block_restored_climate(hass, mock_block_device, device_reg, monke
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 4.0
+
+    # Test set hvac mode heat, target temp should be set to last target temp (22)
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
+        blocking=True,
+    )
+    mock_block_device.http_request.assert_called_once_with(
+        "get", "thermostat/0", {"target_t_enabled": 1, "target_t": 22.0}
+    )
+
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "targetTemp", 22.0)
+    mock_block_device.mock_update()
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == HVACMode.HEAT
+    assert hass.states.get(entity_id).attributes.get("temperature") == 22.0
 
 
 async def test_block_restored_climate_us_customery(
@@ -229,35 +253,55 @@ async def test_block_restored_climate_us_customery(
         "sensor_0",
         entry,
     )
-    attrs = {"current_temperature": 67, "temperature": 68}
-    mock_restore_cache(hass, [State(entity_id, HVACMode.HEAT, attributes=attrs)])
+    attrs = {"current_temperature": 67, "temperature": 39}
+    extra_data = {"last_target_temp": 10.0}
+    mock_restore_cache_with_extra_data(
+        hass, ((State(entity_id, HVACMode.OFF, attributes=attrs), extra_data),)
+    )
 
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == HVACMode.HEAT
-    assert hass.states.get(entity_id).attributes.get("temperature") == 68
+    assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 39
     assert hass.states.get(entity_id).attributes.get("current_temperature") == 67
 
     # Partial update, should not change state
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == HVACMode.HEAT
-    assert hass.states.get(entity_id).attributes.get("temperature") == 68
+    assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 39
     assert hass.states.get(entity_id).attributes.get("current_temperature") == 67
 
     # Make device online
     monkeypatch.setattr(mock_block_device, "initialized", True)
-    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "targetTemp", 19.7)
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "targetTemp", 4.0)
     monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "temp", 18.2)
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == HVACMode.HEAT
-    assert hass.states.get(entity_id).attributes.get("temperature") == 67
+    assert hass.states.get(entity_id).state == HVACMode.OFF
+    assert hass.states.get(entity_id).attributes.get("temperature") == 39
     assert hass.states.get(entity_id).attributes.get("current_temperature") == 65
+
+    # Test set hvac mode heat, target temp should be set to last target temp (10.0/50)
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
+        blocking=True,
+    )
+    mock_block_device.http_request.assert_called_once_with(
+        "get", "thermostat/0", {"target_t_enabled": 1, "target_t": 10.0}
+    )
+
+    monkeypatch.setattr(mock_block_device.blocks[SENSOR_BLOCK_ID], "targetTemp", 10.0)
+    mock_block_device.mock_update()
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == HVACMode.HEAT
+    assert hass.states.get(entity_id).attributes.get("temperature") == 50
 
 
 async def test_block_restored_climate_unavailable(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Store the value of `last_target_temp` value in restore extra data and restore this value after HA restart/config entry reload. This will prevent the default temperature (20°C) from being used when changing from `off` to `heat` mode. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85562
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
