### PR TITLE
Add Input number set min/max service

### DIFF
--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -340,6 +340,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         if minimum > self._current_value:
             self._current_value = minimum
         self._minimum = minimum
+        self._config[CONF_MIN] = minimum
         self.async_write_ha_state()
 
     async def async_set_max(self, value):
@@ -352,6 +353,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         if maximum < self._current_value:
             self._current_value = maximum
         self._maximum = maximum
+        self._config[CONF_MAX] = maximum
         self.async_write_ha_state()
 
 

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -244,16 +244,6 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         input_num.editable = False
         return input_num
 
-    #    @property
-    #    def _minimum(self) -> float:
-    #        """Return minimum allowed value."""
-    #        return self._minimum
-
-    #    @property
-    #    def _maximum(self) -> float:
-    #        """Return maximum allowed value."""
-    #        return self._maximum
-
     @property
     def name(self):
         """Return the name of the input slider."""
@@ -371,10 +361,13 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         self._config = config
 
         # just in case min/max values changed
-        if self._current_value is None:
+        if (
+            self._current_value is None
+            or self._maximum is None
+            or self._minimum is None
+        ):
             return
-
-        # self._current_value = min(self._current_value, self._maximum)
-        # self._current_value = max(self._current_value, self._minimum)
+        self._current_value = min(self._current_value, self._maximum)
+        self._current_value = max(self._current_value, self._minimum)
 
         self.async_write_ha_state()

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -166,15 +166,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     component.async_register_entity_service(
-        SERVICE_SET_MIN, 
-        {vol.Required(ATTR_VALUE): vol.Coerce(float)},
-        'async_set_min'
+        SERVICE_SET_MIN, {vol.Required(ATTR_VALUE): vol.Coerce(float)}, "async_set_min"
     )
 
     component.async_register_entity_service(
-        SERVICE_SET_MAX, 
-        {vol.Required(ATTR_VALUE): vol.Coerce(float)},
-        'async_set_max'
+        SERVICE_SET_MAX, {vol.Required(ATTR_VALUE): vol.Coerce(float)}, "async_set_max"
     )
 
     component.async_register_entity_service(SERVICE_INCREMENT, {}, "async_increment")
@@ -248,15 +244,15 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         input_num.editable = False
         return input_num
 
-#    @property
-#    def _minimum(self) -> float:
-#        """Return minimum allowed value."""
-#        return self._minimum
+    #    @property
+    #    def _minimum(self) -> float:
+    #        """Return minimum allowed value."""
+    #        return self._minimum
 
-#    @property
-#    def _maximum(self) -> float:
-#        """Return maximum allowed value."""
-#        return self._maximum
+    #    @property
+    #    def _maximum(self) -> float:
+    #        """Return maximum allowed value."""
+    #        return self._maximum
 
     @property
     def name(self):
@@ -333,8 +329,11 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         """Set new min value."""
         minimum = float(value)
         if minimum >= self._maximum:
-            _LOGGER.warning("Invalid minimum: %s (must be lower than maximum %s)",
-                            minimum, self._maximum)
+            _LOGGER.warning(
+                "Invalid minimum: %s (must be lower than maximum %s)",
+                minimum,
+                self._maximum,
+            )
             return
         # Adjust value to minimim if it is less than the new minimum
         if minimum > self._current_value:
@@ -347,15 +346,17 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         """Set new max value."""
         maximum = float(value)
         if self._minimum >= maximum:
-            _LOGGER.warning("Invalid maximum: %s (must be higher than minimum %s)",
-                            maximum, self._minimum)
+            _LOGGER.warning(
+                "Invalid maximum: %s (must be higher than minimum %s)",
+                maximum,
+                self._minimum,
+            )
             return
         if maximum < self._current_value:
             self._current_value = maximum
         self._maximum = maximum
         self._config[CONF_MAX] = maximum
         self.async_write_ha_state()
-
 
     async def async_increment(self):
         """Increment value."""
@@ -368,9 +369,12 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config
+
         # just in case min/max values changed
         if self._current_value is None:
             return
-        self._current_value = min(self._current_value, self._maximum)
-        self._current_value = max(self._current_value, self._minimum)
+
+        # self._current_value = min(self._current_value, self._maximum)
+        # self._current_value = max(self._current_value, self._minimum)
+
         self.async_write_ha_state()

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -361,13 +361,13 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         self._config = config
 
         # just in case min/max values changed
-        if (
-            self._current_value is None
-            or self._maximum is None
-            or self._minimum is None
-        ):
+        if self._current_value is None:
             return
-        self._current_value = min(self._current_value, self._maximum)
-        self._current_value = max(self._current_value, self._minimum)
+
+        if self._maximum is not None:
+            self._current_value = min(self._current_value, self._maximum)
+
+        if self._minimum is not None:
+            self._current_value = max(self._current_value, self._minimum)
 
         self.async_write_ha_state()

--- a/homeassistant/components/input_number/manifest.json
+++ b/homeassistant/components/input_number/manifest.json
@@ -4,5 +4,6 @@
   "name": "Input Number",
   "documentation": "https://www.home-assistant.io/integrations/input_number",
   "codeowners": ["@home-assistant/core"],
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "version":"0.1"
 }

--- a/homeassistant/components/input_number/manifest.json
+++ b/homeassistant/components/input_number/manifest.json
@@ -4,6 +4,5 @@
   "name": "Input Number",
   "documentation": "https://www.home-assistant.io/integrations/input_number",
   "codeowners": ["@home-assistant/core"],
-  "quality_scale": "internal",
-  "version":"0.1"
+  "quality_scale": "internal"
 }

--- a/homeassistant/components/input_number/services.yaml
+++ b/homeassistant/components/input_number/services.yaml
@@ -30,6 +30,42 @@ set_value:
           step: 0.001
           mode: box
 
+set_min:
+  name: Set min
+  description: Set the minimal value of the entity.
+  target:
+    entity:
+      domain: input_number
+  fields:
+    value:
+      name: Value
+      description: The minimum value the entity can be set to.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          step: 0.001
+          mode: box
+
+set_max:
+  name: Set max
+  description: Set the maximal value of the entity.
+  target:
+    entity:
+      domain: input_number
+  fields:
+    value:
+      name: Value
+      description: The maximum value the entity can be set to.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          step: 0.001
+          mode: box
+
 reload:
   name: Reload
   description: Reload the input_number configuration.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Changing the input_number handler to allow modification of the min and max value by a service.

My use case is from the following situation, i like to control my basement thermostat by using a slider. If it's too cold my thermostat move from the set temperature of the slider to an higher degree slightly (incrementing by the step .5).  Usually the basement is kept at 12, and if the split heat pump cannot keep the temperature to 20, the basement will be moving towards 12.5, 13, 13.5, ...

Each 15 minutes there's an automation that verify that it's not too hot or too cold in a room of the house. However the main reason of the changes was to allow modification of the min and max value of the slider since sometimes I have my children and they live mostly in the basement (actually when sleeping). So when they comes home, I want to automatically adjust the minimal of the slider to 16 so that they won't be too cold when coming here. ;)

Sorry for the duplicate, I have forgotten to create a different branch and didn't know how to fix that issue. I didn't tough I closed it initially.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
