### PR TITLE
Add ParamSpec TypeAliases [mypy 1.0]

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -140,12 +140,13 @@ async def async_setup_entry(
     )
 
 
+_FuncType = Callable[Concatenate[_ADBDeviceT, _P], Awaitable[_R]]
+_ReturnFuncType = Callable[Concatenate[_ADBDeviceT, _P], Coroutine[Any, Any, _R | None]]
+
+
 def adb_decorator(
     override_available: bool = False,
-) -> Callable[
-    [Callable[Concatenate[_ADBDeviceT, _P], Awaitable[_R]]],
-    Callable[Concatenate[_ADBDeviceT, _P], Coroutine[Any, Any, _R | None]],
-]:
+) -> Callable[[_FuncType[_ADBDeviceT, _P, _R]], _ReturnFuncType[_ADBDeviceT, _P, _R]]:
     """Wrap ADB methods and catch exceptions.
 
     Allows for overriding the available status of the ADB connection via the
@@ -153,8 +154,8 @@ def adb_decorator(
     """
 
     def _adb_decorator(
-        func: Callable[Concatenate[_ADBDeviceT, _P], Awaitable[_R]]
-    ) -> Callable[Concatenate[_ADBDeviceT, _P], Coroutine[Any, Any, _R | None]]:
+        func: _FuncType[_ADBDeviceT, _P, _R]
+    ) -> _ReturnFuncType[_ADBDeviceT, _P, _R]:
         """Wrap the provided ADB method and catch exceptions."""
 
         @functools.wraps(func)

--- a/homeassistant/components/hassio/addon_manager.py
+++ b/homeassistant/components/hassio/addon_manager.py
@@ -31,18 +31,20 @@ _AddonManagerT = TypeVar("_AddonManagerT", bound="AddonManager")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
+_FuncType = Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]
+_ReturnFuncType = Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]]
+
 
 def api_error(
     error_message: str,
 ) -> Callable[
-    [Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]],
-    Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]],
+    [_FuncType[_AddonManagerT, _P, _R]], _ReturnFuncType[_AddonManagerT, _P, _R]
 ]:
     """Handle HassioAPIError and raise a specific AddonError."""
 
     def handle_hassio_api_error(
-        func: Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]
-    ) -> Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]]:
+        func: _FuncType[_AddonManagerT, _P, _R]
+    ) -> _ReturnFuncType[_AddonManagerT, _P, _R]:
         """Handle a HassioAPIError."""
 
         @wraps(func)

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -88,14 +88,14 @@ async def async_setup_entry(
     async_add_entities(devices, True)
 
 
-def log_command_error(
-    command: str,
-) -> Callable[[Callable[_P, Awaitable[Any]]], Callable[_P, Coroutine[Any, Any, None]]]:
+_FuncType = Callable[_P, Awaitable[Any]]
+_ReturnFuncType = Callable[_P, Coroutine[Any, Any, None]]
+
+
+def log_command_error(command: str) -> Callable[[_FuncType[_P]], _ReturnFuncType[_P]]:
     """Return decorator that logs command failure."""
 
-    def decorator(
-        func: Callable[_P, Awaitable[Any]]
-    ) -> Callable[_P, Coroutine[Any, Any, None]]:
+    def decorator(func: _FuncType[_P]) -> _ReturnFuncType[_P]:
         @wraps(func)
         async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
             try:

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -79,17 +79,22 @@ async def async_setup_platform(
     )
 
 
+_FuncType = Callable[Concatenate[_OpenhomeDeviceT, _P], Awaitable[_R]]
+_ReturnFuncType = Callable[
+    Concatenate[_OpenhomeDeviceT, _P], Coroutine[Any, Any, _R | None]
+]
+
+
 def catch_request_errors() -> (
     Callable[
-        [Callable[Concatenate[_OpenhomeDeviceT, _P], Awaitable[_R]]],
-        Callable[Concatenate[_OpenhomeDeviceT, _P], Coroutine[Any, Any, _R | None]],
+        [_FuncType[_OpenhomeDeviceT, _P, _R]], _ReturnFuncType[_OpenhomeDeviceT, _P, _R]
     ]
 ):
     """Catch asyncio.TimeoutError, aiohttp.ClientError, UpnpError errors."""
 
     def call_wrapper(
-        func: Callable[Concatenate[_OpenhomeDeviceT, _P], Awaitable[_R]]
-    ) -> Callable[Concatenate[_OpenhomeDeviceT, _P], Coroutine[Any, Any, _R | None]]:
+        func: _FuncType[_OpenhomeDeviceT, _P, _R]
+    ) -> _ReturnFuncType[_OpenhomeDeviceT, _P, _R]:
         """Call wrapper for decorator."""
 
         @functools.wraps(func)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -582,20 +582,18 @@ def end_incomplete_runs(session: Session, start_time: datetime) -> None:
         session.add(run)
 
 
+_FuncType = Callable[Concatenate[_RecorderT, _P], bool]
+
+
 def retryable_database_job(
     description: str,
-) -> Callable[
-    [Callable[Concatenate[_RecorderT, _P], bool]],
-    Callable[Concatenate[_RecorderT, _P], bool],
-]:
+) -> Callable[[_FuncType[_RecorderT, _P]], _FuncType[_RecorderT, _P]]:
     """Try to execute a database job.
 
     The job should return True if it finished, and False if it needs to be rescheduled.
     """
 
-    def decorator(
-        job: Callable[Concatenate[_RecorderT, _P], bool]
-    ) -> Callable[Concatenate[_RecorderT, _P], bool]:
+    def decorator(job: _FuncType[_RecorderT, _P]) -> _FuncType[_RecorderT, _P]:
         @functools.wraps(job)
         def wrapper(instance: _RecorderT, *args: _P.args, **kwargs: _P.kwargs) -> bool:
             try:

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -14,6 +14,9 @@ from .entity import RokuEntity
 _RokuEntityT = TypeVar("_RokuEntityT", bound=RokuEntity)
 _P = ParamSpec("_P")
 
+_FuncType = Callable[Concatenate[_RokuEntityT, _P], Awaitable[Any]]
+_ReturnFuncType = Callable[Concatenate[_RokuEntityT, _P], Coroutine[Any, Any, None]]
+
 
 def format_channel_name(channel_number: str, channel_name: str | None = None) -> str:
     """Format a Roku Channel name."""
@@ -25,15 +28,12 @@ def format_channel_name(channel_number: str, channel_name: str | None = None) ->
 
 def roku_exception_handler(
     ignore_timeout: bool = False,
-) -> Callable[
-    [Callable[Concatenate[_RokuEntityT, _P], Awaitable[Any]]],
-    Callable[Concatenate[_RokuEntityT, _P], Coroutine[Any, Any, None]],
-]:
+) -> Callable[[_FuncType[_RokuEntityT, _P]], _ReturnFuncType[_RokuEntityT, _P]]:
     """Decorate Roku calls to handle Roku exceptions."""
 
     def decorator(
-        func: Callable[Concatenate[_RokuEntityT, _P], Awaitable[Any]],
-    ) -> Callable[Concatenate[_RokuEntityT, _P], Coroutine[Any, Any, None]]:
+        func: _FuncType[_RokuEntityT, _P]
+    ) -> _ReturnFuncType[_RokuEntityT, _P]:
         @wraps(func)
         async def wrapper(
             self: _RokuEntityT, *args: _P.args, **kwargs: _P.kwargs

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -31,33 +31,30 @@ _T = TypeVar(
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
+_FuncType = Callable[Concatenate[_T, _P], _R]
+_ReturnFuncType = Callable[Concatenate[_T, _P], _R | None]
+
 
 @overload
 def soco_error(
     errorcodes: None = ...,
-) -> Callable[[Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R]]:
+) -> Callable[[_FuncType[_T, _P, _R]], _FuncType[_T, _P, _R]]:
     ...
 
 
 @overload
 def soco_error(
     errorcodes: list[str],
-) -> Callable[
-    [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R | None]
-]:
+) -> Callable[[_FuncType[_T, _P, _R]], _ReturnFuncType[_T, _P, _R]]:
     ...
 
 
 def soco_error(
     errorcodes: list[str] | None = None,
-) -> Callable[
-    [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R | None]
-]:
+) -> Callable[[_FuncType[_T, _P, _R]], _ReturnFuncType[_T, _P, _R]]:
     """Filter out specified UPnP errors and raise exceptions for service calls."""
 
-    def decorator(
-        funct: Callable[Concatenate[_T, _P], _R]
-    ) -> Callable[Concatenate[_T, _P], _R | None]:
+    def decorator(funct: _FuncType[_T, _P, _R]) -> _ReturnFuncType[_T, _P, _R]:
         """Decorate functions."""
 
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:


### PR DESCRIPTION
## Proposed change
Followup to #87586
Add TypeAliases for ParamSpec types where it's helpful. Mostly for complex decorator functions. E.g.

```py
# before
def log_command_error(
    command: str,
) -> Callable[[Callable[_P, Awaitable[Any]]], Callable[_P, Coroutine[Any, Any, None]]]:

    def decorator(
        func: Callable[_P, Awaitable[Any]]
    ) -> Callable[_P, Coroutine[Any, Any, None]]:
        @wraps(func)
        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
            ...
            await func(*args, **kwargs)

        return wrapper
    return decorator
```

```py
# after
_FuncType = Callable[_P, Awaitable[Any]]
_ReturnFuncType = Callable[_P, Coroutine[Any, Any, None]]


def log_command_error(command: str) -> Callable[[_FuncType[_P]], _ReturnFuncType[_P]]:

    def decorator(func: _FuncType[_P]) -> _ReturnFuncType[_P]:
        @wraps(func)
        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
            ...
            await func(*args, **kwargs)

        return wrapper
    return decorator
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
