### PR TITLE
Uses PolledSmartEnergySummation for ZLinky

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -511,7 +511,7 @@ class PolledSmartEnergySummation(SmartEnergySummation):
     models={"ZLinky_TIC"},
 )
 class Tier1SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier1_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier1_summation_delivered"
 ):
     """Tier 1 Smart Energy Metering summation sensor."""
 
@@ -524,7 +524,7 @@ class Tier1SmartEnergySummation(
     models={"ZLinky_TIC"},
 )
 class Tier2SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier2_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier2_summation_delivered"
 ):
     """Tier 2 Smart Energy Metering summation sensor."""
 
@@ -537,7 +537,7 @@ class Tier2SmartEnergySummation(
     models={"ZLinky_TIC"},
 )
 class Tier3SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier3_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier3_summation_delivered"
 ):
     """Tier 3 Smart Energy Metering summation sensor."""
 
@@ -550,7 +550,7 @@ class Tier3SmartEnergySummation(
     models={"ZLinky_TIC"},
 )
 class Tier4SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier4_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier4_summation_delivered"
 ):
     """Tier 4 Smart Energy Metering summation sensor."""
 
@@ -563,7 +563,7 @@ class Tier4SmartEnergySummation(
     models={"ZLinky_TIC"},
 )
 class Tier5SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier5_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier5_summation_delivered"
 ):
     """Tier 5 Smart Energy Metering summation sensor."""
 
@@ -576,7 +576,7 @@ class Tier5SmartEnergySummation(
     models={"ZLinky_TIC"},
 )
 class Tier6SmartEnergySummation(
-    SmartEnergySummation, id_suffix="tier6_summation_delivered"
+    PolledSmartEnergySummation, id_suffix="tier6_summation_delivered"
 ):
     """Tier 6 Smart Energy Metering summation sensor."""
 


### PR DESCRIPTION
## Proposed change

Uses PolledSmartEnergySummation for Zlinky summation tier because they does not always update.
Following https://github.com/home-assistant/core/pull/82602

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
