### PR TITLE
Enable T20 (flake8-print) to ban use of print statements

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -330,7 +330,7 @@ async def async_ensure_config_exists(hass: HomeAssistant) -> bool:
     if os.path.isfile(config_path):
         return True
 
-    print(
+    print(  # noqa: T201
         "Unable to find configuration. Creating default one in", hass.config.config_dir
     )
     return await async_create_default_config(hass)
@@ -384,7 +384,7 @@ def _write_default_config(config_dir: str) -> bool:
         return True
 
     except OSError:
-        print("Unable to create default configuration file", config_path)
+        print("Unable to create default configuration file", config_path)  # noqa: T201
         return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ select = [
     "D",  # docstrings
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
+    "T20",  # flake8-print
     "W",  # pycodestyle
     "UP",  # pyupgrade
     "PGH004",  # Use specific rule codes when using noqa
@@ -278,6 +279,11 @@ select = [
 "homeassistant/components/light/__init__.py" = ["C901"]
 "homeassistant/components/mqtt/discovery.py" = ["C901"]
 "homeassistant/components/websocket_api/http.py" = ["C901"]
+
+# Allow for main entry & scripts to write to stdout
+"homeassistant/__main__.py" = ["T201"]
+"homeassistant/scripts/*" = ["T201"]
+"script/*" = ["T20"]
 
 [tool.ruff.mccabe]
 max-complexity = 25

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,13 @@ ignore =
     D202,
     W504
 noqa-require-code = True
+
+# Ignores, that are currently caused by mismatching configurations
+# between ruff and flake8 configurations. Once ruff becomes permanent flake8
+# will be removed, including these ignores below.
+# In case we decide not to continue with ruff, we should remove these
+# and probably need to clean up a couple of noqa comments.
+per-file-ignores =
+    homeassistant/config.py:NQA102
+    tests/components/tts/conftest.py:NQA102
+    tests/helpers/test_icon.py:NQA102

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -1587,9 +1587,6 @@ async def test_multiple_instances_with_tls_v12(hass):
         )
         await hass.async_block_till_done()
 
-    import pprint
-
-    pprint.pprint(result2)
     assert result2["type"] == "create_entry"
     assert result2["title"] == "guest_house"
     assert result2["data"] == {

--- a/tests/components/tts/conftest.py
+++ b/tests/components/tts/conftest.py
@@ -55,9 +55,9 @@ def empty_cache_dir(tmp_path, mock_init_cache_dir, mock_get_cache_files, request
         return
 
     # Print contents of dir if failed
-    print("Content of dir for", request.node.nodeid)
+    print("Content of dir for", request.node.nodeid)  # noqa: T201
     for fil in tmp_path.iterdir():
-        print(fil.relative_to(tmp_path))
+        print(fil.relative_to(tmp_path))  # noqa: T201
 
     # To show the log.
     assert False

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -166,7 +166,6 @@ async def test_1st_discovers_2nd_component(hass):
 
     async def component1_setup(hass, config):
         """Set up mock component."""
-        print("component1 setup")
         await discovery.async_discover(
             hass, "test_component2", {}, "test_component2", {}
         )

--- a/tests/helpers/test_icon.py
+++ b/tests/helpers/test_icon.py
@@ -16,7 +16,7 @@ def test_battery_icon():
 
     iconbase = "mdi:battery"
     for level in range(0, 100, 5):
-        print(
+        print(  # noqa: T201
             "Level: %d. icon: %s, charging: %s"
             % (
                 level,

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -183,12 +183,6 @@ def test_norway_in_june(hass):
 
     june = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
 
-    print(sun.get_astral_event_date(hass, SUN_EVENT_SUNRISE, datetime(2017, 7, 25)))
-    print(sun.get_astral_event_date(hass, SUN_EVENT_SUNSET, datetime(2017, 7, 25)))
-
-    print(sun.get_astral_event_date(hass, SUN_EVENT_SUNRISE, datetime(2017, 7, 26)))
-    print(sun.get_astral_event_date(hass, SUN_EVENT_SUNSET, datetime(2017, 7, 26)))
-
     assert sun.get_astral_event_next(hass, SUN_EVENT_SUNRISE, june) == datetime(
         2016, 7, 24, 22, 59, 45, 689645, tzinfo=dt_util.UTC
     )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -24,21 +24,13 @@ async def test_component_dependencies(hass):
     mock_integration(hass, MockModule("mod1", ["mod3"]))
 
     with pytest.raises(loader.CircularDependency):
-        print(
-            await loader._async_component_dependencies(
-                hass, "mod_3", mod_3, set(), set()
-            )
-        )
+        await loader._async_component_dependencies(hass, "mod_3", mod_3, set(), set())
 
     # Depend on non-existing component
     mod_1 = mock_integration(hass, MockModule("mod1", ["nonexisting"]))
 
     with pytest.raises(loader.IntegrationNotFound):
-        print(
-            await loader._async_component_dependencies(
-                hass, "mod_1", mod_1, set(), set()
-            )
-        )
+        await loader._async_component_dependencies(hass, "mod_1", mod_1, set(), set())
 
     # Having an after dependency 2 deps down that is circular
     mod_1 = mock_integration(
@@ -46,11 +38,7 @@ async def test_component_dependencies(hass):
     )
 
     with pytest.raises(loader.CircularDependency):
-        print(
-            await loader._async_component_dependencies(
-                hass, "mod_3", mod_3, set(), set()
-            )
-        )
+        await loader._async_component_dependencies(hass, "mod_3", mod_3, set(), set())
 
 
 def test_component_loader(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now we have `ruff` enabled, we can add simple linting rules with ease.

This PR adds bans the use of `print` & `pprint` statements from our codebase.
They sneak in from time to time, most are caught during code review, however, catching them automatically would be nicer of course.

Removed some cases, and exempted some others.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
