### PR TITLE
Mark ESPHome update entity unavailable when device is offline

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -108,6 +108,11 @@ class RuntimeEntryData:
         return self.name
 
     @property
+    def signal_device_updated(self) -> str:
+        """Return the signal to listen to for core device state update."""
+        return f"esphome_{self.entry_id}_on_device_update"
+
+    @property
     def signal_static_info_updated(self) -> str:
         """Return the signal to listen to for updates on static info."""
         return f"esphome_{self.entry_id}_on_list"
@@ -207,8 +212,7 @@ class RuntimeEntryData:
     @callback
     def async_update_device_state(self, hass: HomeAssistant) -> None:
         """Distribute an update of a core device state like availability."""
-        signal = f"esphome_{self.entry_id}_on_device_update"
-        async_dispatcher_send(hass, signal)
+        async_dispatcher_send(hass, self.signal_device_updated)
 
     async def async_load_from_store(self) -> tuple[list[EntityInfo], list[UserService]]:
         """Load the retained data from store and return de-serialized data."""

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -96,7 +96,16 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
     @property
     def available(self) -> bool:
         """Return if update is available."""
-        return super().available and self._device_info.name in self.coordinator.data
+        if self._device_info.has_deep_sleep:
+            # During deep sleep the ESP will not be connectable (by design)
+            # For these cases, show it as available
+            return True
+
+        return (
+            super().available
+            and self._entry_data.available
+            and self._device_info.name in self.coordinator.data
+        )
 
     @property
     def installed_version(self) -> str | None:

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -98,15 +98,14 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
 
     @property
     def available(self) -> bool:
-        """Return if update is available."""
-        if self._device_info.has_deep_sleep:
-            # During deep sleep the ESP will not be connectable (by design)
-            # For these cases, show it as available
-            return True
+        """Return if update is available.
 
+        During deep sleep the ESP will not be connectable (by design)
+        and thus, even when unavailable, we'll show it as available.
+        """
         return (
             super().available
-            and self._entry_data.available
+            and (self._entry_data.available or self._device_info.has_deep_sleep)
             and self._device_info.name in self.coordinator.data
         )
 

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -84,7 +84,10 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
                 (dr.CONNECTION_NETWORK_MAC, entry_data.device_info.mac_address)
             }
         )
-        if coordinator.supports_update:
+
+        # If the device has deep sleep, we can't assume we can install updates
+        # as the ESP will not be connectable (by design).
+        if coordinator.supports_update and not self._device_info.has_deep_sleep:
             self._attr_supported_features = UpdateEntityFeature.INSTALL
 
     @property

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
             unsub()  # type: ignore[unreachable]
 
         assert dashboard is not None
-        async_add_entities([ESPHomeUpdateEntity(entry.entry_id, entry_data, dashboard)])
+        async_add_entities([ESPHomeUpdateEntity(entry_data, dashboard)])
 
     if entry_data.available:
         await setup_update_entity()
@@ -72,12 +72,11 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
     _attr_name = "Firmware"
 
     def __init__(
-        self, entry_id: str, entry_data: RuntimeEntryData, coordinator: ESPHomeDashboard
+        self, entry_data: RuntimeEntryData, coordinator: ESPHomeDashboard
     ) -> None:
         """Initialize the update entity."""
         super().__init__(coordinator=coordinator)
         assert entry_data.device_info is not None
-        self._entry_id = entry_id
         self._entry_data = entry_data
         self._attr_unique_id = entry_data.device_info.mac_address
         self._attr_device_info = DeviceInfo(
@@ -153,7 +152,7 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"esphome_{self._entry_id}_on_device_update",
+                self._entry_data.signal_device_updated,
                 _on_device_update,
             )
         )

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
             unsub()  # type: ignore[unreachable]
 
         assert dashboard is not None
-        async_add_entities([ESPHomeUpdateEntity(entry_data, dashboard)])
+        async_add_entities([ESPHomeUpdateEntity(entry.entry_id, entry_data, dashboard)])
 
     if entry_data.available:
         await setup_update_entity()
@@ -72,11 +72,12 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
     _attr_name = "Firmware"
 
     def __init__(
-        self, entry_data: RuntimeEntryData, coordinator: ESPHomeDashboard
+        self, entry_id: str, entry_data: RuntimeEntryData, coordinator: ESPHomeDashboard
     ) -> None:
         """Initialize the update entity."""
         super().__init__(coordinator=coordinator)
         assert entry_data.device_info is not None
+        self._entry_id = entry_id
         self._entry_data = entry_data
         self._attr_unique_id = entry_data.device_info.mac_address
         self._attr_device_info = DeviceInfo(
@@ -141,6 +142,19 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
                 self.hass,
                 self._entry_data.signal_static_info_updated,
                 _static_info_updated,
+            )
+        )
+
+        @callback
+        def _on_device_update() -> None:
+            """Handle update of device state, like availability."""
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"esphome_{self._entry_id}_on_device_update",
+                _on_device_update,
             )
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update entities for ESPHome are provided by the ESPHome dashboard, so they don't go "unavailable" when the device is offline. This is odd a bit, as well, we can't update the device if it is offline.

This PR takes the state of the device into account for the update entity and marks it unavailable when it is offline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
