### PR TITLE
Add filter options to entity and device selectors

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -84,9 +84,9 @@ ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Integration that provided the entity
         vol.Optional("integration"): str,
         # Domain the entity belongs to
-        vol.Optional("domain"): vol.Any(str, [str]),
+        vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
         # Device class of the entity
-        vol.Optional("device_class"): vol.Any(str, [str]),
+        vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
     }
 )
 
@@ -108,8 +108,8 @@ DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Model of device
         vol.Optional("model"): str,
         # Device has to contain entities matching this selector
-        vol.Optional("entity"): vol.Any(
-            ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA, [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA]
+        vol.Optional("entity"): vol.All(
+            cv.ensure_list, [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA]
         ),
     }
 )
@@ -192,12 +192,12 @@ class AreaSelector(Selector[AreaSelectorConfig]):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Optional("entity"): vol.Any(
-                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("entity"): vol.All(
+                cv.ensure_list,
                 [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
-            vol.Optional("device"): vol.Any(
-                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("device"): vol.All(
+                cv.ensure_list,
                 [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
             vol.Optional("multiple", default=False): cv.boolean,
@@ -421,8 +421,8 @@ class DeviceSelector(Selector[DeviceSelectorConfig]):
     CONFIG_SCHEMA = DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA.extend(
         {
             vol.Optional("multiple", default=False): cv.boolean,
-            vol.Optional("filter"): vol.Any(
-                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("filter"): vol.All(
+                cv.ensure_list,
                 [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
         },
@@ -491,8 +491,8 @@ class EntitySelector(Selector[EntitySelectorConfig]):
             vol.Optional("exclude_entities"): [str],
             vol.Optional("include_entities"): [str],
             vol.Optional("multiple", default=False): cv.boolean,
-            vol.Optional("filter"): vol.Any(
-                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("filter"): vol.All(
+                cv.ensure_list,
                 [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
         }
@@ -851,12 +851,12 @@ class TargetSelector(Selector[TargetSelectorConfig]):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Optional("entity"): vol.Any(
-                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("entity"): vol.All(
+                cv.ensure_list,
                 [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
-            vol.Optional("device"): vol.Any(
-                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("device"): vol.All(
+                cv.ensure_list,
                 [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
         }

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -86,7 +86,7 @@ SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Domain the entity belongs to
         vol.Optional("domain"): vol.Any(str, [str]),
         # Device class of the entity
-        vol.Optional("device_class"): str,
+        vol.Optional("device_class"): vol.Any(str, [str]),
     }
 )
 
@@ -96,7 +96,7 @@ class SingleEntitySelectorConfig(TypedDict, total=False):
 
     integration: str
     domain: str | list[str]
-    device_class: str
+    device_class: str | list[str]
 
 
 SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -79,7 +79,7 @@ class Selector(Generic[_T]):
         return {"selector": {self.selector_type: self.config}}
 
 
-SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA = vol.Schema(
+ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
     {
         # Integration that provided the entity
         vol.Optional("integration"): str,
@@ -91,7 +91,7 @@ SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class SingleEntitySelectorConfig(TypedDict, total=False):
+class EntityFilterSelectorConfig(TypedDict, total=False):
     """Class to represent a single entity selector config."""
 
     integration: str
@@ -108,7 +108,9 @@ SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Model of device
         vol.Optional("model"): str,
         # Device has to contain entities matching this selector
-        vol.Optional("entity"): SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA,
+        vol.Optional("entity"): vol.Any(
+            ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA, [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA]
+        ),
     }
 )
 
@@ -119,7 +121,7 @@ class SingleDeviceSelectorConfig(TypedDict, total=False):
     integration: str
     manufacturer: str
     model: str
-    entity: SingleEntitySelectorConfig
+    entity: EntityFilterSelectorConfig
 
 
 class ActionSelectorConfig(TypedDict):
@@ -176,7 +178,7 @@ class AddonSelector(Selector[AddonSelectorConfig]):
 class AreaSelectorConfig(TypedDict, total=False):
     """Class to represent an area selector config."""
 
-    entity: SingleEntitySelectorConfig
+    entity: EntityFilterSelectorConfig
     device: SingleDeviceSelectorConfig
     multiple: bool
 
@@ -189,7 +191,10 @@ class AreaSelector(Selector[AreaSelectorConfig]):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Optional("entity"): SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("entity"): vol.Any(
+                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
             vol.Optional("device"): SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA,
             vol.Optional("multiple", default=False): cv.boolean,
         }
@@ -399,7 +404,7 @@ class DeviceSelectorConfig(TypedDict, total=False):
     integration: str
     manufacturer: str
     model: str
-    entity: SingleEntitySelectorConfig
+    entity: EntityFilterSelectorConfig
     multiple: bool
 
 
@@ -457,7 +462,7 @@ class DurationSelector(Selector[DurationSelectorConfig]):
         return cast(dict[str, float], data)
 
 
-class EntitySelectorConfig(SingleEntitySelectorConfig, total=False):
+class EntitySelectorConfig(EntityFilterSelectorConfig, total=False):
     """Class to represent an entity selector config."""
 
     exclude_entities: list[str]
@@ -471,11 +476,15 @@ class EntitySelector(Selector[EntitySelectorConfig]):
 
     selector_type = "entity"
 
-    CONFIG_SCHEMA = SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA.extend(
+    CONFIG_SCHEMA = ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA.extend(
         {
             vol.Optional("exclude_entities"): [str],
             vol.Optional("include_entities"): [str],
             vol.Optional("multiple", default=False): cv.boolean,
+            vol.Optional("filter"): vol.Any(
+                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
         }
     )
 
@@ -784,7 +793,7 @@ class SelectSelector(Selector[SelectSelectorConfig]):
 class TargetSelectorConfig(TypedDict, total=False):
     """Class to represent a target selector config."""
 
-    entity: SingleEntitySelectorConfig
+    entity: EntityFilterSelectorConfig
     device: SingleDeviceSelectorConfig
 
 
@@ -832,7 +841,10 @@ class TargetSelector(Selector[TargetSelectorConfig]):
 
     CONFIG_SCHEMA = vol.Schema(
         {
-            vol.Optional("entity"): SINGLE_ENTITY_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("entity"): vol.Any(
+                ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
             vol.Optional("device"): SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA,
         }
     )

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -84,7 +84,7 @@ ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         # Integration that provided the entity
         vol.Optional("integration"): str,
         # Domain the entity belongs to
-        vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
+        vol.Optional("domain"): vol.All(cv.ensure_list, [str]),
         # Device class of the entity
         vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
     }

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -99,7 +99,7 @@ class EntityFilterSelectorConfig(TypedDict, total=False):
     device_class: str | list[str]
 
 
-SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA = vol.Schema(
+DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
     {
         # Integration linked to it with a config entry
         vol.Optional("integration"): str,
@@ -115,13 +115,14 @@ SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class SingleDeviceSelectorConfig(TypedDict, total=False):
+class DeviceFilterSelectorConfig(TypedDict, total=False):
     """Class to represent a single device selector config."""
 
     integration: str
     manufacturer: str
     model: str
-    entity: EntityFilterSelectorConfig
+    entity: EntityFilterSelectorConfig | list[EntityFilterSelectorConfig]
+    filter: DeviceFilterSelectorConfig | list[DeviceFilterSelectorConfig]
 
 
 class ActionSelectorConfig(TypedDict):
@@ -178,8 +179,8 @@ class AddonSelector(Selector[AddonSelectorConfig]):
 class AreaSelectorConfig(TypedDict, total=False):
     """Class to represent an area selector config."""
 
-    entity: EntityFilterSelectorConfig
-    device: SingleDeviceSelectorConfig
+    entity: EntityFilterSelectorConfig | list[EntityFilterSelectorConfig]
+    device: DeviceFilterSelectorConfig | list[DeviceFilterSelectorConfig]
     multiple: bool
 
 
@@ -195,7 +196,10 @@ class AreaSelector(Selector[AreaSelectorConfig]):
                 ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
                 [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
-            vol.Optional("device"): SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("device"): vol.Any(
+                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
             vol.Optional("multiple", default=False): cv.boolean,
         }
     )
@@ -404,7 +408,7 @@ class DeviceSelectorConfig(TypedDict, total=False):
     integration: str
     manufacturer: str
     model: str
-    entity: EntityFilterSelectorConfig
+    entity: EntityFilterSelectorConfig | list[EntityFilterSelectorConfig]
     multiple: bool
 
 
@@ -414,8 +418,14 @@ class DeviceSelector(Selector[DeviceSelectorConfig]):
 
     selector_type = "device"
 
-    CONFIG_SCHEMA = SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA.extend(
-        {vol.Optional("multiple", default=False): cv.boolean}
+    CONFIG_SCHEMA = DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA.extend(
+        {
+            vol.Optional("multiple", default=False): cv.boolean,
+            vol.Optional("filter"): vol.Any(
+                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
+        },
     )
 
     def __init__(self, config: DeviceSelectorConfig | None = None) -> None:
@@ -793,8 +803,8 @@ class SelectSelector(Selector[SelectSelectorConfig]):
 class TargetSelectorConfig(TypedDict, total=False):
     """Class to represent a target selector config."""
 
-    entity: EntityFilterSelectorConfig
-    device: SingleDeviceSelectorConfig
+    entity: EntityFilterSelectorConfig | list[EntityFilterSelectorConfig]
+    device: DeviceFilterSelectorConfig | list[DeviceFilterSelectorConfig]
 
 
 class StateSelectorConfig(TypedDict, total=False):
@@ -845,7 +855,10 @@ class TargetSelector(Selector[TargetSelectorConfig]):
                 ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA,
                 [ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA],
             ),
-            vol.Optional("device"): SINGLE_DEVICE_SELECTOR_CONFIG_SCHEMA,
+            vol.Optional("device"): vol.Any(
+                DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA,
+                [DEVICE_FILTER_SELECTOR_CONFIG_SCHEMA],
+            ),
         }
     )
 

--- a/tests/components/blueprint/snapshots/test_importer.ambr
+++ b/tests/components/blueprint/snapshots/test_importer.ambr
@@ -18,9 +18,13 @@
       'description': 'The light(s) to control',
       'selector': dict({
         'target': OrderedDict({
-          'entity': OrderedDict({
-            'domain': 'light',
-          }),
+          'entity': list([
+            OrderedDict({
+              'domain': list([
+                'light',
+              ]),
+            }),
+          ]),
         }),
       }),
     }),
@@ -111,9 +115,13 @@
       'description': 'The light(s) to control',
       'selector': dict({
         'target': OrderedDict({
-          'entity': OrderedDict({
-            'domain': 'light',
-          }),
+          'entity': list([
+            OrderedDict({
+              'domain': list([
+                'light',
+              ]),
+            }),
+          ]),
         }),
       }),
     }),
@@ -191,8 +199,12 @@
       'name': 'Motion Sensor',
       'selector': dict({
         'entity': OrderedDict({
-          'domain': 'binary_sensor',
-          'device_class': 'motion',
+          'domain': list([
+            'binary_sensor',
+          ]),
+          'device_class': list([
+            'motion',
+          ]),
           'multiple': False,
         }),
       }),
@@ -201,7 +213,9 @@
       'name': 'Light',
       'selector': dict({
         'entity': OrderedDict({
-          'domain': 'light',
+          'domain': list([
+            'light',
+          ]),
           'multiple': False,
         }),
       }),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -118,6 +118,35 @@ def _test_selector(
             (["abc123", "def456"],),
             ("abc123", None, ["abc123", None]),
         ),
+        (
+            {
+                "filter": {
+                    "integration": "zha",
+                    "manufacturer": "mock-manuf",
+                    "model": "mock-model",
+                }
+            },
+            ("abc123",),
+            (None,),
+        ),
+        (
+            {
+                "filter": [
+                    {
+                        "integration": "zha",
+                        "manufacturer": "mock-manuf",
+                        "model": "mock-model",
+                    },
+                    {
+                        "integration": "matter",
+                        "manufacturer": "other-mock-manuf",
+                        "model": "other-mock-model",
+                    },
+                ]
+            },
+            ("abc123",),
+            (None,),
+        ),
     ),
 )
 def test_device_selector_schema(schema, valid_selections, invalid_selections) -> None:
@@ -239,6 +268,16 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
         ),
         (
             {"device": {"integration": "demo", "model": "mock-model"}},
+            ("abc123",),
+            (None,),
+        ),
+        (
+            {
+                "device": [
+                    {"integration": "demo", "model": "mock-model"},
+                    {"integration": "other-demo", "model": "other-mock-model"},
+                ]
+            },
             ("abc123",),
             (None,),
         ),
@@ -408,6 +447,16 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
             (),
         ),
         ({"device": {"integration": "demo", "model": "mock-model"}}, (), ()),
+        (
+            {
+                "device": [
+                    {"integration": "demo", "model": "mock-model"},
+                    {"integration": "other-demo", "model": "other-mock-model"},
+                ],
+            },
+            (),
+            (),
+        ),
         (
             {
                 "entity": {"domain": "binary_sensor", "device_class": "motion"},

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -92,6 +92,7 @@ def _test_selector(
             (None,),
         ),
         ({"entity": {"device_class": "motion"}}, ("abc123",), (None,)),
+        ({"entity": {"device_class": ["motion", "temperature"]}}, ("abc123",), (None,)),
         (
             {
                 "integration": "zha",
@@ -126,6 +127,11 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
             (None, "dog.abc123"),
         ),
         ({"device_class": "motion"}, ("sensor.abc123", FAKE_UUID), (None, "abc123")),
+        (
+            {"device_class": ["motion", "temperature"]},
+            ("sensor.abc123", FAKE_UUID),
+            (None, "abc123"),
+        ),
         (
             {"integration": "zha", "domain": "light"},
             ("light.abc123", FAKE_UUID),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -95,6 +95,16 @@ def _test_selector(
         ({"entity": {"device_class": ["motion", "temperature"]}}, ("abc123",), (None,)),
         (
             {
+                "entity": [
+                    {"domain": "light"},
+                    {"domain": "binary_sensor", "device_class": "motion"},
+                ]
+            },
+            ("abc123",),
+            (None,),
+        ),
+        (
+            {
                 "integration": "zha",
                 "manufacturer": "mock-manuf",
                 "model": "mock-model",
@@ -173,6 +183,21 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
                 ["sensor.abc123", "sensor.ghi789"],
             ),
         ),
+        (
+            {"filter": {"domain": "light"}},
+            ("light.abc123", FAKE_UUID),
+            (None,),
+        ),
+        (
+            {
+                "filter": [
+                    {"domain": "light"},
+                    {"domain": "binary_sensor", "device_class": "motion"},
+                ]
+            },
+            ("light.abc123", "binary_sensor.abc123", FAKE_UUID),
+            (None,),
+        ),
     ),
 )
 def test_entity_selector_schema(schema, valid_selections, invalid_selections) -> None:
@@ -198,6 +223,16 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
                     "device_class": "motion",
                     "integration": "demo",
                 }
+            },
+            ("abc123",),
+            (None,),
+        ),
+        (
+            {
+                "entity": [
+                    {"domain": "light"},
+                    {"domain": "binary_sensor", "device_class": "motion"},
+                ]
             },
             ("abc123",),
             (None,),
@@ -351,6 +386,16 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
         ({"entity": {}}, (), ()),
         ({"entity": {"domain": "light"}}, (), ()),
         ({"entity": {"domain": "binary_sensor", "device_class": "motion"}}, (), ()),
+        (
+            {
+                "entity": [
+                    {"domain": "light"},
+                    {"domain": "binary_sensor", "device_class": "motion"},
+                ]
+            },
+            (),
+            (),
+        ),
         (
             {
                 "entity": {


### PR DESCRIPTION
## Proposed change

Add supports for entity filter and device filter selector config
Front-end PR : https://github.com/home-assistant/frontend/pull/15302

- Add `filter` config for `entity` selector to allow array of filter.
- Add `filter` config for `device` selector to allow array of filter.
- Allow `device_class` list for entity filter config

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26145

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
