### PR TITLE
Prioritize entity names over area names in Assist matching

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -122,10 +122,16 @@ class DefaultAgent(AbstractConversationAgent):
                 conversation_id,
             )
 
+        slot_lists: dict[str, SlotList] = {
+            "area": self._make_areas_list(),
+            "name": self._make_names_list(),
+        }
+
         result = await self.hass.async_add_executor_job(
             self._recognize,
             user_input,
             lang_intents,
+            slot_lists,
         )
         if result is None:
             _LOGGER.debug("No intent was matched for '%s'", user_input.text)
@@ -195,14 +201,12 @@ class DefaultAgent(AbstractConversationAgent):
         )
 
     def _recognize(
-        self, user_input: ConversationInput, lang_intents: LanguageIntents
+        self,
+        user_input: ConversationInput,
+        lang_intents: LanguageIntents,
+        slot_lists: dict[str, SlotList],
     ) -> RecognizeResult | None:
         """Search intents for a match to user input."""
-        slot_lists: dict[str, SlotList] = {
-            "area": self._make_areas_list(),
-            "name": self._make_names_list(),
-        }
-
         # Prioritize matches with entity names above area names
         maybe_result: RecognizeResult | None = None
         for result in recognize_all(

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -204,18 +204,17 @@ class DefaultAgent(AbstractConversationAgent):
         }
 
         # Prioritize matches with entity names above area names
-        area_result: RecognizeResult | None = None
+        maybe_result: RecognizeResult | None = None
         for result in recognize_all(
             user_input.text, lang_intents.intents, slot_lists=slot_lists
         ):
             if "name" in result.entities:
                 return result
 
-            if "area" in result.entities:
-                # Keep looking in case an entity has the same name
-                area_result = result
+            # Keep looking in case an entity has the same name
+            maybe_result = result
 
-        return area_result
+        return maybe_result
 
     async def async_reload(self, language: str | None = None):
         """Clear cached intents for a language."""

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -396,22 +396,19 @@ class DefaultAgent(AbstractConversationAgent):
         if self._names_list is not None:
             return self._names_list
         states = self.hass.states.async_all()
-        registry = entity_registry.async_get(self.hass)
+        entities = entity_registry.async_get(self.hass)
         names = []
         for state in states:
             context = {"domain": state.domain}
 
-            entry = registry.async_get(state.entity_id)
-            if entry is not None:
-                if entry.entity_category:
+            entity = entities.async_get(state.entity_id)
+            if entity is not None:
+                if entity.entity_category:
                     # Skip configuration/diagnostic entities
                     continue
 
-                if entry.name:
-                    names.append((entry.name, state.entity_id, context))
-
-                if entry.aliases:
-                    for alias in entry.aliases:
+                if entity.aliases:
+                    for alias in entity.aliases:
                         names.append((alias, state.entity_id, context))
 
             # Default name

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -140,9 +140,6 @@ def _has_name(
 
     # Check name/aliases
     if entity is not None:
-        if (entity.name is not None) and (name == entity.name.casefold()):
-            return True
-
         if entity.aliases:
             for alias in entity.aliases:
                 if name == alias.casefold():

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -147,6 +147,48 @@ def _has_name(
     return False
 
 
+def _find_area(
+    id_or_name: str, areas: area_registry.AreaRegistry
+) -> area_registry.AreaEntry | None:
+    """Find an area by id or name, checking aliases too."""
+    area = areas.async_get_area(id_or_name) or areas.async_get_area_by_name(id_or_name)
+
+    if area is None:
+        # Check area aliases
+        for maybe_area in areas.areas.values():
+            if maybe_area.aliases:
+                for area_alias in maybe_area.aliases:
+                    if id_or_name == area_alias.casefold():
+                        return maybe_area
+
+    return area
+
+
+def _filter_by_area(
+    states_and_entities: list[tuple[State, entity_registry.RegistryEntry | None]],
+    area: area_registry.AreaEntry,
+    devices: device_registry.DeviceRegistry,
+) -> Iterable[tuple[State, entity_registry.RegistryEntry | None]]:
+    """Filter state/entity pairs by an area."""
+    entity_area_ids: dict[str, str | None] = {}
+    for _state, entity in states_and_entities:
+        if entity is None:
+            continue
+
+        if entity.area_id:
+            # Use entity's area id first
+            entity_area_ids[entity.id] = entity.area_id
+        elif entity.device_id:
+            # Fall back to device area if not set on entity
+            device = devices.async_get(entity.device_id)
+            if device is not None:
+                entity_area_ids[entity.id] = device.area_id
+
+    for state, entity in states_and_entities:
+        if (entity is not None) and (entity_area_ids.get(entity.id) == area.id):
+            yield (state, entity)
+
+
 @callback
 @bind_hass
 def async_match_states(
@@ -200,45 +242,29 @@ def async_match_states(
         if areas is None:
             areas = area_registry.async_get(hass)
 
-        # id or name
-        area = areas.async_get_area(area_name) or areas.async_get_area_by_name(
-            area_name
-        )
+        area = _find_area(area_name, areas)
         assert area is not None, f"No area named {area_name}"
 
     if area is not None:
+        # Filter by states/entities by area
         if devices is None:
             devices = device_registry.async_get(hass)
 
-        entity_area_ids: dict[str, str | None] = {}
-        for _state, entity in states_and_entities:
-            if entity is None:
-                continue
-
-            if entity.area_id:
-                # Use entity's area id first
-                entity_area_ids[entity.id] = entity.area_id
-            elif entity.device_id:
-                # Fall back to device area if not set on entity
-                device = devices.async_get(entity.device_id)
-                if device is not None:
-                    entity_area_ids[entity.id] = device.area_id
-
-        # Filter by area
-        states_and_entities = [
-            (state, entity)
-            for state, entity in states_and_entities
-            if (entity is not None) and (entity_area_ids.get(entity.id) == area.id)
-        ]
+        states_and_entities = list(_filter_by_area(states_and_entities, area, devices))
 
     if name is not None:
+        if devices is None:
+            devices = device_registry.async_get(hass)
+
         # Filter by name
         name = name.casefold()
 
+        # Check states
         for state, entity in states_and_entities:
             if _has_name(state, entity, name):
                 yield state
                 break
+
     else:
         # Not filtered by name
         for state, _entity in states_and_entities:

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -138,11 +138,15 @@ def _has_name(
     if name in (state.entity_id, state.name.casefold()):
         return True
 
-    # Check aliases
-    if (entity is not None) and entity.aliases:
-        for alias in entity.aliases:
-            if name == alias.casefold():
-                return True
+    # Check name/aliases
+    if entity is not None:
+        if (entity.name is not None) and (name == entity.name.casefold()):
+            return True
+
+        if entity.aliases:
+            for alias in entity.aliases:
+                if name == alias.casefold():
+                    return True
 
     return False
 

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -139,11 +139,12 @@ def _has_name(
         return True
 
     # Check name/aliases
-    if entity is not None:
-        if entity.aliases:
-            for alias in entity.aliases:
-                if name == alias.casefold():
-                    return True
+    if (entity is None) or (not entity.aliases):
+        return False
+
+    for alias in entity.aliases:
+        if name == alias.casefold():
+            return True
 
     return False
 
@@ -153,16 +154,19 @@ def _find_area(
 ) -> area_registry.AreaEntry | None:
     """Find an area by id or name, checking aliases too."""
     area = areas.async_get_area(id_or_name) or areas.async_get_area_by_name(id_or_name)
+    if area is not None:
+        return area
 
-    if area is None:
-        # Check area aliases
-        for maybe_area in areas.areas.values():
-            if maybe_area.aliases:
-                for area_alias in maybe_area.aliases:
-                    if id_or_name == area_alias.casefold():
-                        return maybe_area
+    # Check area aliases
+    for maybe_area in areas.areas.values():
+        if not maybe_area.aliases:
+            continue
 
-    return area
+        for area_alias in maybe_area.aliases:
+            if id_or_name == area_alias.casefold():
+                return maybe_area
+
+    return None
 
 
 def _filter_by_area(

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components import conversation
 from homeassistant.components.cover import SERVICE_OPEN_COVER
+from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import DOMAIN as HASS_DOMAIN, Context
 from homeassistant.helpers import (
     area_registry,
@@ -794,17 +795,21 @@ async def test_light_area_same_name(hass, init_components):
     kitchen_area = areas.async_create("kitchen")
     devices.async_update_device(device.id, area_id=kitchen_area.id)
 
-    entities.async_get_or_create("light", "demo", "1234", suggested_object_id="kitchen")
-    entities.async_update_entity(
-        "light.kitchen", name="kitchen light", area_id=kitchen_area.id
+    kitchen_light = entities.async_get_or_create(
+        "light", "demo", "1234", original_name="kitchen light"
     )
-    hass.states.async_set("light.kitchen", "off")
+    entities.async_update_entity(kitchen_light.entity_id, area_id=kitchen_area.id)
+    hass.states.async_set(
+        kitchen_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "kitchen light"}
+    )
 
-    entities.async_get_or_create("light", "demo", "5678", suggested_object_id="ceiling")
-    entities.async_update_entity(
-        "light.ceiling", name="ceiling light", area_id=kitchen_area.id
+    ceiling_light = entities.async_get_or_create(
+        "light", "demo", "5678", original_name="ceiling light"
     )
-    hass.states.async_set("light.ceiling", "off")
+    entities.async_update_entity(ceiling_light.entity_id, area_id=kitchen_area.id)
+    hass.states.async_set(
+        ceiling_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "ceiling light"}
+    )
 
     calls = async_mock_service(hass, HASS_DOMAIN, "turn_on")
 
@@ -820,4 +825,4 @@ async def test_light_area_same_name(hass, init_components):
     call = calls[0]
     assert call.domain == HASS_DOMAIN
     assert call.service == "turn_on"
-    assert call.data == {"entity_id": "light.kitchen"}
+    assert call.data == {"entity_id": kitchen_light.entity_id}

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -132,6 +132,32 @@ async def test_match_device_area(hass):
     )
 
 
+async def test_match_entity_name(hass):
+    """Test async_match_state with a named entity."""
+    devices = device_registry.async_get(hass)
+    kitchen_device = devices.async_get_or_create(
+        config_entry_id="1234",
+        connections=set(),
+        identifiers={("demo", "id-1234")},
+    )
+
+    entities = entity_registry.async_get(hass)
+    entity1 = entities.async_get_or_create("light", "demo", "1234")
+    entities.async_update_entity(
+        entity1.entity_id, device_id=kitchen_device.id, name="kitchen light"
+    )
+    state1 = State(entity1.entity_id, "on")
+
+    # Match on device name
+    assert [state1] == list(
+        intent.async_match_states(
+            hass,
+            name="kitchen light",
+            states=[state1],
+        )
+    )
+
+
 def test_async_validate_slots():
     """Test async_validate_slots of IntentHandler."""
     handler1 = MockIntentHandler({vol.Required("name"): cv.string})

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -140,32 +140,6 @@ async def test_match_device_area(hass):
     )
 
 
-async def test_match_entity_name(hass):
-    """Test async_match_state with a named entity."""
-    devices = device_registry.async_get(hass)
-    kitchen_device = devices.async_get_or_create(
-        config_entry_id="1234",
-        connections=set(),
-        identifiers={("demo", "id-1234")},
-    )
-
-    entities = entity_registry.async_get(hass)
-    entity1 = entities.async_get_or_create("light", "demo", "1234")
-    entities.async_update_entity(
-        entity1.entity_id, device_id=kitchen_device.id, name="kitchen light"
-    )
-    state1 = State(entity1.entity_id, "on")
-
-    # Match on device name
-    assert [state1] == list(
-        intent.async_match_states(
-            hass,
-            name="kitchen light",
-            states=[state1],
-        )
-    )
-
-
 def test_async_validate_slots():
     """Test async_validate_slots of IntentHandler."""
     handler1 = MockIntentHandler({vol.Required("name"): cv.string})

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -27,6 +27,7 @@ async def test_async_match_states(hass):
     """Test async_match_state helper."""
     areas = area_registry.async_get(hass)
     area_kitchen = areas.async_get_or_create("kitchen")
+    areas.async_update(area_kitchen.id, aliases={"food room"})
     area_bedroom = areas.async_get_or_create("bedroom")
 
     state1 = State(
@@ -65,6 +66,13 @@ async def test_async_match_states(hass):
     assert [state1] == list(
         intent.async_match_states(
             hass, name="kitchen light", area_name="kitchen", states=[state1, state2]
+        )
+    )
+
+    # Test area alias
+    assert [state1] == list(
+        intent.async_match_states(
+            hass, name="kitchen light", area_name="food room", states=[state1, state2]
         )
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Matches entity names before area names if they are the same. For example, "turn on kitchen lights" will match the entity "kitchen lights" before turning on all lights in the kitchen. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86912 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
