### PR TITLE
Nest improve error message on climate actions

### DIFF
--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -291,7 +291,7 @@ class ThermostatEntity(ClimateEntity):
             await trait.set_mode(api_mode)
         except ApiException as err:
             raise HomeAssistantError(
-                f"Error setting HVAC mode {self.entity_id} to {hvac_mode}: {err}"
+                f"Error setting {self.entity_id} HVAC mode to {hvac_mode}: {err}"
             ) from err
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -316,7 +316,7 @@ class ThermostatEntity(ClimateEntity):
                 await trait.set_heat(temp)
         except ApiException as err:
             raise HomeAssistantError(
-                f"Error setting temperature {self.entity_id} {kwargs}: {err}"
+                f"Error setting {self.entity_id} temperature to {kwargs}: {err}"
             ) from err
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -330,7 +330,7 @@ class ThermostatEntity(ClimateEntity):
             await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
         except ApiException as err:
             raise HomeAssistantError(
-                f"Error setting preset mode {self.entity_id} {preset_mode}: {err}"
+                f"Error setting {self.entity_id} preset mode to {preset_mode}: {err}"
             ) from err
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -349,5 +349,5 @@ class ThermostatEntity(ClimateEntity):
             await trait.set_timer(FAN_INV_MODE_MAP[fan_mode], duration=duration)
         except ApiException as err:
             raise HomeAssistantError(
-                f"Error setting fan mode {self.entity_id} to {fan_mode}: {err}"
+                f"Error setting {self.entity_id} fan mode to {fan_mode}: {err}"
             ) from err

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -290,7 +290,9 @@ class ThermostatEntity(ClimateEntity):
         try:
             await trait.set_mode(api_mode)
         except ApiException as err:
-            raise HomeAssistantError(f"Error setting HVAC mode: {err}") from err
+            raise HomeAssistantError(
+                f"Error setting HVAC mode {self.entity_id} to {hvac_mode}: {err}"
+            ) from err
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -313,7 +315,9 @@ class ThermostatEntity(ClimateEntity):
             elif hvac_mode == HVACMode.HEAT and temp:
                 await trait.set_heat(temp)
         except ApiException as err:
-            raise HomeAssistantError(f"Error setting HVAC mode: {err}") from err
+            raise HomeAssistantError(
+                f"Error setting temperature {self.entity_id} {kwargs}: {err}"
+            ) from err
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
@@ -325,7 +329,9 @@ class ThermostatEntity(ClimateEntity):
         try:
             await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
         except ApiException as err:
-            raise HomeAssistantError(f"Error setting HVAC mode: {err}") from err
+            raise HomeAssistantError(
+                f"Error setting preset mode {preset_mode}: {err}"
+            ) from err
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
@@ -342,4 +348,6 @@ class ThermostatEntity(ClimateEntity):
         try:
             await trait.set_timer(FAN_INV_MODE_MAP[fan_mode], duration=duration)
         except ApiException as err:
-            raise HomeAssistantError(f"Error setting HVAC mode: {err}") from err
+            raise HomeAssistantError(
+                f"Error setting fan mode {self.entity_id} to {fan_mode}: {err}"
+            ) from err

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -330,7 +330,7 @@ class ThermostatEntity(ClimateEntity):
             await trait.set_mode(PRESET_INV_MODE_MAP[preset_mode])
         except ApiException as err:
             raise HomeAssistantError(
-                f"Error setting preset mode {preset_mode}: {err}"
+                f"Error setting preset mode {self.entity_id} {preset_mode}: {err}"
             ) from err
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -222,10 +222,9 @@ class CreateDevice:
 
     def create(
         self, raw_traits: dict[str, Any] = None, raw_data: dict[str, Any] = None
-    ) -> Device:
+    ) -> None:
         """Create a new device with the specifeid traits."""
         data = copy.deepcopy(self.data)
         data.update(raw_data if raw_data else {})
         data["traits"].update(raw_traits if raw_traits else {})
-        self.device_manager.add_device(dev := Device.MakeDevice(data, auth=self.auth))
-        return dev
+        self.device_manager.add_device(Device.MakeDevice(data, auth=self.auth))

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -222,9 +222,10 @@ class CreateDevice:
 
     def create(
         self, raw_traits: dict[str, Any] = None, raw_data: dict[str, Any] = None
-    ) -> None:
+    ) -> Device:
         """Create a new device with the specifeid traits."""
         data = copy.deepcopy(self.data)
         data.update(raw_data if raw_data else {})
         data["traits"].update(raw_traits if raw_traits else {})
-        self.device_manager.add_device(Device.MakeDevice(data, auth=self.auth))
+        self.device_manager.add_device(dev := Device.MakeDevice(data, auth=self.auth))
+        return dev

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -8,17 +8,10 @@ pubsub subscriber.
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import patch
 
 import aiohttp
 from google_nest_sdm.auth import AbstractAuth
 from google_nest_sdm.event import EventMessage
-from google_nest_sdm.exceptions import ApiException
-from google_nest_sdm.device_traits import FanTrait
-from google_nest_sdm.thermostat_traits import (
-    ThermostatModeTrait,
-    ThermostatTemperatureSetpointTrait,
-)
 import pytest
 
 from homeassistant.components.climate import (
@@ -435,7 +428,7 @@ async def test_thermostat_set_hvac_mode(
     create_event: CreateEvent,
 ) -> None:
     """Test a thermostat changing hvac modes."""
-    device = create_device.create(
+    create_device.create(
         {
             "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
             "sdm.devices.traits.ThermostatMode": {
@@ -496,20 +489,6 @@ async def test_thermostat_set_hvac_mode(
     assert thermostat is not None
     assert thermostat.state == HVACMode.HEAT
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
-
-    trait = device.traits[ThermostatModeTrait.NAME]
-    with patch.object(trait, "set_mode") as set_mode:
-        set_mode.side_effect = ApiException("This is an API exception")
-        ex: HomeAssistantError = None
-        try:
-            await common.async_set_hvac_mode(hass, HVACMode.OFF)
-            await hass.async_block_till_done()
-        except HomeAssistantError as hae:
-            ex = hae
-        assert ex is not None
-        assert "This is an API exception" in str(ex)
-        assert HVACMode.OFF in str(ex)
-        assert "climate.my_thermostat" in str(ex)
 
 
 async def test_thermostat_invalid_hvac_mode(
@@ -820,47 +799,6 @@ async def test_thermostat_set_heat_cool(
     }
 
 
-async def test_thermostat_set_temperature_api_exception(
-    hass: HomeAssistant,
-    setup_platform: PlatformSetup,
-    auth: FakeAuth,
-    create_device: CreateDevice,
-) -> None:
-    """Test a thermostat heating mode with a temperature change."""
-    device = create_device.create(
-        {
-            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
-            "sdm.devices.traits.ThermostatMode": {
-                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
-                "mode": "HEAT",
-            },
-            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
-                "heatCelsius": 19.0,
-            },
-        }
-    )
-    await setup_platform()
-
-    assert len(hass.states.async_all()) == 1
-    thermostat = hass.states.get("climate.my_thermostat")
-    assert thermostat is not None
-    assert thermostat.state == HVACMode.HEAT
-
-    trait = device.traits[ThermostatTemperatureSetpointTrait.NAME]
-    with patch.object(trait, "set_heat") as set_heat:
-        set_heat.side_effect = ApiException("This is an API exception")
-        ex: HomeAssistantError = None
-        try:
-            await common.async_set_temperature(hass, temperature=20.0)
-            await hass.async_block_till_done()
-        except HomeAssistantError as hae:
-            ex = hae
-        assert ex is not None
-        assert "This is an API exception" in str(ex)
-        assert "20.0" in str(ex)
-        assert "climate.my_thermostat" in str(ex)
-
-
 async def test_thermostat_fan_off(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,
@@ -1003,7 +941,7 @@ async def test_thermostat_set_fan(
     create_device: CreateDevice,
 ) -> None:
     """Test a thermostat enabling the fan."""
-    device = create_device.create(
+    create_device.create(
         {
             "sdm.devices.traits.Fan": {
                 "timerMode": "ON",
@@ -1056,20 +994,6 @@ async def test_thermostat_set_fan(
             "timerMode": "ON",
         },
     }
-
-    trait = device.traits[FanTrait.NAME]
-    with patch.object(trait, "set_timer") as set_timer:
-        set_timer.side_effect = ApiException("This is an API exception")
-        ex: HomeAssistantError = None
-        try:
-            await common.async_set_fan_mode(hass, FAN_ON)
-            await hass.async_block_till_done()
-        except HomeAssistantError as hae:
-            ex = hae
-        assert ex is not None
-        assert "This is an API exception" in str(ex)
-        assert FAN_ON in str(ex)
-        assert "climate.my_thermostat" in str(ex)
 
 
 async def test_thermostat_set_fan_when_off(
@@ -1504,6 +1428,9 @@ async def test_thermostat_hvac_mode_failure(
                 "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
                 "mode": "COOL",
             },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {
+                "coolCelsius": 25.0,
+            },
             "sdm.devices.traits.Fan": {
                 "timerMode": "OFF",
                 "timerTimeout": "2019-05-10T03:22:54Z",
@@ -1525,26 +1452,36 @@ async def test_thermostat_hvac_mode_failure(
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_hvac_mode(hass, HVACMode.HEAT)
         await hass.async_block_till_done()
+    assert "setting HVAC mode" in str(e_info)
+    assert "climate.my_thermostat" in str(e_info)
+    assert HVACMode.HEAT in str(e_info)
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
-    with pytest.raises(HomeAssistantError):
-        await common.async_set_temperature(
-            hass, hvac_mode=HVACMode.HEAT, temperature=25.0
-        )
+    with pytest.raises(HomeAssistantError) as e_info:
+        await common.async_set_temperature(hass, temperature=25.0)
         await hass.async_block_till_done()
+    assert "setting temperature" in str(e_info)
+    assert "climate.my_thermostat" in str(e_info)
+    assert "25.0" in str(e_info)
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_fan_mode(hass, FAN_ON)
         await hass.async_block_till_done()
+    assert "setting fan mode" in str(e_info)
+    assert "climate.my_thermostat" in str(e_info)
+    assert FAN_ON in str(e_info)
 
     auth.responses = [aiohttp.web.Response(status=HTTPStatus.BAD_REQUEST)]
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_preset_mode(hass, PRESET_ECO)
         await hass.async_block_till_done()
+    assert "setting preset mode" in str(e_info)
+    assert "climate.my_thermostat" in str(e_info)
+    assert PRESET_ECO in str(e_info)
 
 
 async def test_thermostat_available(

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -1455,7 +1455,7 @@ async def test_thermostat_hvac_mode_failure(
     with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_hvac_mode(hass, HVACMode.HEAT)
         await hass.async_block_till_done()
-    assert "setting HVAC mode" in str(e_info)
+    assert "HVAC mode" in str(e_info)
     assert "climate.my_thermostat" in str(e_info)
     assert HVACMode.HEAT in str(e_info)
 
@@ -1463,7 +1463,7 @@ async def test_thermostat_hvac_mode_failure(
     with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_temperature(hass, temperature=25.0)
         await hass.async_block_till_done()
-    assert "setting temperature" in str(e_info)
+    assert "temperature" in str(e_info)
     assert "climate.my_thermostat" in str(e_info)
     assert "25.0" in str(e_info)
 
@@ -1471,7 +1471,7 @@ async def test_thermostat_hvac_mode_failure(
     with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_fan_mode(hass, FAN_ON)
         await hass.async_block_till_done()
-    assert "setting fan mode" in str(e_info)
+    assert "fan mode" in str(e_info)
     assert "climate.my_thermostat" in str(e_info)
     assert FAN_ON in str(e_info)
 
@@ -1479,7 +1479,7 @@ async def test_thermostat_hvac_mode_failure(
     with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_preset_mode(hass, PRESET_ECO)
         await hass.async_block_till_done()
-    assert "setting preset mode" in str(e_info)
+    assert "preset mode" in str(e_info)
     assert "climate.my_thermostat" in str(e_info)
     assert PRESET_ECO in str(e_info)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Correct content of error messages when setting temperature, preset mode and fan mode
Include additional information in error message - entity_id, operation / parameters

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86850
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
