### PR TITLE
Add ZHA tuya window covering cover and select

### DIFF
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -185,6 +185,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
                 self._current_position = None
                 self._state = None
 
+
 @MULTI_MATCH(channel_names="tuya_window_covering")
 class ZhaTuyaCover(ZhaCover):
     """Representation of a ZHA cover."""
@@ -194,6 +195,7 @@ class ZhaTuyaCover(ZhaCover):
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._cover_channel = self.cluster_channels.get("tuya_window_covering")
         self._current_position = None
+
 
 @MULTI_MATCH(channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF, CHANNEL_SHADE})
 class Shade(ZhaEntity, CoverEntity):

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -185,6 +185,15 @@ class ZhaCover(ZhaEntity, CoverEntity):
                 self._current_position = None
                 self._state = None
 
+@MULTI_MATCH(channel_names="tuya_window_covering")
+class ZhaTuyaCover(ZhaCover):
+    """Representation of a ZHA cover."""
+
+    def __init__(self, unique_id, zha_device, channels, **kwargs):
+        """Init this sensor."""
+        super().__init__(unique_id, zha_device, channels, **kwargs)
+        self._cover_channel = self.cluster_channels.get("tuya_window_covering")
+        self._current_position = None
 
 @MULTI_MATCH(channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF, CHANNEL_SHADE})
 class Shade(ZhaEntity, CoverEntity):

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -494,3 +494,18 @@ class AqaraPetFeederMode(ZCLEnumSelectEntity, id_suffix="feeding_mode"):
     _enum = AqaraFeedingMode
     _attr_name = "Mode"
     _attr_icon: str = "mdi:wrench-clock"
+
+class MotorDirection(types.enum8):
+    """Tuya motor reversal."""
+
+    Normal = 0x00
+    Inverted = 0x01
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="tuya_window_covering")
+class TuyaCoverMode(ZCLEnumSelectEntity, id_suffix="motor_reversal"):
+    """Representation of a ZHA curtain mode configuration entity."""
+
+    _select_attr = "motor_reversal"
+    _enum = MotorDirection
+    _attr_name = "Motor direction"

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -495,6 +495,7 @@ class AqaraPetFeederMode(ZCLEnumSelectEntity, id_suffix="feeding_mode"):
     _attr_name = "Mode"
     _attr_icon: str = "mdi:wrench-clock"
 
+
 class MotorDirection(types.enum8):
     """Tuya motor reversal."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Updated select and cover to add two new sections to be used by ZHA to display various attributes exposed by the device's quirk.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/zigpy/zha-device-handlers/issues/2120


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
