### PR TITLE
Add numeric_state_expected property to Sensor class

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -250,7 +250,7 @@ class SensorEntity(Entity):
     @final
     @property
     def numeric_state_expected(self) -> bool:
-        """Return true if the sensor is expected to be numeric."""
+        """Return true if the sensor state must be numeric."""
         if (
             self.state_class is not None
             or self.native_unit_of_measurement is not None

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -262,10 +262,7 @@ class SensorEntity(Entity):
             or self.native_precision is not None
         ):
             return True
-        with suppress(ValueError):
-            # Custom device classes are not considered as numeric
-            device_class = SensorDeviceClass(str(self.device_class))
-        if device_class and device_class not in _NON_NUMERIC_DEVICE_CLASSES:
+        if self.device_class and self.device_class not in _NON_NUMERIC_DEVICE_CLASSES:
             return True
         return False
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -258,9 +258,7 @@ class SensorEntity(Entity):
         ):
             return True
         # Sensors with custom device classes are not considered numeric
-        device_class: SensorDeviceClass | None = try_parse_enum(
-            SensorDeviceClass, self.device_class
-        )
+        device_class = try_parse_enum(SensorDeviceClass, self.device_class)
         return not (device_class is None or device_class in NON_NUMERIC_DEVICE_CLASSES)
 
     @property

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -495,15 +495,7 @@ class SensorEntity(Entity):
 
         # Sensors with device classes indicating a non-numeric value
         # should not have a unit of measurement
-        if (
-            device_class
-            in {
-                SensorDeviceClass.DATE,
-                SensorDeviceClass.ENUM,
-                SensorDeviceClass.TIMESTAMP,
-            }
-            and unit_of_measurement
-        ):
+        if device_class in _NON_NUMERIC_DEVICE_CLASSES and unit_of_measurement:
             raise ValueError(
                 f"Sensor {self.entity_id} has a unit of measurement and thus "
                 "indicating it has a numeric value; however, it has the "

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -254,7 +254,7 @@ class SensorEntity(Entity):
 
     @final
     @property
-    def is_numeric(self) -> bool:
+    def numeric_state_expected(self) -> bool:
         """Return true if the sensor is numeric."""
         if (
             self.state_class is not None
@@ -594,7 +594,7 @@ class SensorEntity(Entity):
 
         # If the sensor has neither a device class, a state class, a unit of measurement
         # nor a precision then there are no further checks or conversions
-        if not self.is_numeric:
+        if not self.numeric_state_expected:
             return value
 
         # From here on a numerical value is expected

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -89,7 +89,7 @@ NEGATIVE_ZERO_PATTERN = re.compile(r"^-(0\.?0*)$")
 
 SCAN_INTERVAL: Final = timedelta(seconds=30)
 
-_NONE_NUMERIC_DEVICE_CLASSES = {
+_NON_NUMERIC_DEVICE_CLASSES = {
     SensorDeviceClass.ENUM,
     SensorDeviceClass.DATE,
     SensorDeviceClass.TIMESTAMP,
@@ -156,7 +156,6 @@ class SensorEntity(Entity):
 
     entity_description: SensorEntityDescription
     _attr_device_class: SensorDeviceClass | None
-    _attr_is_numeric: bool
     _attr_last_reset: datetime | None
     _attr_native_precision: int | None
     _attr_native_unit_of_measurement: str | None
@@ -253,26 +252,17 @@ class SensorEntity(Entity):
             return self.entity_description.device_class
         return None
 
+    @final
     @property
     def is_numeric(self) -> bool:
         """Return true if the sensor is numeric."""
         if (
             self.state_class is not None
-            or self._attr_unit_of_measurement is not None
+            or self.unit_of_measurement is not None
             or self.native_precision is not None
         ):
             return True
-
-        native_device_class: SensorDeviceClass | None = None
-        with suppress(ValueError):
-            # Custom device classes are not considered as numeric
-            native_device_class = SensorDeviceClass(str(self.device_class))
-        is_custom_device_class = native_device_class != self.device_class
-        if (
-            self.device_class
-            and self.device_class not in _NONE_NUMERIC_DEVICE_CLASSES
-            and not is_custom_device_class
-        ):
+        if self.device_class and self.device_class not in _NON_NUMERIC_DEVICE_CLASSES:
             return True
         return False
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -89,6 +89,12 @@ NEGATIVE_ZERO_PATTERN = re.compile(r"^-(0\.?0*)$")
 
 SCAN_INTERVAL: Final = timedelta(seconds=30)
 
+_NONE_NUMERIC_DEVICE_CLASSES = {
+    SensorDeviceClass.ENUM,
+    SensorDeviceClass.DATE,
+    SensorDeviceClass.TIMESTAMP,
+}
+
 __all__ = [
     "ATTR_LAST_RESET",
     "ATTR_OPTIONS",
@@ -150,6 +156,7 @@ class SensorEntity(Entity):
 
     entity_description: SensorEntityDescription
     _attr_device_class: SensorDeviceClass | None
+    _attr_is_numeric: bool
     _attr_last_reset: datetime | None
     _attr_native_precision: int | None
     _attr_native_unit_of_measurement: str | None
@@ -245,6 +252,29 @@ class SensorEntity(Entity):
         if hasattr(self, "entity_description"):
             return self.entity_description.device_class
         return None
+
+    @property
+    def is_numeric(self) -> bool:
+        """Return true if the sensor is numeric."""
+        if (
+            self.state_class is not None
+            or self._attr_unit_of_measurement is not None
+            or self.native_precision is not None
+        ):
+            return True
+
+        native_device_class: SensorDeviceClass | None = None
+        with suppress(ValueError):
+            # Custom device classes are not considered as numeric
+            native_device_class = SensorDeviceClass(str(self.device_class))
+        is_custom_device_class = native_device_class != self.device_class
+        if (
+            self.device_class
+            and self.device_class not in _NONE_NUMERIC_DEVICE_CLASSES
+            and not is_custom_device_class
+        ):
+            return True
+        return False
 
     @property
     def options(self) -> list[str] | None:

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -262,7 +262,10 @@ class SensorEntity(Entity):
             or self.native_precision is not None
         ):
             return True
-        if self.device_class and self.device_class not in _NON_NUMERIC_DEVICE_CLASSES:
+        with suppress(ValueError):
+            # Custom device classes are not considered as numeric
+            device_class = SensorDeviceClass(str(self.device_class))
+        if device_class and device_class not in _NON_NUMERIC_DEVICE_CLASSES:
             return True
         return False
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -257,10 +257,10 @@ class SensorEntity(Entity):
             or self.native_precision is not None
         ):
             return True
-        device_class: SensorDeviceClass | None = None
-        with suppress(ValueError):
-            # Sensors with custom device classes are not considered numeric
-            device_class = SensorDeviceClass(str(self.device_class))
+        # Sensors with custom device classes are not considered numeric
+        device_class: SensorDeviceClass | None = try_parse_enum(
+            SensorDeviceClass, self.device_class
+        )
         return not (device_class is None or device_class in NON_NUMERIC_DEVICE_CLASSES)
 
     @property

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -249,7 +249,7 @@ class SensorEntity(Entity):
 
     @final
     @property
-    def numeric_state_expected(self) -> bool:
+    def _numeric_state_expected(self) -> bool:
         """Return true if the sensor must be numeric."""
         if (
             self.state_class is not None
@@ -579,7 +579,7 @@ class SensorEntity(Entity):
 
         # If the sensor has neither a device class, a state class, a unit of measurement
         # nor a precision then there are no further checks or conversions
-        if not self.numeric_state_expected:
+        if not self._numeric_state_expected:
             return value
 
         # From here on a numerical value is expected

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -90,8 +90,8 @@ NEGATIVE_ZERO_PATTERN = re.compile(r"^-(0\.?0*)$")
 SCAN_INTERVAL: Final = timedelta(seconds=30)
 
 _NON_NUMERIC_DEVICE_CLASSES = {
-    SensorDeviceClass.ENUM,
     SensorDeviceClass.DATE,
+    SensorDeviceClass.ENUM,
     SensorDeviceClass.TIMESTAMP,
 }
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -262,7 +262,11 @@ class SensorEntity(Entity):
             or self.native_precision is not None
         ):
             return True
-        if self.device_class and self.device_class not in _NON_NUMERIC_DEVICE_CLASSES:
+        device_class: SensorDeviceClass | None = None
+        with suppress(ValueError):
+            # Custom device classes are not considered numeric
+            device_class = SensorDeviceClass(str(self.device_class))
+        if device_class and device_class not in _NON_NUMERIC_DEVICE_CLASSES:
             return True
         return False
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -590,12 +590,7 @@ class SensorEntity(Entity):
 
         # If the sensor has neither a device class, a state class, a unit of measurement
         # nor a precision then there are no further checks or conversions
-        if (
-            not device_class
-            and not state_class
-            and not unit_of_measurement
-            and precision is None
-        ):
+        if not self.is_numeric:
             return value
 
         # From here on a numerical value is expected

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -258,7 +258,7 @@ class SensorEntity(Entity):
         """Return true if the sensor is numeric."""
         if (
             self.state_class is not None
-            or self.unit_of_measurement is not None
+            or self.native_unit_of_measurement is not None
             or self.native_precision is not None
         ):
             return True

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -266,9 +266,7 @@ class SensorEntity(Entity):
         with suppress(ValueError):
             # Custom device classes are not considered numeric
             device_class = SensorDeviceClass(str(self.device_class))
-        if device_class and device_class not in _NON_NUMERIC_DEVICE_CLASSES:
-            return True
-        return False
+        return device_class is None and device_class not in _NON_NUMERIC_DEVICE_CLASSES
 
     @property
     def options(self) -> list[str] | None:

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -261,9 +261,7 @@ class SensorEntity(Entity):
         with suppress(ValueError):
             # Custom device classes are not considered numeric
             device_class = SensorDeviceClass(str(self.device_class))
-        if device_class and device_class not in NON_NUMERIC_DEVICE_CLASSES:
-            return True
-        return False
+        return bool(device_class and device_class not in NON_NUMERIC_DEVICE_CLASSES)
 
     @property
     def options(self) -> list[str] | None:

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -261,7 +261,7 @@ class SensorEntity(Entity):
         with suppress(ValueError):
             # Custom device classes are not considered numeric
             device_class = SensorDeviceClass(str(self.device_class))
-        return bool(device_class and device_class not in NON_NUMERIC_DEVICE_CLASSES)
+        return not (device_class is None or device_class in NON_NUMERIC_DEVICE_CLASSES)
 
     @property
     def options(self) -> list[str] | None:

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -255,7 +255,7 @@ class SensorEntity(Entity):
     @final
     @property
     def numeric_state_expected(self) -> bool:
-        """Return true if the sensor is numeric."""
+        """Return true if the sensor is expected to be numeric."""
         if (
             self.state_class is not None
             or self.native_unit_of_measurement is not None

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -250,7 +250,7 @@ class SensorEntity(Entity):
     @final
     @property
     def numeric_state_expected(self) -> bool:
-        """Return true if the sensor state must be numeric."""
+        """Return true if the sensor must be numeric."""
         if (
             self.state_class is not None
             or self.native_unit_of_measurement is not None
@@ -259,7 +259,7 @@ class SensorEntity(Entity):
             return True
         device_class: SensorDeviceClass | None = None
         with suppress(ValueError):
-            # Custom device classes are not considered numeric
+            # Sensors with custom device classes are not considered numeric
             device_class = SensorDeviceClass(str(self.device_class))
         return not (device_class is None or device_class in NON_NUMERIC_DEVICE_CLASSES)
 

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -379,6 +379,12 @@ class SensorDeviceClass(StrEnum):
     """
 
 
+NON_NUMERIC_DEVICE_CLASSES = {
+    SensorDeviceClass.DATE,
+    SensorDeviceClass.ENUM,
+    SensorDeviceClass.TIMESTAMP,
+}
+
 DEVICE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.Coerce(SensorDeviceClass))
 
 # DEVICE_CLASSES is deprecated as of 2021.12

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1655,7 +1655,7 @@ async def test_device_classes_with_invalid_state_class(
         (None, None, None, None, False),
     ],
 )
-async def test_is_numeric_helper(
+async def test_numeric_state_expected_helper(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
@@ -1665,7 +1665,7 @@ async def test_is_numeric_helper(
     native_precision: int | None,
     is_numeric: bool,
 ) -> None:
-    """Test is_numeric helper."""
+    """Test numeric_state_expected helper."""
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
@@ -1684,4 +1684,4 @@ async def test_is_numeric_helper(
     state = hass.states.get(entity0.entity_id)
     assert state is not None
 
-    assert entity0.is_numeric is is_numeric
+    assert entity0.numeric_state_expected == is_numeric

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1648,7 +1648,7 @@ async def test_device_classes_with_invalid_state_class(
         (SensorDeviceClass.ENUM, None, None, None, False),
         (SensorDeviceClass.DATE, None, None, None, False),
         (SensorDeviceClass.TIMESTAMP, None, None, None, False),
-        ("custom", None, None, None, True),
+        ("custom", None, None, None, False),
         (SensorDeviceClass.POWER, None, "V", None, True),
         (None, SensorStateClass.MEASUREMENT, None, None, True),
         (None, None, PERCENTAGE, None, True),

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1640,3 +1640,48 @@ async def test_device_classes_with_invalid_state_class(
         "is using state class 'INVALID!' which is impossible considering device "
         f"class ('{device_class}') it is using"
     ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    "device_class,state_class,native_unit_of_measurement,native_precision,is_numeric",
+    [
+        (SensorDeviceClass.ENUM, None, None, None, False),
+        (SensorDeviceClass.DATE, None, None, None, False),
+        (SensorDeviceClass.TIMESTAMP, None, None, None, False),
+        ("custom", None, None, None, True),
+        (SensorDeviceClass.POWER, None, "V", None, True),
+        (None, SensorStateClass.MEASUREMENT, None, None, True),
+        (None, None, PERCENTAGE, None, True),
+        (None, None, None, None, False),
+    ],
+)
+async def test_is_numeric_helper(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+    device_class: SensorDeviceClass | None,
+    state_class: SensorStateClass | None,
+    native_unit_of_measurement: str | None,
+    native_precision: int | None,
+    is_numeric: bool,
+) -> None:
+    """Test is_numeric helper."""
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=None,
+        device_class=device_class,
+        state_class=state_class,
+        native_unit_of_measurement=native_unit_of_measurement,
+        native_precision=native_precision,
+    )
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    entity0 = platform.ENTITIES["0"]
+    state = hass.states.get(entity0.entity_id)
+    assert state is not None
+
+    assert entity0.is_numeric is is_numeric

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1684,4 +1684,4 @@ async def test_numeric_state_expected_helper(
     state = hass.states.get(entity0.entity_id)
     assert state is not None
 
-    assert entity0.numeric_state_expected == is_numeric
+    assert entity0._numeric_state_expected == is_numeric


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `numeric_state_expected` helper property to sensor class. The helper will support integrations to validate if numeric value types are supported. An example is the validation of incoming values for a MQTT sensor. For numeric sensors non numeric values are not accepted as state. See also: #87004

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
