### PR TITLE
Update Ruff to 0.0.231, enable D401

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.230
+    rev: v0.0.231
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,6 @@ ignore = [
     "D203",  # 1 blank line required before class docstring
     "D212",  # Multi-line docstring summary should start at the first line
     "D213",  # Multi-line docstring summary should start at the second line
-    "D401",  # TODO: Enable when https://github.com/charliermarsh/ruff/pull/2071 is released
     "D404",  # First word of the docstring should not be This
     "D406",  # Section name should end with a newline
     "D407",  # Section name underlining

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -14,5 +14,5 @@ pycodestyle==2.10.0
 pydocstyle==6.2.3
 pyflakes==3.0.1
 pyupgrade==3.3.1
-ruff==0.0.230
+ruff==0.0.231
 yamllint==1.28.0


### PR DESCRIPTION
## Proposed change

This PR upgrades Ruff (see #86224) to [version 0.0.231](https://github.com/charliermarsh/ruff/releases/tag/v0.0.231) and enables the D401 rule (thanks for fixing it, @scop)!


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
