### PR TITLE
Create repair issue if Sonos subscriptions fail

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -47,6 +47,7 @@ from .const import (
     SONOS_REBOOTED,
     SONOS_SPEAKER_ACTIVITY,
     SONOS_VANISHED,
+    SUB_FAIL_ISSUE_ID,
     SUB_FAIL_URL,
     SUBSCRIPTION_TIMEOUT,
     UPNP_ST,
@@ -237,7 +238,7 @@ class SonosDiscoveryManager:
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,
-                "subscriptions_failed",
+                SUB_FAIL_ISSUE_ID,
                 is_fixable=False,
                 severity=ir.IssueSeverity.ERROR,
                 translation_key="subscriptions_failed",

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -278,6 +278,11 @@ class SonosDiscoveryManager:
             """Create SonosSpeakers when subscription callbacks successfully arrive."""
             _LOGGER.debug("Subscription to %s succeeded", ip_address)
             cancel_failure_callback()
+            ir.async_delete_issue(
+                self.hass,
+                DOMAIN,
+                SUB_FAIL_ISSUE_ID,
+            )
             _async_add_visible_zones(subscription_succeeded=True)
 
         sub.callback = _async_subscription_succeeded

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -19,6 +19,7 @@ PLATFORMS = [
     Platform.SWITCH,
 ]
 
+SUB_FAIL_ISSUE_ID = "subscriptions_failed"
 SUB_FAIL_URL = "https://www.home-assistant.io/integrations/sonos/#network-requirements"
 
 SONOS_ARTIST = "artists"

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -19,6 +19,8 @@ PLATFORMS = [
     Platform.SWITCH,
 ]
 
+SUB_FAIL_URL = "https://www.home-assistant.io/integrations/sonos/#network-requirements"
+
 SONOS_ARTIST = "artists"
 SONOS_ALBUM = "albums"
 SONOS_PLAYLISTS = "playlists"

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -5,10 +5,8 @@ from abc import abstractmethod
 import datetime
 import logging
 
-import soco.config as soco_config
 from soco.core import SoCo
 
-from homeassistant.components import persistent_notification
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -16,8 +14,6 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from .const import DATA_SONOS, DOMAIN, SONOS_FALLBACK_POLL, SONOS_STATE_UPDATED
 from .exception import SonosUpdateError
 from .speaker import SonosSpeaker
-
-SUB_FAIL_URL = "https://www.home-assistant.io/integrations/sonos/#network-requirements"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,29 +53,6 @@ class SonosEntity(Entity):
     async def async_fallback_poll(self, now: datetime.datetime) -> None:
         """Poll the entity if subscriptions fail."""
         if not self.speaker.subscriptions_failed:
-            if soco_config.EVENT_ADVERTISE_IP:
-                listener_msg = (
-                    f"{self.speaker.subscription_address}"
-                    f" (advertising as {soco_config.EVENT_ADVERTISE_IP})"
-                )
-            else:
-                listener_msg = self.speaker.subscription_address
-            message = (
-                f"{self.speaker.zone_name} cannot reach {listener_msg},"
-                " falling back to polling, functionality may be limited"
-            )
-            log_link_msg = f", see {SUB_FAIL_URL} for more details"
-            notification_link_msg = (
-                f'.\n\nSee <a href="{SUB_FAIL_URL}">Sonos documentation</a>'
-                " for more details."
-            )
-            _LOGGER.warning(message + log_link_msg)
-            persistent_notification.async_create(
-                self.hass,
-                message + notification_link_msg,
-                "Sonos networking issue",
-                "sonos_subscriptions_failed",
-            )
             self.speaker.subscriptions_failed = True
             await self.speaker.async_unsubscribe()
         try:

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -14,7 +14,7 @@
   "issues": {
     "subscriptions_failed": {
       "title": "Networking error: subscriptions failed",
-      "description": "Falling back to polling, functionality may be limited.\n\nSonos device at {device_ip} cannot reach Home Assistant at {listener_address}.\n\nSee [documentation]({sub_fail_url}) for more information."
+      "description": "Falling back to polling, functionality may be limited.\n\nSonos device at {device_ip} cannot reach Home Assistant at {listener_address}.\n\nSee our [documentation]({sub_fail_url}) for more information on how to solve this issue."
     }
   }
 }

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -10,5 +10,11 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
+  },
+  "issues": {
+    "subscriptions_failed": {
+      "title": "Networking error: subscriptions failed",
+      "description": "Falling back to polling, functionality may be limited.\n\nSonos device at {device_ip} cannot reach Home Assistant at {listener_address}.\n\nSee [documentation]({sub_fail_url}) for more information."
+    }
   }
 }

--- a/tests/components/sonos/test_repairs.py
+++ b/tests/components/sonos/test_repairs.py
@@ -1,0 +1,47 @@
+"""Test repairs handling for Sonos."""
+from unittest.mock import Mock
+
+from homeassistant.components.sonos.const import (
+    DOMAIN,
+    SCAN_INTERVAL,
+    SUB_FAIL_ISSUE_ID,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+from homeassistant.util import dt as dt_util
+
+from .conftest import SonosMockEvent
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_subscription_repair_issues(
+    hass: HomeAssistant, config_entry: MockConfigEntry, soco, zgs_discovery
+):
+    """Test repair issues handling for failed subscriptions."""
+    issue_registry = async_get_issue_registry(hass)
+
+    subscription = soco.zoneGroupTopology.subscribe.return_value
+    subscription.event_listener = Mock(address=("192.168.4.2", 1400))
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Ensure an issue is registered on subscription failure
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)
+
+    # Ensure the issue still exists after reload
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)
+
+    # Ensure the issue has been removed after a successful subscription callback
+    variables = {"ZoneGroupState": zgs_discovery}
+    event = SonosMockEvent(soco, soco.zoneGroupTopology, variables)
+    sub_callback = subscription.callback
+    sub_callback(event)
+    await hass.async_block_till_done()
+    assert not issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -15,6 +15,7 @@ async def test_fallback_to_polling(
     speaker = list(hass.data[DATA_SONOS].discovered.values())[0]
     assert speaker.soco is soco
     assert speaker._subscriptions
+    assert not speaker.subscriptions_failed
 
     caplog.clear()
 
@@ -27,7 +28,6 @@ async def test_fallback_to_polling(
 
     assert not speaker._subscriptions
     assert speaker.subscriptions_failed
-    assert "falling back to polling" in caplog.text
     assert "Activity on Zone A from SonosSpeaker.update_volume" in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Subscriptions are tested earlier now in setup of the Sonos integration, so the alert is now moved to that location. Additionally, the persistent notification now instead creates a repair issue (which didn't exist in HA when the alert was originally created).

Example repair issue:
![image](https://user-images.githubusercontent.com/1203111/216801949-e65095cc-f039-4f77-8866-c25f390caed8.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #85530
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
