### PR TITLE
Misc typing improvements

### DIFF
--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -1,8 +1,9 @@
 """Config helpers for Alexa."""
 from abc import ABC, abstractmethod
+import asyncio
 import logging
 
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
@@ -16,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class AbstractConfig(ABC):
     """Hold the configuration for Alexa."""
 
-    _unsub_proactive_report = None
+    _unsub_proactive_report: asyncio.Task[CALLBACK_TYPE] | None = None
 
     def __init__(self, hass):
         """Initialize abstract config."""

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -39,8 +39,8 @@ class AlmondFlowHandler(
 
     DOMAIN = DOMAIN
 
-    host = None
-    hassio_discovery = None
+    host: str | None = None
+    hassio_discovery: dict[str, Any] | None = None
 
     @property
     def logger(self) -> logging.Logger:

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -63,7 +63,7 @@ class ComfoConnectFan(FanEntity):
     _attr_should_poll = False
     _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
     _attr_preset_modes = PRESET_MODES
-    current_speed = None
+    current_speed: float | None = None
 
     def __init__(self, ccb: ComfoConnectBridge) -> None:
         """Initialize the ComfoConnect fan."""

--- a/homeassistant/components/coronavirus/config_flow.py
+++ b/homeassistant/components/coronavirus/config_flow.py
@@ -17,7 +17,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    _options = None
+    _options: dict[str, Any] | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for OctoPrint integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import Any
@@ -50,8 +51,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    api_key_task = None
-    _reauth_data = None
+    api_key_task: asyncio.Task[None] | None = None
+    _reauth_data: dict[str, Any] | None = None
 
     def __init__(self) -> None:
         """Handle a config flow for OctoPrint."""

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -19,7 +19,7 @@ from .const import LOGGER
 from .models import Event
 from .parsers import PARSERS
 
-UNHANDLED_TOPICS = set()
+UNHANDLED_TOPICS: set[str] = set()
 SUBSCRIPTION_ERRORS = (
     Fault,
     asyncio.TimeoutError,

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import telnetlib
+from typing import Final
 
 import voluptuous as vol
 
@@ -24,7 +25,7 @@ CONF_SOURCES = "sources"
 
 DEFAULT_NAME = "Pioneer AVR"
 DEFAULT_PORT = 23  # telnet default. Some Pioneer AVRs use 8102
-DEFAULT_TIMEOUT = None
+DEFAULT_TIMEOUT: Final = None
 DEFAULT_SOURCES: dict[str, str] = {}
 
 

--- a/homeassistant/components/qwikswitch/sensor.py
+++ b/homeassistant/components/qwikswitch/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from pyqwikswitch.qwikswitch import SENSORS
 
@@ -34,7 +35,7 @@ async def async_setup_platform(
 class QSSensor(QSEntity, SensorEntity):
     """Sensor based on a Qwikswitch relay/dimmer module."""
 
-    _val = None
+    _val: Any | None = None
 
     def __init__(self, sensor):
         """Initialize the sensor."""

--- a/homeassistant/components/temper/sensor.py
+++ b/homeassistant/components/temper/sensor.py
@@ -33,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-TEMPER_SENSORS = []
+TEMPER_SENSORS: list[TemperSensor] = []
 
 
 def get_temper_devices():

--- a/homeassistant/components/yeelight/scanner.py
+++ b/homeassistant/components/yeelight/scanner.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 class YeelightScanner:
     """Scan for Yeelight devices."""
 
-    _scanner = None
+    _scanner: YeelightScanner | None = None
 
     @classmethod
     @callback


### PR DESCRIPTION
## Proposed change
Add annotations for variables initialized to None and changed later in a different scope.
Necessary for https://github.com/home-assistant/core/pull/86409, to enable local_partial_types [mypy] for all files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
