### PR TITLE
Fix D-Link attributes

### DIFF
--- a/homeassistant/components/dlink/data.py
+++ b/homeassistant/components/dlink/data.py
@@ -19,9 +19,9 @@ class SmartPlugData:
         """Initialize the data object."""
         self.smartplug = smartplug
         self.state: str | None = None
-        self.temperature: str | None = None
-        self.current_consumption = None
-        self.total_consumption: str | None = None
+        self.temperature: str = self.smartplug.temperature
+        self.current_consumption: str = self.smartplug.current_consumption
+        self.total_consumption: str = self.smartplug.total_consumption
         self.available = False
         self._n_tried = 0
         self._last_tried: datetime | None = None

--- a/homeassistant/components/dlink/data.py
+++ b/homeassistant/components/dlink/data.py
@@ -19,9 +19,9 @@ class SmartPlugData:
         """Initialize the data object."""
         self.smartplug = smartplug
         self.state: str | None = None
-        self.temperature: str = self.smartplug.temperature
-        self.current_consumption: str = self.smartplug.current_consumption
-        self.total_consumption: str = self.smartplug.total_consumption
+        self.temperature: str = ""
+        self.current_consumption: str = ""
+        self.total_consumption: str = ""
         self.available = False
         self._n_tried = 0
         self._last_tried: datetime | None = None

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -98,12 +98,12 @@ class SmartPlugSwitch(DLinkEntity, SwitchEntity):
             temperature = self.hass.config.units.temperature(
                 int(self.data.temperature), UnitOfTemperature.CELSIUS
             )
-        except (ValueError, TypeError):
+        except ValueError:
             temperature = None
 
         try:
             total_consumption = float(self.data.total_consumption)
-        except (ValueError, TypeError):
+        except ValueError:
             total_consumption = None
 
         attrs = {

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -94,17 +94,22 @@ class SmartPlugSwitch(DLinkEntity, SwitchEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
-        attrs: dict[str, Any] = {}
-        if self.data.temperature and self.data.temperature.isnumeric():
-            attrs[ATTR_TEMPERATURE] = self.hass.config.units.temperature(
+        try:
+            temperature = self.hass.config.units.temperature(
                 int(self.data.temperature), UnitOfTemperature.CELSIUS
             )
-        else:
-            attrs[ATTR_TEMPERATURE] = None
-        if self.data.total_consumption and self.data.total_consumption.isnumeric():
-            attrs[ATTR_TOTAL_CONSUMPTION] = float(self.data.total_consumption)
-        else:
-            attrs[ATTR_TOTAL_CONSUMPTION] = None
+        except (ValueError, TypeError):
+            temperature = None
+
+        try:
+            total_consumption = float(self.data.total_consumption)
+        except (ValueError, TypeError):
+            total_consumption = None
+
+        attrs = {
+            ATTR_TOTAL_CONSUMPTION: total_consumption,
+            ATTR_TEMPERATURE: temperature,
+        }
 
         return attrs
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix D-Link attributes where `SOAPAction` was not being called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86772
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
