### PR TITLE
Add error handling for OpenAI

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from functools import partial
 import logging
-from typing import cast
 
 import openai
 from openai import error
@@ -13,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, TemplateError
-from homeassistant.helpers import area_registry, device_registry, intent, template
+from homeassistant.helpers import area_registry, intent, template
 from homeassistant.util import ulid
 
 from .const import DEFAULT_MODEL, DEFAULT_PROMPT
@@ -133,20 +132,9 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
     def _async_generate_prompt(self) -> str:
         """Generate a prompt for the user."""
-        dev_reg = device_registry.async_get(self.hass)
         return template.Template(DEFAULT_PROMPT, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
-                "areas": [
-                    area
-                    for area in area_registry.async_get(self.hass).areas.values()
-                    # Filter out areas without devices
-                    if any(
-                        not dev.disabled_by
-                        for dev in device_registry.async_entries_for_area(
-                            dev_reg, cast(str, area.id)
-                        )
-                    )
-                ],
+                "areas": list(area_registry.async_get(self.hass).areas.values()),
             }
         )

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -10,9 +10,9 @@ If a user wants to control a device, reject the request and suggest using the Ho
 An overview of the areas and the devices in this smart home:
 {% for area in areas %}
 {{ area.name }}:
-{% for device in area_devices(area.name) -%}
-{%- if not device_attr(device, "disabled_by") %}
-- {{ device_attr(device, "name") }} ({{ device_attr(device, "model") }} by {{ device_attr(device, "manufacturer") }})
+{%- for device in area_devices(area.name) -%}
+{%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") %}
+- {{ device_attr(device, "name") }}{% if device_attr(device, "model") not in device_attr(device, "name") %} ({{ device_attr(device, "model") }}){% endif %}
 {%- endif %}
 {%- endfor %}
 {% endfor %}

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -8,10 +8,14 @@ You are a conversational AI for a smart home named {{ ha_name }}.
 If a user wants to control a device, reject the request and suggest using the Home Assistant UI.
 
 An overview of the areas and the devices in this smart home:
-{% for area in areas %}
-{{ area.name }}:
+{%- for area in areas %}
+{%- set area_info = namespace(printed=false) %}
 {%- for device in area_devices(area.name) -%}
 {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") %}
+{%- if not area_info.printed %}
+{{ area.name }}:
+{%- set area_info.printed = true %}
+{%- endif %}
 - {{ device_attr(device, "name") }}{% if device_attr(device, "model") not in device_attr(device, "name") %} ({{ device_attr(device, "model") }}){% endif %}
 {%- endif %}
 {%- endfor %}

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -3,9 +3,7 @@
 DOMAIN = "openai_conversation"
 CONF_PROMPT = "prompt"
 DEFAULT_MODEL = "text-davinci-003"
-DEFAULT_PROMPT = """
-You are a conversational AI for a smart home named {{ ha_name }}.
-If a user wants to control a device, reject the request and suggest using the Home Assistant UI.
+DEFAULT_PROMPT = """This smart home is controlled by Home Assistant.
 
 An overview of the areas and the devices in this smart home:
 {%- for area in areas %}
@@ -13,13 +11,18 @@ An overview of the areas and the devices in this smart home:
 {%- for device in area_devices(area.name) -%}
 {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") %}
 {%- if not area_info.printed %}
+
 {{ area.name }}:
 {%- set area_info.printed = true %}
 {%- endif %}
 - {{ device_attr(device, "name") }}{% if device_attr(device, "model") not in device_attr(device, "name") %} ({{ device_attr(device, "model") }}){% endif %}
 {%- endif %}
 {%- endfor %}
-{% endfor %}
+{%- endfor %}
+
+Answer the users questions about the world truthfully.
+
+If the user wants to control a device, reject the request and suggest using the Home Assistant UI.
 
 Now finish this conversation:
 

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -5,12 +5,15 @@ from openai import error
 
 from homeassistant.components import conversation
 from homeassistant.core import Context
-from homeassistant.helpers import device_registry, intent
+from homeassistant.helpers import area_registry, device_registry, intent
 
 
 async def test_default_prompt(hass, mock_init_component):
     """Test that the default prompt works."""
     device_reg = device_registry.async_get(hass)
+    area_reg = area_registry.async_get(hass)
+
+    area_reg.async_create("Empty Area")
 
     device_reg.async_get_or_create(
         config_entry_id="1234",
@@ -34,7 +37,7 @@ async def test_default_prompt(hass, mock_init_component):
         connections={("test", "5678")},
         name="Test Device 2",
         manufacturer="Test Manufacturer 2",
-        model="Test Device 2",
+        model="Device 2",
         suggested_area="Test Area 2",
     )
     device_reg.async_get_or_create(

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -13,7 +13,8 @@ async def test_default_prompt(hass, mock_init_component):
     device_reg = device_registry.async_get(hass)
     area_reg = area_registry.async_get(hass)
 
-    area_reg.async_create("Empty Area")
+    for i in range(3):
+        area_reg.async_create(f"{i}Empty Area")
 
     device_reg.async_get_or_create(
         config_entry_id="1234",
@@ -23,15 +24,16 @@ async def test_default_prompt(hass, mock_init_component):
         model="Test Model",
         suggested_area="Test Area",
     )
-    device_reg.async_get_or_create(
-        config_entry_id="1234",
-        connections={("test", "abcd")},
-        name="Test Service",
-        manufacturer="Test Manufacturer",
-        model="Test Model",
-        suggested_area="Test Area",
-        entry_type=device_registry.DeviceEntryType.SERVICE,
-    )
+    for i in range(3):
+        device_reg.async_get_or_create(
+            config_entry_id="1234",
+            connections={("test", f"{i}abcd")},
+            name="Test Service",
+            manufacturer="Test Manufacturer",
+            model="Test Model",
+            suggested_area="Test Area",
+            entry_type=device_registry.DeviceEntryType.SERVICE,
+        )
     device_reg.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "5678")},
@@ -54,8 +56,7 @@ async def test_default_prompt(hass, mock_init_component):
 
     assert (
         mock_create.mock_calls[0][2]["prompt"]
-        == """You are a conversational AI for a smart home named test home.
-If a user wants to control a device, reject the request and suggest using the Home Assistant UI.
+        == """This smart home is controlled by Home Assistant.
 
 An overview of the areas and the devices in this smart home:
 
@@ -66,6 +67,9 @@ Test Area 2:
 - Test Device 2
 - Test Device 3 (Test Model 3A)
 
+Answer the users questions about the world truthfully.
+
+If the user wants to control a device, reject the request and suggest using the Home Assistant UI.
 
 Now finish this conversation:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add error handling
- Do not include devices with type "Service" in the prompt info
- Limit the characters used in prompt by removing manufacturer and only including model if it's not part of the name

![CleanShot 2023-01-25 at 20 48 02](https://user-images.githubusercontent.com/1444314/214739772-9ca11127-3790-47de-9f39-c4c9f6d6159a.png)


Fixes
```
2023-01-25 20:45:40.750 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [10982873440] Error handling message: Unknown error (unknown_error) from ::1 (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36)
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)
  File "/Users/paulus/dev/hass/core/homeassistant/components/conversation/__init__.py", line 141, in websocket_process
    result = await async_converse(
  File "/Users/paulus/dev/hass/core/homeassistant/components/conversation/__init__.py", line 240, in async_converse
    result = await agent.async_process(
  File "/Users/paulus/dev/hass/core/homeassistant/components/openai_conversation/__init__.py", line 100, in async_process
    result = await self.hass.async_add_executor_job(
  File "/Users/paulus/.pyenv/versions/3.10.6/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.10/site-packages/openai/api_resources/completion.py", line 25, in create
    return super().create(*args, **kwargs)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 153, in create
    response, _, api_key = requestor.request(
  File "/Users/paulus/dev/hass/core/venv/lib/python3.10/site-packages/openai/api_requestor.py", line 227, in request
    resp, got_stream = self._interpret_response(result, stream)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.10/site-packages/openai/api_requestor.py", line 620, in _interpret_response
    self._interpret_response_line(
  File "/Users/paulus/dev/hass/core/venv/lib/python3.10/site-packages/openai/api_requestor.py", line 663, in _interpret_response_line
    raise error.ServiceUnavailableError(
openai.error.ServiceUnavailableError: The server is overloaded or not ready yet.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
