### PR TITLE
Terminate strings at NUL when recording states and events

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -836,7 +836,9 @@ class Recorder(threading.Thread):
             return
 
         try:
-            shared_data_bytes = EventData.shared_data_bytes_from_event(event)
+            shared_data_bytes = EventData.shared_data_bytes_from_event(
+                event, self.dialect_name
+            )
         except JSON_ENCODE_EXCEPTIONS as ex:
             _LOGGER.warning("Event is not JSON serializable: %s: %s", event, ex)
             return
@@ -869,7 +871,7 @@ class Recorder(threading.Thread):
         try:
             dbstate = States.from_event(event)
             shared_attrs_bytes = StateAttributes.shared_attrs_bytes_from_event(
-                event, self._exclude_attributes_by_domain
+                event, self._exclude_attributes_by_domain, self.dialect_name
             )
         except JSON_ENCODE_EXCEPTIONS as ex:
             _LOGGER.warning(

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -42,7 +42,7 @@ from homeassistant.core import Context, Event, EventOrigin, State, split_entity_
 from homeassistant.helpers.json import (
     JSON_DECODE_EXCEPTIONS,
     JSON_DUMP,
-    json_bytes,
+    json_bytes_strip_null,
     json_loads,
 )
 import homeassistant.util.dt as dt_util
@@ -244,7 +244,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
     @staticmethod
     def from_event(event: Event) -> EventData:
         """Create object from an event."""
-        shared_data = json_bytes(event.data)
+        shared_data = json_bytes_strip_null(event.data)
         return EventData(
             shared_data=shared_data.decode("utf-8"),
             hash=EventData.hash_shared_data_bytes(shared_data),
@@ -253,7 +253,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
     @staticmethod
     def shared_data_bytes_from_event(event: Event) -> bytes:
         """Create shared_data from an event."""
-        return json_bytes(event.data)
+        return json_bytes_strip_null(event.data)
 
     @staticmethod
     def hash_shared_data_bytes(shared_data_bytes: bytes) -> int:
@@ -409,7 +409,7 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         """Create object from a state_changed event."""
         state: State | None = event.data.get("new_state")
         # None state means the state was removed from the state machine
-        attr_bytes = b"{}" if state is None else json_bytes(state.attributes)
+        attr_bytes = b"{}" if state is None else json_bytes_strip_null(state.attributes)
         dbstate = StateAttributes(shared_attrs=attr_bytes.decode("utf-8"))
         dbstate.hash = StateAttributes.hash_shared_attrs_bytes(attr_bytes)
         return dbstate
@@ -427,7 +427,7 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         exclude_attrs = (
             exclude_attrs_by_domain.get(domain, set()) | ALL_DOMAIN_EXCLUDE_ATTRS
         )
-        return json_bytes(
+        return json_bytes_strip_null(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )
 

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -42,12 +42,13 @@ from homeassistant.core import Context, Event, EventOrigin, State, split_entity_
 from homeassistant.helpers.json import (
     JSON_DECODE_EXCEPTIONS,
     JSON_DUMP,
+    json_bytes,
     json_bytes_strip_null,
     json_loads,
 )
 import homeassistant.util.dt as dt_util
 
-from .const import ALL_DOMAIN_EXCLUDE_ATTRS
+from .const import ALL_DOMAIN_EXCLUDE_ATTRS, SupportedDialect
 from .models import StatisticData, StatisticMetaData, process_timestamp
 
 # SQLAlchemy Schema
@@ -244,16 +245,20 @@ class EventData(Base):  # type: ignore[misc,valid-type]
     @staticmethod
     def from_event(event: Event) -> EventData:
         """Create object from an event."""
-        shared_data = json_bytes_strip_null(event.data)
+        shared_data = json_bytes(event.data)
         return EventData(
             shared_data=shared_data.decode("utf-8"),
             hash=EventData.hash_shared_data_bytes(shared_data),
         )
 
     @staticmethod
-    def shared_data_bytes_from_event(event: Event) -> bytes:
+    def shared_data_bytes_from_event(
+        event: Event, dialect: SupportedDialect | None
+    ) -> bytes:
         """Create shared_data from an event."""
-        return json_bytes_strip_null(event.data)
+        if dialect == SupportedDialect.POSTGRESQL:
+            return json_bytes_strip_null(event.data)
+        return json_bytes(event.data)
 
     @staticmethod
     def hash_shared_data_bytes(shared_data_bytes: bytes) -> int:
@@ -409,14 +414,16 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         """Create object from a state_changed event."""
         state: State | None = event.data.get("new_state")
         # None state means the state was removed from the state machine
-        attr_bytes = b"{}" if state is None else json_bytes_strip_null(state.attributes)
+        attr_bytes = b"{}" if state is None else json_bytes(state.attributes)
         dbstate = StateAttributes(shared_attrs=attr_bytes.decode("utf-8"))
         dbstate.hash = StateAttributes.hash_shared_attrs_bytes(attr_bytes)
         return dbstate
 
     @staticmethod
     def shared_attrs_bytes_from_event(
-        event: Event, exclude_attrs_by_domain: dict[str, set[str]]
+        event: Event,
+        exclude_attrs_by_domain: dict[str, set[str]],
+        dialect: SupportedDialect | None,
     ) -> bytes:
         """Create shared_attrs from a state_changed event."""
         state: State | None = event.data.get("new_state")
@@ -427,7 +434,11 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         exclude_attrs = (
             exclude_attrs_by_domain.get(domain, set()) | ALL_DOMAIN_EXCLUDE_ATTRS
         )
-        return json_bytes_strip_null(
+        if dialect == SupportedDialect.POSTGRESQL:
+            return json_bytes_strip_null(
+                {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
+            )
+        return json_bytes(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )
 

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -75,15 +75,15 @@ def json_bytes_strip_null(data: Any) -> bytes:
     """Dump json bytes after terminating strings at the first NUL."""
 
     def process_dict(_dict: dict[Any, Any]) -> dict[Any, Any]:
-        """Strip null from objects in a list."""
+        """Strip NUL from items in a dict."""
         return {key: strip_null(o) for key, o in _dict.items()}
 
     def process_list(_list: list[Any]) -> list[Any]:
-        """Strip null from objects in a list."""
+        """Strip NUL from items in a list."""
         return [strip_null(o) for o in _list]
 
     def strip_null(obj: Any) -> Any:
-        """Strip null from an object."""
+        """Strip NUL from an object."""
         if isinstance(obj, str):
             return obj.split("\0", 1)[0]
         if isinstance(obj, dict):
@@ -92,8 +92,12 @@ def json_bytes_strip_null(data: Any) -> bytes:
             return process_list(obj)
         return obj
 
+    # We expect null-characters to be very rare, hence try encoding first and look
+    # for an escaped null-character in the output.
     result = json_bytes(data)
     if b"\\u0000" in result:
+        # We work on the processed result so we don't need to worry about
+        # Home Assistant extensions which allows encoding sets, tuples, etc.
         data_processed = orjson.loads(result)
         data_processed = strip_null(data_processed)
         result = json_bytes(data_processed)

--- a/tests/components/recorder/db_schema_30.py
+++ b/tests/components/recorder/db_schema_30.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import aliased, declarative_base, relationship
 from sqlalchemy.orm.session import Session
 
+from homeassistant.components.recorder.const import SupportedDialect
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_RESTORED,
@@ -287,7 +288,9 @@ class EventData(Base):  # type: ignore[misc,valid-type]
         )
 
     @staticmethod
-    def shared_data_bytes_from_event(event: Event) -> bytes:
+    def shared_data_bytes_from_event(
+        event: Event, dialect: SupportedDialect | None
+    ) -> bytes:
         """Create shared_data from an event."""
         return json_bytes(event.data)
 
@@ -438,7 +441,9 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
 
     @staticmethod
     def shared_attrs_bytes_from_event(
-        event: Event, exclude_attrs_by_domain: dict[str, set[str]]
+        event: Event,
+        exclude_attrs_by_domain: dict[str, set[str]],
+        dialect: SupportedDialect | None,
     ) -> bytes:
         """Create shared_attrs from a state_changed event."""
         state: State | None = event.data.get("new_state")

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -31,6 +31,7 @@ from homeassistant.components.recorder.const import (
     EVENT_RECORDER_5MIN_STATISTICS_GENERATED,
     EVENT_RECORDER_HOURLY_STATISTICS_GENERATED,
     KEEPALIVE_TIME,
+    SupportedDialect,
 )
 from homeassistant.components.recorder.db_schema import (
     SCHEMA_VERSION,
@@ -223,15 +224,27 @@ async def test_saving_state(recorder_mock, hass: HomeAssistant):
     assert state == _state_with_context(hass, entity_id)
 
 
-async def test_saving_state_with_nul(recorder_mock, hass: HomeAssistant):
+@pytest.mark.parametrize(
+    "dialect_name, expected_attributes",
+    (
+        (SupportedDialect.MYSQL, {"test_attr": 5, "test_attr_10": "silly\0stuff"}),
+        (SupportedDialect.POSTGRESQL, {"test_attr": 5, "test_attr_10": "silly"}),
+        (SupportedDialect.SQLITE, {"test_attr": 5, "test_attr_10": "silly\0stuff"}),
+    ),
+)
+async def test_saving_state_with_nul(
+    recorder_mock, hass: HomeAssistant, dialect_name, expected_attributes
+):
     """Test saving and restoring a state with nul in attributes."""
     entity_id = "test.recorder"
     state = "restoring_from_db"
     attributes = {"test_attr": 5, "test_attr_10": "silly\0stuff"}
 
-    hass.states.async_set(entity_id, state, attributes)
-
-    await async_wait_recording_done(hass)
+    with patch(
+        "homeassistant.components.recorder.core.Recorder.dialect_name", dialect_name
+    ):
+        hass.states.async_set(entity_id, state, attributes)
+        await async_wait_recording_done(hass)
 
     with session_scope(hass=hass) as session:
         db_states = []
@@ -243,7 +256,7 @@ async def test_saving_state_with_nul(recorder_mock, hass: HomeAssistant):
         assert db_states[0].event_id is None
 
     expected = _state_with_context(hass, entity_id)
-    expected.attributes = {**expected.attributes, "test_attr_10": "silly"}
+    expected.attributes = expected_attributes
     assert state == expected
 
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -10,6 +10,7 @@ from homeassistant import core
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder,
+    json_bytes_strip_null,
     json_dumps,
     json_dumps_sorted,
 )
@@ -118,3 +119,19 @@ def test_json_dumps_rgb_color_subclass():
     rgb = RGBColor(4, 2, 1)
 
     assert json_dumps(rgb) == "[4,2,1]"
+
+
+def test_json_bytes_strip_null():
+    """Test stripping nul from strings."""
+
+    assert json_bytes_strip_null("\0") == b'""'
+    assert json_bytes_strip_null("silly\0stuff") == b'"silly"'
+    assert json_bytes_strip_null(["one", "two\0", "three"]) == b'["one","two","three"]'
+    assert (
+        json_bytes_strip_null({"k1": "one", "k2": "two\0", "k3": "three"})
+        == b'{"k1":"one","k2":"two","k3":"three"}'
+    )
+    assert (
+        json_bytes_strip_null([[{"k1": {"k2": ["silly\0stuff"]}}]])
+        == b'[[{"k1":{"k2":["silly"]}}]]'
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Terminate strings at NUL when recording states and events to avoid PostgreSQL throwing when we read a recorded state or event back which happens to have some NUL in a JSON string.

The approach in this PR is on the heavy handed side, and we could consider to instead of terminating strings on the first `NUL` replace `NUL` with another character, for example with the [replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character)

At the same time, I don't think there's any realistic use case where event data or state attributes contain `NUL` and it's important that we preserve that.

### Background:
PostgreSQL [does not allow `NUL` in text](https://www.commandprompt.com/blog/null-characters-workarounds-arent-good-enough/). This is problematic when we take responsibility for JSON *encoding* via ORJSON but let PostgreSQL handle JSON *decoding* with its own built in JSON support, because it's possible to record data which can then not be read back.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85691
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
