### PR TITLE
Add author metadata for blueprints

### DIFF
--- a/homeassistant/components/automation/blueprints/motion_light.yaml
+++ b/homeassistant/components/automation/blueprints/motion_light.yaml
@@ -3,6 +3,7 @@ blueprint:
   description: Turn on a light when motion is detected.
   domain: automation
   source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/motion_light.yaml
+  author: Home Assistant
   input:
     motion_entity:
       name: Motion Sensor

--- a/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
+++ b/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
@@ -3,6 +3,7 @@ blueprint:
   description: Send a notification to a device when a person leaves a specific zone.
   domain: automation
   source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
+  author: Home Assistant
   input:
     person_entity:
       name: Person

--- a/homeassistant/components/blueprint/const.py
+++ b/homeassistant/components/blueprint/const.py
@@ -7,5 +7,6 @@ CONF_INPUT = "input"
 CONF_SOURCE_URL = "source_url"
 CONF_HOMEASSISTANT = "homeassistant"
 CONF_MIN_VERSION = "min_version"
+CONF_AUTHOR = "author"
 
 DOMAIN = "blueprint"

--- a/homeassistant/components/blueprint/schemas.py
+++ b/homeassistant/components/blueprint/schemas.py
@@ -15,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, selector
 
 from .const import (
+    CONF_AUTHOR,
     CONF_BLUEPRINT,
     CONF_HOMEASSISTANT,
     CONF_INPUT,
@@ -73,6 +74,7 @@ BLUEPRINT_SCHEMA = vol.Schema(
                 vol.Optional(CONF_DESCRIPTION): str,
                 vol.Required(CONF_DOMAIN): str,
                 vol.Optional(CONF_SOURCE_URL): cv.url,
+                vol.Optional(CONF_AUTHOR): str,
                 vol.Optional(CONF_HOMEASSISTANT): {
                     vol.Optional(CONF_MIN_VERSION): version_validator
                 },

--- a/homeassistant/components/script/blueprints/confirmable_notification.yaml
+++ b/homeassistant/components/script/blueprints/confirmable_notification.yaml
@@ -5,6 +5,7 @@ blueprint:
     running the specified action.
   domain: script
   source_url: https://github.com/home-assistant/core/blob/master/homeassistant/components/script/blueprints/confirmable_notification.yaml
+  author: Home Assistant
   input:
     notify_device:
       name: Device to notify


### PR DESCRIPTION
## Proposed change

Following front-end PR (https://github.com/home-assistant/frontend/pull/15286), this PR adds support for blueprint author metadata.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
