### PR TITLE
Add bypass_zone service for totalconnect

### DIFF
--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import logging
 
 from total_connect_client import ArmingHelper
-from total_connect_client.exceptions import BadResultCodeError, UsercodeInvalid
+from total_connect_client.exceptions import (
+    BadResultCodeError,
+    FailedToBypassZone,
+    UsercodeInvalid,
+)
 import voluptuous as vol
 
 import homeassistant.components.alarm_control_panel as alarm
@@ -293,6 +297,10 @@ class TotalConnectAlarm(
         """Bypass the zone."""
         try:
             await self.hass.async_add_executor_job(self._bypass_zone, zone_id)
+        except FailedToBypassZone as error:
+            raise HomeAssistantError(
+                f"TotalConnect failed to bypass zone {zone_id}."
+            ) from error
         except UsercodeInvalid as error:
             self.coordinator.config_entry.async_start_reauth(self.hass)
             raise HomeAssistantError(

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -306,10 +306,6 @@ class TotalConnectAlarm(
             raise HomeAssistantError(
                 "TotalConnect usercode is invalid. Did not bypass zone."
             ) from error
-        except BadResultCodeError as error:
-            raise HomeAssistantError(
-                f"TotalConnect failed to bypass zone {self.name}."
-            ) from error
         await self.coordinator.async_request_refresh()
 
     def _bypass_zone(self, zone_id: int | None = None) -> None:

--- a/homeassistant/components/totalconnect/services.yaml
+++ b/homeassistant/components/totalconnect/services.yaml
@@ -16,8 +16,14 @@ arm_home_instant:
 
 bypass_zone:
   name: Bypass Zone
-  description: Bypass a security zone.
+  description: Bypass a TotalConnect zone.
   target:
     entity:
       integration: totalconnect
       domain: alarm_control_panel
+  fields:
+    zone_id:
+      name: Zone ID
+      description: The zone number you want to bypass.
+      required: true
+      example: "12"

--- a/homeassistant/components/totalconnect/services.yaml
+++ b/homeassistant/components/totalconnect/services.yaml
@@ -13,3 +13,11 @@ arm_home_instant:
     entity:
       integration: totalconnect
       domain: alarm_control_panel
+
+bypass_zone:
+  name: Bypass Zone
+  description: Bypass a security zone.
+  target:
+    entity:
+      integration: totalconnect
+      domain: alarm_control_panel

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -308,6 +308,7 @@ RESPONSE_USER_CODE_INVALID = {
     "ResultData": "testing user code invalid",
 }
 RESPONSE_SUCCESS = {"ResultCode": ResultCode.SUCCESS.value}
+RESPONSE_BYPASS_FAILED = {"ResultCode": ResultCode.FAILED_TO_BYPASS_ZONE.value}
 
 USERNAME = "username@me.com"
 PASSWORD = "password"

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -147,7 +147,7 @@ PARTITIONS_TRIGGERED_CARBON_MONOXIDE = {
 PARTITIONS_UNKNOWN = {"PartitionInfo": PARTITION_INFO_UNKNOWN}
 
 ZONE_NORMAL = {
-    "ZoneID": "1",
+    "ZoneID": 1,
     "ZoneDescription": "Security",
     "ZoneStatus": ZoneStatus.FAULT,
     "ZoneTypeId": ZoneType.SECURITY,
@@ -155,23 +155,23 @@ ZONE_NORMAL = {
     "CanBeBypassed": 1,
 }
 ZONE_2 = {
-    "ZoneID": "2",
+    "ZoneID": 2,
     "ZoneDescription": "Fire",
     "ZoneStatus": ZoneStatus.LOW_BATTERY,
     "ZoneTypeId": ZoneType.FIRE_SMOKE,
     "PartitionId": "1",
-    "CanBeBypassed": 1,
+    "CanBeBypassed": 0,
 }
 ZONE_3 = {
-    "ZoneID": "3",
+    "ZoneID": 3,
     "ZoneDescription": "Gas",
     "ZoneStatus": ZoneStatus.TAMPER,
     "ZoneTypeId": ZoneType.CARBON_MONOXIDE,
     "PartitionId": "1",
-    "CanBeBypassed": 1,
+    "CanBeBypassed": 0,
 }
 ZONE_4 = {
-    "ZoneID": "4",
+    "ZoneID": 4,
     "ZoneDescription": "Motion",
     "ZoneStatus": ZoneStatus.NORMAL,
     "ZoneTypeId": ZoneType.INTERIOR_FOLLOWER,
@@ -179,7 +179,7 @@ ZONE_4 = {
     "CanBeBypassed": 1,
 }
 ZONE_5 = {
-    "ZoneID": "5",
+    "ZoneID": 5,
     "ZoneDescription": "Medical",
     "ZoneStatus": ZoneStatus.NORMAL,
     "ZoneTypeId": ZoneType.PROA7_MEDICAL,
@@ -188,7 +188,7 @@ ZONE_5 = {
 }
 # 99 is an unknown ZoneType
 ZONE_6 = {
-    "ZoneID": "6",
+    "ZoneID": 6,
     "ZoneDescription": "Medical",
     "ZoneStatus": ZoneStatus.NORMAL,
     "ZoneTypeId": 99,
@@ -343,7 +343,7 @@ ZONE_DETAILS_NORMAL = {
     "Batterylevel": "-1",
     "Signalstrength": "-1",
     "zoneAdditionalInfo": None,
-    "ZoneID": "1",
+    "ZoneID": 1,
     "ZoneStatus": ZoneStatus.NORMAL,
     "ZoneTypeId": ZoneType.SECURITY,
     "CanBeBypassed": 1,

--- a/tests/components/totalconnect/test_diagnostics.py
+++ b/tests/components/totalconnect/test_diagnostics.py
@@ -32,4 +32,4 @@ async def test_entry_diagnostics(
     assert partition["name"] == "Test1"
 
     zone = location["zones"][0]
-    assert zone["zone_id"] == "1"
+    assert zone["zone_id"] == 1


### PR DESCRIPTION
## Proposed change
Adds a service for totalconnect that bypasses a zone. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/craigjmidwinter/total-connect-client/issues/199
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27462

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. (90967 and 89800)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
