### PR TITLE
Mock async_setup_entry in SamsungTV tests

### DIFF
--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -943,7 +943,9 @@ async def test_import_legacy(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote", "remotews", "rest_api_failing")
-async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
+async def test_import_legacy_without_name(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test importing from yaml without a name."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedWSAsyncRemote.start_listening",
@@ -961,10 +963,13 @@ async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
     assert result["result"].unique_id is None
 
+    mock_setup_entry.assert_called_once()
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data[CONF_METHOD] == METHOD_LEGACY
-    assert entries[0].data[CONF_PORT] == LEGACY_PORT
+    # METHOD / PORT failed during import
+    # They will get checked/set on setup
+    assert CONF_METHOD not in entries[0].data
+    assert CONF_PORT not in entries[0].data
 
 
 @pytest.mark.usefixtures("remotews", "rest_api")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Samsung TV config flow."""
+from collections.abc import Generator
 import socket
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
@@ -215,6 +216,15 @@ DEVICEINFO_WEBSOCKET_NO_SSL = {
     "port": 8001,
     "timeout": TIMEOUT_WEBSOCKET,
 }
+
+
+@pytest.fixture(autouse=True, name="mock_setup_entry")
+def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.samsungtv.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.mark.usefixtures("remote", "rest_api_failing")
@@ -1382,7 +1392,7 @@ async def test_update_old_entry(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_from_dhcp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
@@ -1390,10 +1400,7 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -1411,7 +1418,7 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_from_zeroconf(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
@@ -1419,10 +1426,7 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
@@ -1438,7 +1442,9 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
 
 
 @pytest.mark.usefixtures("remote", "rest_api_failing")
-async def test_update_missing_model_added_from_ssdp(hass: HomeAssistant) -> None:
+async def test_update_missing_model_added_from_ssdp(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test missing model added via ssdp on legacy models."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1449,10 +1455,7 @@ async def test_update_missing_model_added_from_ssdp(hass: HomeAssistant) -> None
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1469,7 +1472,7 @@ async def test_update_missing_model_added_from_ssdp(hass: HomeAssistant) -> None
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_ssdp_location_added_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac, ssdp_location, and unique id added via ssdp."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
@@ -1477,10 +1480,7 @@ async def test_update_missing_mac_unique_id_ssdp_location_added_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1525,7 +1525,7 @@ async def test_update_zeroconf_discovery_preserved_unique_id(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id with outdated ssdp_location with the wrong st added via ssdp."""
     entry = MockConfigEntry(
@@ -1540,10 +1540,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssd
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1565,7 +1562,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssd
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_updated_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id with outdated ssdp_location with the correct st added via ssdp."""
     entry = MockConfigEntry(
@@ -1580,10 +1577,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_upd
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1606,7 +1600,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_upd
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st_updated_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id with outdated ssdp_location with the correct st added via ssdp."""
     entry = MockConfigEntry(
@@ -1622,10 +1616,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1652,7 +1643,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_rendering_st_updated_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test with outdated ssdp_location with the correct st added via ssdp."""
     entry = MockConfigEntry(
@@ -1664,10 +1655,7 @@ async def test_update_ssdp_location_rendering_st_updated_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1690,7 +1678,7 @@ async def test_update_ssdp_location_rendering_st_updated_from_ssdp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_main_tv_ssdp_location_rendering_st_updated_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test with outdated ssdp_location with the correct st added via ssdp."""
     entry = MockConfigEntry(
@@ -1702,10 +1690,7 @@ async def test_update_main_tv_ssdp_location_rendering_st_updated_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1728,7 +1713,7 @@ async def test_update_main_tv_ssdp_location_rendering_st_updated_from_ssdp(
 
 @pytest.mark.usefixtures("remotews", "rest_api")
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
@@ -1740,10 +1725,7 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
@@ -1759,7 +1741,9 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
 
 
 @pytest.mark.usefixtures("remote")
-async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
+async def test_update_legacy_missing_mac_from_dhcp(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test missing mac added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1770,10 +1754,7 @@ async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -1792,7 +1773,7 @@ async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("remote")
 async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
-    hass: HomeAssistant, rest_api: Mock
+    hass: HomeAssistant, rest_api: Mock, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing mac added when there is no unique id."""
     rest_api.rest_device_info.side_effect = HttpApiError
@@ -1810,10 +1791,7 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
     ), patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -1832,7 +1810,7 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_unique_id_added_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing ssdp_location, and unique id added via ssdp."""
     entry = MockConfigEntry(
@@ -1844,10 +1822,7 @@ async def test_update_ssdp_location_unique_id_added_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -1867,7 +1842,7 @@ async def test_update_ssdp_location_unique_id_added_from_ssdp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_unique_id_added_from_ssdp_with_rendering_control_st(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test missing ssdp_location, and unique id added via ssdp with rendering control st."""
     entry = MockConfigEntry(
@@ -1879,10 +1854,7 @@ async def test_update_ssdp_location_unique_id_added_from_ssdp_with_rendering_con
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -2085,7 +2057,7 @@ async def test_form_reauth_encrypted(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_upnp_udn_unique_id_added_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test updating the wrong udn from ssdp via upnp udn match."""
     entry = MockConfigEntry(
@@ -2097,10 +2069,7 @@ async def test_update_incorrect_udn_matching_upnp_udn_unique_id_added_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -2118,7 +2087,7 @@ async def test_update_incorrect_udn_matching_upnp_udn_unique_id_added_from_ssdp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_mac_unique_id_added_from_ssdp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test updating the wrong udn from ssdp via mac match."""
     entry = MockConfigEntry(
@@ -2130,10 +2099,7 @@ async def test_update_incorrect_udn_matching_mac_unique_id_added_from_ssdp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
@@ -2151,7 +2117,7 @@ async def test_update_incorrect_udn_matching_mac_unique_id_added_from_ssdp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_mac_from_dhcp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test that DHCP updates the wrong udn from ssdp via mac match."""
     entry = MockConfigEntry(
@@ -2164,10 +2130,7 @@ async def test_update_incorrect_udn_matching_mac_from_dhcp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -2185,7 +2148,7 @@ async def test_update_incorrect_udn_matching_mac_from_dhcp(
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_no_update_incorrect_udn_not_matching_mac_from_dhcp(
-    hass: HomeAssistant,
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test that DHCP does not update the wrong udn from ssdp via host match."""
     entry = MockConfigEntry(
@@ -2198,10 +2161,7 @@ async def test_no_update_incorrect_udn_not_matching_mac_from_dhcp(
     with patch(
         "homeassistant.components.samsungtv.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.samsungtv.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -5,11 +5,14 @@ import pytest
 
 from homeassistant.components.media_player import DOMAIN, SUPPORT_TURN_ON
 from homeassistant.components.samsungtv.const import (
+    CONF_MANUFACTURER,
     CONF_ON_ACTION,
     CONF_SESSION_ID,
     CONF_SSDP_MAIN_TV_AGENT_LOCATION,
     CONF_SSDP_RENDERING_CONTROL_LOCATION,
     DOMAIN as SAMSUNGTV_DOMAIN,
+    LEGACY_PORT,
+    METHOD_LEGACY,
     METHOD_WEBSOCKET,
     UPNP_SVC_MAIN_TV_AGENT,
     UPNP_SVC_RENDERING_CONTROL,
@@ -23,6 +26,7 @@ from homeassistant.const import (
     CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
+    CONF_PORT,
     CONF_TOKEN,
     SERVICE_VOLUME_UP,
 )
@@ -214,3 +218,16 @@ async def test_reauth_triggered_encrypted(hass: HomeAssistant) -> None:
         if flow["context"]["source"] == "reauth"
     ]
     assert len(flows_in_progress) == 1
+
+
+@pytest.mark.usefixtures("remote", "remotews", "rest_api_failing")
+async def test_update_imported_legacy_without_method(hass: HomeAssistant) -> None:
+    """Test updating an imported legacy entry without a method."""
+    await setup_samsungtv_entry(
+        hass, {CONF_HOST: "fake_host", CONF_MANUFACTURER: "Samsung"}
+    )
+
+    entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_METHOD] == METHOD_LEGACY
+    assert entries[0].data[CONF_PORT] == LEGACY_PORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mock async_setup_entry in samsungtv tests

Needed for #86575

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
