### PR TITLE
Sync input_select & select

### DIFF
--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.config_validation import (  # noqa: F401
+from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
@@ -19,7 +19,17 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 
-from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
+from .const import (
+    ATTR_CYCLE,
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    DOMAIN,
+    SERVICE_SELECT_FIRST,
+    SERVICE_SELECT_LAST,
+    SERVICE_SELECT_NEXT,
+    SERVICE_SELECT_OPTION,
+    SERVICE_SELECT_PREVIOUS,
+)
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -28,6 +38,22 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 _LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "ATTR_CYCLE",
+    "ATTR_OPTION",
+    "ATTR_OPTIONS",
+    "DOMAIN",
+    "PLATFORM_SCHEMA_BASE",
+    "PLATFORM_SCHEMA",
+    "SelectEntity",
+    "SelectEntityDescription",
+    "SERVICE_SELECT_FIRST",
+    "SERVICE_SELECT_LAST",
+    "SERVICE_SELECT_NEXT",
+    "SERVICE_SELECT_OPTION",
+    "SERVICE_SELECT_PREVIOUS",
+]
 
 # mypy: disallow-any-generics
 
@@ -40,9 +66,33 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await component.async_setup(config)
 
     component.async_register_entity_service(
+        SERVICE_SELECT_FIRST,
+        {},
+        SelectEntity.async_first.__name__,
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SELECT_LAST,
+        {},
+        SelectEntity.async_last.__name__,
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SELECT_NEXT,
+        {vol.Optional(ATTR_CYCLE, default=True): bool},
+        SelectEntity.async_next.__name__,
+    )
+
+    component.async_register_entity_service(
         SERVICE_SELECT_OPTION,
         {vol.Required(ATTR_OPTION): cv.string},
         async_select_option,
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SELECT_PREVIOUS,
+        {vol.Optional(ATTR_CYCLE, default=True): bool},
+        SelectEntity.async_previous.__name__,
     )
 
     return True
@@ -122,3 +172,58 @@ class SelectEntity(Entity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.hass.async_add_executor_job(self.select_option, option)
+
+    @final
+    async def async_first(self) -> None:
+        """Select first option."""
+        await self._async_select_index(0)
+
+    @final
+    async def async_last(self) -> None:
+        """Select last option."""
+        await self._async_select_index(-1)
+
+    @final
+    async def async_next(self, cycle: bool) -> None:
+        """Select next option.
+
+        If there is no current option, first item is the next.
+        """
+        if self.current_option is None:
+            await self.async_first()
+            return
+        await self._async_offset_index(1, cycle)
+
+    @final
+    async def async_previous(self, cycle: bool) -> None:
+        """Select previous option.
+
+        If there is no current option, last item is the previous.
+        """
+        if self.current_option is None:
+            await self.async_last()
+            return
+        await self._async_offset_index(-1, cycle)
+
+    @final
+    async def _async_offset_index(self, offset: int, cycle: bool) -> None:
+        """Offset current index."""
+        current_index = 0
+        if self.current_option is not None and self.current_option in self.options:
+            current_index = self.options.index(self.current_option)
+
+        new_index = current_index + offset
+        if cycle:
+            new_index = new_index % len(self.options)
+        elif new_index < 0:
+            new_index = 0
+        elif new_index >= len(self.options):
+            new_index = len(self.options) - 1
+
+        await self.async_select_option(self.options[new_index])
+
+    @final
+    async def _async_select_index(self, idx: int) -> None:
+        """Select new option by index."""
+        new_index = idx % len(self.options)
+        await self.async_select_option(self.options[new_index])

--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -2,9 +2,14 @@
 
 DOMAIN = "select"
 
+ATTR_CYCLE = "cycle"
 ATTR_OPTIONS = "options"
 ATTR_OPTION = "option"
 
 CONF_OPTION = "option"
 
+SERVICE_SELECT_FIRST = "select_first"
+SERVICE_SELECT_LAST = "select_last"
+SERVICE_SELECT_NEXT = "select_next"
 SERVICE_SELECT_OPTION = "select_option"
+SERVICE_SELECT_PREVIOUS = "select_previous"

--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -6,6 +6,7 @@ ATTR_CYCLE = "cycle"
 ATTR_OPTIONS = "options"
 ATTR_OPTION = "option"
 
+CONF_CYCLE = "cycle"
 CONF_OPTION = "option"
 
 SERVICE_SELECT_FIRST = "select_first"

--- a/homeassistant/components/select/device_action.py
+++ b/homeassistant/components/select/device_action.py
@@ -1,6 +1,8 @@
 """Provides device actions for Select."""
 from __future__ import annotations
 
+from contextlib import suppress
+
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -17,16 +19,54 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import get_capability
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from .const import ATTR_OPTION, ATTR_OPTIONS, CONF_OPTION, DOMAIN, SERVICE_SELECT_OPTION
+from .const import (
+    ATTR_CYCLE,
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    CONF_CYCLE,
+    CONF_OPTION,
+    DOMAIN,
+    SERVICE_SELECT_FIRST,
+    SERVICE_SELECT_LAST,
+    SERVICE_SELECT_NEXT,
+    SERVICE_SELECT_OPTION,
+    SERVICE_SELECT_PREVIOUS,
+)
 
-ACTION_TYPES = {"select_option"}
-
-ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
-    {
-        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
-        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
-        vol.Required(CONF_OPTION): str,
-    }
+ACTION_SCHEMA = vol.Any(
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): SERVICE_SELECT_FIRST,
+            vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        }
+    ),
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): SERVICE_SELECT_LAST,
+            vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        }
+    ),
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): SERVICE_SELECT_NEXT,
+            vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+            vol.Optional(CONF_CYCLE, default=True): cv.boolean,
+        }
+    ),
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): SERVICE_SELECT_PREVIOUS,
+            vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+            vol.Optional(CONF_CYCLE, default=True): cv.boolean,
+        }
+    ),
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): SERVICE_SELECT_OPTION,
+            vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+            vol.Required(CONF_OPTION): cv.string,
+        }
+    ),
 )
 
 
@@ -40,8 +80,15 @@ async def async_get_actions(
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
-            CONF_TYPE: "select_option",
+            CONF_TYPE: service_conf_type,
         }
+        for service_conf_type in (
+            SERVICE_SELECT_FIRST,
+            SERVICE_SELECT_LAST,
+            SERVICE_SELECT_NEXT,
+            SERVICE_SELECT_OPTION,
+            SERVICE_SELECT_PREVIOUS,
+        )
         for entry in entity_registry.async_entries_for_device(registry, device_id)
         if entry.domain == DOMAIN
     ]
@@ -54,13 +101,16 @@ async def async_call_action_from_config(
     context: Context | None,
 ) -> None:
     """Execute a device action."""
+    service_data = {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]}
+    if config[CONF_TYPE] == SERVICE_SELECT_OPTION:
+        service_data[ATTR_OPTION] = config[CONF_OPTION]
+    if config[CONF_TYPE] in {SERVICE_SELECT_NEXT, SERVICE_SELECT_PREVIOUS}:
+        service_data[ATTR_CYCLE] = config[CONF_CYCLE]
+
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: config[CONF_ENTITY_ID],
-            ATTR_OPTION: config[CONF_OPTION],
-        },
+        config[CONF_TYPE],
+        service_data,
         blocking=True,
         context=context,
     )
@@ -70,9 +120,19 @@ async def async_get_action_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List action capabilities."""
-    try:
-        options = get_capability(hass, config[CONF_ENTITY_ID], ATTR_OPTIONS) or []
-    except HomeAssistantError:
-        options = []
+    if config[CONF_TYPE] in {SERVICE_SELECT_NEXT, SERVICE_SELECT_PREVIOUS}:
+        return {
+            "extra_fields": vol.Schema(
+                {vol.Optional(CONF_CYCLE, default=True): cv.boolean}
+            )
+        }
 
-    return {"extra_fields": vol.Schema({vol.Required(CONF_OPTION): vol.In(options)})}
+    if config[CONF_TYPE] == SERVICE_SELECT_OPTION:
+        options: list[str] = []
+        with suppress(HomeAssistantError):
+            options = get_capability(hass, config[CONF_ENTITY_ID], ATTR_OPTIONS) or []
+        return {
+            "extra_fields": vol.Schema({vol.Required(CONF_OPTION): vol.In(options)})
+        }
+
+    return {}

--- a/homeassistant/components/select/services.yaml
+++ b/homeassistant/components/select/services.yaml
@@ -1,3 +1,31 @@
+select_first:
+  name: First
+  description: Select the first option of an select entity.
+  target:
+    entity:
+      domain: select
+
+select_last:
+  name: Last
+  description: Select the last option of an select entity.
+  target:
+    entity:
+      domain: select
+
+select_next:
+  name: Next
+  description: Select the next options of an select entity.
+  target:
+    entity:
+      domain: select
+  fields:
+    cycle:
+      name: Cycle
+      description: If the option should cycle from the last to the first.
+      default: true
+      selector:
+        boolean:
+
 select_option:
   name: Select
   description: Select an option of an select entity.
@@ -12,3 +40,17 @@ select_option:
       example: '"Item A"'
       selector:
         text:
+
+select_previous:
+  name: Previous
+  description: Select the previous options of an select entity.
+  target:
+    entity:
+      domain: select
+  fields:
+    cycle:
+      name: Cycle
+      description: If the option should cycle from the first to the last.
+      default: true
+      selector:
+        boolean:

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -5,7 +5,11 @@
       "current_option_changed": "{entity_name} option changed"
     },
     "action_type": {
-      "select_option": "Change {entity_name} option"
+      "select_first": "Change {entity_name} to first option",
+      "select_last": "Change {entity_name} to last option",
+      "select_next": "Change {entity_name} to next option",
+      "select_option": "Change {entity_name} option",
+      "select_previous": "Change {entity_name} to previous option"
     },
     "condition_type": {
       "selected_option": "Current {entity_name} selected option"

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -53,11 +53,18 @@ async def test_get_actions(
     expected_actions = [
         {
             "domain": DOMAIN,
-            "type": "select_option",
+            "type": action,
             "device_id": device_entry.id,
             "entity_id": "select.test_5678",
             "metadata": {"secondary": False},
         }
+        for action in [
+            "select_first",
+            "select_last",
+            "select_next",
+            "select_option",
+            "select_previous",
+        ]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -105,7 +112,13 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": f"{DOMAIN}.test_5678",
             "metadata": {"secondary": True},
         }
-        for action in ["select_option"]
+        for action in [
+            "select_first",
+            "select_last",
+            "select_next",
+            "select_option",
+            "select_previous",
+        ]
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -113,7 +126,41 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("action_type", ("select_first", "select_last"))
+async def test_action_select_first_last(hass: HomeAssistant, action_type: str) -> None:
+    """Test for select_first and select_last actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "select.entity",
+                        "type": action_type,
+                    },
+                },
+            ]
+        },
+    )
+
+    select_calls = async_mock_service(hass, DOMAIN, action_type)
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(select_calls) == 1
+    assert select_calls[0].domain == DOMAIN
+    assert select_calls[0].service == action_type
+    assert select_calls[0].data == {"entity_id": "select.entity"}
+
+
+async def test_action_select_option(hass: HomeAssistant) -> None:
     """Test for select_option action."""
     assert await async_setup_component(
         hass,
@@ -145,6 +192,43 @@ async def test_action(hass: HomeAssistant) -> None:
     assert select_calls[0].domain == DOMAIN
     assert select_calls[0].service == "select_option"
     assert select_calls[0].data == {"entity_id": "select.entity", "option": "option1"}
+
+
+@pytest.mark.parametrize("action_type", ["select_next", "select_previous"])
+async def test_action_select_next_previous(
+    hass: HomeAssistant, action_type: str
+) -> None:
+    """Test for select_next and select_previous actions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "select.entity",
+                        "type": action_type,
+                        "cycle": False,
+                    },
+                },
+            ]
+        },
+    )
+
+    select_calls = async_mock_service(hass, DOMAIN, action_type)
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(select_calls) == 1
+    assert select_calls[0].domain == DOMAIN
+    assert select_calls[0].service == action_type
+    assert select_calls[0].data == {"entity_id": "select.entity", "cycle": False}
 
 
 async def test_get_action_capabilities(hass: HomeAssistant) -> None:
@@ -189,3 +273,53 @@ async def test_get_action_capabilities(hass: HomeAssistant) -> None:
             "options": [("option1", "option1"), ("option2", "option2")],
         },
     ]
+
+    # Test next/previous actions
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "select_next",
+        "entity_id": "select.test",
+    }
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "cycle",
+            "optional": True,
+            "type": "boolean",
+            "default": True,
+        },
+    ]
+
+    config["type"] = "select_previous"
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "cycle",
+            "optional": True,
+            "type": "boolean",
+            "default": True,
+        },
+    ]
+
+    # Test action types without extra fields
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "select_first",
+        "entity_id": "select.test",
+    }
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities == {}
+
+    config["type"] = "select_last"
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities == {}

--- a/tests/components/select/test_init.py
+++ b/tests/components/select/test_init.py
@@ -3,14 +3,19 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from homeassistant.components.select import ATTR_OPTIONS, DOMAIN, SelectEntity
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
+from homeassistant.components.select import (
+    ATTR_CYCLE,
     ATTR_OPTION,
-    CONF_PLATFORM,
+    ATTR_OPTIONS,
+    DOMAIN,
+    SERVICE_SELECT_FIRST,
+    SERVICE_SELECT_LAST,
+    SERVICE_SELECT_NEXT,
     SERVICE_SELECT_OPTION,
-    STATE_UNKNOWN,
+    SERVICE_SELECT_PREVIOUS,
+    SelectEntity,
 )
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -42,13 +47,39 @@ async def test_select(hass: HomeAssistant) -> None:
     select.hass = hass
 
     with pytest.raises(NotImplementedError):
+        await select.async_first()
+
+    with pytest.raises(NotImplementedError):
+        await select.async_last()
+
+    with pytest.raises(NotImplementedError):
+        await select.async_next(cycle=False)
+
+    with pytest.raises(NotImplementedError):
+        await select.async_previous(cycle=False)
+
+    with pytest.raises(NotImplementedError):
         await select.async_select_option("option_one")
 
     select.select_option = MagicMock()
-    await select.async_select_option("option_one")
+    select._attr_current_option = None
 
-    assert select.select_option.called
+    await select.async_first()
     assert select.select_option.call_args[0][0] == "option_one"
+
+    await select.async_last()
+    assert select.select_option.call_args[0][0] == "option_three"
+
+    await select.async_next(cycle=False)
+    assert select.select_option.call_args[0][0] == "option_one"
+
+    await select.async_previous(cycle=False)
+    assert select.select_option.call_args[0][0] == "option_three"
+
+    await select.async_select_option("option_two")
+    assert select.select_option.call_args[0][0] == "option_two"
+
+    assert select.select_option.call_count == 5
 
     assert select.capability_attributes[ATTR_OPTIONS] == [
         "option_one",
@@ -109,4 +140,56 @@ async def test_custom_integration_and_validation(hass, enable_custom_integration
     )
     await hass.async_block_till_done()
 
+    assert hass.states.get("select.select_2").state == "option 3"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_FIRST,
+        {ATTR_ENTITY_ID: "select.select_2"},
+        blocking=True,
+    )
+    assert hass.states.get("select.select_2").state == "option 1"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_LAST,
+        {ATTR_ENTITY_ID: "select.select_2"},
+        blocking=True,
+    )
+    assert hass.states.get("select.select_2").state == "option 3"
+
+    # Do no cycle
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_NEXT,
+        {ATTR_ENTITY_ID: "select.select_2", ATTR_CYCLE: False},
+        blocking=True,
+    )
+    assert hass.states.get("select.select_2").state == "option 3"
+
+    # Do cycle (default behavior)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_NEXT,
+        {ATTR_ENTITY_ID: "select.select_2"},
+        blocking=True,
+    )
+    assert hass.states.get("select.select_2").state == "option 1"
+
+    # Do not cycle
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_PREVIOUS,
+        {ATTR_ENTITY_ID: "select.select_2", ATTR_CYCLE: False},
+        blocking=True,
+    )
+    assert hass.states.get("select.select_2").state == "option 1"
+
+    # Do cycle (default behavior)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_PREVIOUS,
+        {ATTR_ENTITY_ID: "select.select_2"},
+        blocking=True,
+    )
     assert hass.states.get("select.select_2").state == "option 3"

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -121,35 +121,31 @@ async def test_get_actions(hass, device_ias):
             "metadata": {},
         },
         {"domain": DOMAIN, "type": "warn", "device_id": reg_device.id, "metadata": {}},
-        {
-            "domain": Platform.SELECT,
-            "type": "select_option",
-            "device_id": reg_device.id,
-            "entity_id": "select.fakemanufacturer_fakemodel_default_siren_tone",
-            "metadata": {"secondary": True},
-        },
-        {
-            "domain": Platform.SELECT,
-            "type": "select_option",
-            "device_id": reg_device.id,
-            "entity_id": "select.fakemanufacturer_fakemodel_default_siren_level",
-            "metadata": {"secondary": True},
-        },
-        {
-            "domain": Platform.SELECT,
-            "type": "select_option",
-            "device_id": reg_device.id,
-            "entity_id": "select.fakemanufacturer_fakemodel_default_strobe_level",
-            "metadata": {"secondary": True},
-        },
-        {
-            "domain": Platform.SELECT,
-            "type": "select_option",
-            "device_id": reg_device.id,
-            "entity_id": "select.fakemanufacturer_fakemodel_default_strobe",
-            "metadata": {"secondary": True},
-        },
     ]
+    expected_actions.extend(
+        [
+            {
+                "domain": Platform.SELECT,
+                "type": action,
+                "device_id": reg_device.id,
+                "entity_id": entity_id,
+                "metadata": {"secondary": True},
+            }
+            for action in [
+                "select_first",
+                "select_last",
+                "select_next",
+                "select_option",
+                "select_previous",
+            ]
+            for entity_id in [
+                "select.fakemanufacturer_fakemodel_default_siren_level",
+                "select.fakemanufacturer_fakemodel_default_siren_tone",
+                "select.fakemanufacturer_fakemodel_default_strobe_level",
+                "select.fakemanufacturer_fakemodel_default_strobe",
+            ]
+        ]
+    )
 
     assert_lists_same(actions, expected_actions)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Brings features from `input_select` and `select` in sync with each other (to the extent possible). Meaning all services are now the same (with the exception of setting the options, which only applies to the `input_select` entity).

Resolves: <https://github.com/home-assistant/architecture/discussions/590>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26092

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
