### PR TITLE
Use device area id in intent matching

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -160,16 +160,18 @@ class DefaultAgent(AbstractConversationAgent):
             ).get(response_key)
             if response_str:
                 response_template = template.Template(response_str, self.hass)
-                intent_response.async_set_speech(
-                    response_template.async_render(
-                        {
-                            "slots": {
-                                entity_name: entity_value.text or entity_value.value
-                                for entity_name, entity_value in result.entities.items()
-                            }
+                speech = response_template.async_render(
+                    {
+                        "slots": {
+                            entity_name: entity_value.text or entity_value.value
+                            for entity_name, entity_value in result.entities.items()
                         }
-                    )
+                    }
                 )
+
+                # Normalize whitespace
+                speech = " ".join(speech.strip().split())
+                intent_response.async_set_speech(speech)
 
         return ConversationResult(
             response=intent_response, conversation_id=conversation_id

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -20,7 +20,7 @@ from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
 
-from . import area_registry, config_validation as cv, entity_registry
+from . import area_registry, config_validation as cv, device_registry, entity_registry
 
 _LOGGER = logging.getLogger(__name__)
 _SlotsType = dict[str, Any]
@@ -159,6 +159,7 @@ def async_match_states(
     states: Iterable[State] | None = None,
     entities: entity_registry.EntityRegistry | None = None,
     areas: area_registry.AreaRegistry | None = None,
+    devices: device_registry.DeviceRegistry | None = None,
 ) -> Iterable[State]:
     """Find states that match the constraints."""
     if states is None:
@@ -206,11 +207,28 @@ def async_match_states(
         assert area is not None, f"No area named {area_name}"
 
     if area is not None:
+        if devices is None:
+            devices = device_registry.async_get(hass)
+
+        entity_area_ids: dict[str, str | None] = {}
+        for _state, entity in states_and_entities:
+            if entity is None:
+                continue
+
+            if entity.area_id:
+                # Use entity's area id first
+                entity_area_ids[entity.id] = entity.area_id
+            elif entity.device_id:
+                # Fall back to device area if not set on entity
+                device = devices.async_get(entity.device_id)
+                if device is not None:
+                    entity_area_ids[entity.id] = device.area_id
+
         # Filter by area
         states_and_entities = [
             (state, entity)
             for state, entity in states_and_entities
-            if (entity is not None) and (entity.area_id == area.id)
+            if (entity is not None) and (entity_area_ids.get(entity.id) == area.id)
         ]
 
     if name is not None:

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -111,6 +111,9 @@ async def test_match_device_area(hass):
     state2 = State(
         "light.bedroom", "on", attributes={ATTR_FRIENDLY_NAME: "bedroom light"}
     )
+    state3 = State(
+        "light.living_room", "on", attributes={ATTR_FRIENDLY_NAME: "living room light"}
+    )
     entities = entity_registry.async_get(hass)
     entities.async_get_or_create("light", "demo", "1234", suggested_object_id="kitchen")
     entities.async_update_entity(state1.entity_id, device_id=kitchen_device.id)
@@ -121,7 +124,10 @@ async def test_match_device_area(hass):
     # Match on area/domain
     assert [state1] == list(
         intent.async_match_states(
-            hass, domains={"light"}, area_name="kitchen", states=[state1, state2]
+            hass,
+            domains={"light"},
+            area_name="kitchen",
+            states=[state1, state2, state3],
         )
     )
 

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -9,6 +9,7 @@ from homeassistant.core import State
 from homeassistant.helpers import (
     area_registry,
     config_validation as cv,
+    device_registry,
     entity_registry,
     intent,
 )
@@ -41,7 +42,7 @@ async def test_async_match_states(hass):
     entities.async_update_entity(state1.entity_id, area_id=area_kitchen.id)
 
     entities.async_get_or_create(
-        "switch", "demo", "1234", suggested_object_id="bedroom"
+        "switch", "demo", "5678", suggested_object_id="bedroom"
     )
     entities.async_update_entity(
         state2.entity_id,
@@ -88,6 +89,39 @@ async def test_async_match_states(hass):
             device_classes={SwitchDeviceClass.OUTLET},
             area_name="bedroom",
             states=[state1, state2],
+        )
+    )
+
+
+async def test_match_device_area(hass):
+    """Test async_match_state with a device in an area."""
+    areas = area_registry.async_get(hass)
+    area_kitchen = areas.async_get_or_create("kitchen")
+    area_bedroom = areas.async_get_or_create("bedroom")
+
+    devices = device_registry.async_get(hass)
+    kitchen_device = devices.async_get_or_create(
+        config_entry_id="1234", connections=set(), identifiers={("demo", "id-1234")}
+    )
+    devices.async_update_device(kitchen_device.id, area_id=area_kitchen.id)
+
+    state1 = State(
+        "light.kitchen", "on", attributes={ATTR_FRIENDLY_NAME: "kitchen light"}
+    )
+    state2 = State(
+        "light.bedroom", "on", attributes={ATTR_FRIENDLY_NAME: "bedroom light"}
+    )
+    entities = entity_registry.async_get(hass)
+    entities.async_get_or_create("light", "demo", "1234", suggested_object_id="kitchen")
+    entities.async_update_entity(state1.entity_id, device_id=kitchen_device.id)
+
+    entities.async_get_or_create("light", "demo", "5678", suggested_object_id="bedroom")
+    entities.async_update_entity(state2.entity_id, area_id=area_bedroom.id)
+
+    # Match on area/domain
+    assert [state1] == list(
+        intent.async_match_states(
+            hass, domains={"light"}, area_name="kitchen", states=[state1, state2]
         )
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Matching entity states now considers device area id instead of just the entity area id.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
