### PR TITLE
Correct type hints mqtt_client_mock and move new generator type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,13 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, location
 
 from .ignore_uncaught_exceptions import IGNORE_UNCAUGHT_EXCEPTIONS
-from .typing import ClientSessionGenerator, MqttMockGenerator, WebSocketGenerator
+from .typing import (
+    ClientSessionGenerator,
+    MqttMockHAClient,
+    MqttMockHAClientGenerator,
+    MqttMockPahoClient,
+    WebSocketGenerator,
+)
 
 pytest.register_assert_rewrite("tests.common")
 
@@ -716,7 +722,7 @@ def mqtt_config_entry_data() -> dict[str, Any] | None:
 
 
 @pytest.fixture
-def mqtt_client_mock(hass: HomeAssistant) -> Generator[MagicMock, None, None]:
+def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient, None, None]:
     """Fixture to mock MQTT client."""
 
     mid: int = 0
@@ -763,10 +769,10 @@ def mqtt_client_mock(hass: HomeAssistant) -> Generator[MagicMock, None, None]:
 @pytest.fixture
 async def mqtt_mock(
     hass: HomeAssistant,
-    mqtt_client_mock: MagicMock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-    mqtt_mock_entry_no_yaml_config: Callable[..., Coroutine[Any, Any, MagicMock]],
-) -> AsyncGenerator[MagicMock, None]:
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+) -> AsyncGenerator[MqttMockHAClient, None]:
     """Fixture to mock MQTT component."""
     return await mqtt_mock_entry_no_yaml_config()
 
@@ -774,9 +780,9 @@ async def mqtt_mock(
 @asynccontextmanager
 async def _mqtt_mock_entry(
     hass: HomeAssistant,
-    mqtt_client_mock: MagicMock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[Callable[..., Coroutine[Any, Any, Any]], None]:
+) -> AsyncGenerator[MqttMockHAClientGenerator, None]:
     """Fixture to mock a delayed setup of the MQTT config entry."""
     # Local import to avoid processing MQTT modules when running a testcase
     # which does not use MQTT.
@@ -839,9 +845,9 @@ async def _mqtt_mock_entry(
 @pytest.fixture
 async def mqtt_mock_entry_no_yaml_config(
     hass: HomeAssistant,
-    mqtt_client_mock: MagicMock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockGenerator, None,]:
+) -> AsyncGenerator[MqttMockHAClientGenerator, None,]:
     """Set up an MQTT config entry without MQTT yaml config."""
 
     async def _async_setup_config_entry(
@@ -865,9 +871,9 @@ async def mqtt_mock_entry_no_yaml_config(
 @pytest.fixture
 async def mqtt_mock_entry_with_yaml_config(
     hass: HomeAssistant,
-    mqtt_client_mock: MagicMock,
+    mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockGenerator, None,]:
+) -> AsyncGenerator[MqttMockHAClientGenerator, None,]:
     """Set up an MQTT config entry with MQTT yaml config."""
 
     async def _async_do_not_setup_config_entry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, location
 
 from .ignore_uncaught_exceptions import IGNORE_UNCAUGHT_EXCEPTIONS
-from .typing import ClientSessionGenerator, WebSocketGenerator
+from .typing import ClientSessionGenerator, MqttMockType, WebSocketGenerator
 
 pytest.register_assert_rewrite("tests.common")
 
@@ -88,8 +88,6 @@ def _utcnow():
 
 dt_util.utcnow = _utcnow
 event.time_tracker_utcnow = _utcnow
-
-MqttMockType = Callable[..., Coroutine[Any, Any, MagicMock]]
 
 
 def pytest_addoption(parser):
@@ -718,7 +716,7 @@ def mqtt_config_entry_data() -> dict[str, Any] | None:
 
 
 @pytest.fixture
-def mqtt_client_mock(hass: HomeAssistant) -> Generator[Any, MagicMock, None]:
+def mqtt_client_mock(hass: HomeAssistant) -> Generator[MagicMock, None, None]:
     """Fixture to mock MQTT client."""
 
     mid: int = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -847,7 +847,7 @@ async def mqtt_mock_entry_no_yaml_config(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockHAClientGenerator, None,]:
+) -> AsyncGenerator[MqttMockHAClientGenerator, None]:
     """Set up an MQTT config entry without MQTT yaml config."""
 
     async def _async_setup_config_entry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -826,12 +826,12 @@ async def _mqtt_mock_entry(
 
         return mock_mqtt_instance
 
-    def create_mock_mqtt(*args, **kwargs) -> MagicMock:
+    def create_mock_mqtt(*args, **kwargs) -> MqttMockHAClient:
         """Create a mock based on mqtt.MQTT."""
         nonlocal mock_mqtt_instance
         nonlocal real_mqtt_instance
         real_mqtt_instance = real_mqtt(*args, **kwargs)
-        mock_mqtt_instance = MagicMock(
+        mock_mqtt_instance = MqttMockHAClient(
             return_value=real_mqtt_instance,
             spec_set=real_mqtt_instance,
             wraps=real_mqtt_instance,
@@ -858,7 +858,7 @@ async def mqtt_mock_entry_no_yaml_config(
         await hass.async_block_till_done()
         return True
 
-    async def _setup_mqtt_entry() -> Callable[..., Coroutine[Any, Any, MagicMock]]:
+    async def _setup_mqtt_entry() -> MqttMockHAClientGenerator:
         """Set up the MQTT config entry."""
         return await mqtt_mock_entry(_async_setup_config_entry)
 
@@ -882,7 +882,7 @@ async def mqtt_mock_entry_with_yaml_config(
         """Do nothing."""
         return True
 
-    async def _setup_mqtt_entry() -> Callable[..., Coroutine[Any, Any, MagicMock]]:
+    async def _setup_mqtt_entry() -> MqttMockHAClientGenerator:
         """Set up the MQTT config entry."""
         return await mqtt_mock_entry(_async_do_not_setup_config_entry)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, location
 
 from .ignore_uncaught_exceptions import IGNORE_UNCAUGHT_EXCEPTIONS
-from .typing import ClientSessionGenerator, MqttMockType, WebSocketGenerator
+from .typing import ClientSessionGenerator, MqttMockGenerator, WebSocketGenerator
 
 pytest.register_assert_rewrite("tests.common")
 
@@ -841,7 +841,7 @@ async def mqtt_mock_entry_no_yaml_config(
     hass: HomeAssistant,
     mqtt_client_mock: MagicMock,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockType, None,]:
+) -> AsyncGenerator[MqttMockGenerator, None,]:
     """Set up an MQTT config entry without MQTT yaml config."""
 
     async def _async_setup_config_entry(
@@ -867,7 +867,7 @@ async def mqtt_mock_entry_with_yaml_config(
     hass: HomeAssistant,
     mqtt_client_mock: MagicMock,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockType, None,]:
+) -> AsyncGenerator[MqttMockGenerator, None,]:
     """Set up an MQTT config entry with MQTT yaml config."""
 
     async def _async_do_not_setup_config_entry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -858,7 +858,7 @@ async def mqtt_mock_entry_no_yaml_config(
         await hass.async_block_till_done()
         return True
 
-    async def _setup_mqtt_entry() -> MqttMockHAClientGenerator:
+    async def _setup_mqtt_entry() -> MqttMockHAClient:
         """Set up the MQTT config entry."""
         return await mqtt_mock_entry(_async_setup_config_entry)
 
@@ -882,7 +882,7 @@ async def mqtt_mock_entry_with_yaml_config(
         """Do nothing."""
         return True
 
-    async def _setup_mqtt_entry() -> MqttMockHAClientGenerator:
+    async def _setup_mqtt_entry() -> MqttMockHAClient:
         """Set up the MQTT config entry."""
         return await mqtt_mock_entry(_async_do_not_setup_config_entry)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -873,7 +873,7 @@ async def mqtt_mock_entry_with_yaml_config(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockHAClientGenerator, None,]:
+) -> AsyncGenerator[MqttMockHAClientGenerator, None]:
     """Set up an MQTT config entry with MQTT yaml config."""
 
     async def _async_do_not_setup_config_entry(

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from typing import Any
+from unittest.mock import MagicMock
 
 from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]
+MqttMockType = Callable[..., Coroutine[Any, Any, MagicMock]]
 WebSocketGenerator = Callable[..., Coroutine[Any, Any, ClientWebSocketResponse]]

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -9,5 +9,5 @@ from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]
-MqttMockType = Callable[..., Coroutine[Any, Any, MagicMock]]
+MqttMockGenerator = Callable[..., Coroutine[Any, Any, MagicMock]]
 WebSocketGenerator = Callable[..., Coroutine[Any, Any, ClientWebSocketResponse]]

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -9,5 +9,10 @@ from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]
-MqttMockGenerator = Callable[..., Coroutine[Any, Any, MagicMock]]
+MqttMockPahoClient = MagicMock
+"""MagicMock for `paho.mqtt.client.Client`"""
+MqttMockHAClient = MagicMock
+"""MagicMock for `homeassistant.components.mqtt.MQTT`."""
+MqttMockHAClientGenerator = Callable[..., Coroutine[Any, Any, MqttMockHAClient]]
+"""MagicMock generator for `homeassistant.components.mqtt.MQTT`."""
 WebSocketGenerator = Callable[..., Coroutine[Any, Any, ClientWebSocketResponse]]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will:
- Move the new `MqttMockType` introduced with #87065 to the typing module and rename it to the more specific name `MqttMockHAClientGenerator`.
- Correct the type hints on `mqtt_client_mock`
- Introduce type aliases for MQTT client: `MqttMockHAClient` and paho MQTT client: `MqttMockPahoClient`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
