### PR TITLE
Shelly code quality

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -20,7 +20,7 @@ from homeassistant.util import slugify
 
 from .const import SHELLY_GAS_MODELS
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
-from .utils import get_block_device_name, get_device_entry_gen, get_rpc_device_name
+from .utils import get_device_entry_gen
 
 _ShellyCoordinatorT = TypeVar(
     "_ShellyCoordinatorT", bound=ShellyBlockCoordinator | ShellyRpcCoordinator
@@ -121,12 +121,7 @@ class ShellyButton(
         super().__init__(coordinator)
         self.entity_description = description
 
-        if isinstance(coordinator, ShellyRpcCoordinator):
-            device_name = get_rpc_device_name(coordinator.device)
-        else:
-            device_name = get_block_device_name(coordinator.device)
-
-        self._attr_name = f"{device_name} {description.name}"
+        self._attr_name = f"{coordinator.device.name} {description.name}"
         self._attr_unique_id = slugify(self._attr_name)
         self._attr_device_info = DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, coordinator.mac)}

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -33,13 +33,11 @@ from .const import (
 )
 from .coordinator import async_reconnect_soon, get_entry_data
 from .utils import (
-    get_block_device_name,
     get_block_device_sleep_period,
     get_coap_context,
     get_info_auth,
     get_info_gen,
     get_model_name,
-    get_rpc_device_name,
     get_rpc_device_sleep_period,
     get_ws_context,
     mac_address_from_name,
@@ -80,7 +78,7 @@ async def validate_input(
         assert rpc_device.shelly
 
         return {
-            "title": get_rpc_device_name(rpc_device),
+            "title": rpc_device.name,
             CONF_SLEEP_PERIOD: get_rpc_device_sleep_period(rpc_device.config),
             "model": rpc_device.shelly.get("model"),
             "gen": 2,
@@ -95,7 +93,7 @@ async def validate_input(
     )
     block_device.shutdown()
     return {
-        "title": get_block_device_name(block_device),
+        "title": block_device.name,
         CONF_SLEEP_PERIOD: get_block_device_sleep_period(block_device.settings),
         "model": block_device.model,
         "gen": 1,

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -51,7 +51,7 @@ from .const import (
     UPDATE_PERIOD_MULTIPLIER,
     BLEScannerMode,
 )
-from .utils import device_update_info, get_device_name, get_rpc_device_wakeup_period
+from .utils import device_update_info, get_rpc_device_wakeup_period
 
 _DeviceT = TypeVar("_DeviceT", bound="BlockDevice|RpcDevice")
 
@@ -86,7 +86,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
         self.entry = entry
         self.device = device
         self.device_id: str | None = None
-        device_name = get_device_name(device) if device.initialized else entry.title
+        device_name = device.name if device.initialized else entry.title
         interval_td = timedelta(seconds=update_interval)
         super().__init__(hass, LOGGER, name=device_name, update_interval=interval_td)
 

--- a/homeassistant/components/shelly/logbook.py
+++ b/homeassistant/components/shelly/logbook.py
@@ -21,7 +21,7 @@ from .coordinator import (
     get_block_coordinator_by_device_id,
     get_rpc_coordinator_by_device_id,
 )
-from .utils import get_block_device_name, get_rpc_entity_name
+from .utils import get_rpc_entity_name
 
 
 @callback
@@ -48,8 +48,7 @@ def async_describe_events(
         elif click_type in BLOCK_INPUTS_EVENTS_TYPES:
             block_coordinator = get_block_coordinator_by_device_id(hass, device_id)
             if block_coordinator and block_coordinator.device.initialized:
-                device_name = get_block_device_name(block_coordinator.device)
-                input_name = f"{device_name} channel {channel}"
+                input_name = f"{block_coordinator.device.name} channel {channel}"
 
         return {
             LOGBOOK_ENTRY_NAME: "Shelly",

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -19,10 +19,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
 
 from .const import CONF_SLEEP_PERIOD
-from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
+from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
 from .entity import (
     RestEntityDescription,
     RpcEntityDescription,
@@ -31,12 +30,7 @@ from .entity import (
     async_setup_entry_rest,
     async_setup_entry_rpc,
 )
-from .utils import (
-    async_remove_shelly_entity,
-    get_block_device_name,
-    get_device_entry_gen,
-    get_rpc_device_name,
-)
+from .utils import get_device_entry_gen
 
 LOGGER = logging.getLogger(__name__)
 
@@ -123,27 +117,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for Shelly component."""
     if get_device_entry_gen(config_entry) == 2:
-        # Remove legacy update binary sensor & buttons, remove in 2023.2.0
-        rpc_coordinator = get_entry_data(hass)[config_entry.entry_id].rpc
-        assert rpc_coordinator
-        mac = rpc_coordinator.mac
-        async_remove_shelly_entity(hass, "binary_sensor", f"{mac}-sys-fwupdate")
-        device_name = slugify(get_rpc_device_name(rpc_coordinator.device))
-        async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update")
-        async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update_beta")
-
         return async_setup_entry_rpc(
             hass, config_entry, async_add_entities, RPC_UPDATES, RpcUpdateEntity
         )
-
-    # Remove legacy update binary sensor & buttons, remove in 2023.2.0
-    block_coordinator = get_entry_data(hass)[config_entry.entry_id].block
-    assert block_coordinator
-    mac = block_coordinator.mac
-    async_remove_shelly_entity(hass, "binary_sensor", f"{mac}-fwupdate")
-    device_name = slugify(get_block_device_name(block_coordinator.device))
-    async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update")
-    async_remove_shelly_entity(hass, "button", f"{device_name}_ota_update_beta")
 
     if not config_entry.data[CONF_SLEEP_PERIOD]:
         async_setup_entry_rest(

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -49,24 +49,6 @@ def async_remove_shelly_entity(
         entity_reg.async_remove(entity_id)
 
 
-def get_block_device_name(device: BlockDevice) -> str:
-    """Get Block device name."""
-    return cast(str, device.settings["name"] or device.settings["device"]["hostname"])
-
-
-def get_rpc_device_name(device: RpcDevice) -> str:
-    """Get RPC device name."""
-    return cast(str, device.config["sys"]["device"].get("name") or device.hostname)
-
-
-def get_device_name(device: BlockDevice | RpcDevice) -> str:
-    """Get device name."""
-    if isinstance(device, BlockDevice):
-        return get_block_device_name(device)
-
-    return get_rpc_device_name(device)
-
-
 def get_number_of_channels(device: BlockDevice, block: Block) -> int:
     """Get number of channels for block type."""
     assert isinstance(device.shelly, dict)
@@ -105,7 +87,7 @@ def get_block_entity_name(
 
 def get_block_channel_name(device: BlockDevice, block: Block | None) -> str:
     """Get name based on device and channel name."""
-    entity_name = get_block_device_name(device)
+    entity_name = device.name
 
     if (
         not block
@@ -306,7 +288,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
     if device.config.get("switch:0"):
         key = key.replace("input", "switch")
-    device_name = get_rpc_device_name(device)
+    device_name = device.name
     entity_name: str | None = None
     if key in device.config:
         entity_name = device.config[key].get("name", device_name)

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -1,7 +1,7 @@
 """Test configuration for Shelly."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from aioshelly.block_device import BlockDevice
 from aioshelly.rpc_device import RpcDevice, UpdateType
@@ -245,7 +245,9 @@ async def mock_block_device():
             status=MOCK_STATUS_COAP,
             firmware_version="some fw string",
             initialized=True,
+            model="SHSW-1",
         )
+        type(device).name = PropertyMock(return_value="Test name")
         block_device_mock.return_value = device
         block_device_mock.return_value.mock_update = Mock(side_effect=update)
 
@@ -254,7 +256,7 @@ async def mock_block_device():
 
 def _mock_rpc_device(version: str | None = None):
     """Mock rpc (Gen2, Websocket) device."""
-    return Mock(
+    device = Mock(
         spec=RpcDevice,
         config=MOCK_CONFIG,
         event={},
@@ -265,6 +267,8 @@ def _mock_rpc_device(version: str | None = None):
         firmware_version="some fw string",
         initialized=True,
     )
+    type(device).name = PropertyMock(return_value="Test name")
+    return device
 
 
 @pytest.fixture

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -4,8 +4,6 @@ from unittest.mock import AsyncMock
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 import pytest
 
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.shelly.const import DOMAIN
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
@@ -21,44 +19,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get
 
 from . import MOCK_MAC, init_integration, mock_rest_update
-
-
-@pytest.mark.parametrize(
-    "gen, domain, unique_id, object_id",
-    [
-        (1, BINARY_SENSOR_DOMAIN, f"{MOCK_MAC}-fwupdate", "firmware_update"),
-        (1, BUTTON_DOMAIN, "test_name_ota_update", "ota_update"),
-        (1, BUTTON_DOMAIN, "test_name_ota_update_beta", "ota_update_beta"),
-        (2, BINARY_SENSOR_DOMAIN, f"{MOCK_MAC}-sys-fwupdate", "firmware_update"),
-        (2, BUTTON_DOMAIN, "test_name_ota_update", "ota_update"),
-        (2, BUTTON_DOMAIN, "test_name_ota_update_beta", "ota_update_beta"),
-    ],
-)
-async def test_remove_legacy_entities(
-    hass: HomeAssistant,
-    gen,
-    domain,
-    unique_id,
-    object_id,
-    mock_block_device,
-    mock_rpc_device,
-):
-    """Test removes legacy update entities."""
-    entity_id = f"{domain}.test_name_{object_id}"
-    entity_registry = async_get(hass)
-    entity_registry.async_get_or_create(
-        domain,
-        DOMAIN,
-        unique_id,
-        suggested_object_id=f"test_name_{object_id}",
-        disabled_by=None,
-    )
-
-    assert entity_registry.async_get(entity_id) is not None
-
-    await init_integration(hass, gen)
-
-    assert entity_registry.async_get(entity_id) is None
 
 
 async def test_block_update(hass: HomeAssistant, mock_block_device, monkeypatch):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Shelly code quality:
- Use device name from upstream - https://github.com/home-assistant-libs/aioshelly/pull/336
- Remove old button migration code marked to be removed at `2023.2.0`
- Use device mock fixtures in config flow tests

Tested on: Shelly 2.5, Shelly Plus 1PM, Shelly Plus HT

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
