### PR TITLE
Migrate totalconnect to use async_forward_entry_setups

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(alarms, True)
+    async_add_entities(alarms)
 
     # Set up services
     platform = entity_platform.async_get_current_platform()

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import dt
 
 from .common import (
@@ -67,11 +68,13 @@ DELAY = timedelta(seconds=10)
 
 async def test_attributes(hass: HomeAssistant) -> None:
     """Test the alarm control panel attributes are correct."""
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(
         "homeassistant.components.totalconnect.TotalConnectClient.request",
         return_value=RESPONSE_DISARMED,
     ) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         state = hass.states.get(ENTITY_ID)
         assert state.state == STATE_ALARM_DISARMED
         mock_request.assert_called_once()
@@ -91,8 +94,10 @@ async def test_attributes(hass: HomeAssistant) -> None:
 async def test_arm_home_success(hass: HomeAssistant) -> None:
     """Test arm home method success."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_STAY]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert hass.states.get(ENTITY_ID_2).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
@@ -113,8 +118,10 @@ async def test_arm_home_success(hass: HomeAssistant) -> None:
 async def test_arm_home_failure(hass: HomeAssistant) -> None:
     """Test arm home method failure."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -143,8 +150,10 @@ async def test_arm_home_failure(hass: HomeAssistant) -> None:
 async def test_arm_home_instant_success(hass: HomeAssistant) -> None:
     """Test arm home instant method success."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_STAY]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert hass.states.get(ENTITY_ID_2).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
@@ -163,8 +172,10 @@ async def test_arm_home_instant_success(hass: HomeAssistant) -> None:
 async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
     """Test arm home instant method failure."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -196,8 +207,10 @@ async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
 async def test_arm_away_instant_success(hass: HomeAssistant) -> None:
     """Test arm home instant method success."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert hass.states.get(ENTITY_ID_2).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
@@ -216,8 +229,10 @@ async def test_arm_away_instant_success(hass: HomeAssistant) -> None:
 async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
     """Test arm home instant method failure."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -249,8 +264,10 @@ async def test_arm_away_instant_failure(hass: HomeAssistant) -> None:
 async def test_arm_away_success(hass: HomeAssistant) -> None:
     """Test arm away method success."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -268,8 +285,10 @@ async def test_arm_away_success(hass: HomeAssistant) -> None:
 async def test_arm_away_failure(hass: HomeAssistant) -> None:
     """Test arm away method failure."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -298,8 +317,10 @@ async def test_arm_away_failure(hass: HomeAssistant) -> None:
 async def test_disarm_success(hass: HomeAssistant) -> None:
     """Test disarm method success."""
     responses = [RESPONSE_ARMED_AWAY, RESPONSE_DISARM_SUCCESS, RESPONSE_DISARMED]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
         assert mock_request.call_count == 1
 
@@ -321,8 +342,10 @@ async def test_disarm_failure(hass: HomeAssistant) -> None:
         RESPONSE_DISARM_FAILURE,
         RESPONSE_USER_CODE_INVALID,
     ]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
         assert mock_request.call_count == 1
 
@@ -351,8 +374,10 @@ async def test_disarm_failure(hass: HomeAssistant) -> None:
 async def test_arm_night_success(hass: HomeAssistant) -> None:
     """Test arm night method success."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_NIGHT]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -370,8 +395,10 @@ async def test_arm_night_success(hass: HomeAssistant) -> None:
 async def test_arm_night_failure(hass: HomeAssistant) -> None:
     """Test arm night method failure."""
     responses = [RESPONSE_DISARMED, RESPONSE_ARM_FAILURE, RESPONSE_USER_CODE_INVALID]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -400,8 +427,10 @@ async def test_arm_night_failure(hass: HomeAssistant) -> None:
 async def test_arming(hass: HomeAssistant) -> None:
     """Test arming."""
     responses = [RESPONSE_DISARMED, RESPONSE_SUCCESS, RESPONSE_ARMING]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 
@@ -419,8 +448,10 @@ async def test_arming(hass: HomeAssistant) -> None:
 async def test_disarming(hass: HomeAssistant) -> None:
     """Test disarming."""
     responses = [RESPONSE_ARMED_AWAY, RESPONSE_SUCCESS, RESPONSE_DISARMING]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
         assert mock_request.call_count == 1
 
@@ -438,8 +469,10 @@ async def test_disarming(hass: HomeAssistant) -> None:
 async def test_triggered_fire(hass: HomeAssistant) -> None:
     """Test triggered by fire."""
     responses = [RESPONSE_TRIGGERED_FIRE]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         state = hass.states.get(ENTITY_ID)
         assert state.state == STATE_ALARM_TRIGGERED
         assert state.attributes.get("triggered_source") == "Fire/Smoke"
@@ -449,8 +482,10 @@ async def test_triggered_fire(hass: HomeAssistant) -> None:
 async def test_triggered_police(hass: HomeAssistant) -> None:
     """Test triggered by police."""
     responses = [RESPONSE_TRIGGERED_POLICE]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         state = hass.states.get(ENTITY_ID)
         assert state.state == STATE_ALARM_TRIGGERED
         assert state.attributes.get("triggered_source") == "Police/Medical"
@@ -460,8 +495,10 @@ async def test_triggered_police(hass: HomeAssistant) -> None:
 async def test_triggered_carbon_monoxide(hass: HomeAssistant) -> None:
     """Test triggered by carbon monoxide."""
     responses = [RESPONSE_TRIGGERED_CARBON_MONOXIDE]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         state = hass.states.get(ENTITY_ID)
         assert state.state == STATE_ALARM_TRIGGERED
         assert state.attributes.get("triggered_source") == "Carbon Monoxide"
@@ -471,8 +508,10 @@ async def test_triggered_carbon_monoxide(hass: HomeAssistant) -> None:
 async def test_armed_custom(hass: HomeAssistant) -> None:
     """Test armed custom."""
     responses = [RESPONSE_ARMED_CUSTOM]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_CUSTOM_BYPASS
         assert mock_request.call_count == 1
 
@@ -480,8 +519,10 @@ async def test_armed_custom(hass: HomeAssistant) -> None:
 async def test_unknown(hass: HomeAssistant) -> None:
     """Test unknown arm status."""
     responses = [RESPONSE_UNKNOWN]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
         assert mock_request.call_count == 1
 
@@ -496,9 +537,11 @@ async def test_other_update_failures(hass: HomeAssistant) -> None:
         RESPONSE_DISARMED,
         ValueError,
     ]
+    await setup_platform(hass, ALARM_DOMAIN)
     with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
         # first things work as planned
-        await setup_platform(hass, ALARM_DOMAIN)
+        await async_update_entity(hass, ENTITY_ID)
+        await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces deprecated async_setup_platforms with async_forward_entry_setups

Removes an unneeded `update_before_add` to fix blocking in the test

Reorders the test a bit to fix double patching

Note: these tests could probably benefit from `@pytest.mark.parametrize`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
