### PR TITLE
Drop IoTaWatt Accumulated sensors

### DIFF
--- a/homeassistant/components/iotawatt/const.py
+++ b/homeassistant/components/iotawatt/const.py
@@ -9,6 +9,4 @@ DOMAIN = "iotawatt"
 VOLT_AMPERE_REACTIVE = "VAR"
 VOLT_AMPERE_REACTIVE_HOURS = "VARh"
 
-ATTR_LAST_UPDATE = "last_update"
-
 CONNECTION_ERRORS = (KeyError, json.JSONDecodeError, httpx.HTTPError)

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -27,17 +27,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity, entity_registry
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 
-from .const import (
-    ATTR_LAST_UPDATE,
-    DOMAIN,
-    VOLT_AMPERE_REACTIVE,
-    VOLT_AMPERE_REACTIVE_HOURS,
-)
+from .const import DOMAIN, VOLT_AMPERE_REACTIVE, VOLT_AMPERE_REACTIVE_HOURS
 from .coordinator import IotawattUpdater
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,10 +128,6 @@ async def async_setup_entry(
         description = ENTITY_DESCRIPTION_KEY_MAP.get(
             data.getUnit(), IotaWattSensorEntityDescription("base_sensor")
         )
-        if data.getUnit() == "WattHours" and not data.getFromStart():
-            return IotaWattAccumulatingSensor(
-                coordinator=coordinator, key=key, entity_description=description
-            )
 
         return IotaWattSensor(
             coordinator=coordinator,
@@ -235,77 +225,3 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
             return func(self._sensor_data.getValue())
 
         return self._sensor_data.getValue()
-
-
-class IotaWattAccumulatingSensor(IotaWattSensor, RestoreEntity):
-    """Defines a IoTaWatt Accumulative Energy (High Accuracy) Sensor."""
-
-    def __init__(
-        self,
-        coordinator: IotawattUpdater,
-        key: str,
-        entity_description: IotaWattSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-
-        super().__init__(coordinator, key, entity_description)
-
-        if self._attr_unique_id is not None:
-            self._attr_unique_id += ".accumulated"
-
-        self._accumulated_value: float | None = None
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        assert (
-            self._accumulated_value is not None
-        ), "async_added_to_hass must have been called first"
-        self._accumulated_value += float(self._sensor_data.getValue())
-
-        super()._handle_coordinator_update()
-
-    @property
-    def native_value(self) -> StateType:
-        """Return the state of the sensor."""
-        if self._accumulated_value is None:
-            return None
-        return round(self._accumulated_value, 1)
-
-    async def async_added_to_hass(self) -> None:
-        """Load the last known state value of the entity if the accumulated type."""
-        await super().async_added_to_hass()
-        state = await self.async_get_last_state()
-        self._accumulated_value = 0.0
-        if state:
-            try:
-                # Previous value could be `unknown` if the connection didn't originally
-                # complete.
-                self._accumulated_value = float(state.state)
-            except (ValueError) as err:
-                _LOGGER.warning("Could not restore last state: %s", err)
-            else:
-                if ATTR_LAST_UPDATE in state.attributes:
-                    last_run = dt.parse_datetime(state.attributes[ATTR_LAST_UPDATE])
-                    if last_run is not None:
-                        self.coordinator.update_last_run(last_run)
-        # Force a second update from the iotawatt to ensure that sensors are up to date.
-        await self.coordinator.async_request_refresh()
-
-    @property
-    def name(self) -> str | None:
-        """Return name of the entity."""
-        return f"{self._sensor_data.getSourceName()} Accumulated"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, str]:
-        """Return the extra state attributes of the entity."""
-        attrs = super().extra_state_attributes
-
-        assert (
-            self.coordinator.api is not None
-            and self.coordinator.api.getLastUpdateTime() is not None
-        )
-        attrs[ATTR_LAST_UPDATE] = self.coordinator.api.getLastUpdateTime().isoformat()
-
-        return attrs

--- a/tests/components/iotawatt/__init__.py
+++ b/tests/components/iotawatt/__init__.py
@@ -22,27 +22,3 @@ OUTPUT_SENSOR = Sensor(
     mac_addr="mock-mac",
     fromStart=True,
 )
-
-INPUT_ACCUMULATED_SENSOR = Sensor(
-    channel="N/A",
-    base_name="My WattHour Accumulated Input Sensor",
-    suffix=".wh",
-    io_type="Input",
-    unit="WattHours",
-    value=500,
-    begin="",
-    mac_addr="mock-mac",
-    fromStart=False,
-)
-
-OUTPUT_ACCUMULATED_SENSOR = Sensor(
-    channel="N/A",
-    base_name="My WattHour Accumulated Output Sensor",
-    suffix=".wh",
-    io_type="Output",
-    unit="WattHours",
-    value=200,
-    begin="",
-    mac_addr="mock-mac",
-    fromStart=False,
-)

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -1,7 +1,6 @@
 """Test setting up sensors."""
 from datetime import timedelta
 
-from homeassistant.components.iotawatt.const import ATTR_LAST_UPDATE
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -14,18 +13,12 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfPower,
 )
-from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from . import (
-    INPUT_ACCUMULATED_SENSOR,
-    INPUT_SENSOR,
-    OUTPUT_ACCUMULATED_SENSOR,
-    OUTPUT_SENSOR,
-)
+from . import INPUT_SENSOR, OUTPUT_SENSOR
 
-from tests.common import async_fire_time_changed, mock_restore_cache
+from tests.common import async_fire_time_changed
 
 
 async def test_sensor_type_input(hass, mock_iotawatt):
@@ -83,161 +76,3 @@ async def test_sensor_type_output(hass, mock_iotawatt):
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.my_watthour_sensor") is None
-
-
-async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
-    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
-    mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_output_sensor_key"
-    ] = OUTPUT_ACCUMULATED_SENSOR
-
-    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
-
-    mock_restore_cache(
-        hass,
-        (
-            State(
-                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
-                "100.0",
-                {
-                    "device_class": SensorDeviceClass.ENERGY,
-                    "unit_of_measurement": UnitOfEnergy.WATT_HOUR,
-                    "last_update": DUMMY_DATE,
-                },
-            ),
-        ),
-    )
-
-    assert await async_setup_component(hass, "iotawatt", {})
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_entity_ids()) == 1
-
-    state = hass.states.get(
-        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
-    )
-    assert state is not None
-
-    assert state.state == "300.0"  # 100 + 200
-    assert (
-        state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Output Sensor.wh Accumulated"
-    )
-    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
-    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
-    assert state.attributes["type"] == "Output"
-    assert state.attributes[ATTR_LAST_UPDATE] is not None
-    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
-
-
-async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt):
-    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
-    mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_output_sensor_key"
-    ] = OUTPUT_ACCUMULATED_SENSOR
-
-    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
-
-    mock_restore_cache(
-        hass,
-        (
-            State(
-                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
-                "unknown",
-            ),
-        ),
-    )
-
-    assert await async_setup_component(hass, "iotawatt", {})
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_entity_ids()) == 1
-
-    state = hass.states.get(
-        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
-    )
-    assert state is not None
-
-    assert state.state == "200.0"  # Returns the new read as restore failed.
-    assert (
-        state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Output Sensor.wh Accumulated"
-    )
-    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
-    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
-    assert state.attributes["type"] == "Output"
-    assert state.attributes[ATTR_LAST_UPDATE] is not None
-    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
-
-
-async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
-    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
-    mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_output_sensor_key"
-    ] = OUTPUT_ACCUMULATED_SENSOR
-    mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_input_sensor_key"
-    ] = INPUT_ACCUMULATED_SENSOR
-
-    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
-
-    mock_restore_cache(
-        hass,
-        (
-            State(
-                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
-                "100.0",
-                {
-                    "device_class": SensorDeviceClass.ENERGY,
-                    "unit_of_measurement": UnitOfEnergy.WATT_HOUR,
-                    "last_update": DUMMY_DATE,
-                },
-            ),
-            State(
-                "sensor.my_watthour_accumulated_input_sensor_wh_accumulated",
-                "50.0",
-                {
-                    "device_class": SensorDeviceClass.ENERGY,
-                    "unit_of_measurement": UnitOfEnergy.WATT_HOUR,
-                    "last_update": DUMMY_DATE,
-                },
-            ),
-        ),
-    )
-
-    assert await async_setup_component(hass, "iotawatt", {})
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_entity_ids()) == 2
-
-    state = hass.states.get(
-        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
-    )
-    assert state is not None
-
-    assert state.state == "300.0"  # 100 + 200
-    assert (
-        state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Output Sensor.wh Accumulated"
-    )
-    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
-    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
-    assert state.attributes["type"] == "Output"
-    assert state.attributes[ATTR_LAST_UPDATE] is not None
-    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
-
-    state = hass.states.get(
-        "sensor.my_watthour_accumulated_input_sensor_wh_accumulated"
-    )
-    assert state is not None
-
-    assert state.state == "550.0"  # 50 + 500
-    assert (
-        state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Input Sensor.wh Accumulated"
-    )
-    assert state.attributes[ATTR_LAST_UPDATE] is not None
-    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The IoTAWatt integration no longer provides sensors with the "Accumulated" suffix. The accumulated sensor have been introduced to support net energy export/import metering. Newer versions of IoTaWatt provide "Integrators", which allow to achieve the same more efficiently and with higher accuracy. Users should configure [Integrators](https://docs.iotawatt.com/en/master/integrators.html) to calculate the net energy export and import.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The accumulated sensors have been a stop-gap solution back when IoTaWatt did not had native Integrators. With the native Integrators, IoTaWatt is able to integrate (in the mathematical sense) in a consistent 5s time interval (compared to 30s time interval provided by the accumulated sensors). This essentially reverts #55512.

This has been proposed by [@boblemaire](https://github.com/home-assistant/core/issues/67698#issuecomment-1065952529) and [me](https://github.com/home-assistant/core/pull/65143#issuecomment-1024464333) previously.

/cc @jyavenard

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
