### PR TITLE
Migrate konnected to use async_forward_entry_setups

### DIFF
--- a/homeassistant/components/konnected/__init__.py
+++ b/homeassistant/components/konnected/__init__.py
@@ -259,7 +259,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # async_connect will handle retries until it establishes a connection
     await client.async_connect()
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # config entry specific data to enable unload
     hass.data[DOMAIN][entry.entry_id] = {

--- a/tests/components/konnected/test_panel.py
+++ b/tests/components/konnected/test_panel.py
@@ -151,16 +151,25 @@ async def test_create_and_setup(hass, mock_panel):
     }
 
     # confirm the device settings are saved in hass.data
+    # This test should not access hass.data since its integration internals
     assert device.stored_configuration == {
         "binary_sensors": {
             "1": {
+                "entity_id": "binary_sensor.konnected_445566_zone_1",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 1",
                 "state": None,
                 "type": "door",
             },
-            "2": {"inverse": True, "name": "winder", "state": None, "type": "window"},
+            "2": {
+                "entity_id": "binary_sensor.winder",
+                "inverse": True,
+                "name": "winder",
+                "state": None,
+                "type": "window",
+            },
             "3": {
+                "entity_id": "binary_sensor.konnected_445566_zone_3",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 3",
                 "state": None,
@@ -168,14 +177,16 @@ async def test_create_and_setup(hass, mock_panel):
             },
         },
         "blink": True,
-        "panel": device,
         "discovery": True,
         "host": "1.2.3.4",
+        "panel": device,
         "port": 1234,
         "sensors": [
             {
+                "humidity": "sensor.konnected_445566_sensor_4_humidity",
                 "name": "Konnected 445566 Sensor 4",
                 "poll_interval": 3,
+                "temperature": "sensor.konnected_445566_sensor_4_temperature",
                 "type": "dht",
                 "zone": "4",
             },
@@ -184,6 +195,7 @@ async def test_create_and_setup(hass, mock_panel):
         "switches": [
             {
                 "activation": "low",
+                "entity_id": "switch.switcher",
                 "momentary": 50,
                 "name": "switcher",
                 "pause": 100,
@@ -193,6 +205,7 @@ async def test_create_and_setup(hass, mock_panel):
             },
             {
                 "activation": "high",
+                "entity_id": "switch.konnected_445566_actuator_6",
                 "momentary": None,
                 "name": "Konnected 445566 Actuator 6",
                 "pause": None,
@@ -307,37 +320,49 @@ async def test_create_and_setup_pro(hass, mock_panel):
     }
 
     # confirm the device settings are saved in hass.data
+    # hass.data should not be accessed in tests as its considered integration internals
     assert device.stored_configuration == {
         "binary_sensors": {
-            "11": {
-                "inverse": False,
-                "name": "Konnected 445566 Zone 11",
-                "state": None,
-                "type": "window",
-            },
             "10": {
+                "entity_id": "binary_sensor.konnected_445566_zone_10",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 10",
                 "state": None,
                 "type": "door",
             },
+            "11": {
+                "entity_id": "binary_sensor.konnected_445566_zone_11",
+                "inverse": False,
+                "name": "Konnected 445566 Zone 11",
+                "state": None,
+                "type": "window",
+            },
             "2": {
+                "entity_id": "binary_sensor.konnected_445566_zone_2",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 2",
                 "state": None,
                 "type": "door",
             },
-            "6": {"inverse": True, "name": "winder", "state": None, "type": "window"},
+            "6": {
+                "entity_id": "binary_sensor.winder",
+                "inverse": True,
+                "name": "winder",
+                "state": None,
+                "type": "window",
+            },
         },
         "blink": True,
-        "panel": device,
         "discovery": True,
         "host": "1.2.3.4",
+        "panel": device,
         "port": 1234,
         "sensors": [
             {
+                "humidity": "sensor.konnected_445566_sensor_3_humidity",
                 "name": "Konnected 445566 Sensor 3",
                 "poll_interval": 5,
+                "temperature": "sensor.konnected_445566_sensor_3_temperature",
                 "type": "dht",
                 "zone": "3",
             },
@@ -346,6 +371,7 @@ async def test_create_and_setup_pro(hass, mock_panel):
         "switches": [
             {
                 "activation": "high",
+                "entity_id": "switch.konnected_445566_actuator_4",
                 "momentary": None,
                 "name": "Konnected 445566 Actuator 4",
                 "pause": None,
@@ -355,6 +381,7 @@ async def test_create_and_setup_pro(hass, mock_panel):
             },
             {
                 "activation": "low",
+                "entity_id": "switch.switcher",
                 "momentary": 50,
                 "name": "switcher",
                 "pause": 100,
@@ -364,6 +391,7 @@ async def test_create_and_setup_pro(hass, mock_panel):
             },
             {
                 "activation": "high",
+                "entity_id": "switch.konnected_445566_actuator_out1",
                 "momentary": None,
                 "name": "Konnected 445566 Actuator out1",
                 "pause": None,
@@ -373,6 +401,7 @@ async def test_create_and_setup_pro(hass, mock_panel):
             },
             {
                 "activation": "high",
+                "entity_id": "switch.konnected_445566_actuator_alarm1",
                 "momentary": None,
                 "name": "Konnected 445566 Actuator alarm1",
                 "pause": None,
@@ -495,16 +524,25 @@ async def test_default_options(hass, mock_panel):
     }
 
     # confirm the device settings are saved in hass.data
+    # This test should not access hass.data since its integration internals
     assert device.stored_configuration == {
         "binary_sensors": {
             "1": {
+                "entity_id": "binary_sensor.konnected_445566_zone_1",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 1",
                 "state": None,
                 "type": "door",
             },
-            "2": {"inverse": True, "name": "winder", "state": None, "type": "window"},
+            "2": {
+                "entity_id": "binary_sensor.winder",
+                "inverse": True,
+                "name": "winder",
+                "state": None,
+                "type": "window",
+            },
             "3": {
+                "entity_id": "binary_sensor.konnected_445566_zone_3",
                 "inverse": False,
                 "name": "Konnected 445566 Zone 3",
                 "state": None,
@@ -512,14 +550,16 @@ async def test_default_options(hass, mock_panel):
             },
         },
         "blink": True,
-        "panel": device,
         "discovery": True,
         "host": "1.2.3.4",
+        "panel": device,
         "port": 1234,
         "sensors": [
             {
+                "humidity": "sensor.konnected_445566_sensor_4_humidity",
                 "name": "Konnected 445566 Sensor 4",
                 "poll_interval": 3,
+                "temperature": "sensor.konnected_445566_sensor_4_temperature",
                 "type": "dht",
                 "zone": "4",
             },
@@ -528,6 +568,7 @@ async def test_default_options(hass, mock_panel):
         "switches": [
             {
                 "activation": "low",
+                "entity_id": "switch.switcher",
                 "momentary": 50,
                 "name": "switcher",
                 "pause": 100,
@@ -537,6 +578,7 @@ async def test_default_options(hass, mock_panel):
             },
             {
                 "activation": "high",
+                "entity_id": "switch.konnected_445566_actuator_6",
                 "momentary": None,
                 "name": "Konnected 445566 Actuator 6",
                 "pause": None,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces deprecated async_setup_platforms with async_forward_entry_setups

These tests are accessing `hass.data` which should not be done
https://developers.home-assistant.io/docs/development_testing?_highlight=writing#writing-tests-for-integrations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
