### PR TITLE
Ignore TAI8570 errors in onewire

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -9,6 +9,8 @@ import os
 from types import MappingProxyType
 from typing import Any
 
+from pyownet import protocol
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -419,6 +421,17 @@ def get_entities(
                 override_key or description.key,
             )
             name = f"{device_id} {description.name}"
+            if family == "12":
+                # We need to check if there is TAI8570 plugged in
+                try:
+                    onewire_hub.owproxy.read(device_file)
+                except protocol.OwnetError as err:
+                    _LOGGER.debug(
+                        "Ignoring unreachable sensor %s",
+                        device_file,
+                        exc_info=err,
+                    )
+                    continue
             entities.append(
                 OneWireSensor(
                     description=description,

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -178,5 +178,9 @@ def _setup_owproxy_mock_device_reads(
 
     # Setup sub-device reads
     device_sensors = mock_device.get(platform, [])
+    if platform is Platform.SENSOR and device_id.startswith("12"):
+        # We need to check if there is TAI8570 plugged in
+        for expected_sensor in device_sensors:
+            sub_read_side_effect.append(expected_sensor[ATTR_INJECT_READS])
     for expected_sensor in device_sensors:
         sub_read_side_effect.append(expected_sensor[ATTR_INJECT_READS])

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -1,12 +1,14 @@
 """Tests for 1-Wire sensors."""
 from collections.abc import Generator
+from copy import deepcopy
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, _patch_dict, patch
 
+from pyownet.protocol import OwnetError
 import pytest
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_validation import ensure_list
 
@@ -16,7 +18,12 @@ from . import (
     check_entities,
     setup_owproxy_mock_devices,
 )
-from .const import ATTR_DEVICE_INFO, ATTR_UNKNOWN_DEVICE, MOCK_OWPROXY_DEVICES
+from .const import (
+    ATTR_DEVICE_INFO,
+    ATTR_INJECT_READS,
+    ATTR_UNKNOWN_DEVICE,
+    MOCK_OWPROXY_DEVICES,
+)
 
 from tests.common import mock_device_registry, mock_registry
 
@@ -68,3 +75,31 @@ async def test_sensors(
     await hass.async_block_till_done()
 
     check_entities(hass, entity_registry, expected_entities)
+
+
+@pytest.mark.parametrize("device_id", ["12.111111111111"])
+async def test_tai8570_sensors(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+) -> None:
+    """The DS2602 is often used without TAI8570.
+
+    The sensors should be ignored.
+    """
+    entity_registry = mock_registry(hass)
+
+    mock_devices = deepcopy(MOCK_OWPROXY_DEVICES)
+    mock_device = mock_devices[device_id]
+    mock_device[ATTR_INJECT_READS].append(OwnetError)
+    mock_device[ATTR_INJECT_READS].append(OwnetError)
+
+    with _patch_dict(MOCK_OWPROXY_DEVICES, mock_devices):
+        setup_owproxy_mock_devices(owproxy, Platform.SENSOR, [device_id])
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    expected_entities = mock_device[Platform.SENSOR]
+    for expected_entity in expected_entities:
+        entity_id = expected_entity[ATTR_ENTITY_ID]
+        registry_entry = entity_registry.entities.get(entity_id)
+        assert registry_entry is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is quite common to use a DS2406 without TAI8570 attached.
Currently, this throws errors in the logs at startup even if the sensors are not enabled.

```console
Failure to read server value, got: [Errno 2] legacy - No such entity: '/12.C88D61000000/TAI8570/temperature'
Failure to read server value, got: [Errno 2] legacy - No such entity: '/12.C88D61000000/TAI8570/pressure'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81452
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
