### PR TITLE
Enable Ruff PT022

### DIFF
--- a/tests/components/airvisual/conftest.py
+++ b/tests/components/airvisual/conftest.py
@@ -141,4 +141,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_pyairvisual):
     """Define a fixture to set up airvisual."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/aladdin_connect/conftest.py
+++ b/tests/components/aladdin_connect/conftest.py
@@ -40,4 +40,4 @@ def fixture_mock_aladdinconnect_api():
         mock_opener.open_door = AsyncMock(return_value=True)
         mock_opener.close_door = AsyncMock(return_value=True)
 
-    yield mock_opener
+    return mock_opener

--- a/tests/components/ambient_station/conftest.py
+++ b/tests/components/ambient_station/conftest.py
@@ -60,4 +60,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_aioambient):
     """Define a fixture to set up ambient_station."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -92,7 +92,7 @@ def full_device(mock_scan, dmap_pin):
             airplay_service(),
         )
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def mrp_device(mock_scan):
             ),
         ]
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -132,7 +132,7 @@ def airplay_with_disabled_mrp(mock_scan):
             ),
         )
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -152,7 +152,7 @@ def dmap_device(mock_scan):
             ),
         )
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -172,7 +172,7 @@ def dmap_device_with_credentials(mock_scan):
             ),
         )
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -187,7 +187,7 @@ def airplay_device_with_password(mock_scan):
             ),
         )
     )
-    yield mock_scan
+    return mock_scan
 
 
 @pytest.fixture
@@ -206,4 +206,4 @@ def dmap_with_requirement(mock_scan, pairing_requirement):
             ),
         )
     )
-    yield mock_scan
+    return mock_scan

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -154,7 +154,7 @@ def default_request_fixture(respx_mock):
         )
         respx.post(f"{path}/local/vmd/control.cgi").respond(json=VMD4_RESPONSE)
 
-    yield __mock_default_requests
+    return __mock_default_requests
 
 
 @pytest.fixture
@@ -187,7 +187,7 @@ async def prep_config_entry_fixture(hass, config_entry, setup_default_vapix_requ
         await hass.async_block_till_done()
         return config_entry
 
-    yield __mock_setup_config_entry
+    return __mock_setup_config_entry
 
 
 @pytest.fixture(name="setup_config_entry")
@@ -195,7 +195,7 @@ async def setup_config_entry_fixture(hass, config_entry, setup_default_vapix_req
     """Define a fixture to set up Axis network device."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield config_entry
+    return config_entry
 
 
 # RTSP fixtures
@@ -283,7 +283,7 @@ def mock_rtsp_event(mock_axis_rtspclient):
 
         mock_axis_rtspclient(data=event.encode("utf-8"))
 
-    yield send_event
+    return send_event
 
 
 @pytest.fixture(autouse=True)
@@ -295,4 +295,4 @@ def mock_rtsp_signal_state(mock_axis_rtspclient):
         signal = Signal.PLAYING if connected else Signal.FAILED
         mock_axis_rtspclient(state=signal)
 
-    yield send_signal
+    return send_signal

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -84,7 +84,7 @@ def product_class_mock_fixture():
     """Return a mocked feature."""
     path = "homeassistant.components.blebox.config_flow.Box"
     patcher = patch(path, DEFAULT, blebox_uniapi.box.Box, True, True)
-    yield patcher
+    return patcher
 
 
 async def test_flow_with_connection_failure(hass, product_class_mock):

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -11,7 +11,7 @@ from tests.common import ANY, mock_area_registry
 def client(hass, hass_ws_client):
     """Fixture that can interact with the config manager API."""
     hass.loop.run_until_complete(area_registry.async_setup(hass))
-    yield hass.loop.run_until_complete(hass_ws_client(hass))
+    return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
 @pytest.fixture

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -18,7 +18,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 def client(hass, hass_ws_client):
     """Fixture that can interact with the config manager API."""
     hass.loop.run_until_complete(device_registry.async_setup(hass))
-    yield hass.loop.run_until_complete(hass_ws_client(hass))
+    return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
 @pytest.fixture

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -26,7 +26,7 @@ from tests.common import (
 def client(hass, hass_ws_client):
     """Fixture that can interact with the config manager API."""
     hass.loop.run_until_complete(entity_registry.async_setup(hass))
-    yield hass.loop.run_until_complete(hass_ws_client(hass))
+    return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
 @pytest.fixture

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -57,7 +57,7 @@ async def setup_integration(recorder_mock):
 @freeze_time("2022-04-19 07:53:05")
 def frozen_time():
     """Freeze clock for tests."""
-    yield
+    return
 
 
 def get_statistics_for_entity(statistics_results, entity_id):

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -18,7 +18,7 @@ def fakeimgbytes_png():
     """Fake image in RAM for testing."""
     buf = BytesIO()
     Image.new("RGB", (1, 1)).save(buf, format="PNG")
-    yield bytes(buf.getbuffer())
+    return bytes(buf.getbuffer())
 
 
 @pytest.fixture(scope="package")
@@ -26,13 +26,13 @@ def fakeimgbytes_jpg():
     """Fake image in RAM for testing."""
     buf = BytesIO()  # fake image in ram for testing.
     Image.new("RGB", (1, 1)).save(buf, format="jpeg")
-    yield bytes(buf.getbuffer())
+    return bytes(buf.getbuffer())
 
 
 @pytest.fixture(scope="package")
 def fakeimgbytes_svg():
     """Fake image in RAM for testing."""
-    yield bytes(
+    return bytes(
         '<svg xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>',
         encoding="utf-8",
     )
@@ -43,7 +43,7 @@ def fakeimgbytes_gif():
     """Fake image in RAM for testing."""
     buf = BytesIO()  # fake image in ram for testing.
     Image.new("RGB", (1, 1)).save(buf, format="gif")
-    yield bytes(buf.getbuffer())
+    return bytes(buf.getbuffer())
 
 
 @pytest.fixture

--- a/tests/components/google_assistant_sdk/conftest.py
+++ b/tests/components/google_assistant_sdk/conftest.py
@@ -1,6 +1,7 @@
 """PyTest fixtures and test helpers."""
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Coroutine
 import time
+from typing import Any
 
 from google.oauth2.credentials import Credentials
 import pytest
@@ -65,7 +66,7 @@ def mock_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
 @pytest.fixture(name="setup_integration")
 async def mock_setup_integration(
     hass: HomeAssistant, config_entry: MockConfigEntry
-) -> Generator[ComponentSetup, None, None]:
+) -> Callable[[], Coroutine[Any, Any, None]]:
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)
 
@@ -81,7 +82,7 @@ async def mock_setup_integration(
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-    yield func
+    return func
 
 
 class ExpectedCredentials:

--- a/tests/components/google_mail/conftest.py
+++ b/tests/components/google_mail/conftest.py
@@ -1,6 +1,7 @@
 """Configure tests for the Google Mail integration."""
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Coroutine
 import time
+from typing import Any
 from unittest.mock import patch
 
 from httplib2 import Response
@@ -93,7 +94,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
 @pytest.fixture(name="setup_integration")
 async def mock_setup_integration(
     hass: HomeAssistant, config_entry: MockConfigEntry
-) -> Generator[ComponentSetup, None, None]:
+) -> Callable[[], Coroutine[Any, Any, None]]:
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)
 
@@ -116,4 +117,4 @@ async def mock_setup_integration(
             assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-    yield func
+    return func

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -1,8 +1,9 @@
 """Tests for Google Sheets."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Coroutine
 import http
 import time
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -58,7 +59,7 @@ def mock_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
 @pytest.fixture(name="setup_integration")
 async def mock_setup_integration(
     hass: HomeAssistant, config_entry: MockConfigEntry
-) -> Generator[ComponentSetup, None, None]:
+) -> Callable[[], Coroutine[Any, Any, None]]:
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)
 
@@ -74,7 +75,7 @@ async def mock_setup_integration(
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-    yield func
+    return func
 
 
 async def test_setup_success(

--- a/tests/components/google_travel_time/conftest.py
+++ b/tests/components/google_travel_time/conftest.py
@@ -21,7 +21,7 @@ async def mock_config_fixture(hass, data, options):
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield config_entry
+    return config_entry
 
 
 @pytest.fixture(name="bypass_setup")

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -69,14 +69,14 @@ def mock_update_duration_fixture(mock_update):
             }
         ]
     }
-    yield mock_update
+    return mock_update
 
 
 @pytest.fixture(name="mock_update_empty")
 def mock_update_empty_fixture(mock_update):
     """Mock an update to the sensor with an empty response."""
     mock_update.return_value = None
-    yield mock_update
+    return mock_update
 
 
 @pytest.mark.parametrize(

--- a/tests/components/history/conftest.py
+++ b/tests/components/history/conftest.py
@@ -27,4 +27,4 @@ def hass_history(hass_recorder):
     )
     assert setup_component(hass, history.DOMAIN, config)
 
-    yield hass
+    return hass

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -14,7 +14,7 @@ def mock_disco():
     disco = Mock()
     disco.pi_disco = Mock()
     disco.pi_disco.controllers = {}
-    yield disco
+    return disco
 
 
 def _mock_start_discovery(hass, mock_disco):

--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -32,7 +32,7 @@ def meraki_client(event_loop, hass, hass_client):
         )
     )
 
-    yield loop.run_until_complete(hass_client())
+    return loop.run_until_complete(hass_client())
 
 
 async def test_invalid_or_missing_data(mock_device_tracker_conf, meraki_client):

--- a/tests/components/mjpeg/conftest.py
+++ b/tests/components/mjpeg/conftest.py
@@ -59,11 +59,11 @@ def mock_reload_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_mjpeg_requests(requests_mock: Mocker) -> Generator[Mocker, None, None]:
+def mock_mjpeg_requests(requests_mock: Mocker) -> Mocker:
     """Fixture to provide a requests mocker."""
     requests_mock.get("https://example.com/mjpeg", text="resp")
     requests_mock.get("https://example.com/still", text="resp")
-    yield requests_mock
+    return requests_mock
 
 
 @pytest.fixture

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -179,4 +179,4 @@ async def mock_ha_fixture(hass, mock_pymodbus_return):
 @pytest.fixture(name="caplog_setup_text")
 async def caplog_setup_text_fixture(caplog):
     """Return setup log of integration."""
-    yield caplog.text
+    return caplog.text

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -115,7 +115,7 @@ async def mock_modbus_with_pymodbus_fixture(hass, caplog, do_config, mock_pymodb
     await hass.async_block_till_done()
     assert DOMAIN in hass.config.components
     assert caplog.text == ""
-    yield mock_pymodbus
+    return mock_pymodbus
 
 
 async def test_number_validator():
@@ -582,7 +582,7 @@ async def mock_modbus_read_pymodbus_fixture(
     freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 60))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    yield mock_pymodbus
+    return mock_pymodbus
 
 
 @pytest.mark.parametrize(

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -69,7 +69,7 @@ def mock_nextbus_predictions(mock_nextbus):
     instance = mock_nextbus.return_value
     instance.get_predictions_for_multi_stops.return_value = BASIC_RESULTS
 
-    yield instance.get_predictions_for_multi_stops
+    return instance.get_predictions_for_multi_stops
 
 
 @pytest.fixture

--- a/tests/components/nibe_heatpump/conftest.py
+++ b/tests/components/nibe_heatpump/conftest.py
@@ -54,4 +54,4 @@ async def fixture_coils(mock_connection):
 
     mock_connection.read_coil = read_coil
     mock_connection.read_coils = read_coils
-    yield coils
+    return coils

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -82,4 +82,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_aionotion):
     """Define a fixture to set up notion."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -79,4 +79,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_pyopenuv):
     """Define a fixture to set up openuv."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -290,7 +290,6 @@ def setup_comp(hass, mock_device_tracker_conf, mqtt_mock):
     hass.states.async_set("zone.inner_2", "zoning", INNER_ZONE)
 
     hass.states.async_set("zone.outer", "zoning", OUTER_ZONE)
-    yield
 
 
 async def setup_owntracks(hass, config, ctx_cls=owntracks.OwnTracksContext):
@@ -334,7 +333,7 @@ def context(hass, setup_comp):
         """Get the current context."""
         return context
 
-    yield get_context
+    return get_context
 
 
 async def send_message(hass, topic, message, corrupt=False):

--- a/tests/components/purpleair/conftest.py
+++ b/tests/components/purpleair/conftest.py
@@ -83,4 +83,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_aiopurpleair):
     """Define a fixture to set up purpleair."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/recollect_waste/conftest.py
+++ b/tests/components/recollect_waste/conftest.py
@@ -70,4 +70,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_aiorecollect):
     """Define a fixture to set up recollect_waste."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -73,7 +73,7 @@ async def rfxtrx_fixture(hass):
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
     await setup_rfx_test_cfg(hass, automatic_add=True, devices={})
-    yield rfxtrx
+    return rfxtrx
 
 
 @pytest.fixture

--- a/tests/components/ridwell/conftest.py
+++ b/tests/components/ridwell/conftest.py
@@ -86,4 +86,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_aioridwell):
     """Define a fixture to set up ridwell."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -25,7 +25,7 @@ def entities(hass):
     """Initialize the test light."""
     platform = getattr(hass.components, "test.light")
     platform.init()
-    yield platform.ENTITIES[0:2]
+    return platform.ENTITIES[0:2]
 
 
 async def test_config_yaml_alias_anchor(hass, entities, enable_custom_integrations):

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -78,7 +78,7 @@ def message():
         0,
         True,
     )
-    yield mailer
+    return mailer
 
 
 HTML = """

--- a/tests/components/snooz/conftest.py
+++ b/tests/components/snooz/conftest.py
@@ -20,4 +20,4 @@ async def mock_connected_snooz(hass: HomeAssistant):
     device = await create_mock_snooz()
     entry = await create_mock_snooz_config_entry(hass, device)
 
-    yield SnoozFixture(entry, device)
+    return SnoozFixture(entry, device)

--- a/tests/components/snooz/test_fan.py
+++ b/tests/components/snooz/test_fan.py
@@ -286,7 +286,7 @@ async def fixture_snooz_fan_entity_id(
 ) -> str:
     """Mock a Snooz fan entity and config entry."""
 
-    yield get_fan_entity_id(hass, mock_connected_snooz.device)
+    return get_fan_entity_id(hass, mock_connected_snooz.device)
 
 
 def get_fan_entity_id(hass: HomeAssistant, device: MockSnoozDevice) -> str:

--- a/tests/components/soundtouch/conftest.py
+++ b/tests/components/soundtouch/conftest.py
@@ -23,7 +23,7 @@ DEVICE_2_ENTITY_ID = f"{MEDIA_PLAYER_DOMAIN}.my_soundtouch_2"
 @pytest.fixture
 def device1_config() -> MockConfigEntry:
     """Mock SoundTouch device 1 config entry."""
-    yield MockConfigEntry(
+    return MockConfigEntry(
         domain=DOMAIN,
         unique_id=DEVICE_1_ID,
         data={
@@ -36,7 +36,7 @@ def device1_config() -> MockConfigEntry:
 @pytest.fixture
 def device2_config() -> MockConfigEntry:
     """Mock SoundTouch device 2 config entry."""
-    yield MockConfigEntry(
+    return MockConfigEntry(
         domain=DOMAIN,
         unique_id=DEVICE_2_ID,
         data={
@@ -155,7 +155,7 @@ def device1_requests_mock(
     requests_mock.get(f"{DEVICE_1_URL}/volume", text=device1_volume)
     requests_mock.get(f"{DEVICE_1_URL}/presets", text=device1_presets)
     requests_mock.get(f"{DEVICE_1_URL}/getZone", text=device1_zone_master)
-    yield requests_mock
+    return requests_mock
 
 
 @pytest.fixture
@@ -229,7 +229,7 @@ def device1_requests_mock_key(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - key endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/key")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/key")
 
 
 @pytest.fixture
@@ -237,7 +237,7 @@ def device1_requests_mock_volume(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - volume endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/volume")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/volume")
 
 
 @pytest.fixture
@@ -245,7 +245,7 @@ def device1_requests_mock_select(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - select endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/select")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/select")
 
 
 @pytest.fixture
@@ -253,7 +253,7 @@ def device1_requests_mock_set_zone(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - setZone endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/setZone")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/setZone")
 
 
 @pytest.fixture
@@ -261,7 +261,7 @@ def device1_requests_mock_add_zone_slave(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - addZoneSlave endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/addZoneSlave")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/addZoneSlave")
 
 
 @pytest.fixture
@@ -269,7 +269,7 @@ def device1_requests_mock_remove_zone_slave(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - removeZoneSlave endpoint."""
-    yield device1_requests_mock.post(f"{DEVICE_1_URL}/removeZoneSlave")
+    return device1_requests_mock.post(f"{DEVICE_1_URL}/removeZoneSlave")
 
 
 @pytest.fixture
@@ -277,7 +277,7 @@ def device1_requests_mock_dlna(
     device1_requests_mock: Mocker,
 ):
     """Mock SoundTouch device 1 API - DLNA endpoint."""
-    yield device1_requests_mock.post(f"http://{DEVICE_1_IP}:8091/AVTransport/Control")
+    return device1_requests_mock.post(f"http://{DEVICE_1_IP}:8091/AVTransport/Control")
 
 
 @pytest.fixture
@@ -294,4 +294,4 @@ def device2_requests_mock_standby(
     requests_mock.get(f"{DEVICE_2_URL}/now_playing", text=device2_now_playing_standby)
     requests_mock.get(f"{DEVICE_2_URL}/getZone", text=device2_zone_slave)
 
-    yield requests_mock
+    return requests_mock

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -14,7 +14,7 @@ def entities(hass):
     """Initialize the test switch."""
     platform = getattr(hass.components, "test.switch")
     platform.init()
-    yield platform.ENTITIES
+    return platform.ENTITIES
 
 
 async def test_methods(hass, entities, enable_custom_integrations):

--- a/tests/components/synology_dsm/conftest.py
+++ b/tests/components/synology_dsm/conftest.py
@@ -34,4 +34,4 @@ def fixture_dsm():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
 
-    yield dsm
+    return dsm

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -30,4 +30,4 @@ async def start_ha(hass, count, domain, config, caplog):
 @pytest.fixture
 async def caplog_setup_text(caplog):
     """Return setup log of integration."""
-    yield caplog.text
+    return caplog.text

--- a/tests/components/tile/conftest.py
+++ b/tests/components/tile/conftest.py
@@ -64,4 +64,3 @@ async def setup_config_entry_fixture(hass, config_entry, mock_pytile):
     """Define a fixture to set up tile."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    yield

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -206,4 +206,4 @@ async def mock_config_entry(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    yield entry
+    return entry

--- a/tests/components/vultr/conftest.py
+++ b/tests/components/vultr/conftest.py
@@ -26,5 +26,3 @@ def valid_config(hass: HomeAssistant, requests_mock):
     ):
         # Setup hub
         vultr.setup(hass, VALID_CONFIG)
-
-    yield

--- a/tests/components/vultr/test_switch.py
+++ b/tests/components/vultr/test_switch.py
@@ -45,7 +45,7 @@ def load_hass_devices(hass: HomeAssistant):
     for config in CONFIGS:
         vultr.setup_platform(hass, config, add_entities, None)
 
-    yield hass_devices
+    return hass_devices
 
 
 @pytest.mark.usefixtures("valid_config")

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -39,7 +39,6 @@ def mock_update_wrcerror_fixture(mock_wrc):
     """Mock an update to the sensor failed with WRCError."""
     obj = mock_wrc.return_value
     obj.calc_all_routes_info.side_effect = WRCError("test")
-    yield
 
 
 @pytest.fixture(name="mock_update_keyerror")
@@ -47,7 +46,6 @@ def mock_update_keyerror_fixture(mock_wrc):
     """Mock an update to the sensor failed with KeyError."""
     obj = mock_wrc.return_value
     obj.calc_all_routes_info.side_effect = KeyError("test")
-    yield
 
 
 @pytest.mark.parametrize(

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -197,7 +197,7 @@ class TestInsight:
             "ontotal": 0,
             "powerthreshold": 0,
         }
-        yield pywemo_device
+        return pywemo_device
 
     @pytest.mark.parametrize(
         "subscribed,state,expected_calls",

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -88,13 +88,13 @@ def get_aircon_mock(said):
 @pytest.fixture(name="mock_aircon1_api", autouse=False)
 def fixture_mock_aircon1_api(mock_auth_api, mock_appliances_manager_api):
     """Set up air conditioner API fixture."""
-    yield get_aircon_mock(MOCK_SAID1)
+    return get_aircon_mock(MOCK_SAID1)
 
 
 @pytest.fixture(name="mock_aircon2_api", autouse=False)
 def fixture_mock_aircon2_api(mock_auth_api, mock_appliances_manager_api):
     """Set up air conditioner API fixture."""
-    yield get_aircon_mock(MOCK_SAID2)
+    return get_aircon_mock(MOCK_SAID2)
 
 
 @pytest.fixture(name="mock_aircon_api_instances", autouse=False)
@@ -143,13 +143,13 @@ def get_sensor_mock(said):
 @pytest.fixture(name="mock_sensor1_api", autouse=False)
 def fixture_mock_sensor1_api(mock_auth_api, mock_appliances_manager_api):
     """Set up sensor API fixture."""
-    yield get_sensor_mock(MOCK_SAID3)
+    return get_sensor_mock(MOCK_SAID3)
 
 
 @pytest.fixture(name="mock_sensor2_api", autouse=False)
 def fixture_mock_sensor2_api(mock_auth_api, mock_appliances_manager_api):
     """Set up sensor API fixture."""
-    yield get_sensor_mock(MOCK_SAID4)
+    return get_sensor_mock(MOCK_SAID4)
 
 
 @pytest.fixture(name="mock_sensor_api_instances", autouse=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ util.get_local_ip = lambda: "127.0.0.1"
 def caplog_fixture(caplog):
     """Set log level to debug for tests using the caplog fixture."""
     caplog.set_level(logging.DEBUG)
-    yield caplog
+    return caplog
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -1103,7 +1103,7 @@ async def async_setup_recorder_instance(
 @pytest.fixture
 async def recorder_mock(recorder_config, async_setup_recorder_instance, hass):
     """Fixture with in-memory recorder."""
-    yield await async_setup_recorder_instance(hass, recorder_config)
+    return await async_setup_recorder_instance(hass, recorder_config)
 
 
 @pytest.fixture

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -20,7 +20,7 @@ def integration():
             "requirements": [],
         },
     )
-    yield integration
+    return integration
 
 
 def test_validate_requirements_format_with_space(integration: Integration):

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -45,7 +45,7 @@ def camera_client_fixture(hass, hass_client):
     )
     hass.loop.run_until_complete(hass.async_block_till_done())
 
-    yield hass.loop.run_until_complete(hass_client())
+    return hass.loop.run_until_complete(hass_client())
 
 
 async def test_get_clientsession_with_ssl(hass):

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -5,4 +5,5 @@ extend-select = [
     "PT001", # Use @pytest.fixture without parentheses
     "PT013", # Found incorrect pytest import, use simple import pytest instead
     "PT015", # Assertion always fails, replace with pytest.fail()
+    "PT022", # No teardown in fixture, replace useless yield with return
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PT022: `no teardown in fixture {name}, use return instead of yield`

`yield` in fixtures is only useful and semantically correct when the fixture contains some teardown code.

### Examples

Bad code:

```python
import pytest

@pytest.fixture()
def my_fixture():
    resource = acquire_resource()
    yield resource
```

Good code:
```python
import pytest

@pytest.fixture()
def my_fixture_with_teardown():
    resource = acquire_resource()
    yield resource
    resource.release()

@pytest.fixture()
def my_fixture_without_teardown():
    resource = acquire_resource()
    return resource
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
