### PR TITLE
Support playback of channel preset in philips_js

### DIFF
--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -2,7 +2,7 @@
   "domain": "philips_js",
   "name": "Philips TV",
   "documentation": "https://www.home-assistant.io/integrations/philips_js",
-  "requirements": ["ha-philipsjs==2.9.0"],
+  "requirements": ["ha-philipsjs==3.0.0"],
   "codeowners": ["@elupus"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -167,12 +167,18 @@ class PhilipsTVMediaPlayer(
 
     async def async_media_previous_track(self) -> None:
         """Send rewind command."""
-        await self._tv.sendKey("Previous")
+        if self._tv.channel_active:
+            await self._tv.sendKey("ChannelStepDown")
+        else:
+            await self._tv.sendKey("Previous")
         await self._async_update_soon()
 
     async def async_media_next_track(self) -> None:
         """Send fast forward command."""
-        await self._tv.sendKey("Next")
+        if self._tv.channel_active:
+            await self._tv.sendKey("ChannelStepUp")
+        else:
+            await self._tv.sendKey("Next")
         await self._async_update_soon()
 
     async def async_media_play_pause(self) -> None:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -377,10 +377,7 @@ class PhilipsTVMediaPlayer(
         if not self._tv.on:
             raise BrowseError("Can't browse when tv is turned off")
 
-        if media_content_id is None:
-            raise BrowseError("Missing media content id")
-
-        if media_content_id in (None, ""):
+        if media_content_id is None or media_content_id == "":
             return await self.async_browse_media_root()
         path = media_content_id.partition("/")
         if path[0] == "channels":

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ ha-av==10.0.0
 ha-ffmpeg==3.0.2
 
 # homeassistant.components.philips_js
-ha-philipsjs==2.9.0
+ha-philipsjs==3.0.0
 
 # homeassistant.components.habitica
 habitipy==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -660,7 +660,7 @@ ha-av==10.0.0
 ha-ffmpeg==3.0.2
 
 # homeassistant.components.philips_js
-ha-philipsjs==2.9.0
+ha-philipsjs==3.0.0
 
 # homeassistant.components.habitica
 habitipy==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Support playback of a channel preset number
- List standard channels based on active favorite list
- Use ChannelStep instead of next/prev when we have active channel
- Bump library version: https://github.com/danielperna84/ha-philipsjs/releases/tag/3.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86380

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
