### PR TITLE
Add type hints to MQTT init tests

### DIFF
--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2643,7 +2643,7 @@ async def test_debug_info_non_mqtt(
     )
     for device_class in DEVICE_CLASSES:
         entity_registry.async_get_or_create(
-            mqtt.DOMAIN,
+            domain,
             "test",
             platform.ENTITIES[device_class].unique_id,
             device_id=device_entry.id,

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -4,6 +4,7 @@ import copy
 from datetime import datetime, timedelta
 from functools import partial
 import json
+from pathlib import Path
 import ssl
 from unittest.mock import ANY, AsyncMock, MagicMock, call, mock_open, patch
 
@@ -97,7 +98,7 @@ def record_calls(calls):
 
 
 @pytest.fixture
-def empty_mqtt_config(hass: HomeAssistant, tmp_path):
+def empty_mqtt_config(hass: HomeAssistant, tmp_path: Path):
     """Fixture to provide an empty config from yaml."""
     new_yaml_config_file = tmp_path / "configuration.yaml"
     new_yaml_config_file.write_text("")
@@ -1443,7 +1444,7 @@ async def test_handle_message_callback(
 
 
 async def test_setup_override_configuration(
-    hass: HomeAssistant, caplog, tmp_path
+    hass: HomeAssistant, caplog, tmp_path: Path
 ) -> None:
     """Test override setup from configuration entry."""
     calls_username_password_set = []
@@ -2837,7 +2838,7 @@ async def test_config_schema_validation(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_unload_config_entry(
-    hass: HomeAssistant, mqtt_mock, mqtt_client_mock, tmp_path, caplog
+    hass: HomeAssistant, mqtt_mock, mqtt_client_mock, tmp_path: Path, caplog
 ) -> None:
     """Test unloading the MQTT entry."""
     assert hass.services.has_service(mqtt.DOMAIN, "dump")
@@ -2895,7 +2896,9 @@ async def test_publish_or_subscribe_without_valid_config_entry(
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_reload_entry_with_new_config(hass: HomeAssistant, tmp_path) -> None:
+async def test_reload_entry_with_new_config(
+    hass: HomeAssistant, tmp_path: Path
+) -> None:
     """Test reloading the config entry with a new yaml config."""
     config_old = {
         "mqtt": {"light": [{"name": "test_old1", "command_topic": "test-topic_old"}]}
@@ -2915,7 +2918,7 @@ async def test_reload_entry_with_new_config(hass: HomeAssistant, tmp_path) -> No
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_disabling_and_enabling_entry(
-    hass: HomeAssistant, tmp_path, caplog
+    hass: HomeAssistant, tmp_path: Path, caplog
 ) -> None:
     """Test disabling and enabling the config entry."""
     config_old = {
@@ -3006,7 +3009,7 @@ async def test_disabling_and_enabling_entry(
     ],
 )
 async def test_setup_manual_items_with_unique_ids(
-    hass: HomeAssistant, tmp_path, caplog, config, unique
+    hass: HomeAssistant, tmp_path: Path, caplog, config, unique
 ) -> None:
     """Test setup manual items is generating unique id's."""
     await help_test_setup_manual_entity_from_yaml(
@@ -3056,7 +3059,7 @@ async def test_remove_unknown_conf_entry_options(
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_link_config_entry(hass: HomeAssistant, tmp_path, caplog) -> None:
+async def test_link_config_entry(hass: HomeAssistant, tmp_path: Path, caplog) -> None:
     """Test manual and dynamically setup entities are linked to the config entry."""
     config_manual = {
         "mqtt": {

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -47,7 +47,7 @@ from tests.common import (
     mock_restore_cache,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
-from tests.typing import WebSocketGenerator
+from tests.typing import MqttMockHAClientGenerator, WebSocketGenerator
 
 
 class RecordCallsPartial(partial):
@@ -111,7 +111,9 @@ def empty_mqtt_config(hass: HomeAssistant, tmp_path: Path):
 
 
 async def test_mqtt_connects_on_home_assistant_mqtt_setup(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test if client is connected after mqtt init on bootstrap."""
     await mqtt_mock_entry_no_yaml_config()
@@ -119,7 +121,9 @@ async def test_mqtt_connects_on_home_assistant_mqtt_setup(
 
 
 async def test_mqtt_disconnects_on_home_assistant_stop(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_client_mock,
 ) -> None:
     """Test if client stops on HA stop."""
     await mqtt_mock_entry_no_yaml_config()
@@ -172,7 +176,9 @@ async def test_mqtt_await_ack_at_disconnect(
         )
 
 
-async def test_publish(hass: HomeAssistant, mqtt_mock_entry_no_yaml_config) -> None:
+async def test_publish(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test the publish function."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_publish(hass, "test-topic", "test-payload")
@@ -273,7 +279,7 @@ async def test_command_template_value(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SELECT])
 async def test_command_template_variables(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the rendering of entity variables."""
     topic = "test/select"
@@ -386,7 +392,7 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
 
 
 async def test_service_call_without_topic_does_not_publish(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call if topic is missing."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -401,7 +407,7 @@ async def test_service_call_without_topic_does_not_publish(
 
 
 async def test_service_call_with_topic_and_topic_template_does_not_publish(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with topic/topic template.
 
@@ -425,7 +431,7 @@ async def test_service_call_with_topic_and_topic_template_does_not_publish(
 
 
 async def test_service_call_with_invalid_topic_template_does_not_publish(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with a problematic topic template."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -442,7 +448,7 @@ async def test_service_call_with_invalid_topic_template_does_not_publish(
 
 
 async def test_service_call_with_template_topic_renders_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with rendered topic template.
 
@@ -463,7 +469,7 @@ async def test_service_call_with_template_topic_renders_template(
 
 
 async def test_service_call_with_template_topic_renders_invalid_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with rendered, invalid topic template.
 
@@ -483,7 +489,7 @@ async def test_service_call_with_template_topic_renders_invalid_topic(
 
 
 async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with unrendered template.
 
@@ -507,7 +513,7 @@ async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_t
 
 
 async def test_service_call_with_template_payload_renders_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with rendered template.
 
@@ -539,7 +545,7 @@ async def test_service_call_with_template_payload_renders_template(
 
 
 async def test_service_call_with_bad_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with a bad template does not publish."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -553,7 +559,7 @@ async def test_service_call_with_bad_template(
 
 
 async def test_service_call_with_payload_doesnt_render_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with unrendered template.
 
@@ -577,7 +583,7 @@ async def test_service_call_with_payload_doesnt_render_template(
 
 
 async def test_service_call_with_ascii_qos_retain_flags(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the service call with args that can be misinterpreted.
 
@@ -603,7 +609,7 @@ async def test_service_call_with_ascii_qos_retain_flags(
 async def test_publish_function_with_bad_encoding_conditions(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test internal publish function with basic use cases."""
     await mqtt_mock_entry_no_yaml_config()
@@ -789,7 +795,7 @@ def test_entity_device_info_schema() -> None:
 
 async def test_receiving_non_utf8_message_gets_logged(
     hass: HomeAssistant,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     calls,
     record_calls,
     caplog: pytest.LogCaptureFixture,
@@ -807,7 +813,10 @@ async def test_receiving_non_utf8_message_gets_logged(
 
 
 async def test_all_subscriptions_run_when_decode_fails(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test all other subscriptions still run when decode fails for one."""
     await mqtt_mock_entry_no_yaml_config()
@@ -821,7 +830,10 @@ async def test_all_subscriptions_run_when_decode_fails(
 
 
 async def test_subscribe_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
@@ -847,7 +859,10 @@ async def test_subscribe_topic(
 
 
 async def test_subscribe_topic_non_async(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of a topic using the non-async function."""
     await mqtt_mock_entry_no_yaml_config()
@@ -872,7 +887,10 @@ async def test_subscribe_topic_non_async(
 
 
 async def test_subscribe_bad_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
@@ -882,7 +900,7 @@ async def test_subscribe_bad_topic(
 
 # Support for a deprecated callback type will be removed from HA core 2023.2.0
 async def test_subscribe_deprecated(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the subscription of a topic using deprecated callback signature."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -933,7 +951,7 @@ async def test_subscribe_deprecated(
 
 # Support for a deprecated callback type will be removed from HA core 2023.2.0
 async def test_subscribe_deprecated_async(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the subscription of a topic using deprecated coroutine signature."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -983,7 +1001,10 @@ async def test_subscribe_deprecated_async(
 
 
 async def test_subscribe_topic_not_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test if subscribed topic is not a match."""
     await mqtt_mock_entry_no_yaml_config()
@@ -996,7 +1017,10 @@ async def test_subscribe_topic_not_match(
 
 
 async def test_subscribe_topic_level_wildcard(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1011,7 +1035,10 @@ async def test_subscribe_topic_level_wildcard(
 
 
 async def test_subscribe_topic_level_wildcard_no_subtree_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1024,7 +1051,10 @@ async def test_subscribe_topic_level_wildcard_no_subtree_match(
 
 
 async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1037,7 +1067,10 @@ async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
 
 
 async def test_subscribe_topic_subtree_wildcard_subtree_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1052,7 +1085,10 @@ async def test_subscribe_topic_subtree_wildcard_subtree_topic(
 
 
 async def test_subscribe_topic_subtree_wildcard_root_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1067,7 +1103,10 @@ async def test_subscribe_topic_subtree_wildcard_root_topic(
 
 
 async def test_subscribe_topic_subtree_wildcard_no_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1080,7 +1119,10 @@ async def test_subscribe_topic_subtree_wildcard_no_match(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1095,7 +1137,10 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1110,7 +1155,10 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1123,7 +1171,10 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1136,7 +1187,10 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
 
 
 async def test_subscribe_topic_sys_root(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of $ root topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1151,7 +1205,10 @@ async def test_subscribe_topic_sys_root(
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of $ root and wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1166,7 +1223,10 @@ async def test_subscribe_topic_sys_root_and_wildcard_topic(
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription of $ root and wildcard subtree topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1181,7 +1241,10 @@ async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
 
 
 async def test_subscribe_special_characters(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    calls,
+    record_calls,
 ) -> None:
     """Test the subscription to topics with special characters."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1198,7 +1261,9 @@ async def test_subscribe_special_characters(
 
 
 async def test_subscribe_same_topic(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscring to same topic twice and simulate retained messages.
 
@@ -1233,7 +1298,9 @@ async def test_subscribe_same_topic(
 
 
 async def test_not_calling_unsubscribe_with_active_subscribers(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -1251,7 +1318,9 @@ async def test_not_calling_unsubscribe_with_active_subscribers(
 
 
 async def test_unsubscribe_race(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -1290,7 +1359,9 @@ async def test_unsubscribe_race(
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],
 )
 async def test_restore_subscriptions_on_reconnect(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscriptions are restored on reconnect."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -1313,7 +1384,9 @@ async def test_restore_subscriptions_on_reconnect(
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],
 )
 async def test_restore_all_active_subscriptions_on_reconnect(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test active subscriptions are restored correctly on reconnect."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -1366,7 +1439,7 @@ async def test_initial_setup_logs_error(
 async def test_logs_error_if_no_connect_broker(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     mqtt_client_mock,
 ) -> None:
     """Test for setup failure if connection to broker is missing."""
@@ -1384,7 +1457,7 @@ async def test_logs_error_if_no_connect_broker(
 async def test_handle_mqtt_on_callback(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     mqtt_client_mock,
 ) -> None:
     """Test receiving an ACK callback before waiting for it."""
@@ -1424,7 +1497,7 @@ async def test_publish_error(
 async def test_subscribe_error(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     mqtt_client_mock,
 ) -> None:
     """Test publish error."""
@@ -1439,7 +1512,9 @@ async def test_subscribe_error(
 
 
 async def test_handle_message_callback(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_client_mock,
 ) -> None:
     """Test for handling an incoming message callback."""
     callbacks = []
@@ -1559,7 +1634,7 @@ async def test_setup_manual_mqtt_empty_platform(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_setup_mqtt_client_protocol(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test MQTT client protocol setup."""
     with patch("paho.mqtt.client.Client") as mock_client:
@@ -1651,7 +1726,10 @@ async def test_setup_raises_ConfigEntryNotReady_if_no_connect_broker(
 )
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_setup_uses_certificate_on_certificate_set_to_auto_and_insecure(
-    hass: HomeAssistant, config, insecure_param, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant,
+    config,
+    insecure_param,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test setup uses bundled certs when certificate is set to auto and insecure."""
     calls = []
@@ -1687,7 +1765,7 @@ async def test_setup_uses_certificate_on_certificate_set_to_auto_and_insecure(
 
 
 async def test_tls_version(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test setup defaults for tls."""
     calls = []
@@ -1725,7 +1803,9 @@ async def test_tls_version(
     ],
 )
 async def test_custom_birth_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test sending birth message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1758,7 +1838,9 @@ async def test_custom_birth_message(
     ],
 )
 async def test_default_birth_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test sending birth message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1783,7 +1865,9 @@ async def test_default_birth_message(
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}],
 )
 async def test_no_birth_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test disabling birth message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1812,7 +1896,7 @@ async def test_delayed_birth_message(
     hass: HomeAssistant,
     mqtt_client_mock,
     mqtt_config_entry_data,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test sending birth message does not happen until Home Assistant starts."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -1873,7 +1957,9 @@ async def test_delayed_birth_message(
     ],
 )
 async def test_custom_will_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1884,7 +1970,9 @@ async def test_custom_will_message(
 
 
 async def test_default_will_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1899,7 +1987,9 @@ async def test_default_will_message(
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_WILL_MESSAGE: {}}],
 )
 async def test_no_will_message(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1918,7 +2008,9 @@ async def test_no_will_message(
     ],
 )
 async def test_mqtt_subscribes_topics_on_connect(
-    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscription to topic on connect."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1946,7 +2038,7 @@ async def test_mqtt_subscribes_topics_on_connect(
 async def test_setup_entry_with_config_override(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    mqtt_mock_entry_with_yaml_config,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test if the MQTT component loads with no config and config entry can be setup."""
     data = (
@@ -2032,7 +2124,7 @@ async def test_fail_no_broker(
 async def test_message_callback_exception_gets_logged(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test exception raised by message handler."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2055,7 +2147,7 @@ async def test_message_callback_exception_gets_logged(
 async def test_mqtt_ws_subscription(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT websocket subscription."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2120,7 +2212,7 @@ async def test_mqtt_ws_subscription(
 async def test_mqtt_ws_subscription_not_admin(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     hass_read_only_access_token,
 ) -> None:
     """Test MQTT websocket user is not admin."""
@@ -2134,7 +2226,7 @@ async def test_mqtt_ws_subscription_not_admin(
 
 
 async def test_dump_service(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that we can dump a topic."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2160,7 +2252,7 @@ async def test_mqtt_ws_remove_discovered_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT websocket device removal."""
     assert await async_setup_component(hass, "config", {})
@@ -2202,7 +2294,7 @@ async def test_mqtt_ws_get_device_debug_info(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2268,7 +2360,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2332,7 +2424,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
 
 
 async def test_debug_info_multiple_devices(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test we get correct debug_info when multiple devices are present."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2414,7 +2506,7 @@ async def test_debug_info_multiple_devices(
 
 
 async def test_debug_info_multiple_entities_triggers(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test we get correct debug_info for a device with multiple entities and triggers."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2503,7 +2595,7 @@ async def test_debug_info_non_mqtt(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mqtt_mock_entry_no_yaml_config,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test we get empty debug_info for a device with non MQTT entities."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2535,7 +2627,7 @@ async def test_debug_info_non_mqtt(
 
 
 async def test_debug_info_wildcard(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2583,7 +2675,7 @@ async def test_debug_info_wildcard(
 
 
 async def test_debug_info_filter_same(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test debug info removes messages with same timestamp."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2643,7 +2735,7 @@ async def test_debug_info_filter_same(
 
 
 async def test_debug_info_same_topic(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2697,7 +2789,7 @@ async def test_debug_info_same_topic(
 
 
 async def test_debug_info_qos_retain(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2756,7 +2848,7 @@ async def test_debug_info_qos_retain(
 
 
 async def test_publish_json_from_template(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test the publishing of call to services."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -2807,7 +2899,9 @@ async def test_publish_json_from_template(
 
 
 async def test_subscribe_connection_status(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_client_mock,
 ) -> None:
     """Test connextion status subscription."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -2848,7 +2942,7 @@ async def test_subscribe_connection_status(
 # This warning and test is to be removed from HA core 2023.6
 async def test_one_deprecation_warning_per_platform(
     hass: HomeAssistant,
-    mqtt_mock_entry_with_yaml_config,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a deprecation warning is is logged once per platform."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -16,7 +16,7 @@ from homeassistant import config as hass_config
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import CONFIG_SCHEMA, debug_info
 from homeassistant.components.mqtt.mixins import MQTT_ENTITY_DEVICE_INFO_SCHEMA
-from homeassistant.components.mqtt.models import ReceiveMessage
+from homeassistant.components.mqtt.models import MessageCallbackType, ReceiveMessage
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -85,19 +85,19 @@ def mock_mqtt():
 
 
 @pytest.fixture
-def calls():
+def calls() -> list[ReceiveMessage]:
     """Fixture to record calls."""
     return []
 
 
 @pytest.fixture
-def record_calls(calls):
+def record_calls(calls: list[ReceiveMessage]) -> MessageCallbackType:
     """Fixture to record calls."""
 
     @callback
-    def record_calls(*args) -> None:
+    def record_calls(msg: ReceiveMessage) -> None:
         """Record calls."""
-        calls.append(args)
+        calls.append(msg)
 
     return record_calls
 
@@ -800,8 +800,8 @@ def test_entity_device_info_schema() -> None:
 async def test_receiving_non_utf8_message_gets_logged(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test receiving a non utf8 encoded message."""
@@ -819,8 +819,8 @@ async def test_receiving_non_utf8_message_gets_logged(
 async def test_all_subscriptions_run_when_decode_fails(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test all other subscriptions still run when decode fails for one."""
     await mqtt_mock_entry_no_yaml_config()
@@ -836,8 +836,8 @@ async def test_all_subscriptions_run_when_decode_fails(
 async def test_subscribe_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
@@ -847,8 +847,8 @@ async def test_subscribe_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "test-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload"
 
     unsub()
 
@@ -865,8 +865,8 @@ async def test_subscribe_topic(
 async def test_subscribe_topic_non_async(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of a topic using the non-async function."""
     await mqtt_mock_entry_no_yaml_config()
@@ -879,8 +879,8 @@ async def test_subscribe_topic_non_async(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "test-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload"
 
     await hass.async_add_executor_job(unsub)
 
@@ -893,8 +893,8 @@ async def test_subscribe_topic_non_async(
 async def test_subscribe_bad_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1007,8 +1007,8 @@ async def test_subscribe_deprecated_async(
 async def test_subscribe_topic_not_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test if subscribed topic is not a match."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1023,8 +1023,8 @@ async def test_subscribe_topic_not_match(
 async def test_subscribe_topic_level_wildcard(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1034,15 +1034,15 @@ async def test_subscribe_topic_level_wildcard(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "test-topic/bier/on"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "test-topic/bier/on"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_no_subtree_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1057,8 +1057,8 @@ async def test_subscribe_topic_level_wildcard_no_subtree_match(
 async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1073,8 +1073,8 @@ async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
 async def test_subscribe_topic_subtree_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1084,15 +1084,15 @@ async def test_subscribe_topic_subtree_wildcard_subtree_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "test-topic/bier/on"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "test-topic/bier/on"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_subtree_wildcard_root_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1102,15 +1102,15 @@ async def test_subscribe_topic_subtree_wildcard_root_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "test-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_subtree_wildcard_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1125,8 +1125,8 @@ async def test_subscribe_topic_subtree_wildcard_no_match(
 async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1136,15 +1136,15 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "hi/test-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "hi/test-topic"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1154,15 +1154,15 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "hi/test-topic/here-iam"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "hi/test-topic/here-iam"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1177,8 +1177,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
 async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1193,8 +1193,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
 async def test_subscribe_topic_sys_root(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1204,15 +1204,15 @@ async def test_subscribe_topic_sys_root(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "$test-topic/subtree/on"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "$test-topic/subtree/on"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root and wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1222,15 +1222,15 @@ async def test_subscribe_topic_sys_root_and_wildcard_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "$test-topic/some-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "$test-topic/some-topic"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root and wildcard subtree topics."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1240,15 +1240,15 @@ async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == "$test-topic/subtree/some-topic"
-    assert calls[0][0].payload == "test-payload"
+    assert calls[0].topic == "$test-topic/subtree/some-topic"
+    assert calls[0].payload == "test-payload"
 
 
 async def test_subscribe_special_characters(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    calls,
-    record_calls,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription to topics with special characters."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1260,8 +1260,8 @@ async def test_subscribe_special_characters(
     async_fire_mqtt_message(hass, topic, payload)
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0][0].topic == topic
-    assert calls[0][0].payload == payload
+    assert calls[0].topic == topic
+    assert calls[0].payload == payload
 
 
 async def test_subscribe_same_topic(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 import homeassistant.core as ha
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, template
+from homeassistant.helpers import device_registry as dr, entity_registry as er, template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.setup import async_setup_component
@@ -1925,7 +1925,9 @@ async def test_mqtt_subscribes_topics_on_connect(
 
 
 async def test_setup_entry_with_config_override(
-    hass: HomeAssistant, device_registry, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock_entry_with_yaml_config,
 ) -> None:
     """Test if the MQTT component loads with no config and config entry can be setup."""
     data = (
@@ -1953,7 +1955,7 @@ async def test_setup_entry_with_config_override(
 
 
 async def test_update_incomplete_entry(
-    hass: HomeAssistant, device_registry, mqtt_client_mock, caplog
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mqtt_client_mock, caplog
 ) -> None:
     """Test if the MQTT component loads when config entry data is incomplete."""
     data = (
@@ -1991,7 +1993,7 @@ async def test_update_incomplete_entry(
 
 
 async def test_fail_no_broker(
-    hass: HomeAssistant, device_registry, mqtt_client_mock, caplog
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mqtt_client_mock, caplog
 ) -> None:
     """Test if the MQTT component loads when broker configuration is missing."""
     # Config entry data is incomplete
@@ -2126,7 +2128,10 @@ async def test_dump_service(
 
 
 async def test_mqtt_ws_remove_discovered_device(
-    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device removal."""
     assert await async_setup_component(hass, "config", {})
@@ -2165,7 +2170,10 @@ async def test_mqtt_ws_remove_discovered_device(
 
 
 async def test_mqtt_ws_get_device_debug_info(
-    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2228,7 +2236,10 @@ async def test_mqtt_ws_get_device_debug_info(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CAMERA])
 async def test_mqtt_ws_get_device_debug_info_binary(
-    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2461,8 +2472,8 @@ async def test_debug_info_multiple_entities_triggers(
 
 async def test_debug_info_non_mqtt(
     hass: HomeAssistant,
-    device_registry,
-    entity_registry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test we get empty debug_info for a device with non MQTT entities."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -47,7 +47,11 @@ from tests.common import (
     mock_restore_cache,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
-from tests.typing import MqttMockHAClientGenerator, WebSocketGenerator
+from tests.typing import (
+    MqttMockHAClientGenerator,
+    MqttMockPahoClient,
+    WebSocketGenerator,
+)
 
 
 class RecordCallsPartial(partial):
@@ -112,7 +116,7 @@ def empty_mqtt_config(hass: HomeAssistant, tmp_path: Path):
 
 async def test_mqtt_connects_on_home_assistant_mqtt_setup(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test if client is connected after mqtt init on bootstrap."""
@@ -123,7 +127,7 @@ async def test_mqtt_connects_on_home_assistant_mqtt_setup(
 async def test_mqtt_disconnects_on_home_assistant_stop(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test if client stops on HA stop."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1262,7 +1266,7 @@ async def test_subscribe_special_characters(
 
 async def test_subscribe_same_topic(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscring to same topic twice and simulate retained messages.
@@ -1299,7 +1303,7 @@ async def test_subscribe_same_topic(
 
 async def test_not_calling_unsubscribe_with_active_subscribers(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
@@ -1319,7 +1323,7 @@ async def test_not_calling_unsubscribe_with_active_subscribers(
 
 async def test_unsubscribe_race(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
@@ -1360,7 +1364,7 @@ async def test_unsubscribe_race(
 )
 async def test_restore_subscriptions_on_reconnect(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscriptions are restored on reconnect."""
@@ -1385,7 +1389,7 @@ async def test_restore_subscriptions_on_reconnect(
 )
 async def test_restore_all_active_subscriptions_on_reconnect(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test active subscriptions are restored correctly on reconnect."""
@@ -1421,7 +1425,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
 async def test_initial_setup_logs_error(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     empty_mqtt_config,
 ) -> None:
     """Test for setup failure if initial client connection fails."""
@@ -1440,7 +1444,7 @@ async def test_logs_error_if_no_connect_broker(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test for setup failure if connection to broker is missing."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1458,7 +1462,7 @@ async def test_handle_mqtt_on_callback(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test receiving an ACK callback before waiting for it."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1498,7 +1502,7 @@ async def test_subscribe_error(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test publish error."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1514,7 +1518,7 @@ async def test_subscribe_error(
 async def test_handle_message_callback(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test for handling an incoming message callback."""
     callbacks = []
@@ -1804,7 +1808,7 @@ async def test_tls_version(
 )
 async def test_custom_birth_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test sending birth message."""
@@ -1839,7 +1843,7 @@ async def test_custom_birth_message(
 )
 async def test_default_birth_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test sending birth message."""
@@ -1866,7 +1870,7 @@ async def test_default_birth_message(
 )
 async def test_no_birth_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test disabling birth message."""
@@ -1894,7 +1898,7 @@ async def test_no_birth_message(
 )
 async def test_delayed_birth_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
@@ -1958,7 +1962,7 @@ async def test_delayed_birth_message(
 )
 async def test_custom_will_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
@@ -1971,7 +1975,7 @@ async def test_custom_will_message(
 
 async def test_default_will_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
@@ -1988,7 +1992,7 @@ async def test_default_will_message(
 )
 async def test_no_will_message(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test will message."""
@@ -2009,7 +2013,7 @@ async def test_no_will_message(
 )
 async def test_mqtt_subscribes_topics_on_connect(
     hass: HomeAssistant,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> None:
     """Test subscription to topic on connect."""
@@ -2068,7 +2072,7 @@ async def test_setup_entry_with_config_override(
 async def test_update_incomplete_entry(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if the MQTT component loads when config entry data is incomplete."""
@@ -2109,7 +2113,7 @@ async def test_update_incomplete_entry(
 async def test_fail_no_broker(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if the MQTT component loads when broker configuration is missing."""
@@ -2901,7 +2905,7 @@ async def test_publish_json_from_template(
 async def test_subscribe_connection_status(
     hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
     """Test connextion status subscription."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -2976,7 +2980,7 @@ async def test_config_schema_validation(hass: HomeAssistant) -> None:
 async def test_unload_config_entry(
     hass: HomeAssistant,
     mqtt_mock,
-    mqtt_client_mock,
+    mqtt_client_mock: MqttMockPahoClient,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -3176,7 +3180,9 @@ async def test_setup_manual_items_with_unique_ids(
 
 
 async def test_remove_unknown_conf_entry_options(
-    hass: HomeAssistant, mqtt_client_mock, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test unknown keys in config entry data is removed."""
     mqtt_config_entry_data = {

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -89,7 +89,7 @@ def record_calls(calls):
     """Fixture to record calls."""
 
     @callback
-    def record_calls(*args):
+    def record_calls(*args) -> None:
         """Record calls."""
         calls.append(args)
 
@@ -97,7 +97,7 @@ def record_calls(calls):
 
 
 @pytest.fixture
-def empty_mqtt_config(hass, tmp_path):
+def empty_mqtt_config(hass: HomeAssistant, tmp_path):
     """Fixture to provide an empty config from yaml."""
     new_yaml_config_file = tmp_path / "configuration.yaml"
     new_yaml_config_file.write_text("")
@@ -109,16 +109,16 @@ def empty_mqtt_config(hass, tmp_path):
 
 
 async def test_mqtt_connects_on_home_assistant_mqtt_setup(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test if client is connected after mqtt init on bootstrap."""
     await mqtt_mock_entry_no_yaml_config()
     assert mqtt_client_mock.connect.call_count == 1
 
 
 async def test_mqtt_disconnects_on_home_assistant_stop(
-    hass, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test if client stops on HA stop."""
     await mqtt_mock_entry_no_yaml_config()
     hass.bus.fire(EVENT_HOMEASSISTANT_STOP)
@@ -129,8 +129,8 @@ async def test_mqtt_disconnects_on_home_assistant_stop(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_mqtt_await_ack_at_disconnect(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test if ACK is awaited correctly when disconnecting."""
 
     class FakeInfo:
@@ -170,7 +170,7 @@ async def test_mqtt_await_ack_at_disconnect(
         )
 
 
-async def test_publish(hass, mqtt_mock_entry_no_yaml_config):
+async def test_publish(hass: HomeAssistant, mqtt_mock_entry_no_yaml_config) -> None:
     """Test the publish function."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_publish(hass, "test-topic", "test-payload")
@@ -236,7 +236,7 @@ async def test_publish(hass, mqtt_mock_entry_no_yaml_config):
     mqtt_mock.reset_mock()
 
 
-async def test_convert_outgoing_payload(hass):
+async def test_convert_outgoing_payload(hass: HomeAssistant) -> None:
     """Test the converting of outgoing MQTT payloads without template."""
     command_template = mqtt.MqttCommandTemplate(None, hass=hass)
     assert command_template.async_render(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
@@ -253,7 +253,7 @@ async def test_convert_outgoing_payload(hass):
     assert command_template.async_render(None) is None
 
 
-async def test_command_template_value(hass):
+async def test_command_template_value(hass: HomeAssistant) -> None:
     """Test the rendering of MQTT command template."""
 
     variables = {"id": 1234, "some_var": "beer"}
@@ -270,7 +270,9 @@ async def test_command_template_value(hass):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SELECT])
-async def test_command_template_variables(hass, mqtt_mock_entry_with_yaml_config):
+async def test_command_template_variables(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the rendering of entity variables."""
     topic = "test/select"
 
@@ -330,7 +332,7 @@ async def test_command_template_variables(hass, mqtt_mock_entry_with_yaml_config
         assert state.state == "milk"
 
 
-async def test_value_template_value(hass):
+async def test_value_template_value(hass: HomeAssistant) -> None:
     """Test the rendering of MQTT value template."""
 
     variables = {"id": 1234, "some_var": "beer"}
@@ -382,8 +384,8 @@ async def test_value_template_value(hass):
 
 
 async def test_service_call_without_topic_does_not_publish(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call if topic is missing."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     with pytest.raises(vol.Invalid):
@@ -397,8 +399,8 @@ async def test_service_call_without_topic_does_not_publish(
 
 
 async def test_service_call_with_topic_and_topic_template_does_not_publish(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with topic/topic template.
 
     If both 'topic' and 'topic_template' are provided then fail.
@@ -421,8 +423,8 @@ async def test_service_call_with_topic_and_topic_template_does_not_publish(
 
 
 async def test_service_call_with_invalid_topic_template_does_not_publish(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with a problematic topic template."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     await hass.services.async_call(
@@ -438,8 +440,8 @@ async def test_service_call_with_invalid_topic_template_does_not_publish(
 
 
 async def test_service_call_with_template_topic_renders_template(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with rendered topic template.
 
     If 'topic_template' is provided and 'topic' is not, then render it.
@@ -459,8 +461,8 @@ async def test_service_call_with_template_topic_renders_template(
 
 
 async def test_service_call_with_template_topic_renders_invalid_topic(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with rendered, invalid topic template.
 
     If a wildcard topic is rendered, then fail.
@@ -479,8 +481,8 @@ async def test_service_call_with_template_topic_renders_invalid_topic(
 
 
 async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_template(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with unrendered template.
 
     If both 'payload' and 'payload_template' are provided then fail.
@@ -503,8 +505,8 @@ async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_t
 
 
 async def test_service_call_with_template_payload_renders_template(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with rendered template.
 
     If 'payload_template' is provided and 'payload' is not, then render it.
@@ -534,7 +536,9 @@ async def test_service_call_with_template_payload_renders_template(
     mqtt_mock.reset_mock()
 
 
-async def test_service_call_with_bad_template(hass, mqtt_mock_entry_no_yaml_config):
+async def test_service_call_with_bad_template(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with a bad template does not publish."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     await hass.services.async_call(
@@ -547,8 +551,8 @@ async def test_service_call_with_bad_template(hass, mqtt_mock_entry_no_yaml_conf
 
 
 async def test_service_call_with_payload_doesnt_render_template(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with unrendered template.
 
     If both 'payload' and 'payload_template' are provided then fail.
@@ -571,8 +575,8 @@ async def test_service_call_with_payload_doesnt_render_template(
 
 
 async def test_service_call_with_ascii_qos_retain_flags(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the service call with args that can be misinterpreted.
 
     Empty payload message and ascii formatted qos and retain flags.
@@ -595,8 +599,8 @@ async def test_service_call_with_ascii_qos_retain_flags(
 
 
 async def test_publish_function_with_bad_encoding_conditions(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test internal publish function with basic use cases."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_publish(
@@ -780,8 +784,8 @@ def test_entity_device_info_schema() -> None:
 
 
 async def test_receiving_non_utf8_message_gets_logged(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls, caplog
+) -> None:
     """Test receiving a non utf8 encoded message."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic", record_calls)
@@ -795,8 +799,8 @@ async def test_receiving_non_utf8_message_gets_logged(
 
 
 async def test_all_subscriptions_run_when_decode_fails(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test all other subscriptions still run when decode fails for one."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic", record_calls, encoding="ascii")
@@ -809,8 +813,8 @@ async def test_all_subscriptions_run_when_decode_fails(
 
 
 async def test_subscribe_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
     unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls)
@@ -835,8 +839,8 @@ async def test_subscribe_topic(
 
 
 async def test_subscribe_topic_non_async(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of a topic using the non-async function."""
     await mqtt_mock_entry_no_yaml_config()
     unsub = await hass.async_add_executor_job(
@@ -860,8 +864,8 @@ async def test_subscribe_topic_non_async(
 
 
 async def test_subscribe_bad_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of a topic."""
     await mqtt_mock_entry_no_yaml_config()
     with pytest.raises(HomeAssistantError):
@@ -869,12 +873,14 @@ async def test_subscribe_bad_topic(
 
 
 # Support for a deprecated callback type will be removed from HA core 2023.2.0
-async def test_subscribe_deprecated(hass, mqtt_mock_entry_no_yaml_config):
+async def test_subscribe_deprecated(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the subscription of a topic using deprecated callback signature."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     @callback
-    def record_calls(topic, payload, qos):
+    def record_calls(topic, payload, qos) -> None:
         """Record calls."""
         calls.append((topic, payload, qos))
 
@@ -918,11 +924,14 @@ async def test_subscribe_deprecated(hass, mqtt_mock_entry_no_yaml_config):
 
 
 # Support for a deprecated callback type will be removed from HA core 2023.2.0
-async def test_subscribe_deprecated_async(hass, mqtt_mock_entry_no_yaml_config):
+async def test_subscribe_deprecated_async(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the subscription of a topic using deprecated coroutine signature."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
-    def async_record_calls(topic, payload, qos):
+    @callback
+    def async_record_calls(topic, payload, qos) -> None:
         """Record calls."""
         calls.append((topic, payload, qos))
 
@@ -966,8 +975,8 @@ async def test_subscribe_deprecated_async(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_subscribe_topic_not_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test if subscribed topic is not a match."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic", record_calls)
@@ -979,8 +988,8 @@ async def test_subscribe_topic_not_match(
 
 
 async def test_subscribe_topic_level_wildcard(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/+/on", record_calls)
@@ -994,8 +1003,8 @@ async def test_subscribe_topic_level_wildcard(
 
 
 async def test_subscribe_topic_level_wildcard_no_subtree_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/+/on", record_calls)
@@ -1007,8 +1016,8 @@ async def test_subscribe_topic_level_wildcard_no_subtree_match(
 
 
 async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/#", record_calls)
@@ -1020,8 +1029,8 @@ async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
 
 
 async def test_subscribe_topic_subtree_wildcard_subtree_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/#", record_calls)
@@ -1035,8 +1044,8 @@ async def test_subscribe_topic_subtree_wildcard_subtree_topic(
 
 
 async def test_subscribe_topic_subtree_wildcard_root_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/#", record_calls)
@@ -1050,8 +1059,8 @@ async def test_subscribe_topic_subtree_wildcard_root_topic(
 
 
 async def test_subscribe_topic_subtree_wildcard_no_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "test-topic/#", record_calls)
@@ -1063,8 +1072,8 @@ async def test_subscribe_topic_subtree_wildcard_no_match(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "+/test-topic/#", record_calls)
@@ -1078,8 +1087,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "+/test-topic/#", record_calls)
@@ -1093,8 +1102,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "+/test-topic/#", record_calls)
@@ -1106,8 +1115,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "+/test-topic/#", record_calls)
@@ -1119,8 +1128,8 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
 
 
 async def test_subscribe_topic_sys_root(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of $ root topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "$test-topic/subtree/on", record_calls)
@@ -1134,8 +1143,8 @@ async def test_subscribe_topic_sys_root(
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of $ root and wildcard topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "$test-topic/#", record_calls)
@@ -1149,8 +1158,8 @@ async def test_subscribe_topic_sys_root_and_wildcard_topic(
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription of $ root and wildcard subtree topics."""
     await mqtt_mock_entry_no_yaml_config()
     await mqtt.async_subscribe(hass, "$test-topic/subtree/#", record_calls)
@@ -1164,8 +1173,8 @@ async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
 
 
 async def test_subscribe_special_characters(
-    hass, mqtt_mock_entry_no_yaml_config, calls, record_calls
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls
+) -> None:
     """Test the subscription to topics with special characters."""
     await mqtt_mock_entry_no_yaml_config()
     topic = "/test-topic/$(.)[^]{-}"
@@ -1181,8 +1190,8 @@ async def test_subscribe_special_characters(
 
 
 async def test_subscribe_same_topic(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test subscring to same topic twice and simulate retained messages.
 
     When subscribing to the same topic again, SUBSCRIBE must be sent to the broker again
@@ -1216,8 +1225,8 @@ async def test_subscribe_same_topic(
 
 
 async def test_not_calling_unsubscribe_with_active_subscribers(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     # Fake that the client is connected
@@ -1233,7 +1242,9 @@ async def test_not_calling_unsubscribe_with_active_subscribers(
     assert not mqtt_client_mock.unsubscribe.called
 
 
-async def test_unsubscribe_race(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config):
+async def test_unsubscribe_race(
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     # Fake that the client is connected
@@ -1271,8 +1282,8 @@ async def test_unsubscribe_race(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],
 )
 async def test_restore_subscriptions_on_reconnect(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test subscriptions are restored on reconnect."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     # Fake that the client is connected
@@ -1294,8 +1305,8 @@ async def test_restore_subscriptions_on_reconnect(
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_DISCOVERY: False}],
 )
 async def test_restore_all_active_subscriptions_on_reconnect(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test active subscriptions are restored correctly on reconnect."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     # Fake that the client is connected
@@ -1327,8 +1338,8 @@ async def test_restore_all_active_subscriptions_on_reconnect(
 
 
 async def test_initial_setup_logs_error(
-    hass, caplog, mqtt_client_mock, empty_mqtt_config
-):
+    hass: HomeAssistant, caplog, mqtt_client_mock, empty_mqtt_config
+) -> None:
     """Test for setup failure if initial client connection fails."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
@@ -1342,8 +1353,8 @@ async def test_initial_setup_logs_error(
 
 
 async def test_logs_error_if_no_connect_broker(
-    hass, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test for setup failure if connection to broker is missing."""
     await mqtt_mock_entry_no_yaml_config()
     # test with rc = 3 -> broker unavailable
@@ -1357,8 +1368,8 @@ async def test_logs_error_if_no_connect_broker(
 
 @patch("homeassistant.components.mqtt.client.TIMEOUT_ACK", 0.3)
 async def test_handle_mqtt_on_callback(
-    hass, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test receiving an ACK callback before waiting for it."""
     await mqtt_mock_entry_no_yaml_config()
     # Simulate an ACK for mid == 1, this will call mqtt_mock._mqtt_handle_mid(mid)
@@ -1373,7 +1384,9 @@ async def test_handle_mqtt_on_callback(
     assert "No ACK from MQTT server" not in caplog.text
 
 
-async def test_publish_error(hass, caplog):
+async def test_publish_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test publish error."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
@@ -1392,8 +1405,8 @@ async def test_publish_error(hass, caplog):
 
 
 async def test_subscribe_error(
-    hass, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test publish error."""
     await mqtt_mock_entry_no_yaml_config()
     mqtt_client_mock.on_connect(mqtt_client_mock, None, None, 0)
@@ -1406,12 +1419,13 @@ async def test_subscribe_error(
 
 
 async def test_handle_message_callback(
-    hass, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test for handling an incoming message callback."""
     callbacks = []
 
-    def _callback(args):
+    @callback
+    def _callback(args) -> None:
         callbacks.append(args)
 
     await mqtt_mock_entry_no_yaml_config()
@@ -1428,11 +1442,13 @@ async def test_handle_message_callback(
     assert callbacks[0].payload == "test-payload"
 
 
-async def test_setup_override_configuration(hass, caplog, tmp_path):
+async def test_setup_override_configuration(
+    hass: HomeAssistant, caplog, tmp_path
+) -> None:
     """Test override setup from configuration entry."""
     calls_username_password_set = []
 
-    def mock_usename_password_set(username, password):
+    def mock_usename_password_set(username, password) -> None:
         calls_username_password_set.append((username, password))
 
     # Mock password setup from config
@@ -1476,7 +1492,9 @@ async def test_setup_override_configuration(hass, caplog, tmp_path):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_setup_manual_mqtt_with_platform_key(hass, caplog):
+async def test_setup_manual_mqtt_with_platform_key(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test set up a manual MQTT item with a platform key."""
     config = {
         mqtt.DOMAIN: {
@@ -1496,7 +1514,9 @@ async def test_setup_manual_mqtt_with_platform_key(hass, caplog):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_setup_manual_mqtt_with_invalid_config(hass, caplog):
+async def test_setup_manual_mqtt_with_invalid_config(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test set up a manual MQTT item with an invalid config."""
     config = {mqtt.DOMAIN: {"light": {"name": "test"}}}
     with pytest.raises(AssertionError):
@@ -1508,7 +1528,9 @@ async def test_setup_manual_mqtt_with_invalid_config(hass, caplog):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_setup_manual_mqtt_empty_platform(hass, caplog):
+async def test_setup_manual_mqtt_empty_platform(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test set up a manual MQTT platform without items."""
     config = {mqtt.DOMAIN: {"light": []}}
     await help_test_setup_manual_entity_from_yaml(hass, config)
@@ -1516,7 +1538,9 @@ async def test_setup_manual_mqtt_empty_platform(hass, caplog):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_setup_mqtt_client_protocol(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setup_mqtt_client_protocol(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT client protocol setup."""
     with patch("paho.mqtt.client.Client") as mock_client:
         assert await async_setup_component(
@@ -1537,7 +1561,9 @@ async def test_setup_mqtt_client_protocol(hass, mqtt_mock_entry_with_yaml_config
 
 @patch("homeassistant.components.mqtt.client.TIMEOUT_ACK", 0.2)
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_handle_mqtt_timeout_on_callback(hass, caplog):
+async def test_handle_mqtt_timeout_on_callback(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test publish without receiving an ACK callback."""
     mid = 0
 
@@ -1549,7 +1575,7 @@ async def test_handle_mqtt_timeout_on_callback(hass, caplog):
 
     with patch("paho.mqtt.client.Client") as mock_client:
 
-        def _mock_ack(topic, qos=0):
+        def _mock_ack(topic, qos=0) -> None:
             # Handle ACK for subscribe normally
             nonlocal mid
             mid += 1
@@ -1581,7 +1607,9 @@ async def test_handle_mqtt_timeout_on_callback(hass, caplog):
         assert "No ACK from MQTT server" in caplog.text
 
 
-async def test_setup_raises_ConfigEntryNotReady_if_no_connect_broker(hass, caplog):
+async def test_setup_raises_ConfigEntryNotReady_if_no_connect_broker(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for setup failure if connection to broker is missing."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
@@ -1603,16 +1631,18 @@ async def test_setup_raises_ConfigEntryNotReady_if_no_connect_broker(hass, caplo
 )
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 async def test_setup_uses_certificate_on_certificate_set_to_auto_and_insecure(
-    hass, config, insecure_param, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, config, insecure_param, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setup uses bundled certs when certificate is set to auto and insecure."""
     calls = []
     insecure_check = {"insecure": "not set"}
 
-    def mock_tls_set(certificate, certfile=None, keyfile=None, tls_version=None):
+    def mock_tls_set(
+        certificate, certfile=None, keyfile=None, tls_version=None
+    ) -> None:
         calls.append((certificate, certfile, keyfile, tls_version))
 
-    def mock_tls_insecure_set(insecure_param):
+    def mock_tls_insecure_set(insecure_param) -> None:
         insecure_check["insecure"] = insecure_param
 
     with patch("paho.mqtt.client.Client") as mock_client:
@@ -1636,11 +1666,15 @@ async def test_setup_uses_certificate_on_certificate_set_to_auto_and_insecure(
         assert insecure_check["insecure"] == insecure_param
 
 
-async def test_tls_version(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tls_version(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setup defaults for tls."""
     calls = []
 
-    def mock_tls_set(certificate, certfile=None, keyfile=None, tls_version=None):
+    def mock_tls_set(
+        certificate, certfile=None, keyfile=None, tls_version=None
+    ) -> None:
         calls.append((certificate, certfile, keyfile, tls_version))
 
     with patch("paho.mqtt.client.Client") as mock_client:
@@ -1671,13 +1705,13 @@ async def test_tls_version(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_custom_birth_message(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test sending birth message."""
     await mqtt_mock_entry_no_yaml_config()
     birth = asyncio.Event()
 
-    async def wait_birth(topic, payload, qos):
+    async def wait_birth(topic, payload, qos) -> None:
         """Handle birth message."""
         birth.set()
 
@@ -1704,13 +1738,13 @@ async def test_custom_birth_message(
     ],
 )
 async def test_default_birth_message(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test sending birth message."""
     await mqtt_mock_entry_no_yaml_config()
     birth = asyncio.Event()
 
-    async def wait_birth(topic, payload, qos):
+    async def wait_birth(topic, payload, qos) -> None:
         """Handle birth message."""
         birth.set()
 
@@ -1728,7 +1762,9 @@ async def test_default_birth_message(
     "mqtt_config_entry_data",
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_BIRTH_MESSAGE: {}}],
 )
-async def test_no_birth_message(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config):
+async def test_no_birth_message(
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test disabling birth message."""
     await mqtt_mock_entry_no_yaml_config()
     with patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.1):
@@ -1753,8 +1789,11 @@ async def test_no_birth_message(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_
     ],
 )
 async def test_delayed_birth_message(
-    hass, mqtt_client_mock, mqtt_config_entry_data, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    mqtt_client_mock,
+    mqtt_config_entry_data,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test sending birth message does not happen until Home Assistant starts."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
@@ -1779,7 +1818,7 @@ async def test_delayed_birth_message(
     mqtt_mock = hass.data["mqtt"].client
     mqtt_mock.reset_mock()
 
-    async def wait_birth(topic, payload, qos):
+    async def wait_birth(topic, payload, qos) -> None:
         """Handle birth message."""
         birth.set()
 
@@ -1814,8 +1853,8 @@ async def test_delayed_birth_message(
     ],
 )
 async def test_custom_will_message(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
 
@@ -1825,8 +1864,8 @@ async def test_custom_will_message(
 
 
 async def test_default_will_message(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
 
@@ -1839,7 +1878,9 @@ async def test_default_will_message(
     "mqtt_config_entry_data",
     [{mqtt.CONF_BROKER: "mock-broker", mqtt.CONF_WILL_MESSAGE: {}}],
 )
-async def test_no_will_message(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config):
+async def test_no_will_message(
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test will message."""
     await mqtt_mock_entry_no_yaml_config()
 
@@ -1857,8 +1898,8 @@ async def test_no_will_message(hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_c
     ],
 )
 async def test_mqtt_subscribes_topics_on_connect(
-    hass, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_client_mock, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test subscription to topic on connect."""
     await mqtt_mock_entry_no_yaml_config()
 
@@ -1883,8 +1924,8 @@ async def test_mqtt_subscribes_topics_on_connect(
 
 
 async def test_setup_entry_with_config_override(
-    hass, device_registry, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test if the MQTT component loads with no config and config entry can be setup."""
     data = (
         '{ "device":{"identifiers":["0AFFD2"]},'
@@ -1912,7 +1953,7 @@ async def test_setup_entry_with_config_override(
 
 async def test_update_incomplete_entry(
     hass: HomeAssistant, device_registry, mqtt_client_mock, caplog
-):
+) -> None:
     """Test if the MQTT component loads when config entry data is incomplete."""
     data = (
         '{ "device":{"identifiers":["0AFFD2"]},'
@@ -1948,7 +1989,9 @@ async def test_update_incomplete_entry(
     assert device_entry is not None
 
 
-async def test_fail_no_broker(hass, device_registry, mqtt_client_mock, caplog):
+async def test_fail_no_broker(
+    hass: HomeAssistant, device_registry, mqtt_client_mock, caplog
+) -> None:
     """Test if the MQTT component loads when broker configuration is missing."""
     # Config entry data is incomplete
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={})
@@ -1959,13 +2002,13 @@ async def test_fail_no_broker(hass, device_registry, mqtt_client_mock, caplog):
 
 @pytest.mark.no_fail_on_log_exception
 async def test_message_callback_exception_gets_logged(
-    hass, caplog, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test exception raised by message handler."""
     await mqtt_mock_entry_no_yaml_config()
 
     @callback
-    def bad_handler(*args):
+    def bad_handler(*args) -> None:
         """Record calls."""
         raise Exception("This is a bad message callback")
 
@@ -1980,8 +2023,8 @@ async def test_message_callback_exception_gets_logged(
 
 
 async def test_mqtt_ws_subscription(
-    hass, hass_ws_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, hass_ws_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT websocket subscription."""
     await mqtt_mock_entry_no_yaml_config()
     client = await hass_ws_client(hass)
@@ -2043,8 +2086,11 @@ async def test_mqtt_ws_subscription(
 
 
 async def test_mqtt_ws_subscription_not_admin(
-    hass, hass_ws_client, mqtt_mock_entry_no_yaml_config, hass_read_only_access_token
-):
+    hass: HomeAssistant,
+    hass_ws_client,
+    mqtt_mock_entry_no_yaml_config,
+    hass_read_only_access_token,
+) -> None:
     """Test MQTT websocket user is not admin."""
     await mqtt_mock_entry_no_yaml_config()
     client = await hass_ws_client(hass, access_token=hass_read_only_access_token)
@@ -2055,7 +2101,9 @@ async def test_mqtt_ws_subscription_not_admin(
     assert response["error"]["message"] == "Unauthorized"
 
 
-async def test_dump_service(hass, mqtt_mock_entry_no_yaml_config):
+async def test_dump_service(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test that we can dump a topic."""
     await mqtt_mock_entry_no_yaml_config()
     mopen = mock_open()
@@ -2077,8 +2125,8 @@ async def test_dump_service(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_mqtt_ws_remove_discovered_device(
-    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT websocket device removal."""
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
@@ -2116,8 +2164,8 @@ async def test_mqtt_ws_remove_discovered_device(
 
 
 async def test_mqtt_ws_get_device_debug_info(
-    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
     config_sensor = {
@@ -2179,8 +2227,8 @@ async def test_mqtt_ws_get_device_debug_info(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CAMERA])
 async def test_mqtt_ws_get_device_debug_info_binary(
-    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -2242,7 +2290,9 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     assert response["result"] == expected_result
 
 
-async def test_debug_info_multiple_devices(hass, mqtt_mock_entry_no_yaml_config):
+async def test_debug_info_multiple_devices(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test we get correct debug_info when multiple devices are present."""
     await mqtt_mock_entry_no_yaml_config()
     devices = [
@@ -2323,8 +2373,8 @@ async def test_debug_info_multiple_devices(hass, mqtt_mock_entry_no_yaml_config)
 
 
 async def test_debug_info_multiple_entities_triggers(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test we get correct debug_info for a device with multiple entities and triggers."""
     await mqtt_mock_entry_no_yaml_config()
     config = [
@@ -2409,8 +2459,11 @@ async def test_debug_info_multiple_entities_triggers(
 
 
 async def test_debug_info_non_mqtt(
-    hass, device_registry, entity_registry, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    device_registry,
+    entity_registry,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test we get empty debug_info for a device with non MQTT entities."""
     await mqtt_mock_entry_no_yaml_config()
     DOMAIN = "sensor"
@@ -2440,7 +2493,9 @@ async def test_debug_info_non_mqtt(
     assert len(debug_info_data["triggers"]) == 0
 
 
-async def test_debug_info_wildcard(hass, mqtt_mock_entry_no_yaml_config):
+async def test_debug_info_wildcard(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -2486,7 +2541,9 @@ async def test_debug_info_wildcard(hass, mqtt_mock_entry_no_yaml_config):
     } in debug_info_data["entities"][0]["subscriptions"]
 
 
-async def test_debug_info_filter_same(hass, mqtt_mock_entry_no_yaml_config):
+async def test_debug_info_filter_same(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test debug info removes messages with same timestamp."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -2544,7 +2601,9 @@ async def test_debug_info_filter_same(hass, mqtt_mock_entry_no_yaml_config):
     } == debug_info_data["entities"][0]["subscriptions"][0]
 
 
-async def test_debug_info_same_topic(hass, mqtt_mock_entry_no_yaml_config):
+async def test_debug_info_same_topic(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -2596,7 +2655,9 @@ async def test_debug_info_same_topic(hass, mqtt_mock_entry_no_yaml_config):
         async_fire_mqtt_message(hass, "sensor/status", "123", qos=0, retain=False)
 
 
-async def test_debug_info_qos_retain(hass, mqtt_mock_entry_no_yaml_config):
+async def test_debug_info_qos_retain(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test debug info."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -2653,7 +2714,9 @@ async def test_debug_info_qos_retain(hass, mqtt_mock_entry_no_yaml_config):
     } in debug_info_data["entities"][0]["subscriptions"][0]["messages"]
 
 
-async def test_publish_json_from_template(hass, mqtt_mock_entry_no_yaml_config):
+async def test_publish_json_from_template(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the publishing of call to services."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
@@ -2703,14 +2766,14 @@ async def test_publish_json_from_template(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_subscribe_connection_status(
-    hass, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+) -> None:
     """Test connextion status subscription."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     mqtt_connected_calls = []
 
     @callback
-    async def async_mqtt_connected(status):
+    async def async_mqtt_connected(status) -> None:
         """Update state on connection/disconnection to MQTT broker."""
         mqtt_connected_calls.append(status)
 
@@ -2743,8 +2806,8 @@ async def test_subscribe_connection_status(
 # Test existence of removed YAML configuration under the platform key
 # This warning and test is to be removed from HA core 2023.6
 async def test_one_deprecation_warning_per_platform(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test a deprecation warning is is logged once per platform."""
     platform = "light"
     config = {"platform": "mqtt", "command_topic": "test-topic"}
@@ -2765,7 +2828,7 @@ async def test_one_deprecation_warning_per_platform(
     assert count == 1
 
 
-async def test_config_schema_validation(hass):
+async def test_config_schema_validation(hass: HomeAssistant) -> None:
     """Test invalid platform options in the config schema do not pass the config validation."""
     config = {"mqtt": {"sensor": [{"some_illegal_topic": "mystate/topic/path"}]}}
     with pytest.raises(vol.MultipleInvalid):
@@ -2774,7 +2837,7 @@ async def test_config_schema_validation(hass):
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_unload_config_entry(
-    hass, mqtt_mock, mqtt_client_mock, tmp_path, caplog
+    hass: HomeAssistant, mqtt_mock, mqtt_client_mock, tmp_path, caplog
 ) -> None:
     """Test unloading the MQTT entry."""
     assert hass.services.has_service(mqtt.DOMAIN, "dump")
@@ -2801,7 +2864,9 @@ async def test_unload_config_entry(
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_setup_with_disabled_entry(hass, caplog) -> None:
+async def test_setup_with_disabled_entry(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setting up the platform with a disabled config entry."""
     # Try to setup the platform with a disabled config entry
     config_entry = MockConfigEntry(
@@ -2817,7 +2882,9 @@ async def test_setup_with_disabled_entry(hass, caplog) -> None:
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
-async def test_publish_or_subscribe_without_valid_config_entry(hass, caplog):
+async def test_publish_or_subscribe_without_valid_config_entry(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test internal publish function with bas use cases."""
     with pytest.raises(HomeAssistantError):
         await mqtt.async_publish(
@@ -2828,7 +2895,7 @@ async def test_publish_or_subscribe_without_valid_config_entry(hass, caplog):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_reload_entry_with_new_config(hass, tmp_path):
+async def test_reload_entry_with_new_config(hass: HomeAssistant, tmp_path) -> None:
     """Test reloading the config entry with a new yaml config."""
     config_old = {
         "mqtt": {"light": [{"name": "test_old1", "command_topic": "test-topic_old"}]}
@@ -2847,7 +2914,9 @@ async def test_reload_entry_with_new_config(hass, tmp_path):
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_disabling_and_enabling_entry(hass, tmp_path, caplog):
+async def test_disabling_and_enabling_entry(
+    hass: HomeAssistant, tmp_path, caplog
+) -> None:
     """Test disabling and enabling the config entry."""
     config_old = {
         "mqtt": {"light": [{"name": "test_old1", "command_topic": "test-topic_old"}]}
@@ -2937,8 +3006,8 @@ async def test_disabling_and_enabling_entry(hass, tmp_path, caplog):
     ],
 )
 async def test_setup_manual_items_with_unique_ids(
-    hass, tmp_path, caplog, config, unique
-):
+    hass: HomeAssistant, tmp_path, caplog, config, unique
+) -> None:
     """Test setup manual items is generating unique id's."""
     await help_test_setup_manual_entity_from_yaml(
         hass, {mqtt.DOMAIN: {"light": config}}
@@ -2959,7 +3028,9 @@ async def test_setup_manual_items_with_unique_ids(
     assert bool("Platform mqtt does not generate unique IDs." in caplog.text) != unique
 
 
-async def test_remove_unknown_conf_entry_options(hass, mqtt_client_mock, caplog):
+async def test_remove_unknown_conf_entry_options(
+    hass: HomeAssistant, mqtt_client_mock, caplog
+) -> None:
     """Test unknown keys in config entry data is removed."""
     mqtt_config_entry_data = {
         mqtt.CONF_BROKER: "mock-broker",
@@ -2985,7 +3056,7 @@ async def test_remove_unknown_conf_entry_options(hass, mqtt_client_mock, caplog)
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_link_config_entry(hass, tmp_path, caplog):
+async def test_link_config_entry(hass: HomeAssistant, tmp_path, caplog) -> None:
     """Test manual and dynamically setup entities are linked to the config entry."""
     config_manual = {
         "mqtt": {
@@ -3021,7 +3092,7 @@ async def test_link_config_entry(hass, tmp_path, caplog):
     mqtt_config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     mqtt_platforms = async_get_platforms(hass, mqtt.DOMAIN)
 
-    def _check_entities():
+    def _check_entities() -> int:
         entities = []
         for mqtt_platform in mqtt_platforms:
             assert mqtt_platform.config_entry is mqtt_config_entry
@@ -3057,6 +3128,8 @@ async def test_link_config_entry(hass, tmp_path, caplog):
         {"mqtt": {"broker": "test"}},
     ],
 )
-async def test_setup_manual_entity_from_yaml(hass: HomeAssistant, config_manual):
+async def test_setup_manual_entity_from_yaml(
+    hass: HomeAssistant, config_manual
+) -> None:
     """Test setup with empty platform keys."""
     await help_test_setup_manual_entity_from_yaml(hass, config_manual)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -47,6 +47,7 @@ from tests.common import (
     mock_restore_cache,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
+from tests.typing import WebSocketGenerator
 
 
 class RecordCallsPartial(partial):
@@ -600,7 +601,9 @@ async def test_service_call_with_ascii_qos_retain_flags(
 
 
 async def test_publish_function_with_bad_encoding_conditions(
-    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test internal publish function with basic use cases."""
     await mqtt_mock_entry_no_yaml_config()
@@ -785,7 +788,11 @@ def test_entity_device_info_schema() -> None:
 
 
 async def test_receiving_non_utf8_message_gets_logged(
-    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, calls, record_calls, caplog
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config,
+    calls,
+    record_calls,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test receiving a non utf8 encoded message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1339,7 +1346,10 @@ async def test_restore_all_active_subscriptions_on_reconnect(
 
 
 async def test_initial_setup_logs_error(
-    hass: HomeAssistant, caplog, mqtt_client_mock, empty_mqtt_config
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_client_mock,
+    empty_mqtt_config,
 ) -> None:
     """Test for setup failure if initial client connection fails."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
@@ -1354,7 +1364,10 @@ async def test_initial_setup_logs_error(
 
 
 async def test_logs_error_if_no_connect_broker(
-    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config,
+    mqtt_client_mock,
 ) -> None:
     """Test for setup failure if connection to broker is missing."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1369,7 +1382,10 @@ async def test_logs_error_if_no_connect_broker(
 
 @patch("homeassistant.components.mqtt.client.TIMEOUT_ACK", 0.3)
 async def test_handle_mqtt_on_callback(
-    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config,
+    mqtt_client_mock,
 ) -> None:
     """Test receiving an ACK callback before waiting for it."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1406,7 +1422,10 @@ async def test_publish_error(
 
 
 async def test_subscribe_error(
-    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config, mqtt_client_mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config,
+    mqtt_client_mock,
 ) -> None:
     """Test publish error."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1444,7 +1463,7 @@ async def test_handle_message_callback(
 
 
 async def test_setup_override_configuration(
-    hass: HomeAssistant, caplog, tmp_path: Path
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, tmp_path: Path
 ) -> None:
     """Test override setup from configuration entry."""
     calls_username_password_set = []
@@ -1955,7 +1974,10 @@ async def test_setup_entry_with_config_override(
 
 
 async def test_update_incomplete_entry(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mqtt_client_mock, caplog
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_client_mock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if the MQTT component loads when config entry data is incomplete."""
     data = (
@@ -1993,7 +2015,10 @@ async def test_update_incomplete_entry(
 
 
 async def test_fail_no_broker(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mqtt_client_mock, caplog
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_client_mock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if the MQTT component loads when broker configuration is missing."""
     # Config entry data is incomplete
@@ -2005,7 +2030,9 @@ async def test_fail_no_broker(
 
 @pytest.mark.no_fail_on_log_exception
 async def test_message_callback_exception_gets_logged(
-    hass: HomeAssistant, caplog, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test exception raised by message handler."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2026,7 +2053,9 @@ async def test_message_callback_exception_gets_logged(
 
 
 async def test_mqtt_ws_subscription(
-    hass: HomeAssistant, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket subscription."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2090,7 +2119,7 @@ async def test_mqtt_ws_subscription(
 
 async def test_mqtt_ws_subscription_not_admin(
     hass: HomeAssistant,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     mqtt_mock_entry_no_yaml_config,
     hass_read_only_access_token,
 ) -> None:
@@ -2130,7 +2159,7 @@ async def test_dump_service(
 async def test_mqtt_ws_remove_discovered_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device removal."""
@@ -2172,7 +2201,7 @@ async def test_mqtt_ws_remove_discovered_device(
 async def test_mqtt_ws_get_device_debug_info(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device debug info."""
@@ -2238,7 +2267,7 @@ async def test_mqtt_ws_get_device_debug_info(
 async def test_mqtt_ws_get_device_debug_info_binary(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test MQTT websocket device debug info."""
@@ -2818,7 +2847,9 @@ async def test_subscribe_connection_status(
 # Test existence of removed YAML configuration under the platform key
 # This warning and test is to be removed from HA core 2023.6
 async def test_one_deprecation_warning_per_platform(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+    hass: HomeAssistant,
+    mqtt_mock_entry_with_yaml_config,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test a deprecation warning is is logged once per platform."""
     platform = "light"
@@ -2849,7 +2880,11 @@ async def test_config_schema_validation(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_unload_config_entry(
-    hass: HomeAssistant, mqtt_mock, mqtt_client_mock, tmp_path: Path, caplog
+    hass: HomeAssistant,
+    mqtt_mock,
+    mqtt_client_mock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test unloading the MQTT entry."""
     assert hass.services.has_service(mqtt.DOMAIN, "dump")
@@ -2929,7 +2964,7 @@ async def test_reload_entry_with_new_config(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 async def test_disabling_and_enabling_entry(
-    hass: HomeAssistant, tmp_path: Path, caplog
+    hass: HomeAssistant, tmp_path: Path
 ) -> None:
     """Test disabling and enabling the config entry."""
     config_old = {
@@ -3020,7 +3055,11 @@ async def test_disabling_and_enabling_entry(
     ],
 )
 async def test_setup_manual_items_with_unique_ids(
-    hass: HomeAssistant, tmp_path: Path, caplog, config, unique
+    hass: HomeAssistant,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    config,
+    unique,
 ) -> None:
     """Test setup manual items is generating unique id's."""
     await help_test_setup_manual_entity_from_yaml(
@@ -3043,7 +3082,7 @@ async def test_setup_manual_items_with_unique_ids(
 
 
 async def test_remove_unknown_conf_entry_options(
-    hass: HomeAssistant, mqtt_client_mock, caplog
+    hass: HomeAssistant, mqtt_client_mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test unknown keys in config entry data is removed."""
     mqtt_config_entry_data = {
@@ -3070,7 +3109,9 @@ async def test_remove_unknown_conf_entry_options(
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
-async def test_link_config_entry(hass: HomeAssistant, tmp_path: Path, caplog) -> None:
+async def test_link_config_entry(
+    hass: HomeAssistant, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test manual and dynamically setup entities are linked to the config entry."""
     config_manual = {
         "mqtt": {

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1571,7 +1571,7 @@ async def test_setup_override_configuration(
     """Test override setup from configuration entry."""
     calls_username_password_set = []
 
-    def mock_usename_password_set(username, password) -> None:
+    def mock_usename_password_set(username: str, password: str) -> None:
         calls_username_password_set.append((username, password))
 
     # Mock password setup from config

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2245,7 +2245,7 @@ async def test_mqtt_ws_subscription_not_admin(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
-    hass_read_only_access_token,
+    hass_read_only_access_token: str,
 ) -> None:
     """Test MQTT websocket user is not admin."""
     await mqtt_mock_entry_no_yaml_config()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to MQTT init tests.

I have splitted up the commits so it is easier to review:

- Add hass type hint and None return type
- Add type hints on tmp_path
- Add registry hints
- Add caplog and hass_ws_client type hints
- Add type hints for MqttMockHAClientGenerator
- Add type hints MqttMockPahoClient
- Hints on fixtures calls and record_calls
- Other fixture type hints tweaks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
