### PR TITLE
Avoid Nest climate set_temperature eating error

### DIFF
--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -303,6 +303,10 @@ class ThermostatEntity(ClimateEntity):
         low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temp = kwargs.get(ATTR_TEMPERATURE)
+        if ThermostatTemperatureSetpointTrait.NAME not in self._device.traits:
+            raise HomeAssistantError(
+                f"Error setting {self.entity_id} temperature to {kwargs}: Unable to find ThermostatTemperatureSetpointTrait in device traits {self._device.traits.keys()}"
+            )
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         try:
             if self.preset_mode == PRESET_ECO or hvac_mode == HVACMode.HEAT_COOL:

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -303,8 +303,6 @@ class ThermostatEntity(ClimateEntity):
         low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temp = kwargs.get(ATTR_TEMPERATURE)
-        if ThermostatTemperatureSetpointTrait.NAME not in self._device.traits:
-            return
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         try:
             if self.preset_mode == PRESET_ECO or hvac_mode == HVACMode.HEAT_COOL:

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -305,7 +305,7 @@ class ThermostatEntity(ClimateEntity):
         temp = kwargs.get(ATTR_TEMPERATURE)
         if ThermostatTemperatureSetpointTrait.NAME not in self._device.traits:
             raise HomeAssistantError(
-                f"Error setting {self.entity_id} temperature to {kwargs}: Unable to find ThermostatTemperatureSetpointTrait in device traits {self._device.traits.keys()}"
+                f"Error setting {self.entity_id} temperature to {kwargs}: Unable to find setpoint trait."
             )
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         try:

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -1265,8 +1265,6 @@ async def test_thermostat_missing_temperature_trait(
     assert "temperature" in str(e_info)
     assert "climate.my_thermostat" in str(e_info)
     assert "24.0" in str(e_info)
-    assert "ThermostatHvac" in str(e_info)
-    assert "ThermostatMode" in str(e_info)
     assert thermostat.attributes[ATTR_TEMPERATURE] is None
 
 

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -1259,9 +1259,14 @@ async def test_thermostat_missing_temperature_trait(
     assert ATTR_FAN_MODE not in thermostat.attributes
     assert ATTR_FAN_MODES not in thermostat.attributes
 
-    with pytest.raises(KeyError):
+    with pytest.raises(HomeAssistantError) as e_info:
         await common.async_set_temperature(hass, temperature=24.0)
     await hass.async_block_till_done()
+    assert "temperature" in str(e_info)
+    assert "climate.my_thermostat" in str(e_info)
+    assert "24.0" in str(e_info)
+    assert "ThermostatHvac" in str(e_info)
+    assert "ThermostatMode" in str(e_info)
     assert thermostat.attributes[ATTR_TEMPERATURE] is None
 
 

--- a/tests/components/nest/test_climate_sdm.py
+++ b/tests/components/nest/test_climate_sdm.py
@@ -1259,7 +1259,8 @@ async def test_thermostat_missing_temperature_trait(
     assert ATTR_FAN_MODE not in thermostat.attributes
     assert ATTR_FAN_MODES not in thermostat.attributes
 
-    await common.async_set_temperature(hass, temperature=24.0)
+    with pytest.raises(KeyError):
+        await common.async_set_temperature(hass, temperature=24.0)
     await hass.async_block_till_done()
     assert thermostat.attributes[ATTR_TEMPERATURE] is None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
If the async_set_temperature method fails to find the device trait to set the temperature it silently returns.  The change is to generate a runtime error when this occurs, so the caller knows the call was unsuccessful.  All of the other async_set routines do not do this; this change makes this routine consistent with the others.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
