### PR TITLE
Improve Axis config flow tests

### DIFF
--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -36,6 +36,13 @@ from .const import DEFAULT_HOST, MAC, MODEL, NAME
 from tests.common import MockConfigEntry
 
 
+@pytest.fixture(name="mock_config_entry")
+async def mock_config_entry_fixture(prepare_config_entry):
+    """Mock config entry and setup entry."""
+    with patch("homeassistant.components.axis.async_setup_entry", return_value=True):
+        yield await prepare_config_entry()
+
+
 async def test_flow_manual_configuration(hass, setup_default_vapix_requests):
     """Test that config flow works."""
     MockConfigEntry(domain=AXIS_DOMAIN, source=SOURCE_IGNORE).add_to_hass(hass)
@@ -70,10 +77,10 @@ async def test_flow_manual_configuration(hass, setup_default_vapix_requests):
 
 
 async def test_manual_configuration_update_configuration(
-    hass, setup_config_entry, mock_vapix_requests
+    hass, mock_config_entry, mock_vapix_requests
 ):
     """Test that config flow fails on already configured device."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
+    assert mock_config_entry.data[CONF_HOST] == "1.2.3.4"
 
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, context={"source": SOURCE_USER}
@@ -82,25 +89,21 @@ async def test_manual_configuration_update_configuration(
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == SOURCE_USER
 
-    with patch(
-        "homeassistant.components.axis.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        mock_vapix_requests("2.3.4.5")
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "2.3.4.5",
-                CONF_USERNAME: "user",
-                CONF_PASSWORD: "pass",
-                CONF_PORT: 80,
-            },
-        )
-        await hass.async_block_till_done()
+    mock_vapix_requests("2.3.4.5")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "2.3.4.5",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_PORT: 80,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert device.host == "2.3.4.5"
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_config_entry.data[CONF_HOST] == "2.3.4.5"
 
 
 async def test_flow_fails_faulty_credentials(hass):
@@ -202,15 +205,17 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
 
 
 async def test_reauth_flow_update_configuration(
-    hass, setup_config_entry, mock_vapix_requests
+    hass, mock_config_entry, mock_vapix_requests
 ):
     """Test that config flow fails on already configured device."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
+    assert mock_config_entry.data[CONF_HOST] == "1.2.3.4"
+    assert mock_config_entry.data[CONF_USERNAME] == "root"
+    assert mock_config_entry.data[CONF_PASSWORD] == "pass"
 
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN,
         context={"source": SOURCE_REAUTH},
-        data=setup_config_entry.data,
+        data=mock_config_entry.data,
     )
 
     assert result["type"] == FlowResultType.FORM
@@ -230,9 +235,9 @@ async def test_reauth_flow_update_configuration(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert device.host == "2.3.4.5"
-    assert device.username == "user2"
-    assert device.password == "pass2"
+    assert mock_config_entry.data[CONF_HOST] == "2.3.4.5"
+    assert mock_config_entry.data[CONF_USERNAME] == "user2"
+    assert mock_config_entry.data[CONF_PASSWORD] == "pass2"
 
 
 @pytest.mark.parametrize(
@@ -376,10 +381,10 @@ async def test_discovery_flow(
     ],
 )
 async def test_discovered_device_already_configured(
-    hass, setup_config_entry, source: str, discovery_info: dict
+    hass, mock_config_entry, source: str, discovery_info: dict
 ):
     """Test that discovery doesn't setup already configured devices."""
-    assert setup_config_entry.data[CONF_HOST] == DEFAULT_HOST
+    assert mock_config_entry.data[CONF_HOST] == DEFAULT_HOST
 
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, data=discovery_info, context={"source": source}
@@ -387,7 +392,7 @@ async def test_discovered_device_already_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert setup_config_entry.data[CONF_HOST] == DEFAULT_HOST
+    assert mock_config_entry.data[CONF_HOST] == DEFAULT_HOST
 
 
 @pytest.mark.parametrize(
@@ -432,14 +437,14 @@ async def test_discovered_device_already_configured(
 )
 async def test_discovery_flow_updated_configuration(
     hass,
-    setup_config_entry,
+    mock_config_entry,
     mock_vapix_requests,
     source: str,
     discovery_info: dict,
     expected_port: int,
 ):
     """Test that discovery flow update configuration with new parameters."""
-    assert setup_config_entry.data == {
+    assert mock_config_entry.data == {
         CONF_HOST: DEFAULT_HOST,
         CONF_PORT: 80,
         CONF_USERNAME: "root",
@@ -448,18 +453,15 @@ async def test_discovery_flow_updated_configuration(
         CONF_NAME: NAME,
     }
 
-    with patch(
-        "homeassistant.components.axis.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        mock_vapix_requests("2.3.4.5")
-        result = await hass.config_entries.flow.async_init(
-            AXIS_DOMAIN, data=discovery_info, context={"source": source}
-        )
-        await hass.async_block_till_done()
+    mock_vapix_requests("2.3.4.5")
+    result = await hass.config_entries.flow.async_init(
+        AXIS_DOMAIN, data=discovery_info, context={"source": source}
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert setup_config_entry.data == {
+    assert mock_config_entry.data == {
         CONF_HOST: "2.3.4.5",
         CONF_PORT: expected_port,
         CONF_USERNAME: "root",
@@ -467,7 +469,6 @@ async def test_discovery_flow_updated_configuration(
         CONF_MODEL: MODEL,
         CONF_NAME: NAME,
     }
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -570,9 +571,8 @@ async def test_discovery_flow_ignore_link_local_address(
 
 async def test_option_flow(hass, setup_config_entry):
     """Test config flow options."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
-    assert device.option_stream_profile == DEFAULT_STREAM_PROFILE
-    assert device.option_video_source == DEFAULT_VIDEO_SOURCE
+    assert CONF_STREAM_PROFILE not in setup_config_entry.options
+    assert CONF_VIDEO_SOURCE not in setup_config_entry.options
 
     result = await hass.config_entries.options.async_init(setup_config_entry.entry_id)
 
@@ -599,5 +599,5 @@ async def test_option_flow(hass, setup_config_entry):
         CONF_STREAM_PROFILE: "profile_1",
         CONF_VIDEO_SOURCE: 1,
     }
-    assert device.option_stream_profile == "profile_1"
-    assert device.option_video_source == 1
+    assert setup_config_entry.options[CONF_STREAM_PROFILE] == "profile_1"
+    assert setup_config_entry.options[CONF_VIDEO_SOURCE] == 1

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -37,10 +37,12 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_config_entry")
-async def mock_config_entry_fixture(prepare_config_entry):
+async def mock_config_entry_fixture(hass, config_entry):
     """Mock config entry and setup entry."""
     with patch("homeassistant.components.axis.async_setup_entry", return_value=True):
-        yield await prepare_config_entry()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        yield config_entry
 
 
 async def test_flow_manual_configuration(hass, setup_default_vapix_requests):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix review comments related to Axis config flow tests from #86034

Avoid accessing hass.data when testing config flow states.
Avoid setting up integration when testing config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #86034
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
