### PR TITLE
Change name to entity_id for lock validation error message

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -90,7 +90,7 @@ async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
     code: str = service_call.data.get(ATTR_CODE, "")
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
-            f"Code '{code}' for locking {entity.name} doesn't match pattern {entity.code_format}"
+            f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
     await entity.async_lock(**service_call.data)
 
@@ -100,7 +100,7 @@ async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
     code: str = service_call.data.get(ATTR_CODE, "")
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
-            f"Code '{code}' for unlocking {entity.name} doesn't match pattern {entity.code_format}"
+            f"Code '{code}' for unlocking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
     await entity.async_unlock(**service_call.data)
 
@@ -110,7 +110,7 @@ async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
     code: str = service_call.data.get(ATTR_CODE, "")
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
-            f"Code '{code}' for opening {entity.name} doesn't match pattern {entity.code_format}"
+            f"Code '{code}' for opening {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
     await entity.async_open(**service_call.data)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change to `entity_id` for showing error to user.

Issue:
With the implementation of `has_entity_name`, `entity.name` might not be the name or even partially the name of an entity as `device.name` plays a role in creating the name. For example with `yale_smart_alarm` integration `entity.name` is `None` thereby not showing to the user which entity creates the error.

Alternatively we should lookup the name from the entity registry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
