### PR TITLE
Alexa Intent: Use the 'id' field and expose nearest resolutions as variables

### DIFF
--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -180,7 +180,7 @@ async def async_handle_intent(hass, message):
     return alexa_response.as_dict()
 
 
-def resolve_slot_data(key, request) -> dict:
+def resolve_slot_data(key: str, request: dict) -> dict[str, str]:
     """Check slot request for synonym resolutions."""
     # Default to the spoken slot value if more than one or none are found. Always
     # passes the id and name of the nearest possible slot resolution. For

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -223,7 +223,7 @@ def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
             _LOGGER.debug(
                 "Found multiple synonym resolutions for slot value: {%s: %s}",
                 key,
-                resolved_data["value"],
+                resolved_data["value_old"],
             )
 
     return resolved_data

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -188,7 +188,6 @@ def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
     # reference to the request object structure, see the Alexa docs:
     # https://tinyurl.com/ybvm7jhs
     resolved_data = {}
-    resolved_data["value_old"] = request["value"]
     resolved_data["value"] = request["value"]
     resolved_data["id"] = ""
 
@@ -207,10 +206,8 @@ def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
 
             possible_values.extend([item["value"] for item in entry["values"]])
 
-        # Always set nearest name and id if available, otherwise the spoken slot
-        # value and an empty string as id is used
+        # Always set id if available, otherwise an empty string is used as id
         if len(possible_values) >= 1:
-            resolved_data["value"] = possible_values[0]["name"]
             # Set ID if available
             if "id" in possible_values[0]:
                 resolved_data["id"] = possible_values[0]["id"]
@@ -218,12 +215,12 @@ def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
         # If there is only one match use the resolved value, otherwise the
         # resolution cannot be determined, so use the spoken slot value and empty string as id
         if len(possible_values) == 1:
-            resolved_data["value_old"] = possible_values[0]["name"]
+            resolved_data["value"] = possible_values[0]["name"]
         else:
             _LOGGER.debug(
                 "Found multiple synonym resolutions for slot value: {%s: %s}",
                 key,
-                resolved_data["value_old"],
+                resolved_data["value"],
             )
 
     return resolved_data
@@ -252,8 +249,7 @@ class AlexaResponse:
                 _key = key.replace(".", "_")
                 _slot_data = resolve_slot_data(key, value)
 
-                # In a future release use: value instead of value_old
-                self.variables[_key] = _slot_data["value_old"]
+                self.variables[_key] = _slot_data["value"]
                 self.variables[_key + "_Id"] = _slot_data["id"]
 
     def add_card(self, card_type, title, content):

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -7,7 +7,6 @@ from homeassistant.components import http
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import intent
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util.decorator import Registry
 
 from .const import DOMAIN, SYN_RESOLUTION_MATCH
@@ -40,17 +39,6 @@ class CardType(enum.Enum):
 def async_setup(hass):
     """Activate Alexa component."""
     hass.http.register_view(AlexaIntentsView)
-
-    # Resolution behavior deprecation warning
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "resolution_behavior_deprecated",
-        breaks_in_ha_version="2023.7.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="resolution_behavior_deprecated",
-    )
 
 
 async def async_setup_intents(hass):
@@ -227,7 +215,6 @@ def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
             if "id" in possible_values[0]:
                 resolved_data["id"] = possible_values[0]["id"]
 
-        # Deprecated Behavior
         # If there is only one match use the resolved value, otherwise the
         # resolution cannot be determined, so use the spoken slot value and empty string as id
         if len(possible_values) == 1:

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -1,6 +1,7 @@
 """Support for Alexa skill service end point."""
 import enum
 import logging
+from typing import Any
 
 from homeassistant.components import http
 from homeassistant.core import callback
@@ -180,7 +181,7 @@ async def async_handle_intent(hass, message):
     return alexa_response.as_dict()
 
 
-def resolve_slot_data(key: str, request: dict) -> dict[str, str]:
+def resolve_slot_data(key: str, request: dict[str, Any]) -> dict[str, str]:
     """Check slot request for synonym resolutions."""
     # Default to the spoken slot value if more than one or none are found. Always
     # passes the id and name of the nearest possible slot resolution. For

--- a/homeassistant/components/alexa/strings.json
+++ b/homeassistant/components/alexa/strings.json
@@ -1,8 +1,0 @@
-{
-  "issues": {
-    "resolution_behavior_deprecated": {
-      "title": "Slot Synonym resolution behavior of Alexa Custom Skill changes",
-      "description": "At the moment the spoken text is used when there is more than one possible synonym resolution. In future the first resolution will always be used. It will only fall back to the spoken text if there is no synonym resolution.\n\nPlease be aware that the Template Variable Value could be slightly different (uppercase, lowercase or whitespaces)."
-    }
-  }
-}

--- a/homeassistant/components/alexa/strings.json
+++ b/homeassistant/components/alexa/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "resolution_behavior_deprecated": {
+      "title": "Slot Synonym resolution behavior of Alexa Custom Skill changes",
+      "description": "At the moment the spoken text is used when there is more than one possible synonym resolution. In future the first resolution will always be used. It will only fall back to the spoken text if there is no synonym resolution.\n\nPlease be aware that the Template Variable Value could be slightly different (uppercase, lowercase or whitespaces)."
+    }
+  }
+}

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -80,19 +80,13 @@ def alexa_client(event_loop, hass, hass_client):
                     "GetZodiacHoroscopeIDIntent": {
                         "speech": {
                             "type": "plain",
-                            "text": "You told us your sign is {{ ZodiacSign_ID }}.",
+                            "text": "You told us your sign is {{ ZodiacSign_Id }}.",
                         }
                     },
                     "GetZodiacHoroscopeNearestValueIntent": {
                         "speech": {
                             "type": "plain",
-                            "text": "You told us your sign is {{ ZodiacSign_NEAREST }}.",
-                        }
-                    },
-                    "GetZodiacHoroscopeNearestIDIntent": {
-                        "speech": {
-                            "type": "plain",
-                            "text": "You told us your sign is {{ ZodiacSign_NEAREST_ID }}.",
+                            "text": "You told us your sign is {{ ZodiacSign_Value }}.",
                         }
                     },
                     "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
@@ -448,7 +442,7 @@ async def test_intent_request_with_slots_and_multi_synonym_nearest_id_resolution
             "requestId": REQUEST_ID,
             "timestamp": "2015-05-13T12:34:56Z",
             "intent": {
-                "name": "GetZodiacHoroscopeNearestIDIntent",
+                "name": "GetZodiacHoroscopeIDIntent",
                 "slots": {
                     "ZodiacSign": {
                         "name": "ZodiacSign",

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -77,6 +77,24 @@ def alexa_client(event_loop, hass, hass_client):
                             "text": "You told us your sign is {{ ZodiacSign }}.",
                         }
                     },
+                    "GetZodiacHoroscopeIDIntent": {
+                        "speech": {
+                            "type": "plain",
+                            "text": "You told us your sign is {{ ZodiacSign_ID }}.",
+                        }
+                    },
+                    "GetZodiacHoroscopeNearestValueIntent": {
+                        "speech": {
+                            "type": "plain",
+                            "text": "You told us your sign is {{ ZodiacSign_NEAREST }}.",
+                        }
+                    },
+                    "GetZodiacHoroscopeNearestIDIntent": {
+                        "speech": {
+                            "type": "plain",
+                            "text": "You told us your sign is {{ ZodiacSign_NEAREST_ID }}.",
+                        }
+                    },
                     "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
                         "speech": {
                             "type": "plain",
@@ -297,6 +315,170 @@ async def test_intent_request_with_slots_and_synonym_resolution(alexa_client) ->
     data = await req.json()
     text = data.get("response", {}).get("outputSpeech", {}).get("text")
     assert text == "You told us your sign is Virgo."
+
+
+async def test_intent_request_with_slots_and_synonym_id_resolution(
+    alexa_client,
+) -> None:
+    """Test a request with slots, id and a name synonym."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": False,
+            "sessionId": SESSION_ID,
+            "application": {"applicationId": APPLICATION_ID},
+            "attributes": {
+                "supportedHoroscopePeriods": {
+                    "daily": True,
+                    "weekly": False,
+                    "monthly": False,
+                }
+            },
+            "user": {"userId": "amzn1.account.AM3B00000000000000000000000"},
+        },
+        "request": {
+            "type": "IntentRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z",
+            "intent": {
+                "name": "GetZodiacHoroscopeIDIntent",
+                "slots": {
+                    "ZodiacSign": {
+                        "name": "ZodiacSign",
+                        "value": "V zodiac",
+                        "resolutions": {
+                            "resolutionsPerAuthority": [
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {"code": "ER_SUCCESS_MATCH"},
+                                    "values": [{"value": {"name": "Virgo", "id": "1"}}],
+                                }
+                            ]
+                        },
+                    }
+                },
+            },
+        },
+    }
+    req = await _intent_req(alexa_client, data)
+    assert req.status == HTTPStatus.OK
+    data = await req.json()
+    text = data.get("response", {}).get("outputSpeech", {}).get("text")
+    assert text == "You told us your sign is 1."
+
+
+async def test_intent_request_with_slots_and_multi_synonym_nearest_value_resolution(
+    alexa_client,
+) -> None:
+    """Test a request with slots and multiple name synonyms (nearest value)."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": False,
+            "sessionId": SESSION_ID,
+            "application": {"applicationId": APPLICATION_ID},
+            "attributes": {
+                "supportedHoroscopePeriods": {
+                    "daily": True,
+                    "weekly": False,
+                    "monthly": False,
+                }
+            },
+            "user": {"userId": "amzn1.account.AM3B00000000000000000000000"},
+        },
+        "request": {
+            "type": "IntentRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z",
+            "intent": {
+                "name": "GetZodiacHoroscopeNearestValueIntent",
+                "slots": {
+                    "ZodiacSign": {
+                        "name": "ZodiacSign",
+                        "value": "Virgio Test",
+                        "resolutions": {
+                            "resolutionsPerAuthority": [
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {"code": "ER_SUCCESS_MATCH"},
+                                    "values": [
+                                        {"value": {"name": "Virgio Test", "id": "2"}}
+                                    ],
+                                },
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {"code": "ER_SUCCESS_MATCH"},
+                                    "values": [{"value": {"name": "Virgo", "id": "1"}}],
+                                },
+                            ]
+                        },
+                    }
+                },
+            },
+        },
+    }
+    req = await _intent_req(alexa_client, data)
+    assert req.status == HTTPStatus.OK
+    data = await req.json()
+    text = data.get("response", {}).get("outputSpeech", {}).get("text")
+    assert text == "You told us your sign is Virgio Test."
+
+
+async def test_intent_request_with_slots_and_multi_synonym_nearest_id_resolution(
+    alexa_client,
+) -> None:
+    """Test a request with slots and multiple name synonyms (nearest id)."""
+    data = {
+        "version": "1.0",
+        "session": {
+            "new": False,
+            "sessionId": SESSION_ID,
+            "application": {"applicationId": APPLICATION_ID},
+            "attributes": {
+                "supportedHoroscopePeriods": {
+                    "daily": True,
+                    "weekly": False,
+                    "monthly": False,
+                }
+            },
+            "user": {"userId": "amzn1.account.AM3B00000000000000000000000"},
+        },
+        "request": {
+            "type": "IntentRequest",
+            "requestId": REQUEST_ID,
+            "timestamp": "2015-05-13T12:34:56Z",
+            "intent": {
+                "name": "GetZodiacHoroscopeNearestIDIntent",
+                "slots": {
+                    "ZodiacSign": {
+                        "name": "ZodiacSign",
+                        "value": "Virgio Test",
+                        "resolutions": {
+                            "resolutionsPerAuthority": [
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {"code": "ER_SUCCESS_MATCH"},
+                                    "values": [
+                                        {"value": {"name": "Virgio Test", "id": "2"}}
+                                    ],
+                                },
+                                {
+                                    "authority": AUTHORITY_ID,
+                                    "status": {"code": "ER_SUCCESS_MATCH"},
+                                    "values": [{"value": {"name": "Virgo", "id": "1"}}],
+                                },
+                            ]
+                        },
+                    }
+                },
+            },
+        },
+    }
+    req = await _intent_req(alexa_client, data)
+    assert req.status == HTTPStatus.OK
+    data = await req.json()
+    text = data.get("response", {}).get("outputSpeech", {}).get("text")
+    assert text == "You told us your sign is 2."
 
 
 async def test_intent_request_with_slots_and_multi_synonym_resolution(

--- a/tests/components/alexa/test_intent.py
+++ b/tests/components/alexa/test_intent.py
@@ -83,12 +83,6 @@ def alexa_client(event_loop, hass, hass_client):
                             "text": "You told us your sign is {{ ZodiacSign_Id }}.",
                         }
                     },
-                    "GetZodiacHoroscopeNearestValueIntent": {
-                        "speech": {
-                            "type": "plain",
-                            "text": "You told us your sign is {{ ZodiacSign_Value }}.",
-                        }
-                    },
                     "AMAZON.PlaybackAction<object@MusicCreativeWork>": {
                         "speech": {
                             "type": "plain",
@@ -361,67 +355,10 @@ async def test_intent_request_with_slots_and_synonym_id_resolution(
     assert text == "You told us your sign is 1."
 
 
-async def test_intent_request_with_slots_and_multi_synonym_nearest_value_resolution(
+async def test_intent_request_with_slots_and_multi_synonym_id_resolution(
     alexa_client,
 ) -> None:
-    """Test a request with slots and multiple name synonyms (nearest value)."""
-    data = {
-        "version": "1.0",
-        "session": {
-            "new": False,
-            "sessionId": SESSION_ID,
-            "application": {"applicationId": APPLICATION_ID},
-            "attributes": {
-                "supportedHoroscopePeriods": {
-                    "daily": True,
-                    "weekly": False,
-                    "monthly": False,
-                }
-            },
-            "user": {"userId": "amzn1.account.AM3B00000000000000000000000"},
-        },
-        "request": {
-            "type": "IntentRequest",
-            "requestId": REQUEST_ID,
-            "timestamp": "2015-05-13T12:34:56Z",
-            "intent": {
-                "name": "GetZodiacHoroscopeNearestValueIntent",
-                "slots": {
-                    "ZodiacSign": {
-                        "name": "ZodiacSign",
-                        "value": "Virgio Test",
-                        "resolutions": {
-                            "resolutionsPerAuthority": [
-                                {
-                                    "authority": AUTHORITY_ID,
-                                    "status": {"code": "ER_SUCCESS_MATCH"},
-                                    "values": [
-                                        {"value": {"name": "Virgio Test", "id": "2"}}
-                                    ],
-                                },
-                                {
-                                    "authority": AUTHORITY_ID,
-                                    "status": {"code": "ER_SUCCESS_MATCH"},
-                                    "values": [{"value": {"name": "Virgo", "id": "1"}}],
-                                },
-                            ]
-                        },
-                    }
-                },
-            },
-        },
-    }
-    req = await _intent_req(alexa_client, data)
-    assert req.status == HTTPStatus.OK
-    data = await req.json()
-    text = data.get("response", {}).get("outputSpeech", {}).get("text")
-    assert text == "You told us your sign is Virgio Test."
-
-
-async def test_intent_request_with_slots_and_multi_synonym_nearest_id_resolution(
-    alexa_client,
-) -> None:
-    """Test a request with slots and multiple name synonyms (nearest id)."""
+    """Test a request with slots and multiple name synonyms (id)."""
     data = {
         "version": "1.0",
         "session": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expose nearest Resolution (ID and Value) as Variables

Using the id value can be valuable if you don't want to use the id for entities but to process it in scripts for example. The ID Value is exposed as SlotName_ID variable.
In addition to the single value it could be useful to have the nearest resolution always available.

For example:
```
"TramStation": {
  "name": "TramStation",
  "value": "hauptbahnhof ost",
  "resolutions": {
    "resolutionsPerAuthority": [
    {
        "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.91b2d64a-aaa7-4390-bb66-a196e950d8ea.TramStation",
        "status": {
          "code": "ER_SUCCESS_MATCH"
        },
        "values": [
          {
            "value": {
              "name": "Hauptbahnhof Ost",
              "id": "80029079"
            }
          },
          {
            "value": {
              "name": "Hauptbahnhof West",
              "id": "80029080"
            }
          }
        ]
      }
    ]
  },
  "confirmationStatus": "NONE",
  "source": "USER"
}
```

In that case I wouldn't get the correct resolution, as it's more than one. So it defaults to the spoken value.
However the first resolution is always the one that fits best.
For that reason I exposed two more variables named "SlotName_NEAREST" and "SlotName_NEAREST_ID".
That way people can use it when they need it and can't rely on the default spoken value.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86629
- This PR is related to issue: #86629
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27326

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
