### PR TITLE
Enable Ruff PT015

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,8 +247,6 @@ select = [
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
     "PGH004",  # Use specific rule codes when using noqa
-    "PT001", # Use @pytest.fixture without parentheses
-    "PT013", # Found incorrect pytest import, use simple import pytest instead
     "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
     "T20",  # flake8-print
     "UP",  # pyupgrade

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -352,7 +352,7 @@ async def test_saving_loading(hass, hass_storage):
             assert r_token.last_used_at is None
             assert r_token.last_used_ip is None
         else:
-            assert False, f"Unknown client_id: {r_token.client_id}"
+            pytest.fail(f"Unknown client_id: {r_token.client_id}")
 
 
 async def test_cannot_retrieve_expired_access_token(hass):

--- a/tests/components/alexa/test_common.py
+++ b/tests/components/alexa/test_common.py
@@ -2,6 +2,8 @@
 from unittest.mock import Mock
 from uuid import uuid4
 
+import pytest
+
 from homeassistant.components.alexa import config, smart_home, smart_home_http
 from homeassistant.components.alexa.const import CONF_ENDPOINT, CONF_FILTER, CONF_LOCALE
 from homeassistant.core import Context, callback
@@ -216,7 +218,7 @@ class ReportedProperties:
         """Assert a property does not exist."""
         for prop in self.properties:
             if prop["namespace"] == namespace and prop["name"] == name:
-                assert False, "Property %s:%s exists"
+                pytest.fail(f"Property {namespace}:{name} exists")
 
     def assert_equal(self, namespace, name, value):
         """Assert a property is equal to a given value."""
@@ -225,4 +227,4 @@ class ReportedProperties:
                 assert prop["value"] == value
                 return prop
 
-        assert False, f"property {namespace}:{name} not in {self.properties!r}"
+        pytest.fail(f"property {namespace}:{name} not in {self.properties!r}")

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 import aprslib
+import pytest
 
 import homeassistant.components.aprs.device_tracker as device_tracker
 
@@ -57,7 +58,7 @@ def test_gps_accuracy_invalid_int():
 
     try:
         device_tracker.gps_accuracy(TEST_COORDS_NULL_ISLAND, level)
-        assert False, "No exception."
+        pytest.fail("No exception.")
     except ValueError:
         pass
 
@@ -68,7 +69,7 @@ def test_gps_accuracy_invalid_string():
 
     try:
         device_tracker.gps_accuracy(TEST_COORDS_NULL_ISLAND, level)
-        assert False, "No exception."
+        pytest.fail("No exception.")
     except ValueError:
         pass
 
@@ -79,7 +80,7 @@ def test_gps_accuracy_invalid_float():
 
     try:
         device_tracker.gps_accuracy(TEST_COORDS_NULL_ISLAND, level)
-        assert False, "No exception."
+        pytest.fail("No exception.")
     except ValueError:
         pass
 

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 import pathlib
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
 from homeassistant.core import callback
@@ -24,7 +26,7 @@ def patch_blueprint(blueprint_path: str, data_path):
     @callback
     def mock_load_blueprint(self, path):
         if path != blueprint_path:
-            assert False, f"Unexpected blueprint {path}"
+            pytest.fail(f"Unexpected blueprint {path}")
             return orig_load(self, path)
 
         return models.Blueprint(

--- a/tests/components/blueprint/test_schemas.py
+++ b/tests/components/blueprint/test_schemas.py
@@ -59,7 +59,7 @@ def test_blueprint_schema(blueprint):
         schemas.BLUEPRINT_SCHEMA(blueprint)
     except vol.Invalid:
         _LOGGER.exception("%s", blueprint)
-        assert False, "Expected schema to be valid"
+        pytest.fail("Expected schema to be valid")
 
 
 @pytest.mark.parametrize(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -291,7 +291,7 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock, hass_storag
         if token.token == refresh_token:
             break
     else:
-        assert False, "refresh token not found"
+        pytest.fail("refresh token not found")
 
 
 async def test_setup_adds_admin_group_to_user(hass, aioclient_mock, hass_storage):

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -330,7 +330,7 @@ async def test_require_admin(hass, hass_read_only_user):
                 context=ha.Context(user_id=hass_read_only_user.id),
                 blocking=True,
             )
-            assert False, f"Should have raises for {service}"
+            pytest.fail(f"Should have raises for {service}")
 
     with pytest.raises(Unauthorized):
         await hass.services.async_call(

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -1,4 +1,6 @@
 """Tests for the humidifier intents."""
+import pytest
+
 from homeassistant.components.humidifier import (
     ATTR_AVAILABLE_MODES,
     ATTR_HUMIDITY,
@@ -178,7 +180,7 @@ async def test_intent_set_mode_tests_feature(hass):
             intent.INTENT_MODE,
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "away"}},
         )
-        assert False, "handling intent should have raised"
+        pytest.fail("handling intent should have raised")
     except IntentHandleError as err:
         assert str(err) == "Entity bedroom humidifier does not support modes"
 
@@ -207,7 +209,7 @@ async def test_intent_set_unknown_mode(hass):
             intent.INTENT_MODE,
             {"name": {"value": "Bedroom humidifier"}, "mode": {"value": "eco"}},
         )
-        assert False, "handling intent should have raised"
+        pytest.fail("handling intent should have raised")
     except IntentHandleError as err:
         assert str(err) == "Entity bedroom humidifier does not support eco mode"
 

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -34,7 +34,7 @@ async def matter_client_fixture() -> AsyncGenerator[MagicMock, None]:
                 init_ready.set()
             listen_block = asyncio.Event()
             await listen_block.wait()
-            assert False, "Listen was not cancelled!"
+            pytest.fail("Listen was not cancelled!")
 
         client.connect = AsyncMock(side_effect=connect)
         client.start_listening = AsyncMock(side_effect=listen)

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -148,7 +148,7 @@ def mock_process_uploaded_file(tmp_path):
                 keyfile.write(b"## mock key file ##")
             return tmp_path / "client.key"
         else:
-            assert False
+            pytest.fail(f"Unexpected file_id: {file_id}")
 
     with patch(
         "homeassistant.components.mqtt.config_flow.process_uploaded_file",

--- a/tests/components/script/test_blueprint.py
+++ b/tests/components/script/test_blueprint.py
@@ -5,6 +5,8 @@ import contextlib
 import pathlib
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components import script
 from homeassistant.components.blueprint.models import Blueprint, DomainBlueprints
 from homeassistant.core import Context, HomeAssistant, callback
@@ -25,7 +27,7 @@ def patch_blueprint(blueprint_path: str, data_path: str) -> Iterator[None]:
     @callback
     def mock_load_blueprint(self, path: str) -> Blueprint:
         if path != blueprint_path:
-            assert False, f"Unexpected blueprint {path}"
+            pytest.fail(f"Unexpected blueprint {path}")
             return orig_load(self, path)
 
         return Blueprint(

--- a/tests/components/tts/conftest.py
+++ b/tests/components/tts/conftest.py
@@ -60,7 +60,7 @@ def empty_cache_dir(tmp_path, mock_init_cache_dir, mock_get_cache_files, request
         print(fil.relative_to(tmp_path))  # noqa: T201
 
     # To show the log.
-    assert False
+    pytest.fail("Test failed, see log for details")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -210,27 +210,21 @@ async def test_data_manager_webhook_subscription(
     api.notify_subscribe.assert_any_call(
         data_manager.webhook_config.url, NotifyAppli.SLEEP
     )
-    try:
+
+    with pytest.raises(AssertionError):
         api.notify_subscribe.assert_any_call(
             data_manager.webhook_config.url, NotifyAppli.USER
         )
-        assert False
-    except AssertionError:
-        pass
-    try:
+
+    with pytest.raises(AssertionError):
         api.notify_subscribe.assert_any_call(
             data_manager.webhook_config.url, NotifyAppli.BED_IN
         )
-        assert False
-    except AssertionError:
-        pass
-    try:
+
+    with pytest.raises(AssertionError):
         api.notify_subscribe.assert_any_call(
             data_manager.webhook_config.url, NotifyAppli.BED_OUT
         )
-        assert False
-    except AssertionError:
-        pass
 
     # Test unsubscribing.
     await data_manager.async_unsubscribe_webhook()

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -36,7 +36,7 @@ def config_schema_assert_fail(withings_config) -> None:
     """Assert a schema config will fail."""
     try:
         config_schema_validate(withings_config)
-        assert False, "This line should not have run."
+        pytest.fail("This line should not have run.")
     except vol.error.MultipleInvalid:
         assert True
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -614,7 +614,7 @@ def mock_client_fixture(
             driver_ready.set()
             listen_block = asyncio.Event()
             await listen_block.wait()
-            assert False, "Listen wasn't canceled!"
+            pytest.fail("Listen wasn't canceled!")
 
         async def disconnect():
             client.connected = False

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -4404,7 +4404,7 @@ async def test_validate_action_config(hass):
                 hass, validated_config[action_type]
             )
         except vol.Invalid as err:
-            assert False, f"{action_type} config invalid: {err}"
+            pytest.fail(f"{action_type} config invalid: {err}")
 
     # Verify non-static actions have validated
     for action_type, paths_to_templates in expected_templates.items():

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,8 @@
+# This extend our general Ruff rules specifically for tests
+extend = "../pyproject.toml"
+
+extend-select = [
+    "PT001", # Use @pytest.fixture without parentheses
+    "PT013", # Found incorrect pytest import, use simple import pytest instead
+    "PT015", # Assertion always fails, replace with pytest.fail()
+]

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -146,9 +146,7 @@ class AiohttpClientMocker:
                     raise response.exc
                 return response
 
-        assert False, "No mock registered for {} {} {}".format(
-            method.upper(), url, params
-        )
+        raise AssertionError(f"No mock registered for {method.upper()} {url} {params}")
 
 
 class AiohttpClientMockResponse:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PT015: `assertion always fails, replace with pytest.fail()`

Rationale:

- To enforce consistency across all tests in a codebase.
- To improve the readability of test code and error messages.

### Notes

This PR moves tests specific Ruff configuration out of `pyproject.yaml` (as it applies to the whole project), into a `tests/ruff.toml` configuration file. This ensures our pytest-specific rules are only applied to our tests codebase.

### Examples

Bad code:

```python
def test_foo():
    if some_condition:
        assert False, 'some_condition was True'
```

Good code:

```python
import pytest

def test_foo():
    if some_condition:
        pytest.fail('some_condition was True')
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
