### PR TITLE
Replace `None` constants [minecraft_server]

### DIFF
--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -36,6 +36,3 @@ SRV_RECORD_PREFIX = "_minecraft._tcp"
 
 UNIT_PLAYERS_MAX = "players"
 UNIT_PLAYERS_ONLINE = "players"
-UNIT_PROTOCOL_VERSION = None
-UNIT_VERSION = None
-UNIT_MOTD = None

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -23,11 +23,8 @@ from .const import (
     NAME_PLAYERS_ONLINE,
     NAME_PROTOCOL_VERSION,
     NAME_VERSION,
-    UNIT_MOTD,
     UNIT_PLAYERS_MAX,
     UNIT_PLAYERS_ONLINE,
-    UNIT_PROTOCOL_VERSION,
-    UNIT_VERSION,
 )
 
 
@@ -61,7 +58,7 @@ class MinecraftServerSensorEntity(MinecraftServerEntity, SensorEntity):
         server: MinecraftServer,
         type_name: str,
         icon: str,
-        unit: str | None,
+        unit: str | None = None,
         device_class: str | None = None,
     ) -> None:
         """Initialize sensor base entity."""
@@ -79,9 +76,7 @@ class MinecraftServerVersionSensor(MinecraftServerSensorEntity):
 
     def __init__(self, server: MinecraftServer) -> None:
         """Initialize version sensor."""
-        super().__init__(
-            server=server, type_name=NAME_VERSION, icon=ICON_VERSION, unit=UNIT_VERSION
-        )
+        super().__init__(server=server, type_name=NAME_VERSION, icon=ICON_VERSION)
 
     async def async_update(self) -> None:
         """Update version."""
@@ -97,7 +92,6 @@ class MinecraftServerProtocolVersionSensor(MinecraftServerSensorEntity):
             server=server,
             type_name=NAME_PROTOCOL_VERSION,
             icon=ICON_PROTOCOL_VERSION,
-            unit=UNIT_PROTOCOL_VERSION,
         )
 
     async def async_update(self) -> None:
@@ -173,7 +167,6 @@ class MinecraftServerMOTDSensor(MinecraftServerSensorEntity):
             server=server,
             type_name=NAME_MOTD,
             icon=ICON_MOTD,
-            unit=UNIT_MOTD,
         )
 
     async def async_update(self) -> None:


### PR DESCRIPTION
## Proposed change
Set `unit` default in base class to `None` and remove `None` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
