### PR TITLE
Bump UPB integration library to 0.5.3

### DIFF
--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -2,9 +2,15 @@
   "domain": "upb",
   "name": "Universal Powerline Bus (UPB)",
   "documentation": "https://www.home-assistant.io/integrations/upb",
-  "requirements": ["upb_lib==0.4.12"],
-  "codeowners": ["@gwww"],
+  "requirements": [
+    "upb_lib==0.5.3"
+  ],
+  "codeowners": [
+    "@gwww"
+  ],
   "config_flow": true,
   "iot_class": "local_push",
-  "loggers": ["upb_lib"]
+  "loggers": [
+    "upb_lib"
+  ]
 }

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -2,15 +2,9 @@
   "domain": "upb",
   "name": "Universal Powerline Bus (UPB)",
   "documentation": "https://www.home-assistant.io/integrations/upb",
-  "requirements": [
-    "upb_lib==0.5.3"
-  ],
-  "codeowners": [
-    "@gwww"
-  ],
+  "requirements": ["upb_lib==0.5.3"],
+  "codeowners": ["@gwww"],
   "config_flow": true,
   "iot_class": "local_push",
-  "loggers": [
-    "upb_lib"
-  ]
+  "loggers": ["upb_lib"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2544,7 +2544,7 @@ unifi-discovery==1.1.7
 unifiled==0.11
 
 # homeassistant.components.upb
-upb_lib==0.4.12
+upb_lib==0.5.3
 
 # homeassistant.components.upcloud
 upcloud-api==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1790,7 +1790,7 @@ ultraheat-api==0.5.1
 unifi-discovery==1.1.7
 
 # homeassistant.components.upb
-upb_lib==0.4.12
+upb_lib==0.5.3
 
 # homeassistant.components.upcloud
 upcloud-api==2.0.0


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There have been a number of fixes in this library over the past year or so. All have been fixes that are not affecting HA functionality (i.e.: people using the library for other purposes). While the library change may look like a lot, they fall mostly into two categories: formatting changes (due to wrapping something in an if, for example and changes to the program in the bin directory, which is not a factor for HA. The only change that is affecting HA is the very last one, fixing the bug referenced below.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86642
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/gwww/upb-lib/compare/0.4.12...0.5.3

### Summary of the library changes
- https://github.com/gwww/upb-lib/compare/0.4.12...0.5.0: Mostly a simple refactor to more easily accommodate being able to control two different flags. This is not (currently) used by HA 
- https://github.com/gwww/upb-lib/compare/0.5.0...0.5.1: Some more tweaks around the tx_count flags; not used by HA
- https://github.com/gwww/upb-lib/compare/0.5.1...0.5.2: This patch has improvement that is used by HA. The bit of hardware that plugs into the wall to control the lights has two modes. A part of this patch ensures that devices is in the right mode. It's never come up in the context of HA but outside of HA someone was having a problem. This is a low risk change. The other part of this patch is the the `bin/upb` program is used for command line testing; not part of anything for HA.
- https://github.com/gwww/upb-lib/compare/0.5.2...0.5.3: This patch address the issue and is the reason for this PR.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
