### PR TITLE
Enforce sorting of manifests

### DIFF
--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -395,8 +395,8 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
             if sort_manifest(integration):
                 manifests_resorted.append(integration.manifest_path)
     if manifests_resorted:
-        print("\nManifests have been resorted, running prettier...", flush=True)
         subprocess.run(
             ["pre-commit", "run", "--hook-stage", "manual", "prettier", "--files"]
-            + manifests_resorted
+            + manifests_resorted,
+            stdout=subprocess.DEVNULL,
         )

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -388,3 +388,4 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         validate_manifest(integration, core_components_dir)
         if not integration.errors:
             sort_manifest(integration)
+            integration.add_error("manifest", "Key in the manifest are unsorted")

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -382,4 +382,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         validate_manifest(integration, core_components_dir)
         if not integration.errors:
             sort_manifest(integration)
-            integration.add_error("manifest", "Key in the manifest are unsorted")
+            integration.add_error(
+                "manifest",
+                "Manifest keys have been sorted: domain, name, then alphabetical order",
+            )

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -363,20 +363,14 @@ def validate_manifest(integration: Integration, core_components_dir: Path) -> No
         validate_version(integration)
 
 
-def keyfn(val):
-    match val:  # noqa: E999
-        case "domain":
-            return ".domain"
-        case "name":
-            return ".name"
-        case _:
-            return val
+def _sort_manifest_keys(key: str) -> str:
+    return {"domain": ".domain", "name": ".name"}.get(key, key)
 
 
 def sort_manifest(integration: Integration) -> None:
     """Sort manifest."""
     keys = list(integration.manifest.keys())
-    if (keys_sorted := sorted(keys, key=keyfn)) != keys:
+    if (keys_sorted := sorted(keys, key=_sort_manifest_keys)) != keys:
         manifest = {key: integration.manifest[key] for key in keys_sorted}
         integration.manifest_path.write_text(json.dumps(manifest, indent=2))
 

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -130,6 +130,7 @@ class Integration:
 
     path: pathlib.Path
     _manifest: dict[str, Any] | None = None
+    manifest_path: pathlib.Path | None = None
     errors: list[Error] = field(default_factory=list)
     warnings: list[Error] = field(default_factory=list)
     translated_name: bool = False
@@ -223,3 +224,4 @@ class Integration:
             return
 
         self._manifest = manifest
+        self.manifest_path = manifest_path

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ noqa-require-code = True
 # and probably need to clean up a couple of noqa comments.
 per-file-ignores =
     homeassistant/config.py:NQA102
+    script/hassfest/manifest.py:NQA102
     tests/components/august/mocks.py:NQA102
     tests/components/tts/conftest.py:NQA102
     tests/helpers/test_icon.py:NQA102

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ noqa-require-code = True
 # and probably need to clean up a couple of noqa comments.
 per-file-ignores =
     homeassistant/config.py:NQA102
-    script/hassfest/manifest.py:NQA102
     tests/components/august/mocks.py:NQA102
     tests/components/tts/conftest.py:NQA102
     tests/helpers/test_icon.py:NQA102


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sort manifests:
- domain
- name
- remaining keys alphabetically sorted

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
