### PR TITLE
Add service to add package to 17track

### DIFF
--- a/homeassistant/components/seventeentrack/const.py
+++ b/homeassistant/components/seventeentrack/const.py
@@ -1,0 +1,20 @@
+"""Constants for the seventeentrack integration."""
+
+from typing import Final
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN: Final = "seventeentrack"
+SERVICE_ADD_TRACKING: Final = "add_tracking"
+
+CONF_TRACKING_NUMBER: Final = "tracking_number"
+CONF_FRIENDLY_NAME: Final = "friendly_name"
+
+ADD_TRACKING_SERVICE_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_TRACKING_NUMBER): cv.string,
+        vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    }
+)

--- a/homeassistant/components/seventeentrack/services.yaml
+++ b/homeassistant/components/seventeentrack/services.yaml
@@ -1,0 +1,17 @@
+add_tracking:
+  name: Add tracking
+  description: Add new tracking number to 17Track.
+  fields:
+    tracking_number:
+      name: Tracking number
+      description: Tracking number for the new tracking
+      required: true
+      example: "123456789"
+      selector:
+        text:
+    friendly_name:
+      name: Friendly Name
+      description: A custom name for the new tracking
+      example: "Laptop"
+      selector:
+        text:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a Service for adding packages to 17TRACK.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25908

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
	Log:
	 
```*  Executing task: pytest ./tests/components/seventeentrack/ --cov=homeassistant.components.seventeentrack --cov-report term-missing --durations-min=1 --durations=0 --numprocesses=auto 

Test session starts (platform: linux, Python 3.9.16, pytest 7.2.1, pytest-sugar 0.9.5)
rootdir: /workspaces/homeassistant-core, configfile: pyproject.toml
plugins: forked-1.4.0, asyncio-0.20.2, test-groups-1.0.3, pytest_freezer-0.4.6, socket-0.5.1, unordered-0.5.2, aiohttp-1.0.4, cov-3.0.0, timeout-2.1.0, respx-0.20.1, requests-mock-1.10.0, sugar-0.9.5, xdist-2.5.0, anyio-3.6.2
asyncio: mode=auto
gw0 [11] / gw1 [11] / gw2 [11] / gw3 [11] / gw4 [11] / gw5 [11] / gw6 [11] / gw7 [11]

 tests/components/seventeentrack/test_sensor.py ✓✓✓✓✓✓✓✓✓✓✓                                                                 100% ██████████
============================================================ warnings summary =============================================================
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256
  /usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:256: PytestDeprecationWarning: The hookimpl CovPlugin.pytest_configure_node uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    def pytest_configure_node(self, node):

../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
../../usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265
  /usr/local/lib/python3.9/site-packages/pytest_cov/plugin.py:265: PytestDeprecationWarning: The hookimpl CovPlugin.pytest_testnodedown uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    def pytest_testnodedown(self, node, error):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.9.16-final-0 -----------
Name                                                  Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------
homeassistant/components/seventeentrack/__init__.py       0      0   100%
homeassistant/components/seventeentrack/const.py          8      0   100%
-----------------------------------------------------------------------------------
TOTAL                                                     8      0   100%

============================================================ slowest durations ============================================================

(33 durations < 1s hidden.  Use -vv to show these durations.)

Results (5.70s):
      11 passed
 *  Press any key to close the terminal. 
```
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
