### PR TITLE
Update elgato to 4.0.1

### DIFF
--- a/homeassistant/components/elgato/manifest.json
+++ b/homeassistant/components/elgato/manifest.json
@@ -3,7 +3,7 @@
   "name": "Elgato Light",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/elgato",
-  "requirements": ["elgato==3.0.0"],
+  "requirements": ["elgato==4.0.1"],
   "zeroconf": ["_elg._tcp.local."],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -634,7 +634,7 @@ ebusdpy==0.0.17
 ecoaliface==0.4.0
 
 # homeassistant.components.elgato
-elgato==3.0.0
+elgato==4.0.1
 
 # homeassistant.components.eliqonline
 eliqonline==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -493,7 +493,7 @@ eagle100==0.1.1
 easyenergy==0.1.2
 
 # homeassistant.components.elgato
-elgato==3.0.0
+elgato==4.0.1
 
 # homeassistant.components.elkm1
 elkm1-lib==2.2.1

--- a/tests/components/elgato/test_diagnostics.py
+++ b/tests/components/elgato/test_diagnostics.py
@@ -21,8 +21,10 @@ async def test_diagnostics(
             "firmware_build_number": 192,
             "firmware_version": "1.0.3",
             "hardware_board_type": 53,
+            "mac_address": None,
             "product_name": "Elgato Key Light",
             "serial_number": "CN11A1A00001",
+            "wifi": None,
             "features": ["lights"],
         },
         "state": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates `elgato` to 4.0.1.
Release notes:
- https://github.com/frenck/python-elgato/releases/tag/v4.0.0
- https://github.com/frenck/python-elgato/releases/tag/v4.0.1

The v4.0.1 version only fixes an issue with the release/publish, which caused v4.0.0 not to be released on PyPi.

Full compare: <https://github.com/frenck/python-elgato/compare/v3.0.0...v4.0.1>

This release unlocks lots of new features for the Elgato key lights. The focus for this PR is just to get the dependency upgraded, new features will be done in follow-up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
