### PR TITLE
Add support for multiple conversation agents

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -378,4 +378,4 @@ class AgentManager:
         """Unset the agent."""
         if self.default_agent == agent_id:
             self.default_agent = AgentManager.HOME_ASSISTANT_AGENT
-        self._agents.pop(agent_id)
+        self._agents.pop(agent_id, None)

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.components import http, websocket_api
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, intent
+from homeassistant.helpers import config_validation as cv, intent, singleton
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -23,20 +23,31 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_TEXT = "text"
 ATTR_LANGUAGE = "language"
+ATTR_AGENT_ID = "agent_id"
 
 DOMAIN = "conversation"
 
 REGEX_TYPE = type(re.compile(""))
-DATA_AGENT = "conversation_agent"
 DATA_CONFIG = "conversation_config"
 
 SERVICE_PROCESS = "process"
 SERVICE_RELOAD = "reload"
 
+
+def agent_id_validator(value: Any) -> str:
+    """Validate agent ID."""
+    hass = core.async_get_hass()
+    manager = _get_agent_manager(hass)
+    if not manager.async_is_valid_agent_id(cv.string(value)):
+        raise vol.Invalid("invalid agent ID")
+    return value
+
+
 SERVICE_PROCESS_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_TEXT): cv.string,
         vol.Optional(ATTR_LANGUAGE): cv.string,
+        vol.Optional(ATTR_AGENT_ID): agent_id_validator,
     }
 )
 
@@ -44,6 +55,7 @@ SERVICE_PROCESS_SCHEMA = vol.Schema(
 SERVICE_RELOAD_SCHEMA = vol.Schema(
     {
         vol.Optional(ATTR_LANGUAGE): cv.string,
+        vol.Optional(ATTR_AGENT_ID): agent_id_validator,
     }
 )
 
@@ -61,6 +73,13 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+@singleton.singleton("conversation_agent")
+@core.callback
+def _get_agent_manager(hass: HomeAssistant) -> AgentManager:
+    """Get the active agent."""
+    return AgentManager(hass)
+
+
 @core.callback
 @bind_hass
 def async_set_agent(
@@ -69,7 +88,7 @@ def async_set_agent(
     agent: AbstractConversationAgent,
 ):
     """Set the agent to handle the conversations."""
-    hass.data[DATA_AGENT] = agent
+    _get_agent_manager(hass).async_set_agent(config_entry.entry_id, agent)
 
 
 @core.callback
@@ -79,11 +98,13 @@ def async_unset_agent(
     config_entry: ConfigEntry,
 ):
     """Set the agent to handle the conversations."""
-    hass.data[DATA_AGENT] = None
+    _get_agent_manager(hass).async_unset_agent(config_entry.entry_id)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Register the process service."""
+    agent_manager = _get_agent_manager(hass)
+
     if config_intents := config.get(DOMAIN, {}).get("intents"):
         hass.data[DATA_CONFIG] = config_intents
 
@@ -91,22 +112,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Parse text into commands."""
         text = service.data[ATTR_TEXT]
         _LOGGER.debug("Processing: <%s>", text)
-        agent = await _get_agent(hass)
         try:
-            await agent.async_process(
-                ConversationInput(
-                    text=text,
-                    context=service.context,
-                    conversation_id=None,
-                    language=service.data.get(ATTR_LANGUAGE, hass.config.language),
-                )
+            await async_converse(
+                hass=hass,
+                text=text,
+                conversation_id=None,
+                context=service.context,
+                language=service.data.get(ATTR_LANGUAGE),
+                agent_id=service.data.get(ATTR_AGENT_ID),
             )
         except intent.IntentHandleError as err:
             _LOGGER.error("Error processing %s: %s", text, err)
 
     async def handle_reload(service: core.ServiceCall) -> None:
         """Reload intents."""
-        agent = await _get_agent(hass)
+        agent = await agent_manager.async_get_agent()
         await agent.async_reload(language=service.data.get(ATTR_LANGUAGE))
 
     hass.services.async_register(
@@ -119,6 +139,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, websocket_process)
     websocket_api.async_register_command(hass, websocket_prepare)
     websocket_api.async_register_command(hass, websocket_get_agent_info)
+    websocket_api.async_register_command(hass, websocket_list_agents)
 
     return True
 
@@ -129,6 +150,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         vol.Required("text"): str,
         vol.Optional("conversation_id"): vol.Any(str, None),
         vol.Optional("language"): str,
+        vol.Optional("agent_id"): agent_id_validator,
     }
 )
 @websocket_api.async_response
@@ -139,11 +161,12 @@ async def websocket_process(
 ) -> None:
     """Process text."""
     result = await async_converse(
-        hass,
-        msg["text"],
-        msg.get("conversation_id"),
-        connection.context(msg),
-        msg.get("language"),
+        hass=hass,
+        text=msg["text"],
+        conversation_id=msg.get("conversation_id"),
+        context=connection.context(msg),
+        language=msg.get("language"),
+        agent_id=msg.get("agent_id"),
     )
     connection.send_result(msg["id"], result.as_dict())
 
@@ -152,6 +175,7 @@ async def websocket_process(
     {
         "type": "conversation/prepare",
         vol.Optional("language"): str,
+        vol.Optional("agent_id"): agent_id_validator,
     }
 )
 @websocket_api.async_response
@@ -161,7 +185,8 @@ async def websocket_prepare(
     msg: dict[str, Any],
 ) -> None:
     """Reload intents."""
-    agent = await _get_agent(hass)
+    manager = _get_agent_manager(hass)
+    agent = await manager.async_get_agent(msg.get("agent_id"))
     await agent.async_prepare(msg.get("language"))
     connection.send_result(msg["id"])
 
@@ -169,6 +194,7 @@ async def websocket_prepare(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "conversation/agent/info",
+        vol.Optional("agent_id"): agent_id_validator,
     }
 )
 @websocket_api.async_response
@@ -178,12 +204,35 @@ async def websocket_get_agent_info(
     msg: dict[str, Any],
 ) -> None:
     """Info about the agent in use."""
-    agent = await _get_agent(hass)
+    agent = await _get_agent_manager(hass).async_get_agent(msg.get("agent_id"))
 
     connection.send_result(
         msg["id"],
         {
             "attribution": agent.attribution,
+        },
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "conversation/agent/list",
+    }
+)
+@core.callback
+def websocket_list_agents(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List available agents."""
+    manager = _get_agent_manager(hass)
+
+    connection.send_result(
+        msg["id"],
+        {
+            "default_agent": manager.default_agent,
+            "agents": manager.async_get_agent_info(),
         },
     )
 
@@ -200,29 +249,24 @@ class ConversationProcessView(http.HomeAssistantView):
                 vol.Required("text"): str,
                 vol.Optional("conversation_id"): str,
                 vol.Optional("language"): str,
+                vol.Optional("agent_id"): agent_id_validator,
             }
         )
     )
     async def post(self, request, data):
         """Send a request for processing."""
         hass = request.app["hass"]
+
         result = await async_converse(
             hass,
             text=data["text"],
             conversation_id=data.get("conversation_id"),
             context=self.context(request),
             language=data.get("language"),
+            agent_id=data.get("agent_id"),
         )
 
         return self.json(result.as_dict())
-
-
-async def _get_agent(hass: core.HomeAssistant) -> AbstractConversationAgent:
-    """Get the active conversation agent."""
-    if (agent := hass.data.get(DATA_AGENT)) is None:
-        agent = hass.data[DATA_AGENT] = DefaultAgent(hass)
-        await agent.async_initialize(hass.data.get(DATA_CONFIG))
-    return agent
 
 
 async def async_converse(
@@ -231,12 +275,15 @@ async def async_converse(
     conversation_id: str | None,
     context: core.Context,
     language: str | None = None,
+    agent_id: str | None = None,
 ) -> ConversationResult:
     """Process text and get intent."""
-    agent = await _get_agent(hass)
+    agent = await _get_agent_manager(hass).async_get_agent(agent_id)
+
     if language is None:
         language = hass.config.language
 
+    _LOGGER.debug("Processing in %s: %s", language, text)
     result = await agent.async_process(
         ConversationInput(
             text=text,
@@ -246,3 +293,80 @@ async def async_converse(
         )
     )
     return result
+
+
+class AgentManager:
+    """Class to manage conversation agents."""
+
+    HOME_ASSISTANT_AGENT = "homeassistant"
+
+    default_agent: str = HOME_ASSISTANT_AGENT
+    _builtin_agent: AbstractConversationAgent | None = None
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the conversation agents."""
+        self.hass = hass
+        self._agents: dict[str, AbstractConversationAgent] = {}
+
+    async def async_get_agent(
+        self, agent_id: str | None = None
+    ) -> AbstractConversationAgent:
+        """Get the agent."""
+        if agent_id is None:
+            agent_id = self.default_agent
+
+        if agent_id == AgentManager.HOME_ASSISTANT_AGENT:
+            if self._builtin_agent is None:
+                self._builtin_agent = DefaultAgent(self.hass)
+                await self._builtin_agent.async_initialize(
+                    self.hass.data.get(DATA_CONFIG)
+                )
+            return self._builtin_agent
+
+        return self._agents[agent_id]
+
+    @core.callback
+    def async_get_agent_info(self) -> list[dict[str, Any]]:
+        """List all agents."""
+        agents = [
+            {
+                "id": AgentManager.HOME_ASSISTANT_AGENT,
+                "name": "Home Assistant",
+            }
+        ]
+        for agent_id, agent in self._agents.items():
+            config_entry = self.hass.config_entries.async_get_entry(agent_id)
+
+            # This is a bug, agent should have been unset when config entry was unloaded
+            if config_entry is None:
+                _LOGGER.warning(
+                    "Agent was still loaded while config entry is gone: %s", agent
+                )
+                continue
+
+            agents.append(
+                {
+                    "id": agent_id,
+                    "name": config_entry.title,
+                }
+            )
+        return agents
+
+    @core.callback
+    def async_is_valid_agent_id(self, agent_id: str) -> bool:
+        """Check if the agent id is valid."""
+        return agent_id in self._agents or agent_id == AgentManager.HOME_ASSISTANT_AGENT
+
+    @core.callback
+    def async_set_agent(self, agent_id: str, agent: AbstractConversationAgent) -> None:
+        """Set the agent."""
+        self._agents[agent_id] = agent
+        if self.default_agent == AgentManager.HOME_ASSISTANT_AGENT:
+            self.default_agent = agent_id
+
+    @core.callback
+    def async_unset_agent(self, agent_id: str) -> None:
+        """Unset the agent."""
+        if self.default_agent == agent_id:
+            self.default_agent = AgentManager.HOME_ASSISTANT_AGENT
+        self._agents.pop(agent_id)

--- a/homeassistant/components/conversation/services.yaml
+++ b/homeassistant/components/conversation/services.yaml
@@ -9,3 +9,15 @@ process:
       example: Turn all lights on
       selector:
         text:
+    language:
+      name: Language
+      description: Language of text. Defaults to server language
+      example: NL
+      selector:
+        text:
+    agent_id:
+      name: Agent
+      description: Assist engine to process your request
+      example: homeassistant
+      selector:
+        text:

--- a/tests/components/conversation/__init__.py
+++ b/tests/components/conversation/__init__.py
@@ -8,8 +8,9 @@ from homeassistant.helpers import intent
 class MockAgent(conversation.AbstractConversationAgent):
     """Test Agent."""
 
-    def __init__(self) -> None:
+    def __init__(self, agent_id: str) -> None:
         """Initialize the agent."""
+        self.agent_id = agent_id
         self.calls = []
         self.response = "Test response"
 

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -6,10 +6,14 @@ from homeassistant.components import conversation
 
 from . import MockAgent
 
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture
 def mock_agent(hass):
     """Mock agent."""
-    agent = MockAgent()
-    conversation.async_set_agent(hass, None, agent)
+    entry = MockConfigEntry(entry_id="mock-entry")
+    entry.add_to_hass(hass)
+    agent = MockAgent(entry.entry_id)
+    conversation.async_set_agent(hass, entry, agent)
     return agent


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for multiple conversation agent.

Right now it's only exposed at API level, allow passing in an agent_id to the various APIs.

New API added to list the available agents and which one is the default.

Agent IDs are the config entries that registered the agents. Special agent_id `homeassistant` is reserved for the built-in agent.

Future support will include setting a default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
