### PR TITLE
Fix handling `None` or empty value for numeric MQTT sensor

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -38,7 +38,7 @@ from homeassistant.util import dt as dt_util
 
 from . import subscription
 from .config import MQTT_RO_SCHEMA
-from .const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC
+from .const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC, PAYLOAD_NONE
 from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
@@ -276,7 +276,18 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 SensorDeviceClass.DATE,
                 SensorDeviceClass.TIMESTAMP,
             }:
-                self._attr_native_value = str(payload)
+                new_value = str(payload)
+                if self.device_class is not None and new_value == "":
+                    _LOGGER.debug(
+                        "Ignore empty state for numeric value '%s' from '%s'",
+                        msg.payload,
+                        msg.topic,
+                    )
+                else:
+                    if new_value == PAYLOAD_NONE:
+                        self._attr_native_value = None
+                    else:
+                        self._attr_native_value = new_value
                 return
             if (payload_datetime := dt_util.parse_datetime(str(payload))) is None:
                 _LOGGER.warning(

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -272,12 +272,12 @@ class MqttSensor(MqttEntity, RestoreSensor):
             payload = self._template(msg.payload, PayloadSentinel.DEFAULT)
             if payload is PayloadSentinel.DEFAULT:
                 return
-            if (new_value := str(payload)) == PAYLOAD_NONE:
-                self._attr_native_value = None
-                return
+            new_value = str(payload)
             if self._numeric_state_expected:
                 if new_value == "":
                     _LOGGER.debug("Ignore empty state from '%s'", msg.topic)
+                elif new_value == PAYLOAD_NONE:
+                    self._attr_native_value = None
                 else:
                     self._attr_native_value = new_value
                 return

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -218,6 +218,11 @@ async def test_setting_numeric_sensor_native_value_handling_via_mqtt_message(
     state = hass.states.get("sensor.test")
     assert state.state == "21"
 
+    # omitting value, causing it to be ignored, native sensor value should not change (template warning will be logged though)
+    async_fire_mqtt_message(hass, "test-topic", '{ "current": 5.34 }')
+    state = hass.states.get("sensor.test")
+    assert state.state == "21"
+
 
 async def test_setting_sensor_value_expires_availability_topic(
     hass, mqtt_mock_entry_with_yaml_config, caplog


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The behavior for receiving value on sensors that expect numeric* values has changed.
- From now on a `'None'` value or a value rendered to `'None'` will set such a sensor sensor to an `unknown` state.
- Empty values on such sensor (`''`) are ignored and will not effect the state of the sensor.
Integrations need to be corrected to send the correct values if an update is published and no valid update value is available for the sensor.
- Other sensors that do not expect a numeric value will still accept an empty string as a value.

\* Sensors expect numeric values if at least one of the following applies:
- `device_class` is set but is not a `DATE`, `TIMESTAMP`, `ENUM` or any custom device class.
- a `state_class` is set.
- `unit_of_measurement` is set.
- `suggested_display_precision` is set (#87129)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT sensors can accept string or numeric values. When `device_class` is set a numeric value is expected. Many configurations use `value_templates` when getting a sensor value from a published JSON.
When a sensor has no value, and the `device_class` is set, this would give warnings in the log indicating an invalid non-numeric value was received.

This PR will change the behavior for MQTT sensors that have a `device_class` set and receive a value in two ways:
- ignore when empty string value `''` is returned from the `value_template` for a numeric sensor.
- set a sensor to an `unknown state` when `None` as value us returned from the `value template`.

This is needed to allow maintainers get rid of warnings about invalid non-numeric in values in the logs asking people to open an issue.

example log for value rendering to an empty state:

```log
Sensor sensor.power_dc has device class power, state class measurement and unit W thus indicating it has a numeric value; however, it has the non-numeric value: (<class 'str'>); Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87194 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26026

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
