### PR TITLE
Fix Ruuvi Gateway data being ignored when system is not using UTC time

### DIFF
--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import datetime
 import logging
+import time
 
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.components.bluetooth import (
+    FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     BaseHaRemoteScanner,
     async_get_advertisement_callback,
     async_register_scanner,
@@ -15,7 +16,6 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
-from .const import OLD_ADVERTISEMENT_CUTOFF
 from .coordinator import RuuviGatewayUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,10 +46,11 @@ class RuuviGatewayScanner(BaseHaRemoteScanner):
 
     @callback
     def _async_handle_new_data(self) -> None:
-        now = datetime.datetime.now()
+        now = time.time()
         for tag_data in self.coordinator.data:
-            if now - tag_data.datetime > OLD_ADVERTISEMENT_CUTOFF:
-                # Don't process data that is older than 10 minutes
+            data_age_seconds = now - tag_data.timestamp  # Both are Unix time
+            if data_age_seconds > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
+                # Don't process stale data at all
                 continue
             anno = tag_data.parse_announcement()
             self._async_on_advertisement(

--- a/homeassistant/components/ruuvi_gateway/const.py
+++ b/homeassistant/components/ruuvi_gateway/const.py
@@ -1,12 +1,5 @@
 """Constants for the Ruuvi Gateway integration."""
 from datetime import timedelta
 
-from homeassistant.components.bluetooth import (
-    FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
-)
-
 DOMAIN = "ruuvi_gateway"
 SCAN_INTERVAL = timedelta(seconds=5)
-OLD_ADVERTISEMENT_CUTOFF = timedelta(
-    seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
-)


### PR DESCRIPTION
## Proposed change

The stale data comparison in the Ruuvi Gateway integration did the Wrong Thing around timezones, so if your system timezone is UTC+anything, all data was and ignored. 

I'm not sure why this worked with HA 38f183a6838a77ea72ebf81c434252fe303bdff9 (#84853) and has now broken.

This should probably be released in a bugfix version of 2023.2.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #87143

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the dev checklist
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
