### PR TITLE
Remove Audio Content Restrictions From vlc_telnet

### DIFF
--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -21,7 +21,6 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -293,7 +292,6 @@ class VlcDevice(MediaPlayerEntity):
             sourced_media = await media_source.async_resolve_media(
                 self.hass, media_id, self.entity_id
             )
-            media_type = sourced_media.mime_type
             media_id = sourced_media.url
 
         # If media ID is a relative URL, we serve it from HA.

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -296,11 +296,6 @@ class VlcDevice(MediaPlayerEntity):
             media_type = sourced_media.mime_type
             media_id = sourced_media.url
 
-        if media_type != MediaType.MUSIC and not media_type.startswith("audio/"):
-            raise HomeAssistantError(
-                f"Invalid media type {media_type}. Only {MediaType.MUSIC} is supported"
-            )
-
         # If media ID is a relative URL, we serve it from HA.
         media_id = async_process_play_media_url(
             self.hass, media_id, for_supervisor_network=self._using_addon
@@ -336,8 +331,4 @@ class VlcDevice(MediaPlayerEntity):
         media_content_id: str | None = None,
     ) -> BrowseMedia:
         """Implement the websocket media browsing helper."""
-        return await media_source.async_browse_media(
-            self.hass,
-            media_content_id,
-            content_filter=lambda item: item.media_content_type.startswith("audio/"),
-        )
+        return await media_source.async_browse_media(self.hass, media_content_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The VLC Telnet component restricts content to audio only. This isn't necessary, as it's possible to run VLC in a non-headless mode with the Telnet interface active. See https://alanedwardes.com/blog/posts/vlc-remote-control-home-assistant/ for a full howto.

NOTE: I am unable to run the tests locally, I get the following error when running `pip3 install -r requirements_all.txt`:

```
ERROR: Cannot install -r requirements_all.txt (line 1003), -r requirements_all.txt (line 1054), -r requirements_all.txt (line 1165), -r requirements_all.txt (line 592), -r requirements_all.txt (line 919) and -r requirements_all.txt (line 949) because these package versions have conflicting dependencies.

The conflict is caused by:
    devolo-home-control-api 0.18.2 depends on websocket-client>=0.58.0
    homematicip 1.0.13 depends on websocket-client>=1.0.0
    ibm-watson 5.2.2 depends on websocket-client==1.1.0
    jellyfin-apiclient-python 1.9.2 depends on websocket-client
    libsoundtouch 0.8.0 depends on websocket-client>=0.40.0
    mycroftapi 2.0 depends on websocket-client==0.44.0
```

There do not seem to be tests around the code I am changing anyway.

In addition, the command `black --fast homeassistant tests` hangs for me (I am using Visual Studio Code w/the Dev Container on Windows 11).

I have however validated the changes work as expected by running Home Assistant locally (that does work fine).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
