### PR TITLE
Migrates tests to use MediaPlayerEntityFeature enum

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -8,22 +8,7 @@ import pytest
 from homeassistant.components.alexa import messages, smart_home
 import homeassistant.components.camera as camera
 from homeassistant.components.cover import CoverDeviceClass
-from homeassistant.components.media_player import (
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SEEK,
-    SUPPORT_SELECT_SOUND_MODE,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
-)
+from homeassistant.components.media_player import MediaPlayerEntityFeature
 import homeassistant.components.vacuum as vacuum
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_UNKNOWN, UnitOfTemperature
@@ -1131,17 +1116,17 @@ async def test_media_player(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_NEXT_TRACK
-            | SUPPORT_PAUSE
-            | SUPPORT_PLAY
-            | SUPPORT_PLAY_MEDIA
-            | SUPPORT_PREVIOUS_TRACK
-            | SUPPORT_SELECT_SOURCE
-            | SUPPORT_STOP
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_VOLUME_SET,
+            "supported_features": MediaPlayerEntityFeature.NEXT_TRACK
+            | MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.PREVIOUS_TRACK
+            | MediaPlayerEntityFeature.SELECT_SOURCE
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
             "volume_level": 0.75,
             "source_list": ["hdmi", "tv"],
         },
@@ -1339,7 +1324,7 @@ async def test_media_player_inputs(hass):
         "on",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_SELECT_SOURCE,
+            "supported_features": MediaPlayerEntityFeature.SELECT_SOURCE,
             "volume_level": 0.75,
             "source_list": [
                 "foo",
@@ -1443,7 +1428,7 @@ async def test_media_player_no_supported_inputs(hass):
         "off",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_SELECT_SOURCE,
+            "supported_features": MediaPlayerEntityFeature.SELECT_SOURCE,
             "volume_level": 0.75,
             "source_list": [
                 "foo",
@@ -1478,7 +1463,8 @@ async def test_media_player_speaker(hass):
         "off",
         {
             "friendly_name": "Test media player speaker",
-            "supported_features": SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET,
+            "supported_features": MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET,
             "volume_level": 0.75,
             "device_class": "speaker",
         },
@@ -1551,7 +1537,8 @@ async def test_media_player_step_speaker(hass):
         "off",
         {
             "friendly_name": "Test media player step speaker",
-            "supported_features": SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP,
+            "supported_features": MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_STEP,
             "device_class": "speaker",
         },
     )
@@ -1616,7 +1603,7 @@ async def test_media_player_seek(hass):
         "playing",
         {
             "friendly_name": "Test media player seek",
-            "supported_features": SUPPORT_SEEK,
+            "supported_features": MediaPlayerEntityFeature.SEEK,
             "media_position": 300,  # 5min
             "media_duration": 600,  # 10min
         },
@@ -1701,7 +1688,10 @@ async def test_media_player_seek_error(hass):
     device = (
         "media_player.test_seek",
         "playing",
-        {"friendly_name": "Test media player seek", "supported_features": SUPPORT_SEEK},
+        {
+            "friendly_name": "Test media player seek",
+            "supported_features": MediaPlayerEntityFeature.SEEK,
+        },
     )
     await discovery_test(device, hass)
 
@@ -3529,7 +3519,7 @@ async def test_media_player_eq_modes(hass):
         "on",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_SELECT_SOUND_MODE,
+            "supported_features": MediaPlayerEntityFeature.SELECT_SOUND_MODE,
             "sound_mode": "tv",
             "sound_mode_list": ["movie", "music", "night", "sport", "tv", "rocknroll"],
         },
@@ -3577,7 +3567,7 @@ async def test_media_player_sound_mode_list_unsupported(hass):
         "on",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_SELECT_SOUND_MODE,
+            "supported_features": MediaPlayerEntityFeature.SELECT_SOUND_MODE,
             "sound_mode": "unknown",
             "sound_mode_list": ["unsupported", "non-existing"],
         },
@@ -3599,7 +3589,7 @@ async def test_media_player_eq_bands_not_supported(hass):
         "on",
         {
             "friendly_name": "Test media player",
-            "supported_features": SUPPORT_SELECT_SOUND_MODE,
+            "supported_features": MediaPlayerEntityFeature.SELECT_SOUND_MODE,
             "sound_mode": "tv",
             "sound_mode_list": ["movie", "music", "night", "sport", "tv", "rocknroll"],
         },

--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -11,11 +11,7 @@ from homeassistant.components.blackbird.media_player import (
     PLATFORM_SCHEMA,
     setup_platform,
 )
-from homeassistant.components.media_player import (
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-)
+from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.const import STATE_OFF, STATE_ON
 
 
@@ -290,7 +286,9 @@ async def test_state(hass, media_player_entity, mock_blackbird):
 async def test_supported_features(media_player_entity):
     """Test supported features property."""
     assert (
-        SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+        MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.SELECT_SOURCE
         == media_player_entity.supported_features
     )
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1865,7 +1865,10 @@ async def test_inputselector(hass):
     """Test input selector trait."""
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
     assert trait.InputSelectorTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_SELECT_SOURCE, None, None
+        media_player.DOMAIN,
+        media_player.MediaPlayerEntityFeature.SELECT_SOURCE,
+        None,
+        None,
     )
 
     trt = trait.InputSelectorTrait(
@@ -2252,7 +2255,10 @@ async def test_sound_modes(hass):
     """Test Mode trait."""
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
     assert trait.ModesTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_SELECT_SOUND_MODE, None, None
+        media_player.DOMAIN,
+        media_player.MediaPlayerEntityFeature.SELECT_SOUND_MODE,
+        None,
+        None,
     )
 
     trt = trait.ModesTrait(
@@ -2698,7 +2704,10 @@ async def test_volume_media_player(hass):
     """Test volume trait support for media player domain."""
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
     assert trait.VolumeTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_VOLUME_SET, None, None
+        media_player.DOMAIN,
+        media_player.MediaPlayerEntityFeature.VOLUME_SET,
+        None,
+        None,
     )
 
     trt = trait.VolumeTrait(
@@ -2707,7 +2716,7 @@ async def test_volume_media_player(hass):
             "media_player.bla",
             media_player.STATE_PLAYING,
             {
-                ATTR_SUPPORTED_FEATURES: media_player.SUPPORT_VOLUME_SET,
+                ATTR_SUPPORTED_FEATURES: media_player.MediaPlayerEntityFeature.VOLUME_SET,
                 media_player.ATTR_MEDIA_VOLUME_LEVEL: 0.3,
             },
         ),
@@ -2749,7 +2758,10 @@ async def test_volume_media_player(hass):
 async def test_volume_media_player_relative(hass):
     """Test volume trait support for relative-volume-only media players."""
     assert trait.VolumeTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_VOLUME_STEP, None, None
+        media_player.DOMAIN,
+        media_player.MediaPlayerEntityFeature.VOLUME_STEP,
+        None,
+        None,
     )
     trt = trait.VolumeTrait(
         hass,
@@ -2758,7 +2770,7 @@ async def test_volume_media_player_relative(hass):
             media_player.STATE_PLAYING,
             {
                 ATTR_ASSUMED_STATE: True,
-                ATTR_SUPPORTED_FEATURES: media_player.SUPPORT_VOLUME_STEP,
+                ATTR_SUPPORTED_FEATURES: media_player.MediaPlayerEntityFeature.VOLUME_STEP,
             },
         ),
         BASIC_CONFIG,
@@ -2815,7 +2827,8 @@ async def test_media_player_mute(hass):
     """Test volume trait support for muting."""
     assert trait.VolumeTrait.supported(
         media_player.DOMAIN,
-        media_player.SUPPORT_VOLUME_STEP | media_player.SUPPORT_VOLUME_MUTE,
+        media_player.MediaPlayerEntityFeature.VOLUME_STEP
+        | media_player.MediaPlayerEntityFeature.VOLUME_MUTE,
         None,
         None,
     )
@@ -2826,7 +2839,8 @@ async def test_media_player_mute(hass):
             media_player.STATE_PLAYING,
             {
                 ATTR_SUPPORTED_FEATURES: (
-                    media_player.SUPPORT_VOLUME_STEP | media_player.SUPPORT_VOLUME_MUTE
+                    media_player.MediaPlayerEntityFeature.VOLUME_STEP
+                    | media_player.MediaPlayerEntityFeature.VOLUME_MUTE
                 ),
                 media_player.ATTR_MEDIA_VOLUME_MUTED: False,
             },
@@ -2986,8 +3000,8 @@ async def test_transport_control(hass):
                 media_player.ATTR_MEDIA_POSITION_UPDATED_AT: now
                 - timedelta(seconds=10),
                 media_player.ATTR_MEDIA_VOLUME_LEVEL: 0.5,
-                ATTR_SUPPORTED_FEATURES: media_player.SUPPORT_PLAY
-                | media_player.SUPPORT_STOP,
+                ATTR_SUPPORTED_FEATURES: media_player.MediaPlayerEntityFeature.PLAY
+                | media_player.MediaPlayerEntityFeature.STOP,
             },
         ),
         BASIC_CONFIG,
@@ -3101,7 +3115,7 @@ async def test_media_state(hass, state):
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
 
     assert trait.TransportControlTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_PLAY, None, None
+        media_player.DOMAIN, media_player.MediaPlayerEntityFeature.PLAY, None, None
     )
 
     trt = trait.MediaStateTrait(
@@ -3113,8 +3127,8 @@ async def test_media_state(hass, state):
                 media_player.ATTR_MEDIA_POSITION: 100,
                 media_player.ATTR_MEDIA_DURATION: 200,
                 media_player.ATTR_MEDIA_VOLUME_LEVEL: 0.5,
-                ATTR_SUPPORTED_FEATURES: media_player.SUPPORT_PLAY
-                | media_player.SUPPORT_STOP,
+                ATTR_SUPPORTED_FEATURES: media_player.MediaPlayerEntityFeature.PLAY
+                | media_player.MediaPlayerEntityFeature.STOP,
             },
         ),
         BASIC_CONFIG,
@@ -3135,13 +3149,16 @@ async def test_channel(hass):
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
     assert trait.ChannelTrait.supported(
         media_player.DOMAIN,
-        media_player.SUPPORT_PLAY_MEDIA,
+        media_player.MediaPlayerEntityFeature.PLAY_MEDIA,
         media_player.MediaPlayerDeviceClass.TV,
         None,
     )
     assert (
         trait.ChannelTrait.supported(
-            media_player.DOMAIN, media_player.SUPPORT_PLAY_MEDIA, None, None
+            media_player.DOMAIN,
+            media_player.MediaPlayerEntityFeature.PLAY_MEDIA,
+            None,
+            None,
         )
         is False
     )

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -179,8 +179,8 @@ def test_type_covers(type_name, entity_id, state, attrs):
             "media_player.test",
             "on",
             {
-                ATTR_SUPPORTED_FEATURES: media_player_c.SUPPORT_TURN_ON
-                | media_player_c.SUPPORT_TURN_OFF
+                ATTR_SUPPORTED_FEATURES: media_player_c.MediaPlayerEntityFeature.TURN_ON
+                | media_player_c.MediaPlayerEntityFeature.TURN_OFF
             },
             {CONF_FEATURE_LIST: {FEATURE_ON_OFF: None}},
         ),

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -1,10 +1,6 @@
 """Make sure that handling real world LG HomeKit characteristics isn't broken."""
 
-from homeassistant.components.media_player import (
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_SELECT_SOURCE,
-)
+from homeassistant.components.media_player import MediaPlayerEntityFeature
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -38,7 +34,9 @@ async def test_lg_tv(hass):
                     friendly_name="LG webOS TV AF80",
                     unique_id="00:00:00:00:00:00_1_48",
                     supported_features=(
-                        SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SELECT_SOURCE
+                        MediaPlayerEntityFeature.PAUSE
+                        | MediaPlayerEntityFeature.PLAY
+                        | MediaPlayerEntityFeature.SELECT_SOURCE
                     ),
                     capabilities={
                         "source_list": [

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -10,12 +10,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_VOLUME_LEVEL,
     DOMAIN as MEDIA_PLAYER_DOMAIN,
     SERVICE_SELECT_SOURCE,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
+    MediaPlayerEntityFeature,
 )
 from homeassistant.components.monoprice.const import (
     CONF_NOT_FIRST_RUN,
@@ -364,12 +359,12 @@ async def test_supported_features(hass):
 
     state = hass.states.get(ZONE_1_ID)
     assert (
-        SUPPORT_VOLUME_MUTE
-        | SUPPORT_VOLUME_SET
-        | SUPPORT_VOLUME_STEP
-        | SUPPORT_TURN_ON
-        | SUPPORT_TURN_OFF
-        | SUPPORT_SELECT_SOURCE
+        MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.SELECT_SOURCE
         == state.attributes["supported_features"]
     )
 

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.components.media_player import DOMAIN, SUPPORT_TURN_ON
+from homeassistant.components.media_player import DOMAIN, MediaPlayerEntityFeature
 from homeassistant.components.samsungtv.const import (
     CONF_MANUFACTURER,
     CONF_ON_ACTION,
@@ -87,7 +87,8 @@ async def test_setup(hass: HomeAssistant) -> None:
     assert state
     assert state.name == "fake_name"
     assert (
-        state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_SAMSUNGTV | MediaPlayerEntityFeature.TURN_ON
     )
 
     # test host and port

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -582,7 +582,7 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     await client.mock_state_update()
 
     # TV off, restored state supports mute, step
-    # validate SUPPORT_TURN_ON is not cached
+    # validate MediaPlayerEntityFeature.TURN_ON is not cached
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the use of deprecated constants from our tests that can be replaced with the `MediaPlayerEntityFeature` enum.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
