### PR TITLE
Use try_parse_enum in integrations

### DIFF
--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -1,7 +1,6 @@
 """Support for Abode Security System binary sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import cast
 
 from jaraco.abode.devices.sensor import BinarySensor as ABBinarySensor
@@ -14,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import AbodeDevice, AbodeSystem
 from .const import DOMAIN
@@ -54,6 +54,4 @@ class AbodeBinarySensor(AbodeDevice, BinarySensorEntity):
         """Return the class of the binary sensor."""
         if self._device.get_value("is_window") == "1":
             return BinarySensorDeviceClass.WINDOW
-        with suppress(ValueError):
-            return BinarySensorDeviceClass(cast(str, self._device.generic_type))
-        return None
+        return try_parse_enum(BinarySensorDeviceClass, self._device.generic_type)

--- a/homeassistant/components/dynalite/cover.py
+++ b/homeassistant/components/dynalite/cover.py
@@ -1,6 +1,5 @@
 """Support for the Dynalite channels as covers."""
 
-from contextlib import suppress
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -11,6 +10,7 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from .dynalitebase import DynaliteBase, async_setup_entry_base
 
@@ -39,10 +39,8 @@ class DynaliteCover(DynaliteBase, CoverEntity):
     @property
     def device_class(self) -> CoverDeviceClass:
         """Return the class of the device."""
-        if device_class := self._device.device_class:
-            with suppress(ValueError):
-                return CoverDeviceClass(device_class)
-        return CoverDeviceClass.SHUTTER
+        device_class = try_parse_enum(CoverDeviceClass, self._device.device_class)
+        return device_class or CoverDeviceClass.SHUTTER
 
     @property
     def current_cover_position(self) -> int:

--- a/homeassistant/components/esphome/binary_sensor.py
+++ b/homeassistant/components/esphome/binary_sensor.py
@@ -1,8 +1,6 @@
 """Support for ESPHome binary sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
-
 from aioesphomeapi import BinarySensorInfo, BinarySensorState
 
 from homeassistant.components.binary_sensor import (
@@ -12,6 +10,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import EsphomeEntity, platform_async_setup_entry
 
@@ -52,9 +51,7 @@ class EsphomeBinarySensor(
     @property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        with suppress(ValueError):
-            return BinarySensorDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(BinarySensorDeviceClass, self._static_info.device_class)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/esphome/button.py
+++ b/homeassistant/components/esphome/button.py
@@ -1,14 +1,13 @@
 """Support for ESPHome buttons."""
 from __future__ import annotations
 
-from contextlib import suppress
-
 from aioesphomeapi import ButtonInfo, EntityState
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import EsphomeEntity, platform_async_setup_entry
 
@@ -34,9 +33,7 @@ class EsphomeButton(EsphomeEntity[ButtonInfo, EntityState], ButtonEntity):
     @property
     def device_class(self) -> ButtonDeviceClass | None:
         """Return the class of this entity."""
-        with suppress(ValueError):
-            return ButtonDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(ButtonDeviceClass, self._static_info.device_class)
 
     @callback
     def _on_device_update(self) -> None:

--- a/homeassistant/components/esphome/cover.py
+++ b/homeassistant/components/esphome/cover.py
@@ -1,7 +1,6 @@
 """Support for ESPHome covers."""
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import Any
 
 from aioesphomeapi import CoverInfo, CoverOperation, CoverState
@@ -16,6 +15,7 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
@@ -57,9 +57,7 @@ class EsphomeCover(EsphomeEntity[CoverInfo, CoverState], CoverEntity):
     @property
     def device_class(self) -> CoverDeviceClass | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        with suppress(ValueError):
-            return CoverDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(CoverDeviceClass, self._static_info.device_class)
 
     @property
     def assumed_state(self) -> bool:

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -1,7 +1,6 @@
 """Support for esphome numbers."""
 from __future__ import annotations
 
-from contextlib import suppress
 import math
 
 from aioesphomeapi import NumberInfo, NumberMode as EsphomeNumberMode, NumberState
@@ -10,6 +9,7 @@ from homeassistant.components.number import NumberDeviceClass, NumberEntity, Num
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import (
     EsphomeEntity,
@@ -51,9 +51,7 @@ class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     @property
     def device_class(self) -> NumberDeviceClass | None:
         """Return the class of this entity."""
-        with suppress(ValueError):
-            return NumberDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(NumberDeviceClass, self._static_info.device_class)
 
     @property
     def native_min_value(self) -> float:

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -1,7 +1,6 @@
 """Support for esphome sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
 from datetime import datetime
 import math
 
@@ -23,6 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt
+from homeassistant.util.enum import try_parse_enum
 
 from . import (
     EsphomeEntity,
@@ -98,9 +98,7 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        with suppress(ValueError):
-            return SensorDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(SensorDeviceClass, self._static_info.device_class)
 
     @property
     def state_class(self) -> SensorStateClass | None:

--- a/homeassistant/components/esphome/switch.py
+++ b/homeassistant/components/esphome/switch.py
@@ -1,7 +1,6 @@
 """Support for ESPHome switches."""
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import Any
 
 from aioesphomeapi import SwitchInfo, SwitchState
@@ -10,6 +9,7 @@ from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.enum import try_parse_enum
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
@@ -46,9 +46,7 @@ class EsphomeSwitch(EsphomeEntity[SwitchInfo, SwitchState], SwitchEntity):
     @property
     def device_class(self) -> SwitchDeviceClass | None:
         """Return the class of this device."""
-        with suppress(ValueError):
-            return SwitchDeviceClass(self._static_info.device_class)
-        return None
+        return try_parse_enum(SwitchDeviceClass, self._static_info.device_class)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -1,7 +1,6 @@
 """Support for KNX/IP sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import Any
 
 from xknx import XKNX
@@ -23,6 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, StateType
+from homeassistant.util.enum import try_parse_enum
 
 from .const import ATTR_SOURCE, DATA_KNX_CONFIG, DOMAIN
 from .knx_entity import KnxEntity
@@ -64,10 +64,10 @@ class KNXSensor(KnxEntity, SensorEntity):
         if device_class := config.get(CONF_DEVICE_CLASS):
             self._attr_device_class = device_class
         else:
-            with suppress(ValueError):
-                self._attr_device_class = SensorDeviceClass(
-                    str(self._device.ha_device_class())
-                )
+            self._attr_device_class = try_parse_enum(
+                SensorDeviceClass, self._device.ha_device_class()
+            )
+
         self._attr_force_update = self._device.always_callback
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.sensor_value.group_address_state)

--- a/homeassistant/components/onvif/binary_sensor.py
+++ b/homeassistant/components/onvif/binary_sensor.py
@@ -1,8 +1,6 @@
 """Support for ONVIF binary sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
-
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -13,6 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.enum import try_parse_enum
 
 from .base import ONVIFBaseEntity
 from .const import DOMAIN
@@ -66,21 +65,17 @@ class ONVIFBinarySensor(ONVIFBaseEntity, RestoreEntity, BinarySensorEntity):
         """Initialize the ONVIF binary sensor."""
         self._attr_unique_id = uid
         if entry is not None:
-            if entry.original_device_class:
-                with suppress(ValueError):
-                    self._attr_device_class = BinarySensorDeviceClass(
-                        entry.original_device_class
-                    )
+            self._attr_device_class = try_parse_enum(
+                BinarySensorDeviceClass, entry.original_device_class
+            )
             self._attr_entity_category = entry.entity_category
             self._attr_name = entry.name
         else:
             event = device.events.get_uid(uid)
             assert event
-            if event.device_class:
-                with suppress(ValueError):
-                    self._attr_device_class = BinarySensorDeviceClass(
-                        event.device_class
-                    )
+            self._attr_device_class = try_parse_enum(
+                BinarySensorDeviceClass, event.device_class
+            )
             self._attr_entity_category = event.entity_category
             self._attr_entity_registry_enabled_default = event.entity_enabled
             self._attr_name = f"{device.name} {event.name}"

--- a/homeassistant/components/onvif/sensor.py
+++ b/homeassistant/components/onvif/sensor.py
@@ -1,7 +1,6 @@
 """Support for ONVIF binary sensors."""
 from __future__ import annotations
 
-from contextlib import suppress
 from datetime import date, datetime
 from decimal import Decimal
 
@@ -11,6 +10,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
+from homeassistant.util.enum import try_parse_enum
 
 from .base import ONVIFBaseEntity
 from .const import DOMAIN
@@ -59,20 +59,18 @@ class ONVIFSensor(ONVIFBaseEntity, RestoreSensor):
         """Initialize the ONVIF binary sensor."""
         self._attr_unique_id = uid
         if entry is not None:
-            if entry.original_device_class:
-                with suppress(ValueError):
-                    self._attr_device_class = SensorDeviceClass(
-                        entry.original_device_class
-                    )
+            self._attr_device_class = try_parse_enum(
+                SensorDeviceClass, entry.original_device_class
+            )
             self._attr_entity_category = entry.entity_category
             self._attr_name = entry.name
             self._attr_native_unit_of_measurement = entry.unit_of_measurement
         else:
             event = device.events.get_uid(uid)
             assert event
-            if event.device_class:
-                with suppress(ValueError):
-                    self._attr_device_class = SensorDeviceClass(event.device_class)
+            self._attr_device_class = try_parse_enum(
+                SensorDeviceClass, event.device_class
+            )
             self._attr_entity_category = event.entity_category
             self._attr_entity_registry_enabled_default = event.entity_enabled
             self._attr_name = f"{device.name} {event.name}"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87082

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
