### PR TITLE
Conversation cleanup

### DIFF
--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -147,7 +147,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, almond_hass_start)
 
-    conversation.async_set_agent(hass, agent)
+    conversation.async_set_agent(hass, entry, agent)
     return True
 
 
@@ -223,7 +223,7 @@ async def _configure_almond_for_ha(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Almond."""
-    conversation.async_set_agent(hass, None)
+    conversation.async_unset_agent(hass, entry)
     return True
 
 

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_TYPE,
     EVENT_HOMEASSISTANT_START,
 )
-from homeassistant.core import Context, CoreState, HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     aiohttp_client,
@@ -265,15 +265,12 @@ class AlmondAgent(conversation.AbstractConversationAgent):
         return {"name": "Powered by Almond", "url": "https://almond.stanford.edu/"}
 
     async def async_process(
-        self,
-        text: str,
-        context: Context,
-        conversation_id: str | None = None,
-        language: str | None = None,
+        self, user_input: conversation.ConversationInput
     ) -> conversation.ConversationResult:
         """Process a sentence."""
-        response = await self.api.async_converse_text(text, conversation_id)
-        language = language or self.hass.config.language
+        response = await self.api.async_converse_text(
+            user_input.text, user_input.conversation_id
+        )
 
         first_choice = True
         buffer = ""
@@ -294,8 +291,8 @@ class AlmondAgent(conversation.AbstractConversationAgent):
                     buffer += ","
                 buffer += f" {message['title']}"
 
-        intent_response = intent.IntentResponse(language=language)
+        intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(buffer.strip())
         return conversation.ConversationResult(
-            response=intent_response, conversation_id=conversation_id
+            response=intent_response, conversation_id=user_input.conversation_id
         )

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -264,30 +264,6 @@ class AlmondAgent(conversation.AbstractConversationAgent):
         """Return the attribution."""
         return {"name": "Powered by Almond", "url": "https://almond.stanford.edu/"}
 
-    async def async_get_onboarding(self):
-        """Get onboard url if not onboarded."""
-        if self.entry.data.get("onboarded"):
-            return None
-
-        host = self.entry.data["host"]
-        if self.entry.data.get("is_hassio"):
-            host = "/core_almond"
-        return {
-            "text": (
-                "Would you like to opt-in to share your anonymized commands with"
-                " Stanford to improve Almond's responses?"
-            ),
-            "url": f"{host}/conversation",
-        }
-
-    async def async_set_onboarding(self, shown):
-        """Set onboarding status."""
-        self.hass.config_entries.async_update_entry(
-            self.entry, data={**self.entry.data, "onboarded": shown}
-        )
-
-        return True
-
     async def async_process(
         self,
         text: str,

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant import core
 from homeassistant.components import http, websocket_api
 from homeassistant.components.http.data_validator import RequestDataValidator
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, intent
 from homeassistant.helpers.typing import ConfigType
@@ -62,9 +63,23 @@ CONFIG_SCHEMA = vol.Schema(
 
 @core.callback
 @bind_hass
-def async_set_agent(hass: core.HomeAssistant, agent: AbstractConversationAgent | None):
+def async_set_agent(
+    hass: core.HomeAssistant,
+    config_entry: ConfigEntry,
+    agent: AbstractConversationAgent,
+):
     """Set the agent to handle the conversations."""
     hass.data[DATA_AGENT] = agent
+
+
+@core.callback
+@bind_hass
+def async_unset_agent(
+    hass: core.HomeAssistant,
+    config_entry: ConfigEntry,
+):
+    """Set the agent to handle the conversations."""
+    hass.data[DATA_AGENT] = None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -114,7 +114,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, websocket_process)
     websocket_api.async_register_command(hass, websocket_prepare)
     websocket_api.async_register_command(hass, websocket_get_agent_info)
-    websocket_api.async_register_command(hass, websocket_set_onboarding)
 
     return True
 
@@ -173,39 +172,15 @@ async def websocket_get_agent_info(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Do we need onboarding."""
+    """Info about the agent in use."""
     agent = await _get_agent(hass)
 
     connection.send_result(
         msg["id"],
         {
-            "onboarding": await agent.async_get_onboarding(),
             "attribution": agent.attribution,
         },
     )
-
-
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): "conversation/onboarding/set",
-        vol.Required("shown"): bool,
-    }
-)
-@websocket_api.async_response
-async def websocket_set_onboarding(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
-    """Set onboarding status."""
-    agent = await _get_agent(hass)
-
-    success = await agent.async_set_onboarding(msg["shown"])
-
-    if success:
-        connection.send_result(msg["id"])
-    else:
-        connection.send_error(msg["id"], "error", "Failed to set onboarding")
 
 
 class ConversationProcessView(http.HomeAssistantView):

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypedDict
 
 from homeassistant.core import Context
 from homeassistant.helpers import intent
@@ -24,11 +24,18 @@ class ConversationResult:
         }
 
 
+class Attribution(TypedDict):
+    """Attribution for a conversation agent."""
+
+    name: str
+    url: str
+
+
 class AbstractConversationAgent(ABC):
     """Abstract conversation agent."""
 
     @property
-    def attribution(self):
+    def attribution(self) -> Attribution | None:
         """Return the attribution."""
         return None
 
@@ -42,8 +49,8 @@ class AbstractConversationAgent(ABC):
     ) -> ConversationResult:
         """Process a sentence."""
 
-    async def async_reload(self, language: str | None = None):
+    async def async_reload(self, language: str | None = None) -> None:
         """Clear cached intents for a language."""
 
-    async def async_prepare(self, language: str | None = None):
+    async def async_prepare(self, language: str | None = None) -> None:
         """Load intents for a language."""

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -10,6 +10,16 @@ from homeassistant.helpers import intent
 
 
 @dataclass
+class ConversationInput:
+    """User input to be processed."""
+
+    text: str
+    context: Context
+    conversation_id: str | None
+    language: str
+
+
+@dataclass
 class ConversationResult:
     """Result of async_process."""
 
@@ -40,13 +50,7 @@ class AbstractConversationAgent(ABC):
         return None
 
     @abstractmethod
-    async def async_process(
-        self,
-        text: str,
-        context: Context,
-        conversation_id: str | None = None,
-        language: str | None = None,
-    ) -> ConversationResult:
+    async def async_process(self, user_input: ConversationInput) -> ConversationResult:
         """Process a sentence."""
 
     async def async_reload(self, language: str | None = None) -> None:

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -32,14 +32,6 @@ class AbstractConversationAgent(ABC):
         """Return the attribution."""
         return None
 
-    async def async_get_onboarding(self):
-        """Get onboard data."""
-        return None
-
-    async def async_set_onboarding(self, shown):
-        """Set onboard data."""
-        return True
-
     @abstractmethod
     async def async_process(
         self,

--- a/homeassistant/components/google_assistant_sdk/__init__.py
+++ b/homeassistant/components/google_assistant_sdk/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME, Platform
-from homeassistant.core import Context, HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, discovery, intent
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -148,11 +148,7 @@ class GoogleAssistantConversationAgent(conversation.AbstractConversationAgent):
         }
 
     async def async_process(
-        self,
-        text: str,
-        context: Context,
-        conversation_id: str | None = None,
-        language: str | None = None,
+        self, user_input: conversation.ConversationInput
     ) -> conversation.ConversationResult:
         """Process a sentence."""
         if self.session:
@@ -170,12 +166,11 @@ class GoogleAssistantConversationAgent(conversation.AbstractConversationAgent):
             )
             self.assistant = TextAssistant(credentials, language_code)
 
-        resp = self.assistant.assist(text)
+        resp = self.assistant.assist(user_input.text)
         text_response = resp[0]
 
-        language = language or self.hass.config.language
-        intent_response = intent.IntentResponse(language=language)
+        intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(text_response)
         return conversation.ConversationResult(
-            response=intent_response, conversation_id=conversation_id
+            response=intent_response, conversation_id=user_input.conversation_id
         )

--- a/homeassistant/components/google_assistant_sdk/__init__.py
+++ b/homeassistant/components/google_assistant_sdk/__init__.py
@@ -124,9 +124,9 @@ async def update_listener(hass, entry):
     """Handle options update."""
     if entry.options.get(CONF_ENABLE_CONVERSATION_AGENT, False):
         agent = GoogleAssistantConversationAgent(hass, entry)
-        conversation.async_set_agent(hass, agent)
+        conversation.async_set_agent(hass, entry, agent)
     else:
-        conversation.async_set_agent(hass, None)
+        conversation.async_unset_agent(hass, entry)
 
 
 class GoogleAssistantConversationAgent(conversation.AbstractConversationAgent):

--- a/tests/components/conversation/__init__.py
+++ b/tests/components/conversation/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from homeassistant.components import conversation
-from homeassistant.core import Context
 from homeassistant.helpers import intent
 
 
@@ -15,16 +14,12 @@ class MockAgent(conversation.AbstractConversationAgent):
         self.response = "Test response"
 
     async def async_process(
-        self,
-        text: str,
-        context: Context,
-        conversation_id: str | None = None,
-        language: str | None = None,
+        self, user_input: conversation.ConversationInput
     ) -> conversation.ConversationResult:
         """Process some text."""
-        self.calls.append((text, context, conversation_id, language))
-        response = intent.IntentResponse(language=language)
+        self.calls.append(user_input)
+        response = intent.IntentResponse(language=user_input.language)
         response.async_set_speech(self.response)
         return conversation.ConversationResult(
-            response=response, conversation_id=conversation_id
+            response=response, conversation_id=user_input.conversation_id
         )

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -11,5 +11,5 @@ from . import MockAgent
 def mock_agent(hass):
     """Mock agent."""
     agent = MockAgent()
-    conversation.async_set_agent(hass, agent)
+    conversation.async_set_agent(hass, None, agent)
     return agent


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is for developers. Dev blog PR @ https://github.com/home-assistant/developers.home-assistant/pull/1647.

`AbstractConversationAgent` has the following changes

- All onboarding logic removed
- `async_process` now takes new `ConversationInput` parameter with the same arguments. Language is now always set.

Setting an agent now requires a config entry: `conversation.async_set_agent(hass, config_entry, agent).

Unsetting an agent now goes via a new endpoint: `conversation.async_unset_agent(hass, config_entry)


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some cleanup of the conversation integration to make it future proof and avoid having to break it in the future.

- Require config entry when adding a conversation agent. This will allow us to support multiple conversation agents in the future and track them across reboots
- Add new endpoint to unset a conversation agent (instead of setting it to None)
- Type the attribution property on `AbstractConversationAgent`
- Remove onboarding from `AbstractConversationAgent`. It was added for now-defunct Almond and it should really be done during the config flow to set it up. Frontend cleanup @ https://github.com/home-assistant/frontend/pull/15187
- Wrap all parameters for `async_process` in a new ConversationInput data class. This will allow us to add more parameters in the future.
- Language is already defaulted to the Home Assistant configured language in the API endpoints so I removed this logic from the conversation agents that implemented it themselves
- Default conversation agent now always returns `conversation_id=None` because it does not support tracking conversations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
