### PR TITLE
Add available to LiteJet

### DIFF
--- a/homeassistant/components/litejet/__init__.py
+++ b/homeassistant/components/litejet/__init__.py
@@ -2,7 +2,6 @@
 import logging
 
 import pylitejet
-from serial import SerialException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -53,11 +52,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         system = await pylitejet.open(port)
-    except SerialException as ex:
-        _LOGGER.error("Error connecting to the LiteJet MCP at %s", port, exc_info=ex)
-        raise ConfigEntryNotReady from ex
+    except pylitejet.LiteJetError as exc:
+        raise ConfigEntryNotReady from exc
 
-    def handle_connected_changed(self, connected: bool, reason: str) -> None:
+    def handle_connected_changed(connected: bool, reason: str) -> None:
         if connected:
             _LOGGER.info("Connected")
         else:

--- a/homeassistant/components/litejet/__init__.py
+++ b/homeassistant/components/litejet/__init__.py
@@ -57,6 +57,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Error connecting to the LiteJet MCP at %s", port, exc_info=ex)
         raise ConfigEntryNotReady from ex
 
+    def handle_connected_changed(self, connected: bool, reason: str) -> None:
+        if connected:
+            _LOGGER.info("Connected")
+        else:
+            _LOGGER.warning("Disconnected %s", reason)
+
+    system.on_connected_changed(handle_connected_changed)
+
     async def handle_stop(event) -> None:
         await system.close()
 

--- a/homeassistant/components/litejet/light.py
+++ b/homeassistant/components/litejet/light.py
@@ -74,7 +74,7 @@ class LiteJetLight(LightEntity):
         """Handle state changes."""
         self.schedule_update_ha_state(True)
 
-    def _on_connected_changed(self, connected) -> None:
+    def _on_connected_changed(self, connected: bool, reason: str) -> None:
         """Handle connected changes."""
         self.schedule_update_ha_state(True)
 

--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -2,7 +2,7 @@
   "domain": "litejet",
   "name": "LiteJet",
   "documentation": "https://www.home-assistant.io/integrations/litejet",
-  "requirements": ["pylitejet==0.4.6"],
+  "requirements": ["pylitejet==0.5.0"],
   "codeowners": ["@joncar"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -51,7 +51,7 @@ class LiteJetScene(Scene):
         """Entity being removed from hass."""
         self._lj.unsubscribe(self._on_connected_changed)
 
-    def _on_connected_changed(self, connected):
+    def _on_connected_changed(self, connected: bool, reason: str) -> None:
         self._attr_available = connected
         self.schedule_update_ha_state()
 

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -1,4 +1,5 @@
 """Support for LiteJet scenes."""
+import logging
 from typing import Any
 
 from pylitejet import LiteJet
@@ -9,6 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_NUMBER = "number"
 
@@ -35,20 +38,22 @@ class LiteJetScene(Scene):
 
     def __init__(self, entry_id, lj: LiteJet, i, name):  # pylint: disable=invalid-name
         """Initialize the scene."""
-        self._entry_id = entry_id
         self._lj = lj
         self._index = i
-        self._name = name
+        self._attr_unique_id = f"{entry_id}_{i}"
+        self._attr_name = name
 
-    @property
-    def name(self):
-        """Return the name of the scene."""
-        return self._name
+    async def async_added_to_hass(self) -> None:
+        """Run when this Entity has been added to HA."""
+        self._lj.on_connected_changed(self._on_connected_changed)
 
-    @property
-    def unique_id(self):
-        """Return a unique identifier for this scene."""
-        return f"{self._entry_id}_{self._index}"
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        self._lj.unsubscribe(self._on_connected_changed)
+
+    def _on_connected_changed(self, connected):
+        self._attr_available = connected
+        self.schedule_update_ha_state()
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -2,11 +2,12 @@
 import logging
 from typing import Any
 
-from pylitejet import LiteJet
+from pylitejet import LiteJet, LiteJetError
 
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -62,7 +63,10 @@ class LiteJetScene(Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
-        await self._lj.activate_scene(self._index)
+        try:
+            await self._lj.activate_scene(self._index)
+        except LiteJetError as exc:
+            raise HomeAssistantError() from exc
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -1,11 +1,12 @@
 """Support for LiteJet switch."""
 from typing import Any
 
-from pylitejet import LiteJet
+from pylitejet import LiteJet, LiteJetError
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -79,11 +80,17 @@ class LiteJetSwitch(SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Press the switch."""
-        await self._lj.press_switch(self._index)
+        try:
+            await self._lj.press_switch(self._index)
+        except LiteJetError as exc:
+            raise HomeAssistantError() from exc
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Release the switch."""
-        await self._lj.release_switch(self._index)
+        try:
+            await self._lj.release_switch(self._index)
+        except LiteJetError as exc:
+            raise HomeAssistantError() from exc
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -63,7 +63,7 @@ class LiteJetSwitch(SwitchEntity):
         self._attr_is_on = False
         self.schedule_update_ha_state()
 
-    def _on_connected_changed(self, connected):
+    def _on_connected_changed(self, connected: bool, reason: str) -> None:
         self._attr_available = connected
         self.schedule_update_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1744,7 +1744,7 @@ pylgnetcast==0.3.7
 pylibrespot-java==0.1.1
 
 # homeassistant.components.litejet
-pylitejet==0.4.6
+pylitejet==0.5.0
 
 # homeassistant.components.litterrobot
 pylitterbot==2023.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1251,7 +1251,7 @@ pylaunches==1.3.0
 pylibrespot-java==0.1.1
 
 # homeassistant.components.litejet
-pylitejet==0.4.6
+pylitejet==0.5.0
 
 # homeassistant.components.litterrobot
 pylitterbot==2023.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve the resiliency when the serial connection to the MCP is lost. In particular this achieves the following silver integration quality requirements:
* Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
* Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ValueError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device.
* Set available property to False if appropriate ([docs](https://developers.home-assistant.io/docs/core/entity#generic-properties))

Dependency bump's diff: https://github.com/joncar/pylitejet/compare/v0.4.6...v0.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
