### PR TITLE
Revert "Adjust D-Link entity naming"

### DIFF
--- a/homeassistant/components/dlink/entity.py
+++ b/homeassistant/components/dlink/entity.py
@@ -1,7 +1,7 @@
 """Entity representing a D-Link Power Plug device."""
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
@@ -14,7 +14,6 @@ class DLinkEntity(Entity):
     """Representation of a D-Link Power Plug entity."""
 
     _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -25,6 +24,10 @@ class DLinkEntity(Entity):
         """Initialize a D-Link Power Plug entity."""
         self.data = data
         self.entity_description = description
+        if config_entry.source == SOURCE_IMPORT:
+            self._attr_name = config_entry.title
+        else:
+            self._attr_has_entity_name = True
         self._attr_unique_id = f"{config_entry.entry_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},

--- a/homeassistant/components/dlink/switch.py
+++ b/homeassistant/components/dlink/switch.py
@@ -47,7 +47,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SWITCH_TYPE = SwitchEntityDescription(key="")
+SWITCH_TYPE = SwitchEntityDescription(
+    key="switch",
+    name="Switch",
+)
 
 
 def setup_platform(

--- a/tests/components/dlink/test_switch.py
+++ b/tests/components/dlink/test_switch.py
@@ -44,7 +44,7 @@ async def test_switch_state(
 
     await setup_integration()
 
-    entity_id = "switch.mock_title"
+    entity_id = "switch.mock_title_switch"
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
     assert state.attributes["total_consumption"] == 1040.0
@@ -71,7 +71,7 @@ async def test_switch_no_value(
     """Test we handle 'N/A' being passed by the pypi package."""
     await setup_integration_legacy()
 
-    state = hass.states.get("switch.mock_title")
+    state = hass.states.get("switch.mock_title_switch")
     assert state.state == STATE_OFF
     assert state.attributes["total_consumption"] is None
     assert state.attributes["temperature"] is None


### PR DESCRIPTION
Reverts home-assistant/core#86906

To avoid a breaking change. We can't adopt a new naming style until legacy/migration/YAML imports have been removed.