### PR TITLE
Bump zwave-js-server-python to 0.45.0

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -35,14 +35,14 @@ from zwave_js_server.model.controller import (
     QRProvisioningInformation,
 )
 from zwave_js_server.model.driver import Driver
-from zwave_js_server.model.firmware import (
-    FirmwareUpdateData,
-    FirmwareUpdateProgress,
-    FirmwareUpdateResult,
-)
+from zwave_js_server.model.firmware import FirmwareUpdateData
 from zwave_js_server.model.log_config import LogConfig
 from zwave_js_server.model.log_message import LogMessage
 from zwave_js_server.model.node import Node, NodeStatistics
+from zwave_js_server.model.node.firmware import (
+    NodeFirmwareUpdateProgress,
+    NodeFirmwareUpdateResult,
+)
 from zwave_js_server.model.utils import async_parse_qr_code_string
 from zwave_js_server.util.node import async_set_config_parameter
 
@@ -1897,7 +1897,7 @@ async def websocket_is_node_firmware_update_in_progress(
 
 
 def _get_firmware_update_progress_dict(
-    progress: FirmwareUpdateProgress,
+    progress: NodeFirmwareUpdateProgress,
 ) -> dict[str, int | float]:
     """Get a dictionary of firmware update progress."""
     return {
@@ -1934,7 +1934,7 @@ async def websocket_subscribe_firmware_update_status(
 
     @callback
     def forward_progress(event: dict) -> None:
-        progress: FirmwareUpdateProgress = event["firmware_update_progress"]
+        progress: NodeFirmwareUpdateProgress = event["firmware_update_progress"]
         connection.send_message(
             websocket_api.event_message(
                 msg[ID],
@@ -1947,7 +1947,7 @@ async def websocket_subscribe_firmware_update_status(
 
     @callback
     def forward_finished(event: dict) -> None:
-        finished: FirmwareUpdateResult = event["firmware_update_finished"]
+        finished: NodeFirmwareUpdateResult = event["firmware_update_finished"]
         connection.send_message(
             websocket_api.event_message(
                 msg[ID],

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.44.0"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.45.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -11,12 +11,12 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import NodeStatus
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
 from zwave_js_server.model.driver import Driver
-from zwave_js_server.model.firmware import (
-    FirmwareUpdateInfo,
-    FirmwareUpdateProgress,
-    FirmwareUpdateResult,
-)
 from zwave_js_server.model.node import Node as ZwaveNode
+from zwave_js_server.model.node.firmware import (
+    NodeFirmwareUpdateInfo,
+    NodeFirmwareUpdateProgress,
+    NodeFirmwareUpdateResult,
+)
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -84,13 +84,13 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self.driver = driver
         self.node = node
         self.semaphore = semaphore
-        self._latest_version_firmware: FirmwareUpdateInfo | None = None
+        self._latest_version_firmware: NodeFirmwareUpdateInfo | None = None
         self._status_unsub: Callable[[], None] | None = None
         self._poll_unsub: Callable[[], None] | None = None
         self._progress_unsub: Callable[[], None] | None = None
         self._finished_unsub: Callable[[], None] | None = None
         self._finished_event = asyncio.Event()
-        self._result: FirmwareUpdateResult | None = None
+        self._result: NodeFirmwareUpdateResult | None = None
 
         # Entity class attributes
         self._attr_name = "Firmware"
@@ -109,7 +109,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
     @callback
     def _update_progress(self, event: dict[str, Any]) -> None:
         """Update install progress on event."""
-        progress: FirmwareUpdateProgress = event["firmware_update_progress"]
+        progress: NodeFirmwareUpdateProgress = event["firmware_update_progress"]
         if not self._latest_version_firmware:
             return
         self._attr_in_progress = int(progress.progress)
@@ -118,7 +118,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
     @callback
     def _update_finished(self, event: dict[str, Any]) -> None:
         """Update install progress on event."""
-        result: FirmwareUpdateResult = event["firmware_update_finished"]
+        result: NodeFirmwareUpdateResult = event["firmware_update_finished"]
         self._result = result
         self._finished_event.set()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2720,7 +2720,7 @@ zigpy==0.53.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.44.0
+zwave-js-server-python==0.45.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1924,7 +1924,7 @@ zigpy-znp==0.9.2
 zigpy==0.53.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.44.0
+zwave-js-server-python==0.45.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.3.0

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedZWaveCommand
-from zwave_js_server.model.firmware import FirmwareUpdateStatus
+from zwave_js_server.model.node.firmware import NodeFirmwareUpdateStatus
 
 from homeassistant.components.update import (
     ATTR_AUTO_UPDATE,
@@ -375,7 +375,7 @@ async def test_update_entity_progress(
             "event": "firmware update finished",
             "nodeId": node.node_id,
             "result": {
-                "status": FirmwareUpdateStatus.OK_NO_RESTART,
+                "status": NodeFirmwareUpdateStatus.OK_NO_RESTART,
                 "success": True,
                 "reInterview": False,
             },
@@ -466,7 +466,7 @@ async def test_update_entity_install_failed(
             "event": "firmware update finished",
             "nodeId": node.node_id,
             "result": {
-                "status": FirmwareUpdateStatus.ERROR_TIMEOUT,
+                "status": NodeFirmwareUpdateStatus.ERROR_TIMEOUT,
                 "success": False,
                 "reInterview": False,
             },


### PR DESCRIPTION
## Proposed change
Changelog: https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.45.0

Should wait for merge until https://github.com/home-assistant/addons/pull/2858 is merged

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
