### PR TITLE
Fix Yamaha MusicCast zone sleep select entity

### DIFF
--- a/homeassistant/components/yamaha_musiccast/const.py
+++ b/homeassistant/components/yamaha_musiccast/const.py
@@ -55,12 +55,3 @@ TRANSLATION_KEY_MAPPING = {
     "zone_LINK_CONTROL": "zone_link_control",
     "zone_LINK_AUDIO_DELAY": "zone_link_audio_delay",
 }
-
-ZONE_SLEEP_STATE_MAPPING = {
-    "off": "off",
-    "30 min": "30_min",
-    "60 min": "60_min",
-    "90 min": "90_min",
-    "120 min": "120_min",
-}
-STATE_ZONE_SLEEP_MAPPING = {val: key for key, val in ZONE_SLEEP_STATE_MAPPING.items()}

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -3,7 +3,7 @@
   "name": "MusicCast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
-  "requirements": ["aiomusiccast==0.14.4"],
+  "requirements": ["aiomusiccast==0.14.7"],
   "ssdp": [
     {
       "manufacturer": "Yamaha Corporation"

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -9,11 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
-from .const import (
-    STATE_ZONE_SLEEP_MAPPING,
-    TRANSLATION_KEY_MAPPING,
-    ZONE_SLEEP_STATE_MAPPING,
-)
+from .const import TRANSLATION_KEY_MAPPING
 
 
 async def async_setup_entry(
@@ -48,10 +44,6 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Select the given option."""
         value = {val: key for key, val in self.capability.options.items()}[option]
-        # If the translation key is "zone_sleep", we need to translate
-        # Home Assistant state back to the MusicCast value
-        if self.translation_key == "zone_sleep":
-            value = STATE_ZONE_SLEEP_MAPPING[value]
         await self.capability.set(value)
 
     @property
@@ -62,20 +54,9 @@ class SelectableCapapility(MusicCastCapabilityEntity, SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return the list possible options."""
-        # If the translation key is "zone_sleep", we need to translate
-        # the options to make them compatible with Home Assistant
-        if self.translation_key == "zone_sleep":
-            return list(STATE_ZONE_SLEEP_MAPPING)
         return list(self.capability.options.values())
 
     @property
     def current_option(self) -> str | None:
         """Return the currently selected option."""
-        # If the translation key is "zone_sleep", we need to translate
-        # the value to make it compatible with Home Assistant
-        if (
-            value := self.capability.current
-        ) is not None and self.translation_key == "zone_sleep":
-            return ZONE_SLEEP_STATE_MAPPING[value]
-
-        return value
+        return self.capability.options.get(self.capability.current)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -214,7 +214,7 @@ aiolyric==1.0.9
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.4
+aiomusiccast==0.14.7
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -195,7 +195,7 @@ aiolyric==1.0.9
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.4
+aiomusiccast==0.14.7
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes <https://github.com/home-assistant/core/issues/86672>
replaces https://github.com/home-assistant/core/pull/86755

Dependency bump changeset: <https://github.com/vigonotion/aiomusiccast/compare/0.14.4...0.14.7>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86672
- This PR is related to issue: issue caused by #85292
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
