### PR TITLE
Migrate cast to use async_forward_entry_setups

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -57,7 +57,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cast from a config entry."""
     await home_assistant_cast.async_setup_ha_cast(hass, entry)
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     hass.data[DOMAIN] = {"cast_platform": {}, "unknown_models": {}}
     await async_process_integration_platforms(hass, DOMAIN, _register_cast_platform)
     return True

--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -16,6 +16,7 @@ from .const import DOMAIN, SIGNAL_HASS_CAST_SHOW_VIEW
 SERVICE_SHOW_VIEW = "show_lovelace_view"
 ATTR_VIEW_PATH = "view_path"
 ATTR_URL_PATH = "dashboard_path"
+CAST_USER_NAME = "Home Assistant Cast"
 NO_URL_AVAILABLE_ERROR = (
     "Home Assistant Cast requires your instance to be reachable via HTTPS. Enable Home"
     " Assistant Cloud or set up an external URL with valid SSL certificates"
@@ -34,7 +35,7 @@ async def async_setup_ha_cast(
 
     if user is None:
         user = await hass.auth.async_create_system_user(
-            "Home Assistant Cast", group_ids=[auth.const.GROUP_ID_ADMIN]
+            CAST_USER_NAME, group_ids=[auth.const.GROUP_ID_ADMIN]
         )
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, "user_id": user.id}

--- a/tests/components/cast/test_config_flow.py
+++ b/tests/components/cast/test_config_flow.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import cast
+from homeassistant.components.cast.home_assistant_cast import CAST_USER_NAME
 
 from tests.common import MockConfigEntry
 
@@ -64,7 +65,7 @@ async def test_user_setup(hass):
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     users = await hass.auth.async_get_users()
-    assert len(users) == 1
+    assert next(user for user in users if user.name == CAST_USER_NAME)
     assert result["type"] == "create_entry"
     assert result["result"].data == {
         "ignore_cec": [],
@@ -86,7 +87,7 @@ async def test_user_setup_options(hass):
     )
 
     users = await hass.auth.async_get_users()
-    assert len(users) == 1
+    assert next(user for user in users if user.name == CAST_USER_NAME)
     assert result["type"] == "create_entry"
     assert result["result"].data == {
         "ignore_cec": [],
@@ -106,7 +107,7 @@ async def test_zeroconf_setup(hass):
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     users = await hass.auth.async_get_users()
-    assert len(users) == 1
+    assert next(user for user in users if user.name == CAST_USER_NAME)
     assert result["type"] == "create_entry"
     assert result["result"].data == {
         "ignore_cec": [],
@@ -126,7 +127,7 @@ async def test_zeroconf_setup_onboarding(hass):
         )
 
     users = await hass.auth.async_get_users()
-    assert len(users) == 1
+    assert next(user for user in users if user.name == CAST_USER_NAME)
     assert result["type"] == "create_entry"
     assert result["result"].data == {
         "ignore_cec": [],


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces deprecated async_setup_platforms with async_forward_entry_setups



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
