### PR TITLE
Refactor onewire options flow

### DIFF
--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -148,7 +148,7 @@ class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
         if user_input is not None:
             if user_input.get(INPUT_ENTRY_CLEAR_OPTIONS):
                 # Reset all options
-                return self.async_create_entry(title="", data={})
+                return self.async_create_entry(data={})
 
             selected_devices: list[str] = (
                 user_input.get(INPUT_ENTRY_DEVICE_SELECTION) or []
@@ -193,7 +193,7 @@ class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
             self._update_device_options(user_input)
             if self.devices_to_configure:
                 return await self.async_step_configure_device(user_input=None)
-            return self.async_create_entry(title="", data=self.options)
+            return self.async_create_entry(data=self.options)
 
         self.current_device, onewire_id = self.devices_to_configure.popitem()
         data_schema = vol.Schema(

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -129,10 +129,10 @@ class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
         device_registry = dr.async_get(self.hass)
         self.configurable_devices = {
             self._get_device_friendly_name(device, device.name): device.name
-            for device in device_registry.devices.values()
-            if self.config_entry.entry_id in device.config_entries
-            and device.name
-            and device.name[0:2] in DEVICE_SUPPORT_OPTIONS
+            for device in dr.async_entries_for_config_entry(
+                device_registry, self.config_entry.entry_id
+            )
+            if device.name and device.name[0:2] in DEVICE_SUPPORT_OPTIONS
         }
 
         if not self.configurable_devices:

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -5,12 +5,17 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlow,
+    OptionsFlowWithConfigEntry,
+)
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv, device_registry as dr
-from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import (
     DEFAULT_HOST,
@@ -23,7 +28,6 @@ from .const import (
     OPTION_ENTRY_SENSOR_PRECISION,
     PRECISION_MAPPING_FAMILY_28,
 )
-from .model import OWDeviceDescription
 from .onewirehub import CannotConnect, OneWireHub
 
 DATA_SCHEMA = vol.Schema(
@@ -101,32 +105,39 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
         return OnewireOptionsFlowHandler(config_entry)
 
 
-class OnewireOptionsFlowHandler(OptionsFlow):
+class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
     """Handle OneWire Config options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize OneWire Network options flow."""
-        self.entry_id = config_entry.entry_id
-        self.options = dict(config_entry.options)
-        self.configurable_devices: dict[str, OWDeviceDescription] = {}
-        self.devices_to_configure: dict[str, OWDeviceDescription] = {}
-        self.current_device: str = ""
+    configurable_devices: dict[str, str]
+    """Mapping of the configurable devices.
+
+        `key`: friendly name
+        `value`: onewire id
+    """
+    devices_to_configure: dict[str, str]
+    """Mapping of the devices selected for configuration.
+
+        `key`: friendly name
+        `value`: onewire id
+    """
+    current_device: str
+    """Friendly name of the currently selected device."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
-        controller: OneWireHub = self.hass.data[DOMAIN][self.entry_id]
-        all_devices: list[OWDeviceDescription] = controller.devices  # type: ignore[assignment]
-        if not all_devices:
-            return self.async_abort(reason="No configurable devices found.")
-
         device_registry = dr.async_get(self.hass)
         self.configurable_devices = {
-            self._get_device_long_name(device_registry, device.id): device
-            for device in all_devices
-            if device.family in DEVICE_SUPPORT_OPTIONS
+            self._get_device_friendly_name(device, device.name): device.name
+            for device in device_registry.devices.values()
+            if self.config_entry.entry_id in device.config_entries
+            and device.name
+            and device.name[0:2] in DEVICE_SUPPORT_OPTIONS
         }
+
+        if not self.configurable_devices:
+            return self.async_abort(reason="No configurable devices found.")
 
         return await self.async_step_device_selection(user_input=None)
 
@@ -138,16 +149,15 @@ class OnewireOptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             if user_input.get(INPUT_ENTRY_CLEAR_OPTIONS):
                 # Reset all options
-                self.options = {}
-                return self._async_update_options()
+                return self.async_create_entry(title="", data={})
 
-            selected_devices: list[str] = (
-                user_input.get(INPUT_ENTRY_DEVICE_SELECTION) or []
+            selected_devices: list[str] = user_input.get(
+                INPUT_ENTRY_DEVICE_SELECTION, []
             )
             if selected_devices:
                 self.devices_to_configure = {
-                    device_name: self.configurable_devices[device_name]
-                    for device_name in selected_devices
+                    friendly_name: self.configurable_devices[friendly_name]
+                    for friendly_name in selected_devices
                 }
 
                 return await self.async_step_configure_device(user_input=None)
@@ -166,7 +176,10 @@ class OnewireOptionsFlowHandler(OptionsFlow):
                         default=self._get_current_configured_sensors(),
                         description="Multiselect with list of devices to choose from",
                     ): cv.multi_select(
-                        {device: False for device in self.configurable_devices}
+                        {
+                            friendly_name: False
+                            for friendly_name in self.configurable_devices
+                        }
                     ),
                 }
             ),
@@ -181,15 +194,15 @@ class OnewireOptionsFlowHandler(OptionsFlow):
             self._update_device_options(user_input)
             if self.devices_to_configure:
                 return await self.async_step_configure_device(user_input=None)
-            return self._async_update_options()
+            return self.async_create_entry(title="", data=self.options)
 
-        self.current_device, description = self.devices_to_configure.popitem()
+        self.current_device, onewire_id = self.devices_to_configure.popitem()
         data_schema = vol.Schema(
             {
                 vol.Required(
                     OPTION_ENTRY_SENSOR_PRECISION,
                     default=self._get_current_setting(
-                        description.id, OPTION_ENTRY_SENSOR_PRECISION, "temperature"
+                        onewire_id, OPTION_ENTRY_SENSOR_PRECISION, "temperature"
                     ),
                 ): vol.In(PRECISION_MAPPING_FAMILY_28),
             }
@@ -201,19 +214,11 @@ class OnewireOptionsFlowHandler(OptionsFlow):
             description_placeholders={"sensor_id": self.current_device},
         )
 
-    @callback
-    def _async_update_options(self) -> FlowResult:
-        """Update config entry options."""
-        return self.async_create_entry(title="", data=self.options)
-
     @staticmethod
-    def _get_device_long_name(
-        device_registry: DeviceRegistry, current_device: str
-    ) -> str:
-        device = device_registry.async_get_device({(DOMAIN, current_device)})
-        if device and device.name_by_user:
-            return f"{device.name_by_user} ({current_device})"
-        return current_device
+    def _get_device_friendly_name(entry: DeviceEntry, onewire_id: str) -> str:
+        if entry.name_by_user:
+            return f"{entry.name_by_user} ({onewire_id})"
+        return onewire_id
 
     def _get_current_configured_sensors(self) -> list[str]:
         """Get current list of sensors that are configured."""
@@ -221,9 +226,9 @@ class OnewireOptionsFlowHandler(OptionsFlow):
         if not configured_sensors:
             return []
         return [
-            device_name
-            for device_name, description in self.configurable_devices.items()
-            if description.id in configured_sensors
+            friendly_name
+            for friendly_name, onewire_id in self.configurable_devices.items()
+            if onewire_id in configured_sensors
         ]
 
     def _get_current_setting(self, device_id: str, setting: str, default: Any) -> Any:
@@ -239,9 +244,9 @@ class OnewireOptionsFlowHandler(OptionsFlow):
             OPTION_ENTRY_DEVICE_OPTIONS, {}
         )
 
-        description = self.configurable_devices[self.current_device]
-        device_options: dict[str, Any] = options.setdefault(description.id, {})
-        if description.family == "28":
+        onewire_id = self.configurable_devices[self.current_device]
+        device_options: dict[str, Any] = options.setdefault(onewire_id, {})
+        if onewire_id[0:2] == "28":
             device_options[OPTION_ENTRY_SENSOR_PRECISION] = user_input[
                 OPTION_ENTRY_SENSOR_PRECISION
             ]

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
-    OptionsFlow,
     OptionsFlowWithConfigEntry,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -100,7 +99,7 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OnewireOptionsFlowHandler:
         """Get the options flow for this handler."""
         return OnewireOptionsFlowHandler(config_entry)
 
@@ -151,8 +150,8 @@ class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 # Reset all options
                 return self.async_create_entry(title="", data={})
 
-            selected_devices: list[str] = user_input.get(
-                INPUT_ENTRY_DEVICE_SELECTION, []
+            selected_devices: list[str] = (
+                user_input.get(INPUT_ENTRY_DEVICE_SELECTION) or []
             )
             if selected_devices:
                 self.devices_to_configure = {

--- a/tests/components/onewire/test_options_flow.py
+++ b/tests/components/onewire/test_options_flow.py
@@ -9,11 +9,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_owproxy_mock_devices
 from .const import MOCK_OWPROXY_DEVICES
-
-from tests.common import mock_device_registry
 
 
 class FakeDevice:
@@ -135,14 +134,15 @@ async def test_user_options_set_multiple(
     )
 
     # Initialize onewire hub
-    device_registry = mock_device_registry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     # Verify that first config step comes back with a selection list of all the 28-family devices
-    for entry in device_registry.devices.values():
-        if config_entry.entry_id in entry.config_entries:
-            device_registry.async_update_device(entry.id, name_by_user="Given Name")
+    device_registry = dr.async_get(hass)
+    for entry in dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    ):
+        device_registry.async_update_device(entry.id, name_by_user="Given Name")
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["data_schema"].schema["device_selection"].options == {
         "Given Name (28.111111111111)": False,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor onewire options flow:
- inherit `OptionsFlowWithConfigEntry`
- get device list from `device_registry` instead of `hass.data`
- rename variables to `friendly_name` / `onewire_id` when accessing the dict items

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
