### PR TITLE
Simplify zwave_js code

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -254,17 +254,15 @@ class DriverEvents:
                 self.dev_reg.async_remove_device(device.id)
 
         # run discovery on controller node
-        c_node_id = controller.own_node_id
-        controller_node = controller.nodes.get(c_node_id) if c_node_id else None
-        if controller_node:
-            await self.controller_events.async_on_node_added(controller_node)
+        if controller.own_node:
+            await self.controller_events.async_on_node_added(controller.own_node)
 
         # run discovery on all other ready nodes
         await asyncio.gather(
             *(
                 self.controller_events.async_on_node_added(node)
                 for node in controller.nodes.values()
-                if controller_node is None or node != controller_node
+                if node != controller.own_node
             )
         )
 
@@ -396,13 +394,8 @@ class ControllerEvents:
         via_device_id = None
         controller = driver.controller
         # Get the controller node device ID if this node is not the controller
-        if (
-            controller.own_node_id is not None
-            and controller.own_node_id != node.node_id
-        ):
-            via_device_id = get_device_id(
-                driver, controller.nodes[controller.own_node_id]
-            )
+        if controller.own_node and controller.own_node != node:
+            via_device_id = get_device_id(driver, controller.own_node)
 
         # Replace the device if it can be determined that this node is not the
         # same product as it was previously.

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -150,7 +150,7 @@ async def async_get_actions(
 
     node = async_get_node_from_device_id(hass, device_id)
 
-    if node.client.driver and node.client.driver.controller.own_node_id == node.node_id:
+    if node.client.driver and node.client.driver.controller.own_node == node:
         return actions
 
     base_action = {

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -134,7 +134,7 @@ async def async_get_conditions(
     }
     node = async_get_node_from_device_id(hass, device_id)
 
-    if node.client.driver and node.client.driver.controller.own_node_id == node.node_id:
+    if node.client.driver and node.client.driver.controller.own_node == node:
         return conditions
 
     # Any value's value condition

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -258,7 +258,7 @@ async def async_get_triggers(
     dev_reg = device_registry.async_get(hass)
     node = async_get_node_from_device_id(hass, device_id, dev_reg)
 
-    if node.client.driver and node.client.driver.controller.own_node_id == node.node_id:
+    if node.client.driver and node.client.driver.controller.own_node == node:
         return triggers
 
     # We can add a node status trigger if the node status sensor is enabled


### PR DESCRIPTION
## Proposed change
Updates the zwave_js integration to support features introduced in [zwave-js 10.4.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.4.0) and [zwave-js-server-python 0.45.0](https://github.com/home-assistant/core/pull/url):
- Cleans up some stuff related to controller node checking based on a new property added upstream


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
