### PR TITLE
Fix MQTT discovery failing after bad config update

### DIFF
--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -881,7 +881,6 @@ class MqttDiscoveryUpdate(Entity):
                         await self._discovery_update(payload)
                     finally:
                         send_discovery_done(self.hass, self._discovery_data)
-
                 else:
                     # Non-empty, unchanged payload: Ignore to avoid changing states
                     _LOGGER.debug("Ignoring unchanged update for: %s", self.entity_id)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -883,7 +883,6 @@ class MqttDiscoveryUpdate(Entity):
                     except vol.MultipleInvalid as schema_exception:
                         send_discovery_done(self.hass, self._discovery_data)
                         raise schema_exception
-                    self._discovery_data[ATTR_DISCOVERY_PAYLOAD] = payload
                 else:
                     # Non-empty, unchanged payload: Ignore to avoid changing states
                     _LOGGER.debug("Ignoring unchanged update for: %s", self.entity_id)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -749,6 +749,7 @@ class MqttDiscoveryDeviceUpdate(ABC):
             except vol.MultipleInvalid as schema_exception:
                 send_discovery_done(self.hass, self._discovery_data)
                 raise schema_exception
+            self._discovery_data[ATTR_DISCOVERY_PAYLOAD] = discovery_payload
         if not discovery_payload:
             # Unregister and clean up the current discovery instance
             stop_discovery_updates(
@@ -882,6 +883,7 @@ class MqttDiscoveryUpdate(Entity):
                     except vol.MultipleInvalid as schema_exception:
                         send_discovery_done(self.hass, self._discovery_data)
                         raise schema_exception
+                    self._discovery_data[ATTR_DISCOVERY_PAYLOAD] = payload
                 else:
                     # Non-empty, unchanged payload: Ignore to avoid changing states
                     _LOGGER.debug("Ignoring unchanged update for: %s", self.entity_id)

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -746,9 +746,10 @@ class MqttDiscoveryDeviceUpdate(ABC):
             )
             try:
                 await self.async_update(discovery_payload)
-            except vol.MultipleInvalid as schema_exception:
-                send_discovery_done(self.hass, self._discovery_data)
+            except vol.Error as schema_exception:
                 raise schema_exception
+            finally:
+                send_discovery_done(self.hass, self._discovery_data)
             self._discovery_data[ATTR_DISCOVERY_PAYLOAD] = discovery_payload
         if not discovery_payload:
             # Unregister and clean up the current discovery instance
@@ -764,7 +765,6 @@ class MqttDiscoveryDeviceUpdate(ABC):
             )
         else:
             # Normal update without change
-            send_discovery_done(self.hass, self._discovery_data)
             _LOGGER.info(
                 "%s %s no changes",
                 self.log_name,
@@ -880,7 +880,7 @@ class MqttDiscoveryUpdate(Entity):
                     _LOGGER.info("Updating component: %s", self.entity_id)
                     try:
                         await self._discovery_update(payload)
-                    except vol.MultipleInvalid as schema_exception:
+                    except vol.Error as schema_exception:
                         send_discovery_done(self.hass, self._discovery_data)
                         raise schema_exception
                 else:

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -749,7 +749,7 @@ class MqttDiscoveryDeviceUpdate(ABC):
             finally:
                 send_discovery_done(self.hass, self._discovery_data)
             self._discovery_data[ATTR_DISCOVERY_PAYLOAD] = discovery_payload
-        if not discovery_payload:
+        elif not discovery_payload:
             # Unregister and clean up the current discovery instance
             stop_discovery_updates(
                 self.hass, self._discovery_data, self._remove_discovery_updated
@@ -763,6 +763,7 @@ class MqttDiscoveryDeviceUpdate(ABC):
             )
         else:
             # Normal update without change
+            send_discovery_done(self.hass, self._discovery_data)
             _LOGGER.info(
                 "%s %s no changes",
                 self.log_name,

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -6,6 +6,7 @@ import re
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
+from voluptuous import MultipleInvalid
 
 from homeassistant import config_entries
 from homeassistant.components import mqtt
@@ -1494,7 +1495,7 @@ async def test_clean_up_registry_monitoring(
 async def test_unique_id_collission_has_priority(
     hass, mqtt_mock_entry_no_yaml_config, entity_reg
 ):
-    """Test tehe unique_id collision detection has priority over registry disabled items."""
+    """Test the unique_id collision detection has priority over registry disabled items."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
         "name": "sbfspot_12345",
@@ -1534,3 +1535,57 @@ async def test_unique_id_collission_has_priority(
     assert entity_reg.async_get("sensor.sbfspot_12345_1") is not None
     # Verify the second entity is not created because it is not unique
     assert entity_reg.async_get("sensor.sbfspot_12345_2") is None
+
+
+@pytest.mark.xfail(raises=MultipleInvalid)
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
+async def test_update_with_bad_config_not_breaks_discovery(
+    hass: ha.HomeAssistant, mqtt_mock_entry_no_yaml_config, entity_reg
+) -> None:
+    """Test a bad update does not break discovery."""
+    await mqtt_mock_entry_no_yaml_config()
+    # discover a sensor
+    config1 = {
+        "name": "sbfspot_12345",
+        "state_topic": "homeassistant_test/sensor/sbfspot_0/state",
+    }
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/sensor/sbfspot_0/config",
+        json.dumps(config1),
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.sbfspot_12345") is not None
+    # update with a breaking config
+    config2 = {
+        "name": "sbfspot_12345",
+        "availability": 1,
+        "state_topic": "homeassistant_test/sensor/sbfspot_0/state",
+    }
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/sensor/sbfspot_0/config",
+        json.dumps(config2),
+    )
+    await hass.async_block_till_done()
+    # update the state topic
+    config3 = {
+        "name": "sbfspot_12345",
+        "state_topic": "homeassistant_test/sensor/sbfspot_0/new_state_topic",
+    }
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/sensor/sbfspot_0/config",
+        json.dumps(config3),
+    )
+    await hass.async_block_till_done()
+
+    # Send an update for the state
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant_test/sensor/sbfspot_0/new_state_topic",
+        "new_value",
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.sbfspot_12345").state == "new_value"

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -826,7 +826,7 @@ async def test_update_with_bad_config_not_breaks_discovery(
 
     config3 = {
         "topic": "test-topic-update",
-        "device": {"identifiers": "bad identifier"},
+        "device": {"identifiers": ["helloworld"]},
     }
 
     data1 = json.dumps(config1)

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -821,7 +821,7 @@ async def test_update_with_bad_config_not_breaks_discovery(
     }
     config2 = {
         "topic": "test-topic",
-        "device": {"identifiers": "bad identifier"},
+        "device": {"bad_key": "some bad value"},
     }
 
     config3 = {

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -4,10 +4,12 @@ import json
 from unittest.mock import ANY, patch
 
 import pytest
+from voluptuous import MultipleInvalid
 
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -803,6 +805,50 @@ async def test_cleanup_device_with_entity2(
     # Verify device registry entry is cleared
     device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
+
+
+@pytest.mark.xfail(raises=MultipleInvalid)
+async def test_update_with_bad_config_not_breaks_discovery(
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config,
+    tag_mock,
+) -> None:
+    """Test a bad update does not break discovery."""
+    await mqtt_mock_entry_no_yaml_config()
+    config1 = {
+        "topic": "test-topic",
+        "device": {"identifiers": ["helloworld"]},
+    }
+    config2 = {
+        "topic": "test-topic",
+        "device": {"identifiers": "bad identifier"},
+    }
+
+    config3 = {
+        "topic": "test-topic-update",
+        "device": {"identifiers": "bad identifier"},
+    }
+
+    data1 = json.dumps(config1)
+    data2 = json.dumps(config2)
+    data3 = json.dumps(config3)
+
+    async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", data1)
+    await hass.async_block_till_done()
+
+    # Update with bad identifier
+    async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", data2)
+    await hass.async_block_till_done()
+
+    # Topic update
+    async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", data3)
+    await hass.async_block_till_done()
+
+    # Fake tag scan.
+    async_fire_mqtt_message(hass, "test-topic-update", "12345")
+
+    await hass.async_block_till_done()
+    tag_mock.assert_called_once_with(ANY, "12345", ANY)
 
 
 async def test_unload_entry(hass, device_reg, mqtt_mock, tag_mock, tmp_path) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a discovery update for an MQTT entity or MQTT tag scanner for which the config violates with the schema an exception is raised but the discovery updated queue is not handled properly. This causes that new updates are not processed as the last update is still in a pending state.

This fix handles schema violations handles the queue by sending a `mqtt_discovery_done_{}` message  and then throws the schema exception. This allows correct future updates to be handled correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
