### PR TITLE
Improve type hints in google assistant

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -1,9 +1,12 @@
 """Support for Google Assistant Smart Home API."""
 import asyncio
+from collections.abc import Callable, Coroutine
 from itertools import product
 import logging
+from typing import Any
 
 from homeassistant.const import ATTR_ENTITY_ID, __version__
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import instance_id
 from homeassistant.util.decorator import Registry
 
@@ -20,7 +23,13 @@ from .helpers import GoogleEntity, RequestData, async_get_entities
 
 EXECUTE_LIMIT = 2  # Wait 2 seconds for execute to finish
 
-HANDLERS = Registry()  # type: ignore[var-annotated]
+HANDLERS: Registry[
+    str,
+    Callable[
+        [HomeAssistant, RequestData, dict[str, Any]],
+        Coroutine[Any, Any, dict[str, Any] | None],
+    ],
+] = Registry()
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -90,7 +99,9 @@ async def async_devices_sync_response(hass, config, agent_user_id):
 
 
 @HANDLERS.register("action.devices.SYNC")
-async def async_devices_sync(hass, data, payload):
+async def async_devices_sync(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.SYNC request.
 
     https://developers.google.com/assistant/smarthome/develop/process-intents#SYNC
@@ -113,7 +124,9 @@ async def async_devices_sync(hass, data, payload):
 
 
 @HANDLERS.register("action.devices.QUERY")
-async def async_devices_query(hass, data, payload):
+async def async_devices_query(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.QUERY request.
 
     https://developers.google.com/assistant/smarthome/develop/process-intents#QUERY
@@ -173,14 +186,16 @@ async def _entity_execute(entity, data, executions):
 
 
 @HANDLERS.register("action.devices.EXECUTE")
-async def handle_devices_execute(hass, data, payload):
+async def handle_devices_execute(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.EXECUTE request.
 
     https://developers.google.com/assistant/smarthome/develop/process-intents#EXECUTE
     """
-    entities = {}
-    executions = {}
-    results = {}
+    entities: dict[str, GoogleEntity] = {}
+    executions: dict[str, list[Any]] = {}
+    results: dict[str, dict[str, Any]] = {}
 
     for command in payload["commands"]:
         hass.bus.async_fire(
@@ -254,7 +269,9 @@ async def handle_devices_execute(hass, data, payload):
 
 
 @HANDLERS.register("action.devices.DISCONNECT")
-async def async_devices_disconnect(hass, data: RequestData, payload):
+async def async_devices_disconnect(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> None:
     """Handle action.devices.DISCONNECT request.
 
     https://developers.google.com/assistant/smarthome/develop/process-intents#DISCONNECT
@@ -265,7 +282,9 @@ async def async_devices_disconnect(hass, data: RequestData, payload):
 
 
 @HANDLERS.register("action.devices.IDENTIFY")
-async def async_devices_identify(hass, data: RequestData, payload):
+async def async_devices_identify(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.IDENTIFY request.
 
     https://developers.google.com/assistant/smarthome/develop/local#implement_the_identify_handler
@@ -286,7 +305,9 @@ async def async_devices_identify(hass, data: RequestData, payload):
 
 
 @HANDLERS.register("action.devices.REACHABLE_DEVICES")
-async def async_devices_reachable(hass, data: RequestData, payload):
+async def async_devices_reachable(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.REACHABLE_DEVICES request.
 
     https://developers.google.com/assistant/smarthome/develop/local#implement_the_reachable_devices_handler_hub_integrations_only
@@ -303,7 +324,9 @@ async def async_devices_reachable(hass, data: RequestData, payload):
 
 
 @HANDLERS.register("action.devices.PROXY_SELECTED")
-async def async_devices_proxy_selected(hass, data: RequestData, payload):
+async def async_devices_proxy_selected(
+    hass: HomeAssistant, data: RequestData, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Handle action.devices.PROXY_SELECTED request.
 
     When selected for local SDK.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #87068

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
