### PR TITLE
Enable Ruff PT001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,10 +246,11 @@ select = [
     "D",  # docstrings
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
-    "T20",  # flake8-print
-    "W",  # pycodestyle
-    "UP",  # pyupgrade
     "PGH004",  # Use specific rule codes when using noqa
+    "PT001", # Use @pytest.fixture without parentheses
+    "T20",  # flake8-print
+    "UP",  # pyupgrade
+    "W",  # pycodestyle
 ]
 
 ignore = [
@@ -267,6 +268,9 @@ ignore = [
     "E731",  # do not assign a lambda expression, use a def
     "UP024", # Replace aliased errors with `OSError`
 ]
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
 
 [tool.ruff.per-file-ignores]
 

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -157,7 +157,7 @@ def default_request_fixture(respx_mock):
     yield __mock_default_requests
 
 
-@pytest.fixture()
+@pytest.fixture
 def api_discovery_items():
     """Additional Apidiscovery items."""
     return {}

--- a/tests/components/axis/test_light.py
+++ b/tests/components/axis/test_light.py
@@ -25,7 +25,7 @@ API_DISCOVERY_LIGHT_CONTROL = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def light_control_items():
     """Available lights."""
     return [

--- a/tests/components/cast/conftest.py
+++ b/tests/components/cast/conftest.py
@@ -6,7 +6,7 @@ import pychromecast
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_multizone_status_mock():
     """Mock pychromecast dial."""
     mock = MagicMock(spec_set=pychromecast.dial.get_multizone_status)
@@ -14,32 +14,32 @@ def get_multizone_status_mock():
     return mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_cast_type_mock():
     """Mock pychromecast dial."""
     mock = MagicMock(spec_set=pychromecast.dial.get_cast_type)
     return mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def castbrowser_mock():
     """Mock pychromecast CastBrowser."""
     return MagicMock(spec=pychromecast.discovery.CastBrowser)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mz_mock():
     """Mock pychromecast MultizoneManager."""
     return MagicMock(spec_set=pychromecast.controllers.multizone.MultizoneManager)
 
 
-@pytest.fixture()
+@pytest.fixture
 def quick_play_mock():
     """Mock pychromecast quick_play."""
     return MagicMock()
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_chromecast_mock():
     """Mock pychromecast get_chromecast_from_cast_info."""
     return MagicMock()

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import EntityCategory
 from tests.common import async_fire_time_changed, mock_registry
 
 
-@pytest.fixture()
+@pytest.fixture
 def cloud_stub():
     """Stub the cloud."""
     return Mock(is_logged_in=True, subscription_expired=False)

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.cloud import const, tts
 
 
-@pytest.fixture()
+@pytest.fixture
 def cloud_with_prefs(cloud_prefs):
     """Return a cloud mock with prefs."""
     return Mock(client=Mock(prefs=cloud_prefs))

--- a/tests/components/devolo_home_network/conftest.py
+++ b/tests/components/devolo_home_network/conftest.py
@@ -8,7 +8,7 @@ from .const import DISCOVERY_INFO, IP
 from .mock import MockDevice
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_device():
     """Mock connecting to a devolo home network device."""
     device = MockDevice(ip=IP)

--- a/tests/components/dlink/conftest.py
+++ b/tests/components/dlink/conftest.py
@@ -48,13 +48,13 @@ def create_entry(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Add config entry in Home Assistant."""
     return create_entry(hass)
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_entry_with_uid(hass: HomeAssistant) -> MockConfigEntry:
     """Add config entry with unique ID in Home Assistant."""
     config_entry = create_entry(hass)
@@ -62,7 +62,7 @@ def config_entry_with_uid(hass: HomeAssistant) -> MockConfigEntry:
     return config_entry
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_plug() -> MagicMock:
     """Create mocked plug device."""
     mocked_plug = MagicMock()
@@ -74,7 +74,7 @@ def mocked_plug() -> MagicMock:
     return mocked_plug
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_plug_no_auth(mocked_plug: MagicMock) -> MagicMock:
     """Create mocked unauthenticated plug device."""
     mocked_plug = deepcopy(mocked_plug)

--- a/tests/components/eafm/conftest.py
+++ b/tests/components/eafm/conftest.py
@@ -5,14 +5,14 @@ from unittest.mock import patch
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_stations():
     """Mock aioeafm.get_stations."""
     with patch("homeassistant.components.eafm.config_flow.get_stations") as patched:
         yield patched
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_station():
     """Mock aioeafm.get_station."""
     with patch("homeassistant.components.eafm.sensor.get_station") as patched:

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -79,7 +79,7 @@ def fc_data_mock():
     return MOCK_FB_SERVICES
 
 
-@pytest.fixture()
+@pytest.fixture
 def fc_class_mock(fc_data):
     """Fixture that sets up a mocked FritzConnection class."""
     with patch(
@@ -89,7 +89,7 @@ def fc_class_mock(fc_data):
         yield result
 
 
-@pytest.fixture()
+@pytest.fixture
 def fh_class_mock():
     """Fixture that sets up a mocked FritzHosts class."""
     with patch(

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -141,13 +141,13 @@ class FakeHarmonyClient:
         self._callbacks.disconnect(None)
 
 
-@pytest.fixture()
+@pytest.fixture
 def harmony_client():
     """Create the FakeHarmonyClient instance."""
     return FakeHarmonyClient()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_hc(harmony_client):
     """Patch the real HarmonyClient with initialization side effect."""
 
@@ -158,7 +158,7 @@ def mock_hc(harmony_client):
         yield fake
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_write_config():
     """Patches write_config_file to remove side effects."""
     with patch(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -25,13 +25,13 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
 
-@pytest.fixture()
+@pytest.fixture
 def extra_os_info():
     """Extra os/info."""
     return {}
 
 
-@pytest.fixture()
+@pytest.fixture
 def os_info(extra_os_info):
     """Mock os/info."""
     return {

--- a/tests/components/home_plus_control/conftest.py
+++ b/tests/components/home_plus_control/conftest.py
@@ -12,7 +12,7 @@ CLIENT_SECRET = "5678"
 SUBSCRIPTION_KEY = "12345678901234567890123456789012"
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_config_entry():
     """Return a fake config entry.
 
@@ -40,7 +40,7 @@ def mock_config_entry():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_modules():
     """Return the full set of mock modules."""
     plant = HomePlusPlant(

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -20,7 +20,7 @@ def iid_storage(hass):
         yield AccessoryIIDStorage(hass, "")
 
 
-@pytest.fixture()
+@pytest.fixture
 def run_driver(hass, event_loop, iid_storage):
     """Return a custom AccessoryDriver instance for HomeKit accessory init.
 

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -15,7 +15,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         yield mock_setup
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_fireplace_finder_none() -> Generator[None, MagicMock, None]:
     """Mock fireplace finder."""
     mock_found_fireplaces = Mock()
@@ -26,7 +26,7 @@ def mock_fireplace_finder_none() -> Generator[None, MagicMock, None]:
         yield mock_found_fireplaces
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_fireplace_finder_single() -> Generator[None, MagicMock, None]:
     """Mock fireplace finder."""
     mock_found_fireplaces = Mock()

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -64,7 +64,7 @@ async def hass_(recorder_mock, hass):
     return hass
 
 
-@pytest.fixture()
+@pytest.fixture
 def set_utc(hass):
     """Set timezone to UTC."""
     hass.config.set_time_zone("UTC")

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -47,7 +47,7 @@ from tests.components.recorder.common import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def set_utc(hass):
     """Set timezone to UTC."""
     hass.config.set_time_zone("UTC")

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -19,7 +19,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def mock_impl(hass):
     """Mock implementation."""
     await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/metoffice/conftest.py
+++ b/tests/components/metoffice/conftest.py
@@ -5,7 +5,7 @@ from datapoint.exceptions import APIException
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simple_manager_fail():
     """Mock datapoint Manager with default values for testing in config_flow."""
     with patch("datapoint.Manager") as mock_manager:

--- a/tests/components/nws/conftest.py
+++ b/tests/components/nws/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from .const import DEFAULT_FORECAST, DEFAULT_OBSERVATION
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simple_nws():
     """Mock pynws SimpleNWS with default values."""
     with patch("homeassistant.components.nws.SimpleNWS") as mock_nws:
@@ -23,7 +23,7 @@ def mock_simple_nws():
         yield mock_nws
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simple_nws_config():
     """Mock pynws SimpleNWS with default values in config_flow."""
     with patch("homeassistant.components.nws.config_flow.SimpleNWS") as mock_nws:
@@ -34,7 +34,7 @@ def mock_simple_nws_config():
         yield mock_nws
 
 
-@pytest.fixture()
+@pytest.fixture
 def no_sensor():
     """Remove sensors."""
     with patch(
@@ -43,7 +43,7 @@ def no_sensor():
         yield mock_setup_entry
 
 
-@pytest.fixture()
+@pytest.fixture
 def no_weather():
     """Remove weather."""
     with patch(

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -54,7 +54,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         yield mock_setup
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_smile_config_flow() -> Generator[None, MagicMock, None]:
     """Return a mocked Smile client."""
     with patch(

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -48,7 +48,7 @@ def get_config_entry_with_auth(hass: HomeAssistant) -> ConfigEntry:
     return config_entry_with_auth
 
 
-@pytest.fixture()
+@pytest.fixture
 def system_get_info() -> Generator[SystemInfo, None, None]:
     """Fixture for SFRBox.system_get_info."""
     system_info = SystemInfo(**json.loads(load_fixture("system_getInfo.json", DOMAIN)))
@@ -59,7 +59,7 @@ def system_get_info() -> Generator[SystemInfo, None, None]:
         yield system_info
 
 
-@pytest.fixture()
+@pytest.fixture
 def dsl_get_info() -> Generator[DslInfo, None, None]:
     """Fixture for SFRBox.dsl_get_info."""
     dsl_info = DslInfo(**json.loads(load_fixture("dsl_getInfo.json", DOMAIN)))

--- a/tests/components/snooz/conftest.py
+++ b/tests/components/snooz/conftest.py
@@ -13,7 +13,7 @@ def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
 
 
-@pytest.fixture()
+@pytest.fixture
 async def mock_connected_snooz(hass: HomeAssistant):
     """Mock a Snooz configuration entry and device."""
 

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -59,7 +59,7 @@ class WorkerSync:
         self._original(stream_state)
 
 
-@pytest.fixture()
+@pytest.fixture
 def stream_worker_sync(hass):
     """Patch StreamOutput to allow test to synchronize worker stream end."""
     sync = WorkerSync()
@@ -138,7 +138,7 @@ class HLSSync:
         return await self._original_part_recv(output)
 
 
-@pytest.fixture()
+@pytest.fixture
 def hls_sync():
     """Patch HLSOutput to allow test to synchronize playlist requests and responses."""
     sync = HLSSync()

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -8,7 +8,7 @@ from .common import ComponentFactory
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
-@pytest.fixture()
+@pytest.fixture
 def vera_component_factory():
     """Return a factory for initializing the vera component."""
     with patch("pyvera.VeraController") as vera_controller_class_mock:

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -11,7 +11,7 @@ from .common import ComponentFactory
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-@pytest.fixture()
+@pytest.fixture
 def component_factory(
     hass: HomeAssistant,
     hass_client_no_auth,

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -82,7 +82,7 @@ def com_port(device="/dev/ttyUSB1234"):
     return port
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_connect_zigpy_app() -> Generator[None, None, None]:
     """Mock the radio connection."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enable `PT001` (from flake8-pytest-style) in Ruff.

Configured as `use @pytest.fixture over @pytest.fixture()`

Rationale: to enforce consistency between all fixtures in a codebase.

### Examples

Bad code (assuming `fixture-parentheses` set to false):

```python
import pytest

@pytest.fixture()
def my_fixture():
    ...
```
Good code:

```python
import pytest

@pytest.fixture
def my_fixture():
    ...
```

NB: All changes otherwise, have been fixed automatically by Ruff.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
