### PR TITLE
Bypass validation empty code for lock

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -87,8 +87,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Lock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
+    if (
+        (code := service_call.data.get(ATTR_CODE))
+        and entity.code_format_cmp
+        and not entity.code_format_cmp.match(code)
+    ):
         raise ValueError(
             f"Code '{code}' for locking {entity.name} doesn't match pattern {entity.code_format}"
         )
@@ -97,8 +100,11 @@ async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Unlock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
+    if (
+        (code := service_call.data.get(ATTR_CODE))
+        and entity.code_format_cmp
+        and not entity.code_format_cmp.match(code)
+    ):
         raise ValueError(
             f"Code '{code}' for unlocking {entity.name} doesn't match pattern {entity.code_format}"
         )
@@ -107,8 +113,11 @@ async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
     """Open the door latch."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
+    if (
+        (code := service_call.data.get(ATTR_CODE))
+        and entity.code_format_cmp
+        and not entity.code_format_cmp.match(code)
+    ):
         raise ValueError(
             f"Code '{code}' for opening {entity.name} doesn't match pattern {entity.code_format}"
         )

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -87,8 +87,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Lock the lock."""
+    code: str | None
     if (
-        (code := service_call.data.get(ATTR_CODE))
+        (code := service_call.data.get(ATTR_CODE)) is not None
         and entity.code_format_cmp
         and not entity.code_format_cmp.match(code)
     ):
@@ -100,8 +101,9 @@ async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Unlock the lock."""
+    code: str | None
     if (
-        (code := service_call.data.get(ATTR_CODE))
+        (code := service_call.data.get(ATTR_CODE)) is not None
         and entity.code_format_cmp
         and not entity.code_format_cmp.match(code)
     ):
@@ -113,8 +115,9 @@ async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
     """Open the door latch."""
+    code: str | None
     if (
-        (code := service_call.data.get(ATTR_CODE))
+        (code := service_call.data.get(ATTR_CODE)) is not None
         and entity.code_format_cmp
         and not entity.code_format_cmp.match(code)
     ):

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -105,10 +105,6 @@ async def test_lock_open_with_code(hass: HomeAssistant) -> None:
     assert lock.state_attributes == {"code_format": r"^\d{4}$"}
 
     with pytest.raises(ValueError):
-        await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {}))
-    with pytest.raises(ValueError):
-        await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: ""}))
-    with pytest.raises(ValueError):
         await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: "HELLO"}))
     await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: "1234"}))
     assert lock.calls_open.call_count == 1
@@ -123,10 +119,6 @@ async def test_lock_lock_with_code(hass: HomeAssistant) -> None:
     assert not lock.is_locked
 
     with pytest.raises(ValueError):
-        await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
-    with pytest.raises(ValueError):
-        await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: ""}))
-    with pytest.raises(ValueError):
         await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: "HELLO"}))
     await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: "1234"}))
     assert lock.is_locked
@@ -140,10 +132,6 @@ async def test_lock_unlock_with_code(hass: HomeAssistant) -> None:
     await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: "1234"}))
     assert lock.is_locked
 
-    with pytest.raises(ValueError):
-        await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))
-    with pytest.raises(ValueError):
-        await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: ""}))
     with pytest.raises(ValueError):
         await _async_unlock(
             lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: "HELLO"})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PR #85842 implemented a validation for lock which provides a problem in two use-cases
- Can no longer use a default code configured by the user
- Locks where code is only required one-way (unlock but not lock) the user know need to provide a code anyway

Change so validation is only tested if code is provided, otherwise leave it to integration to do necessary checks (as mentioned above).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87474 fixes #86963
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
