### PR TITLE
Migrates tests to use UnitOfSpeed enum

### DIFF
--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -21,10 +21,10 @@ from homeassistant.const import (
     LENGTH_MILLIMETERS,
     MASS_GRAMS,
     PRESSURE_PA,
-    SPEED_KILOMETERS_PER_HOUR,
     STATE_ON,
     TEMP_CELSIUS,
     VOLUME_LITERS,
+    UnitOfSpeed,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
@@ -55,7 +55,7 @@ def _set_up_units(hass: HomeAssistant) -> None:
         pressure=PRESSURE_PA,
         temperature=TEMP_CELSIUS,
         volume=VOLUME_LITERS,
-        wind_speed=SPEED_KILOMETERS_PER_HOUR,
+        wind_speed=UnitOfSpeed.KILOMETERS_PER_HOUR,
     )
 
 

--- a/tests/util/test_speed.py
+++ b/tests/util/test_speed.py
@@ -2,20 +2,16 @@
 import pytest
 
 from homeassistant.const import (
-    SPEED_FEET_PER_SECOND,
     SPEED_INCHES_PER_DAY,
     SPEED_INCHES_PER_HOUR,
-    SPEED_KILOMETERS_PER_HOUR,
-    SPEED_KNOTS,
-    SPEED_METERS_PER_SECOND,
-    SPEED_MILES_PER_HOUR,
     SPEED_MILLIMETERS_PER_DAY,
+    UnitOfSpeed,
 )
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.speed as speed_util
 
 INVALID_SYMBOL = "bob"
-VALID_SYMBOL = SPEED_KILOMETERS_PER_HOUR
+VALID_SYMBOL = UnitOfSpeed.KILOMETERS_PER_HOUR
 
 
 def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
@@ -29,10 +25,21 @@ def test_convert_same_unit():
     assert speed_util.convert(2, SPEED_INCHES_PER_DAY, SPEED_INCHES_PER_DAY) == 2
     assert speed_util.convert(3, SPEED_INCHES_PER_HOUR, SPEED_INCHES_PER_HOUR) == 3
     assert (
-        speed_util.convert(4, SPEED_KILOMETERS_PER_HOUR, SPEED_KILOMETERS_PER_HOUR) == 4
+        speed_util.convert(
+            4, UnitOfSpeed.KILOMETERS_PER_HOUR, UnitOfSpeed.KILOMETERS_PER_HOUR
+        )
+        == 4
     )
-    assert speed_util.convert(5, SPEED_METERS_PER_SECOND, SPEED_METERS_PER_SECOND) == 5
-    assert speed_util.convert(6, SPEED_MILES_PER_HOUR, SPEED_MILES_PER_HOUR) == 6
+    assert (
+        speed_util.convert(
+            5, UnitOfSpeed.METERS_PER_SECOND, UnitOfSpeed.METERS_PER_SECOND
+        )
+        == 5
+    )
+    assert (
+        speed_util.convert(6, UnitOfSpeed.MILES_PER_HOUR, UnitOfSpeed.MILES_PER_HOUR)
+        == 6
+    )
     assert (
         speed_util.convert(7, SPEED_MILLIMETERS_PER_DAY, SPEED_MILLIMETERS_PER_DAY) == 7
     )
@@ -50,16 +57,18 @@ def test_convert_invalid_unit():
 def test_convert_nonnumeric_value():
     """Test exception is thrown for nonnumeric type."""
     with pytest.raises(TypeError):
-        speed_util.convert("a", SPEED_KILOMETERS_PER_HOUR, SPEED_MILES_PER_HOUR)
+        speed_util.convert(
+            "a", UnitOfSpeed.KILOMETERS_PER_HOUR, UnitOfSpeed.MILES_PER_HOUR
+        )
 
 
 @pytest.mark.parametrize(
     "from_value, from_unit, expected, to_unit",
     [
         # 5 km/h / 1.609 km/mi = 3.10686 mi/h
-        (5, SPEED_KILOMETERS_PER_HOUR, 3.10686, SPEED_MILES_PER_HOUR),
+        (5, UnitOfSpeed.KILOMETERS_PER_HOUR, 3.10686, UnitOfSpeed.MILES_PER_HOUR),
         # 5 mi/h * 1.609 km/mi = 8.04672 km/h
-        (5, SPEED_MILES_PER_HOUR, 8.04672, SPEED_KILOMETERS_PER_HOUR),
+        (5, UnitOfSpeed.MILES_PER_HOUR, 8.04672, UnitOfSpeed.KILOMETERS_PER_HOUR),
         # 5 in/day * 25.4 mm/in = 127 mm/day
         (5, SPEED_INCHES_PER_DAY, 127, SPEED_MILLIMETERS_PER_DAY),
         # 5 mm/day / 25.4 mm/in = 0.19685 in/day
@@ -67,13 +76,13 @@ def test_convert_nonnumeric_value():
         # 5 in/hr * 24 hr/day = 3048 mm/day
         (5, SPEED_INCHES_PER_HOUR, 3048, SPEED_MILLIMETERS_PER_DAY),
         # 5 m/s * 39.3701 in/m * 3600 s/hr = 708661
-        (5, SPEED_METERS_PER_SECOND, 708661, SPEED_INCHES_PER_HOUR),
+        (5, UnitOfSpeed.METERS_PER_SECOND, 708661, SPEED_INCHES_PER_HOUR),
         # 5000 in/h / 39.3701 in/m / 3600 s/h = 0.03528 m/s
-        (5000, SPEED_INCHES_PER_HOUR, 0.03528, SPEED_METERS_PER_SECOND),
+        (5000, SPEED_INCHES_PER_HOUR, 0.03528, UnitOfSpeed.METERS_PER_SECOND),
         # 5 kt * 1852 m/nmi / 3600 s/h = 2.5722 m/s
-        (5, SPEED_KNOTS, 2.5722, SPEED_METERS_PER_SECOND),
+        (5, UnitOfSpeed.KNOTS, 2.5722, UnitOfSpeed.METERS_PER_SECOND),
         # 5 ft/s * 0.3048 m/ft = 1.524 m/s
-        (5, SPEED_FEET_PER_SECOND, 1.524, SPEED_METERS_PER_SECOND),
+        (5, UnitOfSpeed.FEET_PER_SECOND, 1.524, UnitOfSpeed.METERS_PER_SECOND),
     ],
 )
 def test_convert_different_units(from_value, from_unit, expected, to_unit):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the use of deprecated constants from our tests that can be replaced with the `UnitOfSpeed` enum.

Regex: `SPEED_(FEET_PER_SECOND|METERS_PER_SECOND|KILOMETERS_PER_HOUR|KNOTS|MILES_PER_HOUR)`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
