### PR TITLE
Allow workday binary_sensor to be configured without a country.

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -60,7 +60,7 @@ def valid_country(value: Any) -> str:
 
 PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_COUNTRY): valid_country,
+        vol.Optional(CONF_COUNTRY): valid_country,
         vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES): vol.All(
             cv.ensure_list, [vol.In(ALLOWED_DAYS)]
         ),
@@ -89,7 +89,7 @@ def setup_platform(
     """Set up the Workday sensor."""
     add_holidays: list[DateLike] = config[CONF_ADD_HOLIDAYS]
     remove_holidays: list[str] = config[CONF_REMOVE_HOLIDAYS]
-    country: str = config[CONF_COUNTRY]
+    country: str | None = config.get(CONF_COUNTRY)
     days_offset: int = config[CONF_OFFSET]
     excludes: list[str] = config[CONF_EXCLUDES]
     province: str | None = config.get(CONF_PROVINCE)
@@ -97,9 +97,16 @@ def setup_platform(
     workdays: list[str] = config[CONF_WORKDAYS]
 
     year: int = (get_date(dt.now()) + timedelta(days=days_offset)).year
-    obj_holidays: HolidayBase = getattr(holidays, country)(years=year)
+    if country:
+        obj_holidays: HolidayBase = getattr(holidays, country)(years=year)
+    else:
+        obj_holidays = holidays.HolidayBase(years=year)
 
     if province:
+        if not country:
+            _LOGGER.error("Cannot use a subdivision/province without a country")
+            return
+
         if (
             hasattr(obj_holidays, "subdivisions")
             and province in obj_holidays.subdivisions

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -25,6 +25,10 @@ class TestWorkdaySetup:
             "binary_sensor": {"platform": "workday", "add_holidays": ["2020-02-24"]}
         }
 
+        self.config_nocountry_province = {
+            "binary_sensor": {"platform": "workday", "province": "OOPS"}
+        }
+
         self.config_province = {
             "binary_sensor": {"platform": "workday", "country": "DE", "province": "BW"}
         }
@@ -141,6 +145,14 @@ class TestWorkdaySetup:
 
         entity = self.hass.states.get("binary_sensor.workday_sensor")
         assert entity is not None
+
+    def test_setup_component_nocountry_province(self):
+        """Set up workday component with no country but a province specified, which is not allowed."""
+        with assert_setup_component(1, "binary_sensor"):
+            setup_component(self.hass, "binary_sensor", self.config_nocountry_province)
+
+        entity = self.hass.states.get("binary_sensor.workday_sensor")
+        assert entity is None
 
     # Freeze time to a workday - Mar 15th, 2017
     @patch(FUNCTION_PATH, return_value=date(2017, 3, 15))


### PR DESCRIPTION
## Proposed change

Allow workday binary_sensor to be configured without a country.

This uses an empty set of holidays but still allows the addition of custom holidays with the add_holidays configuration setting.

For example:
```yaml
- platform: workday
  workdays: [mon, tue, wed, thu, fri]
  excludes: [sat, sun, holiday]
  add_holidays:
    - '2023-01-02'  # New Year's Day observed
    - '2023-01-16'  # Martin Luther King, Jr. Day
    - '2023-05-29'  # Memorial Day
    - '2023-06-19'  # Juneteenth
    - '2023-07-03'  # Fourth of July observed
    - '2023-07-04'  # Fourth of July
    - '2023-09-04'  # Labor Day
    - '2023-11-23'  # Thanksgiving
    - '2023-11-24'  # Thanksgiving observed
    - '2023-12-25'  # Christmas
    - '2023-12-26'  # Christmas observed
    - '2024-01-01'  # New Year's Day
```


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85996
- This PR is related to issue: #85996
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26079

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
