### PR TITLE
Migrates tests to use UnitOfPressure enum

### DIFF
--- a/tests/components/homekit_controller/specific_devices/test_eve_degree.py
+++ b/tests/components/homekit_controller/specific_devices/test_eve_degree.py
@@ -2,7 +2,7 @@
 
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorStateClass
-from homeassistant.const import PERCENTAGE, PRESSURE_HPA, TEMP_CELSIUS
+from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, UnitOfPressure
 from homeassistant.helpers.entity import EntityCategory
 
 from ..common import (
@@ -52,7 +52,7 @@ async def test_eve_degree_setup(hass):
                     entity_id="sensor.eve_degree_aa11_air_pressure",
                     unique_id="00:00:00:00:00:00_1_30_32",
                     friendly_name="Eve Degree AA11 Air Pressure",
-                    unit_of_measurement=PRESSURE_HPA,
+                    unit_of_measurement=UnitOfPressure.HPA,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     state="1005.70001220703",
                 ),

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -20,10 +20,10 @@ from homeassistant.const import (
     LENGTH_METERS,
     LENGTH_MILLIMETERS,
     MASS_GRAMS,
-    PRESSURE_PA,
     STATE_ON,
     TEMP_CELSIUS,
     VOLUME_LITERS,
+    UnitOfPressure,
     UnitOfSpeed,
 )
 from homeassistant.core import HomeAssistant
@@ -52,7 +52,7 @@ def _set_up_units(hass: HomeAssistant) -> None:
         conversions={},
         length=LENGTH_METERS,
         mass=MASS_GRAMS,
-        pressure=PRESSURE_PA,
+        pressure=UnitOfPressure.PA,
         temperature=TEMP_CELSIUS,
         volume=VOLUME_LITERS,
         wind_speed=UnitOfSpeed.KILOMETERS_PER_HOUR,

--- a/tests/testing_config/custom_components/test/sensor.py
+++ b/tests/testing_config/custom_components/test/sensor.py
@@ -17,9 +17,9 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_VOLT_AMPERE,
     POWER_VOLT_AMPERE_REACTIVE,
-    PRESSURE_HPA,
     SIGNAL_STRENGTH_DECIBELS,
     VOLUME_CUBIC_METERS,
+    UnitOfPressure,
 )
 
 from tests.common import MockEntity
@@ -44,7 +44,7 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.SIGNAL_STRENGTH: SIGNAL_STRENGTH_DECIBELS,  # signal strength (dB/dBm)
     SensorDeviceClass.SULPHUR_DIOXIDE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of sulphur dioxide
     SensorDeviceClass.TEMPERATURE: "C",  # temperature (C/F)
-    SensorDeviceClass.PRESSURE: PRESSURE_HPA,  # pressure (hPa/mbar)
+    SensorDeviceClass.PRESSURE: UnitOfPressure.HPA,  # pressure (hPa/mbar)
     SensorDeviceClass.POWER: "kW",  # power (W/kW)
     SensorDeviceClass.CURRENT: "A",  # current (A)
     SensorDeviceClass.ENERGY: "kWh",  # energy (Wh/kWh/MWh)

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -1,38 +1,29 @@
 """Test Home Assistant pressure utility functions."""
 import pytest
 
-from homeassistant.const import (
-    PRESSURE_CBAR,
-    PRESSURE_HPA,
-    PRESSURE_INHG,
-    PRESSURE_KPA,
-    PRESSURE_MBAR,
-    PRESSURE_MMHG,
-    PRESSURE_PA,
-    PRESSURE_PSI,
-)
+from homeassistant.const import UnitOfPressure
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.pressure as pressure_util
 
 INVALID_SYMBOL = "bob"
-VALID_SYMBOL = PRESSURE_PA
+VALID_SYMBOL = UnitOfPressure.PA
 
 
 def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
     """Ensure that a warning is raised on use of convert."""
-    assert pressure_util.convert(2, PRESSURE_PA, PRESSURE_PA) == 2
+    assert pressure_util.convert(2, UnitOfPressure.PA, UnitOfPressure.PA) == 2
     assert "use unit_conversion.PressureConverter instead" in caplog.text
 
 
 def test_convert_same_unit():
     """Test conversion from any unit to same unit."""
-    assert pressure_util.convert(2, PRESSURE_PA, PRESSURE_PA) == 2
-    assert pressure_util.convert(3, PRESSURE_HPA, PRESSURE_HPA) == 3
-    assert pressure_util.convert(4, PRESSURE_MBAR, PRESSURE_MBAR) == 4
-    assert pressure_util.convert(5, PRESSURE_INHG, PRESSURE_INHG) == 5
-    assert pressure_util.convert(6, PRESSURE_KPA, PRESSURE_KPA) == 6
-    assert pressure_util.convert(7, PRESSURE_CBAR, PRESSURE_CBAR) == 7
-    assert pressure_util.convert(8, PRESSURE_MMHG, PRESSURE_MMHG) == 8
+    assert pressure_util.convert(2, UnitOfPressure.PA, UnitOfPressure.PA) == 2
+    assert pressure_util.convert(3, UnitOfPressure.HPA, UnitOfPressure.HPA) == 3
+    assert pressure_util.convert(4, UnitOfPressure.MBAR, UnitOfPressure.MBAR) == 4
+    assert pressure_util.convert(5, UnitOfPressure.INHG, UnitOfPressure.INHG) == 5
+    assert pressure_util.convert(6, UnitOfPressure.KPA, UnitOfPressure.KPA) == 6
+    assert pressure_util.convert(7, UnitOfPressure.CBAR, UnitOfPressure.CBAR) == 7
+    assert pressure_util.convert(8, UnitOfPressure.MMHG, UnitOfPressure.MMHG) == 8
 
 
 def test_convert_invalid_unit():
@@ -47,102 +38,102 @@ def test_convert_invalid_unit():
 def test_convert_nonnumeric_value():
     """Test exception is thrown for nonnumeric type."""
     with pytest.raises(TypeError):
-        pressure_util.convert("a", PRESSURE_HPA, PRESSURE_INHG)
+        pressure_util.convert("a", UnitOfPressure.HPA, UnitOfPressure.INHG)
 
 
 def test_convert_from_hpascals():
     """Test conversion from hPA to other units."""
     hpascals = 1000
-    assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_PSI) == pytest.approx(
-        14.5037743897
-    )
     assert pressure_util.convert(
-        hpascals, PRESSURE_HPA, PRESSURE_INHG
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.PSI
+    ) == pytest.approx(14.5037743897)
+    assert pressure_util.convert(
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.INHG
     ) == pytest.approx(29.5299801647)
-    assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_PA) == pytest.approx(
-        100000
-    )
-    assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_KPA) == pytest.approx(
-        100
-    )
     assert pressure_util.convert(
-        hpascals, PRESSURE_HPA, PRESSURE_MBAR
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.PA
+    ) == pytest.approx(100000)
+    assert pressure_util.convert(
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.KPA
+    ) == pytest.approx(100)
+    assert pressure_util.convert(
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.MBAR
     ) == pytest.approx(1000)
     assert pressure_util.convert(
-        hpascals, PRESSURE_HPA, PRESSURE_CBAR
+        hpascals, UnitOfPressure.HPA, UnitOfPressure.CBAR
     ) == pytest.approx(100)
 
 
 def test_convert_from_kpascals():
     """Test conversion from hPA to other units."""
     kpascals = 100
-    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_PSI) == pytest.approx(
-        14.5037743897
-    )
     assert pressure_util.convert(
-        kpascals, PRESSURE_KPA, PRESSURE_INHG
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.PSI
+    ) == pytest.approx(14.5037743897)
+    assert pressure_util.convert(
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.INHG
     ) == pytest.approx(29.5299801647)
-    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_PA) == pytest.approx(
-        100000
-    )
-    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_HPA) == pytest.approx(
-        1000
-    )
     assert pressure_util.convert(
-        kpascals, PRESSURE_KPA, PRESSURE_MBAR
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.PA
+    ) == pytest.approx(100000)
+    assert pressure_util.convert(
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.HPA
     ) == pytest.approx(1000)
     assert pressure_util.convert(
-        kpascals, PRESSURE_KPA, PRESSURE_CBAR
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.MBAR
+    ) == pytest.approx(1000)
+    assert pressure_util.convert(
+        kpascals, UnitOfPressure.KPA, UnitOfPressure.CBAR
     ) == pytest.approx(100)
 
 
 def test_convert_from_inhg():
     """Test conversion from inHg to other units."""
     inhg = 30
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_PSI) == pytest.approx(
-        14.7346266155
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_KPA) == pytest.approx(
-        101.59167
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_HPA) == pytest.approx(
-        1015.9167
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_PA) == pytest.approx(
-        101591.67
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_MBAR) == pytest.approx(
-        1015.9167
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_CBAR) == pytest.approx(
-        101.59167
-    )
-    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_MMHG) == pytest.approx(
-        762
-    )
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.PSI
+    ) == pytest.approx(14.7346266155)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.KPA
+    ) == pytest.approx(101.59167)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.HPA
+    ) == pytest.approx(1015.9167)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.PA
+    ) == pytest.approx(101591.67)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.MBAR
+    ) == pytest.approx(1015.9167)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.CBAR
+    ) == pytest.approx(101.59167)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.INHG, UnitOfPressure.MMHG
+    ) == pytest.approx(762)
 
 
 def test_convert_from_mmhg():
     """Test conversion from mmHg to other units."""
     inhg = 30
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_PSI) == pytest.approx(
-        0.580103
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_KPA) == pytest.approx(
-        3.99967
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_HPA) == pytest.approx(
-        39.9967
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_PA) == pytest.approx(
-        3999.67
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_MBAR) == pytest.approx(
-        39.9967
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_CBAR) == pytest.approx(
-        3.99967
-    )
-    assert pressure_util.convert(inhg, PRESSURE_MMHG, PRESSURE_INHG) == pytest.approx(
-        1.181102
-    )
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.PSI
+    ) == pytest.approx(0.580103)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.KPA
+    ) == pytest.approx(3.99967)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.HPA
+    ) == pytest.approx(39.9967)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.PA
+    ) == pytest.approx(3999.67)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.MBAR
+    ) == pytest.approx(39.9967)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.CBAR
+    ) == pytest.approx(3.99967)
+    assert pressure_util.convert(
+        inhg, UnitOfPressure.MMHG, UnitOfPressure.INHG
+    ) == pytest.approx(1.181102)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use `UnitOfPressure` enum in some tests where deprecated constants were in use.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
