### PR TITLE
Fix statistics graphs not loading with data_rate, electric_current, voltage, information, and unitless units

### DIFF
--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -15,13 +15,18 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import JSON_DUMP
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import (
+    DataRateConverter,
     DistanceConverter,
+    ElectricCurrentConverter,
+    ElectricPotentialConverter,
     EnergyConverter,
+    InformationConverter,
     MassConverter,
     PowerConverter,
     PressureConverter,
     SpeedConverter,
     TemperatureConverter,
+    UnitlessRatioConverter,
     VolumeConverter,
 )
 
@@ -95,13 +100,20 @@ def _ws_get_statistic_during_period(
         ),
         vol.Optional("units"): vol.Schema(
             {
+                vol.Optional("data_rate"): vol.In(DataRateConverter.VALID_UNITS),
                 vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
+                vol.Optional("electric_current"): vol.In(
+                    ElectricCurrentConverter.VALID_UNITS
+                ),
+                vol.Optional("voltage"): vol.In(ElectricPotentialConverter.VALID_UNITS),
                 vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
+                vol.Optional("information"): vol.In(InformationConverter.VALID_UNITS),
                 vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
                 vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
                 vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
                 vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
                 vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
+                vol.Optional("unitless"): vol.In(UnitlessRatioConverter.VALID_UNITS),
                 vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
             }
         ),

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -52,6 +52,24 @@ from .util import (
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+UNIT_SCHEMA = vol.Schema(
+    {
+        vol.Optional("data_rate"): vol.In(DataRateConverter.VALID_UNITS),
+        vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
+        vol.Optional("electric_current"): vol.In(ElectricCurrentConverter.VALID_UNITS),
+        vol.Optional("voltage"): vol.In(ElectricPotentialConverter.VALID_UNITS),
+        vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
+        vol.Optional("information"): vol.In(InformationConverter.VALID_UNITS),
+        vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
+        vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
+        vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
+        vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
+        vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
+        vol.Optional("unitless"): vol.In(UnitlessRatioConverter.VALID_UNITS),
+        vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
+    }
+)
+
 
 @callback
 def async_setup(hass: HomeAssistant) -> None:
@@ -98,25 +116,7 @@ def _ws_get_statistic_during_period(
         vol.Optional("types"): vol.All(
             [vol.Any("max", "mean", "min", "change")], vol.Coerce(set)
         ),
-        vol.Optional("units"): vol.Schema(
-            {
-                vol.Optional("data_rate"): vol.In(DataRateConverter.VALID_UNITS),
-                vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
-                vol.Optional("electric_current"): vol.In(
-                    ElectricCurrentConverter.VALID_UNITS
-                ),
-                vol.Optional("voltage"): vol.In(ElectricPotentialConverter.VALID_UNITS),
-                vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
-                vol.Optional("information"): vol.In(InformationConverter.VALID_UNITS),
-                vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
-                vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
-                vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
-                vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
-                vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
-                vol.Optional("unitless"): vol.In(UnitlessRatioConverter.VALID_UNITS),
-                vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
-            }
-        ),
+        vol.Optional("units"): UNIT_SCHEMA,
         **PERIOD_SCHEMA.schema,
     }
 )
@@ -223,18 +223,7 @@ async def ws_handle_get_statistics_during_period(
         vol.Optional("end_time"): str,
         vol.Optional("statistic_ids"): [str],
         vol.Required("period"): vol.Any("5minute", "hour", "day", "week", "month"),
-        vol.Optional("units"): vol.Schema(
-            {
-                vol.Optional("distance"): vol.In(DistanceConverter.VALID_UNITS),
-                vol.Optional("energy"): vol.In(EnergyConverter.VALID_UNITS),
-                vol.Optional("mass"): vol.In(MassConverter.VALID_UNITS),
-                vol.Optional("power"): vol.In(PowerConverter.VALID_UNITS),
-                vol.Optional("pressure"): vol.In(PressureConverter.VALID_UNITS),
-                vol.Optional("speed"): vol.In(SpeedConverter.VALID_UNITS),
-                vol.Optional("temperature"): vol.In(TemperatureConverter.VALID_UNITS),
-                vol.Optional("volume"): vol.In(VolumeConverter.VALID_UNITS),
-            }
-        ),
+        vol.Optional("units"): UNIT_SCHEMA,
         vol.Optional("types"): vol.All(
             [vol.Any("last_reset", "max", "mean", "min", "state", "sum")],
             vol.Coerce(set),


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing converters to the `recorder/statistics_during_period` API schema

This was resulting in the stats graphs not loading on the frontend

related issue #87137


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
