### PR TITLE
Improve nuki typing

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -1,4 +1,6 @@
 """The nuki component."""
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import timedelta
 import logging
@@ -109,38 +111,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class NukiEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
-    """An entity using CoordinatorEntity.
-
-    The CoordinatorEntity class provides:
-      should_poll
-      async_update
-      async_added_to_hass
-      available
-
-    """
-
-    def __init__(
-        self, coordinator: DataUpdateCoordinator[None], nuki_device: NukiDevice
-    ) -> None:
-        """Pass coordinator to CoordinatorEntity."""
-        super().__init__(coordinator)
-        self._nuki_device = nuki_device
-
-    @property
-    def device_info(self):
-        """Device info for Nuki entities."""
-        return {
-            "identifiers": {(DOMAIN, parse_id(self._nuki_device.nuki_id))},
-            "name": self._nuki_device.name,
-            "manufacturer": "Nuki Home Solutions GmbH",
-            "model": self._nuki_device.device_type_str.capitalize(),
-            "sw_version": self._nuki_device.firmware_version,
-            "via_device": (DOMAIN, self.coordinator.bridge_id),
-        }
-
-
-class NukiCoordinator(DataUpdateCoordinator):
+class NukiCoordinator(DataUpdateCoordinator[None]):
     """Data Update Coordinator for the Nuki integration."""
 
     def __init__(self, hass, bridge, locks, openers):
@@ -217,3 +188,32 @@ class NukiCoordinator(DataUpdateCoordinator):
                     break
 
         return events
+
+
+class NukiEntity(CoordinatorEntity[NukiCoordinator]):
+    """An entity using CoordinatorEntity.
+
+    The CoordinatorEntity class provides:
+      should_poll
+      async_update
+      async_added_to_hass
+      available
+
+    """
+
+    def __init__(self, coordinator: NukiCoordinator, nuki_device: NukiDevice) -> None:
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(coordinator)
+        self._nuki_device = nuki_device
+
+    @property
+    def device_info(self):
+        """Device info for Nuki entities."""
+        return {
+            "identifiers": {(DOMAIN, parse_id(self._nuki_device.nuki_id))},
+            "name": self._nuki_device.name,
+            "manufacturer": "Nuki Home Solutions GmbH",
+            "model": self._nuki_device.device_type_str.capitalize(),
+            "sw_version": self._nuki_device.firmware_version,
+            "via_device": (DOMAIN, self.coordinator.bridge_id),
+        }

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import timedelta
 import logging
+from typing import Generic, TypeVar
 
 import async_timeout
 from pynuki import NukiBridge, NukiLock, NukiOpener
@@ -32,6 +33,8 @@ from .const import (
     ERROR_STATES,
 )
 from .helpers import parse_id
+
+_NukiDeviceT = TypeVar("_NukiDeviceT", bound=NukiDevice)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -190,7 +193,7 @@ class NukiCoordinator(DataUpdateCoordinator[None]):
         return events
 
 
-class NukiEntity(CoordinatorEntity[NukiCoordinator]):
+class NukiEntity(CoordinatorEntity[NukiCoordinator], Generic[_NukiDeviceT]):
     """An entity using CoordinatorEntity.
 
     The CoordinatorEntity class provides:
@@ -201,7 +204,7 @@ class NukiEntity(CoordinatorEntity[NukiCoordinator]):
 
     """
 
-    def __init__(self, coordinator: NukiCoordinator, nuki_device: NukiDevice) -> None:
+    def __init__(self, coordinator: NukiCoordinator, nuki_device: _NukiDeviceT) -> None:
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)
         self._nuki_device = nuki_device

--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -1,4 +1,5 @@
 """Doorsensor Support for the Nuki Lock."""
+from __future__ import annotations
 
 from pynuki.constants import STATE_DOORSENSOR_OPENED
 
@@ -9,9 +10,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import NukiEntity
+from . import NukiCoordinator, NukiEntity
 from .const import ATTR_NUKI_ID, DATA_COORDINATOR, DATA_LOCKS, DOMAIN as NUKI_DOMAIN
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Nuki lock binary sensor."""
     data = hass.data[NUKI_DOMAIN][entry.entry_id]
-    coordinator: DataUpdateCoordinator[None] = data[DATA_COORDINATOR]
+    coordinator: NukiCoordinator = data[DATA_COORDINATOR]
 
     entities = []
 

--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pynuki.constants import STATE_DOORSENSOR_OPENED
+from pynuki.device import NukiDevice
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -31,7 +32,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NukiDoorsensorEntity(NukiEntity, BinarySensorEntity):
+class NukiDoorsensorEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     """Representation of a Nuki Lock Doorsensor."""
 
     _attr_has_entity_name = True

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -1,7 +1,7 @@
 """Nuki.io lock platform."""
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, TypeVar
 
 from pynuki import NukiLock, NukiOpener
@@ -66,7 +66,7 @@ async def async_setup_entry(
     )
 
 
-class NukiDeviceEntity(NukiEntity[_NukiDeviceT], LockEntity, ABC):
+class NukiDeviceEntity(NukiEntity[_NukiDeviceT], LockEntity):
     """Representation of a Nuki device."""
 
     _attr_has_entity_name = True

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TypeVar
 
 from pynuki import NukiLock, NukiOpener
 from pynuki.constants import MODE_OPENER_CONTINUOUS
+from pynuki.device import NukiDevice
 from requests.exceptions import RequestException
 import voluptuous as vol
 
@@ -28,6 +29,8 @@ from .const import (
     ERROR_STATES,
 )
 from .helpers import CannotConnect
+
+_NukiDeviceT = TypeVar("_NukiDeviceT", bound=NukiDevice)
 
 
 async def async_setup_entry(
@@ -63,7 +66,7 @@ async def async_setup_entry(
     )
 
 
-class NukiDeviceEntity(NukiEntity, LockEntity, ABC):
+class NukiDeviceEntity(NukiEntity[_NukiDeviceT], LockEntity, ABC):
     """Representation of a Nuki device."""
 
     _attr_has_entity_name = True
@@ -100,10 +103,8 @@ class NukiDeviceEntity(NukiEntity, LockEntity, ABC):
         """Open the door latch."""
 
 
-class NukiLockEntity(NukiDeviceEntity):
+class NukiLockEntity(NukiDeviceEntity[NukiLock]):
     """Representation of a Nuki lock."""
-
-    _nuki_device: NukiLock
 
     @property
     def is_locked(self) -> bool:
@@ -143,10 +144,8 @@ class NukiLockEntity(NukiDeviceEntity):
             raise CannotConnect from err
 
 
-class NukiOpenerEntity(NukiDeviceEntity):
+class NukiOpenerEntity(NukiDeviceEntity[NukiOpener]):
     """Representation of a Nuki opener."""
-
-    _nuki_device: NukiOpener
 
     @property
     def is_locked(self) -> bool:

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -14,9 +14,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import NukiEntity
+from . import NukiCoordinator, NukiEntity
 from .const import (
     ATTR_BATTERY_CRITICAL,
     ATTR_ENABLE,
@@ -36,7 +35,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Nuki lock platform."""
     data = hass.data[NUKI_DOMAIN][entry.entry_id]
-    coordinator: DataUpdateCoordinator[None] = data[DATA_COORDINATOR]
+    coordinator: NukiCoordinator = data[DATA_COORDINATOR]
 
     entities: list[NukiDeviceEntity] = [
         NukiLockEntity(coordinator, lock) for lock in data[DATA_LOCKS]

--- a/homeassistant/components/nuki/sensor.py
+++ b/homeassistant/components/nuki/sensor.py
@@ -1,4 +1,7 @@
 """Battery sensor for the Nuki Lock."""
+from __future__ import annotations
+
+from pynuki.device import NukiDevice
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -23,7 +26,7 @@ async def async_setup_entry(
     )
 
 
-class NukiBatterySensor(NukiEntity, SensorEntity):
+class NukiBatterySensor(NukiEntity[NukiDevice], SensorEntity):
     """Representation of a Nuki Lock Battery sensor."""
 
     _attr_has_entity_name = True


### PR DESCRIPTION
## Proposed change
* Move `NukiEntity` to make it possible to inherit from `CoordinatorEntity[NukiCoordinator]`
* Make `NukiEntity` generic
* Remove unnecessary `ABC`. It's already a base class of `LockEntity`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
