### PR TITLE
Update Ruff to 0.0.241

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.237
+    rev: v0.0.241
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,9 @@ ignore = [
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
 
+[tool.ruff.pyupgrade]
+keep-runtime-typing = true
+
 [tool.ruff.per-file-ignores]
 
 # TODO: these files have functions that are too complex, but flake8's and ruff's

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -14,5 +14,5 @@ pycodestyle==2.10.0
 pydocstyle==6.2.3
 pyflakes==3.0.1
 pyupgrade==3.3.1
-ruff==0.0.237
+ruff==0.0.241
 yamllint==1.28.0


### PR DESCRIPTION
## Proposed change

Update the ruff linter to 0.0.241.

Changes: https://github.com/charliermarsh/ruff/compare/v0.0.237...v0.0.241

This may make it possible to enable switching from `isort` to ruff `I` checks with my PR https://github.com/charliermarsh/ruff/pull/2268 merged.

Enabling `ANN` is still pending me cleaning up https://github.com/charliermarsh/ruff/pull/2128 ...

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the devlist
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

