### PR TITLE
Reduce required permissions for fritzbox_callmonitor

### DIFF
--- a/homeassistant/components/fritzbox_callmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_callmonitor/config_flow.py
@@ -5,7 +5,6 @@ from typing import Any, cast
 
 from fritzconnection import FritzConnection
 from fritzconnection.core.exceptions import FritzConnectionException, FritzSecurityError
-from fritzconnection.lib.fritzstatus import FritzStatus
 from requests.exceptions import ConnectionError as RequestsConnectionError
 import voluptuous as vol
 
@@ -31,6 +30,7 @@ from .const import (
     DEFAULT_USERNAME,
     DOMAIN,
     FRITZ_ATTR_NAME,
+    FRITZ_ATTR_SERIAL_NUMBER,
     SERIAL_NUMBER,
 )
 
@@ -102,9 +102,8 @@ class FritzBoxCallMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             fritz_connection = FritzConnection(
                 address=self._host, user=self._username, password=self._password
             )
-            fritz_status = FritzStatus(fc=fritz_connection)
-            device_info = fritz_status.get_device_info()
-            self._serial_number = device_info.serial_number
+            info = fritz_connection.updatecheck
+            self._serial_number = info[FRITZ_ATTR_SERIAL_NUMBER]
 
             return ConnectResult.SUCCESS
         except RequestsConnectionError:

--- a/homeassistant/components/fritzbox_callmonitor/const.py
+++ b/homeassistant/components/fritzbox_callmonitor/const.py
@@ -19,7 +19,7 @@ ICON_PHONE: Final = "mdi:phone"
 ATTR_PREFIXES = "prefixes"
 
 FRITZ_ATTR_NAME = "name"
-FRITZ_ATTR_SERIAL_NUMBER = "NewSerialNumber"
+FRITZ_ATTR_SERIAL_NUMBER = "Serial"
 
 UNKNOWN_NAME = "unknown"
 SERIAL_NUMBER = "serial_number"

--- a/tests/components/fritzbox_callmonitor/test_config_flow.py
+++ b/tests/components/fritzbox_callmonitor/test_config_flow.py
@@ -8,7 +8,6 @@ from fritzconnection.core.exceptions import (
     FritzConnectionException,
     FritzSecurityError,
 )
-from fritzconnection.lib.fritztools import ArgumentNamespace
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -18,7 +17,6 @@ from homeassistant.components.fritzbox_callmonitor.const import (
     CONF_PREFIXES,
     DOMAIN,
     FRITZ_ATTR_NAME,
-    FRITZ_ATTR_SERIAL_NUMBER,
     SERIAL_NUMBER,
 )
 from homeassistant.config_entries import SOURCE_USER
@@ -66,7 +64,20 @@ MOCK_YAML_CONFIG = {
     CONF_PHONEBOOK: MOCK_PHONEBOOK_ID,
     CONF_NAME: MOCK_NAME,
 }
-MOCK_DEVICE_INFO = ArgumentNamespace({FRITZ_ATTR_SERIAL_NUMBER: MOCK_SERIAL_NUMBER})
+MOCK_DEVICE_INFO = {
+    "Name": "FRITZ!Box 7590",
+    "HW": "226",
+    "Version": "100.01.01",
+    "Revision": "10000",
+    "Serial": MOCK_SERIAL_NUMBER,
+    "OEM": "avm",
+    "Lang": "de",
+    "Annex": "B",
+    "Lab": None,
+    "Country": "049",
+    "Flag": "mesh_master",
+    "UpdateConfig": "2",
+}
 MOCK_PHONEBOOK_INFO_1 = {FRITZ_ATTR_NAME: MOCK_PHONEBOOK_NAME_1}
 MOCK_PHONEBOOK_INFO_2 = {FRITZ_ATTR_NAME: MOCK_PHONEBOOK_NAME_2}
 MOCK_UNIQUE_ID = f"{MOCK_SERIAL_NUMBER}-{MOCK_PHONEBOOK_ID}"
@@ -98,10 +109,8 @@ async def test_setup_one_phonebook(hass: HomeAssistant) -> None:
         "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.__init__",
         return_value=None,
     ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzStatus.__init__",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzStatus.get_device_info",
+        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.updatecheck",
+        new_callable=PropertyMock,
         return_value=MOCK_DEVICE_INFO,
     ), patch(
         "homeassistant.components.fritzbox_callmonitor.async_setup_entry",
@@ -137,10 +146,8 @@ async def test_setup_multiple_phonebooks(hass: HomeAssistant) -> None:
         "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.__init__",
         return_value=None,
     ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzStatus.__init__",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzStatus.get_device_info",
+        "homeassistant.components.fritzbox_callmonitor.config_flow.FritzConnection.updatecheck",
+        new_callable=PropertyMock,
         return_value=MOCK_DEVICE_INFO,
     ), patch(
         "homeassistant.components.fritzbox_callmonitor.base.FritzPhonebook.phonebook_info",


### PR DESCRIPTION
## Proposed change
`fritzconnection` version `1.11.0` added a new option to retrieve the device serial number which doesn't require any permissions. Previously settings access was required.

https://github.com/kbr/fritzconnection/compare/1.10.3...1.11.0
_Library was updated in #79434_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26048

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
