### PR TITLE
Add `flake8-bugbear` plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
           - flake8-comprehensions==3.10.1
           - flake8-noqa==1.3.0
           - mccabe==0.7.0
+          - flake8-bugbear==22.12.6
         exclude: docs/source/conf.py
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -4,6 +4,7 @@ autoflake==2.0.0
 bandit==1.7.4
 black==22.12.0
 codespell==2.2.2
+flake8-bugbear==22.12.6
 flake8-comprehensions==3.10.1
 flake8-docstrings==1.6.0
 flake8-noqa==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,41 @@ doctests = True
 # E203: Whitespace before ':'
 # D202 No blank lines allowed after function docstring
 # W504 line break after binary operator
+# B* are flake8-bugbear rules; these are temporarily disabled since the linter is new, but will be enabled over time.
+#   B005: Temporarily disabled while flake8-bugbear is rolled out
+#   B006: Temporarily disabled while flake8-bugbear is rolled out
+#   B007: Temporarily disabled while flake8-bugbear is rolled out
+#   B008: Temporarily disabled while flake8-bugbear is rolled out
+#   B009: Temporarily disabled while flake8-bugbear is rolled out
+#   B010: Temporarily disabled while flake8-bugbear is rolled out
+#   B011: Temporarily disabled while flake8-bugbear is rolled out
+#   B014: Temporarily disabled while flake8-bugbear is rolled out
+#   B015: Temporarily disabled while flake8-bugbear is rolled out
+#   B019: Temporarily disabled while flake8-bugbear is rolled out
+#   B020: Temporarily disabled while flake8-bugbear is rolled out
+#   B023: Temporarily disabled while flake8-bugbear is rolled out
+#   B024: Temporarily disabled while flake8-bugbear is rolled out
+#   B027: Temporarily disabled while flake8-bugbear is rolled out
+# X999: a placeholder so we can have trailing commas
 ignore =
     E501,
     W503,
     E203,
     D202,
-    W504
+    W504,
+    B005,
+    B006,
+    B007,
+    B008,
+    B009,
+    B010,
+    B011,
+    B014,
+    B015,
+    B019,
+    B020,
+    B023,
+    B024,
+    B027,
+    X999
 noqa-require-code = True


### PR DESCRIPTION

## Proposed change

This adds a new plugin to `flake8` - https://github.com/PyCQA/flake8-bugbear. The purpose of this plugin is to find likely bugs, antipatterns, and other design shortcomings.

This slightly increases `flake8` runtime, by about 9%. However the benefits are a more stable codebase. The long-pole of CI is not `flake8`.

Before:

```console
$ git rev-parse HEAD
6f94e47270d597f67aeac175aa6881fe8702b3d0
$ hyperfine 'pre-commit run flake8 --all-files'
Benchmark 1: pre-commit run flake8 --all-files
  Time (mean ± σ):     81.030 s ±  2.943 s    [User: 722.326 s, System: 15.592 s]
  Range (min … max):   77.675 s … 88.146 s    10 runs
```

After: 
```console
$ git rev-parse HEAD
6536c8082491213a55f381dcb74ec08e191070f6
$ hyperfine 'pre-commit run flake8 --all-files'
Benchmark 1: pre-commit run flake8 --all-files
  Time (mean ± σ):     88.735 s ±  2.873 s    [User: 799.846 s, System: 16.701 s]
  Range (min … max):   85.282 s … 94.092 s    10 runs
```

The PR does not enable any new rules. All rules that are hit are suppressed. Over time, I plan to remove each warning, though others can remove them if desired, too.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
