### PR TITLE
Enable Ruff PT021

### DIFF
--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -72,7 +72,7 @@ TRANSITION_CASES_FOR_TESTS = [None, 0, 1]
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup(request):
+def setup():
     """Set up patches for pytradfri methods."""
     p_1 = patch(
         "pytradfri.device.LightControl.raw",
@@ -83,12 +83,10 @@ def setup(request):
     p_1.start()
     p_2.start()
 
-    def teardown():
-        """Remove patches for pytradfri methods."""
-        p_1.stop()
-        p_2.stop()
+    yield
 
-    request.addfinalizer(teardown)
+    p_1.stop()
+    p_2.stop()
 
 
 async def generate_psk(self, code):

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -5,5 +5,6 @@ extend-select = [
     "PT001", # Use @pytest.fixture without parentheses
     "PT013", # Found incorrect pytest import, use simple import pytest instead
     "PT015", # Assertion always fails, replace with pytest.fail()
+    "PT021", # use yield instead of request.addfinalizer
     "PT022", # No teardown in fixture, replace useless yield with return
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PT021: use yield instead of request.addfinalizer

Rationale: to make fixture code more linear and straightforward.

`pytest` offers two ways to perform cleanup in fixture code. One is sequential
(`yield` statement), and the other is callback-based (`request.addfinalizer`).

`request.addfinalizer` is allowed when implementing [Factories as fixtures] pattern,
see examples below for more details.

This PR fixes a single occurrence in our codebase.

### Examples

Bad code:

```python
import pytest

@pytest.fixture()
def my_fixture(request):
    resource = acquire_resource()
    request.addfinalizer(resource.release)
    return resource
```

Good code:
```python
import pytest

@pytest.fixture()
def my_fixture():
    resource = acquire_resource()
    yield resource
    resource.release()

# "Factories as fixtures" pattern
@pytest.fixture()
def my_factory(request):
    def create_resource(arg):
        resource = acquire_resource(arg)
        request.addfinalizer(resource.release)
        return resource
    return create_resource
```



[Factories as fixtures]: https://docs.pytest.org/en/stable/fixture.html#factories-as-fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
