### PR TITLE
Ensure humidity is still exported to HomeKit when it is read-only

### DIFF
--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -153,9 +153,10 @@ class RemoteInputSelectAccessory(HomeAccessory, ABC):
         seen = set()
         sources: list[str] = []
         for source in state.attributes.get(self.source_list_key, []):
-            if source not in seen:
-                sources.append(source)
-            seen.add(source)
+            cleaned_up_source = cleanup_name_for_homekit(source)
+            if cleaned_up_source not in seen:
+                sources.append(cleaned_up_source)
+            seen.add(cleaned_up_source)
         return sources
 
     @abstractmethod

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -153,10 +153,9 @@ class RemoteInputSelectAccessory(HomeAccessory, ABC):
         seen = set()
         sources: list[str] = []
         for source in state.attributes.get(self.source_list_key, []):
-            cleaned_up_source = cleanup_name_for_homekit(source)
-            if cleaned_up_source not in seen:
-                sources.append(cleaned_up_source)
-            seen.add(cleaned_up_source)
+            if source not in seen:
+                sources.append(source)
+            seen.add(source)
         return sources
 
     @abstractmethod

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -188,8 +188,14 @@ class Thermostat(HomeAccessory):
                 (CHAR_COOLING_THRESHOLD_TEMPERATURE, CHAR_HEATING_THRESHOLD_TEMPERATURE)
             )
 
+        if (
+            ATTR_CURRENT_HUMIDITY in attributes
+            or features & ClimateEntityFeature.TARGET_HUMIDITY
+        ):
+            self.chars.append(CHAR_CURRENT_HUMIDITY)
+
         if features & ClimateEntityFeature.TARGET_HUMIDITY:
-            self.chars.extend((CHAR_TARGET_HUMIDITY, CHAR_CURRENT_HUMIDITY))
+            self.chars.append(CHAR_TARGET_HUMIDITY)
 
         serv_thermostat = self.add_preload_service(SERV_THERMOSTAT, self.chars)
         self.set_primary_service(serv_thermostat)
@@ -253,7 +259,6 @@ class Thermostat(HomeAccessory):
                 properties={PROP_MIN_VALUE: hc_min_temp, PROP_MAX_VALUE: hc_max_temp},
             )
         self.char_target_humidity = None
-        self.char_current_humidity = None
         if CHAR_TARGET_HUMIDITY in self.chars:
             self.char_target_humidity = serv_thermostat.configure_char(
                 CHAR_TARGET_HUMIDITY,
@@ -265,6 +270,8 @@ class Thermostat(HomeAccessory):
                 # of 0-80%
                 properties={PROP_MIN_VALUE: min_humidity},
             )
+        self.char_current_humidity = None
+        if CHAR_CURRENT_HUMIDITY in self.chars:
             self.char_current_humidity = serv_thermostat.configure_char(
                 CHAR_CURRENT_HUMIDITY, value=50
             )

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -742,6 +742,29 @@ async def test_thermostat_humidity(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "35%"
 
 
+async def test_thermostat_humidity_with_target_humidity(hass, hk_driver, events):
+    """Test if accessory and HA are updated accordingly with humidity without target hudmidity.
+
+    This test is for thermostats that do not support target humidity but
+    have a current humidity sensor.
+    """
+    entity_id = "climate.test"
+
+    # support_auto = True
+    hass.states.async_set(entity_id, HVACMode.OFF, {ATTR_CURRENT_HUMIDITY: 40})
+    await hass.async_block_till_done()
+    acc = Thermostat(hass, hk_driver, "Climate", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    await acc.run()
+    await hass.async_block_till_done()
+
+    assert acc.char_current_humidity.value == 40
+    hass.states.async_set(entity_id, HVACMode.HEAT_COOL, {ATTR_CURRENT_HUMIDITY: 65})
+    await hass.async_block_till_done()
+    assert acc.char_current_humidity.value == 65
+
+
 async def test_thermostat_power_state(hass, hk_driver, events):
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We would only send humidity to HomeKit if the device supported changing the humidity.  We should always send it if the device has a valid humidity value.

I had a device that had the issue so this one was super easy to test the fix:

before
<img width="516" alt="Screenshot 2023-01-31 at 5 08 10 PM" src="https://user-images.githubusercontent.com/663432/215906943-1bf4d86f-b223-41b2-8c94-0858525e75a3.png">

after
<img width="500" alt="Screenshot 2023-01-31 at 5 23 41 PM" src="https://user-images.githubusercontent.com/663432/215906949-7dd4c590-8e1c-46a9-bda3-e8353e32a94e.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86927
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
