### PR TITLE
Add Rain Bird irrigation calendar

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -11,9 +11,15 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_SERIAL_NUMBER
-from .coordinator import RainbirdUpdateCoordinator
+from .coordinator import RainbirdData, RainbirdUpdateCoordinator
 
-PLATFORMS = [Platform.SWITCH, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
+PLATFORMS = [
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.CALENDAR,
+]
 
 
 DOMAIN = "rainbird"
@@ -21,8 +27,6 @@ DOMAIN = "rainbird"
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the config entry for Rain Bird."""
-
-    hass.data.setdefault(DOMAIN, {})
 
     controller = AsyncRainbirdController(
         AsyncRainbirdClient(

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -28,6 +28,8 @@ DOMAIN = "rainbird"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the config entry for Rain Bird."""
 
+    hass.data.setdefault(DOMAIN, {})
+
     controller = AsyncRainbirdController(
         AsyncRainbirdClient(
             async_get_clientsession(hass),
@@ -49,6 +51,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    hass.data[DOMAIN][entry.entry_id] = data
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -10,8 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_SERIAL_NUMBER
-from .coordinator import RainbirdData, RainbirdUpdateCoordinator
+from .coordinator import RainbirdData
 
 PLATFORMS = [
     Platform.SWITCH,
@@ -41,16 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         model_info = await controller.get_model_and_version()
     except RainbirdApiException as err:
         raise ConfigEntryNotReady from err
-    coordinator = RainbirdUpdateCoordinator(
-        hass,
-        name=entry.title,
-        controller=controller,
-        serial_number=entry.data[CONF_SERIAL_NUMBER],
-        model_info=model_info,
-    )
-    await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    data = RainbirdData(hass, entry, controller, model_info)
+    await data.coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = data
 

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry for a Rain Bird binary_sensor."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
     async_add_entities([RainBirdSensor(coordinator, RAIN_SENSOR_ENTITY_DESCRIPTION)])
 
 

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -146,10 +146,10 @@ class RainBirdCalendarEntity(
         # We do not ask for an update with async_add_entities()
         # because it will update disabled entities. This is started as a
         # task to let it sync in the background without blocking startup
-        async def refresh() -> None:
-            await self.coordinator.async_request_refresh()
-            self._apply_coordinator_update()
-
         self.coordinator.config_entry.async_create_background_task(
-            self.hass, refresh(), "rainbird.calendar-refresh"
+            self.hass, self._refresh(), "rainbird.calendar-refresh"
         )
+
+    async def _refresh(self) -> None:
+        await self.coordinator.async_request_refresh()
+        self._apply_coordinator_update()

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -47,6 +47,7 @@ class RainBirdCalendarEntity(
     """A calendar event entity."""
 
     _attr_has_entity_name = True
+    _attr_name = None
     _attr_icon = "mdi:sprinkler"
 
     def __init__(
@@ -57,7 +58,6 @@ class RainBirdCalendarEntity(
     ) -> None:
         """Create the Calendar event device."""
         super().__init__(coordinator)
-        self._attr_name = None
         self._event: CalendarEvent | None = None
         self._attr_unique_id = serial_number
         self._attr_device_info = device_info

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -90,8 +90,9 @@ class RainBirdCalendarEntity(
             raise HomeAssistantError(
                 "Unable to get events: No data from controller yet"
             )
-        cursor = schedule.timeline_tz(dt_util.DEFAULT_TIME_ZONE).overlapping(
-            dt_util.as_local(start_date), dt_util.as_local(end_date)
+        cursor = schedule.timeline_tz(start_date.tzinfo).overlapping(
+            start_date,
+            end_date,
         )
         return [
             CalendarEvent(

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta
 import logging
 
@@ -155,4 +154,6 @@ class RainBirdCalendarEntity(
             await self.coordinator.async_request_refresh()
             self._apply_coordinator_update()
 
-        asyncio.create_task(refresh())
+        self.coordinator.config_entry.async_create_background_task(
+            self.hass, refresh(), "rainbird.calendar-refresh"
+        )

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -18,10 +18,6 @@ from .const import DOMAIN
 from .coordinator import RainbirdScheduleUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-# Polling the calendar requires a number of RPC calls to fetch the data and
-# we don't expect the calendar to change often, so use a long schedule.
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -1,0 +1,155 @@
+"""Rain Bird irrigation calendar."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+import logging
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinator import RainbirdScheduleUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Polling the calendar requires a number of RPC calls to fetch the data and
+# we don't expect the calendar to change often, so use a long schedule.
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up entry for a Rain Bird irrigation calendar."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
+    model = await coordinator.controller.get_model_and_version()
+    if not model.model_info.max_programs:
+        return
+
+    schedule_coordinator = hass.data[DOMAIN][config_entry.entry_id].schedule_coordinator
+    async_add_entities(
+        [
+            RainBirdCalendarEntity(
+                schedule_coordinator,
+                coordinator.serial_number,
+                coordinator.device_info,
+            )
+        ]
+    )
+
+
+class RainBirdCalendarEntity(
+    CoordinatorEntity[RainbirdScheduleUpdateCoordinator], CalendarEntity
+):
+    """A calendar event entity."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:sprinkler"
+
+    def __init__(
+        self,
+        coordinator: RainbirdScheduleUpdateCoordinator,
+        serial_number: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Create the Calendar event device."""
+        super().__init__(coordinator)
+        self._event: CalendarEvent | None = None
+        self._attr_unique_id = serial_number
+        self._attr_device_info = device_info
+
+    @property
+    def should_poll(self) -> bool:
+        """Enable polling for the entity.
+
+        The coordinator has its own polling interval for querying the calendar,
+        and this entity updates its own state more frequently (e.g. to update when
+        an event starts).
+        """
+        return True
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming event."""
+        return self._event
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Get all events in a specific time frame."""
+        schedule = self.coordinator.data
+        if not schedule:
+            raise HomeAssistantError(
+                "Unable to get events: No data from controller yet"
+            )
+        cursor = schedule.timeline_tz(dt_util.DEFAULT_TIME_ZONE).overlapping(
+            dt_util.as_local(start_date), dt_util.as_local(end_date)
+        )
+        return [
+            CalendarEvent(
+                summary=program_event.name,
+                start=program_event.start,
+                end=program_event.end,
+            )
+            for program_event in cursor
+        ]
+
+    def _apply_coordinator_update(self) -> None:
+        """Copy state from the coordinator to this entity."""
+        schedule = self.coordinator.data
+        if not schedule:
+            _LOGGER.debug("No schedule")
+            self._event = None
+            return
+        cursor = schedule.timeline_tz(dt_util.DEFAULT_TIME_ZONE).active_after(
+            dt_util.now()
+        )
+        program_event = next(cursor, None)
+        if not program_event:
+            _LOGGER.debug("No program event")
+            self._event = None
+            return
+        self._event = CalendarEvent(
+            summary=program_event.name,
+            start=program_event.start,
+            end=program_event.end,
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._apply_coordinator_update()
+        super()._handle_coordinator_update()
+
+    async def async_update(self) -> None:
+        """Disable update behavior.
+
+        This disables the parent class behavior that asks the update coordinator to refresh.
+        The coordinator itself updates at a slower pace (actually sending device RPCs) and
+        this entity also updates itself to advance the clock and check if the next upcoming
+        event is active. We don't call the update cordinator here, but do allow the calendar
+        event state updates to happen that evaluate `event`.
+        """
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+
+        # We do not ask for an update with async_add_entities()
+        # because it will update disabled entities. This is started as a
+        # task to let it sync in the background without blocking startup
+        async def refresh() -> None:
+            await self.coordinator.async_request_refresh()
+            self._apply_coordinator_update()
+
+        asyncio.create_task(refresh())

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -27,9 +27,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry for a Rain Bird irrigation calendar."""
     data = hass.data[DOMAIN][config_entry.entry_id]
-    await data.coordinator.controller.get_model_and_version()
-    # if not model.model_info.max_programs:
-    #    return
+    if not data.model_info.model_info.max_programs:
+        return
 
     async_add_entities(
         [

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -97,9 +97,10 @@ class RainBirdCalendarEntity(
         )
         return [
             CalendarEvent(
-                summary=program_event.name,
-                start=program_event.start,
-                end=program_event.end,
+                summary=program_event.program_id.name,
+                start=dt_util.as_local(program_event.start),
+                end=dt_util.as_local(program_event.end),
+                rrule=program_event.rrule_str,
             )
             for program_event in cursor
         ]
@@ -119,10 +120,12 @@ class RainBirdCalendarEntity(
             _LOGGER.debug("No program event")
             self._event = None
             return
+        _LOGGER.debug("Event=%s", program_event.start)
         self._event = CalendarEvent(
-            summary=program_event.name,
-            start=program_event.start,
-            end=program_event.end,
+            summary=program_event.program_id.name,
+            start=dt_util.as_local(program_event.start),
+            end=dt_util.as_local(program_event.end),
+            rrule=program_event.rrule_str,
         )
 
     @callback

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -122,6 +122,8 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
 class RainbirdScheduleUpdateCoordinator(DataUpdateCoordinator[Schedule]):
     """Coordinator for rainbird irrigation schedule calls."""
 
+    config_entry: ConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -26,8 +26,7 @@ from .const import CONF_SERIAL_NUMBER, DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
 
 UPDATE_INTERVAL = datetime.timedelta(minutes=1)
 # The calendar data requires RPCs for each program/zone, and the data rarely
-# changes, so we refresh it less often. However, the calendar entity state refreshes more
-# frequently to check for the start of an event.
+# changes, so we refresh it less often.
 CALENDAR_UPDATE_INTERVAL = datetime.timedelta(minutes=15)
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -10,7 +10,6 @@ import logging
 from typing import TypeVar
 
 import async_timeout
-
 from pyrainbird.async_client import (
     AsyncRainbirdController,
     RainbirdApiException,
@@ -159,6 +158,7 @@ class RainbirdData:
     hass: HomeAssistant
     entry: ConfigEntry
     controller: AsyncRainbirdController
+    model_info: ModelAndVersion
 
     @cached_property
     def coordinator(self) -> RainbirdUpdateCoordinator:
@@ -168,6 +168,7 @@ class RainbirdData:
             name=self.entry.title,
             controller=self.controller,
             serial_number=self.entry.data[CONF_SERIAL_NUMBER],
+            model_info=self.model_info,
         )
 
     @cached_property

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             RainDelayNumber(
-                hass.data[DOMAIN][config_entry.entry_id],
+                hass.data[DOMAIN][config_entry.entry_id].coordinator,
             )
         ]
     )

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             RainBirdSensor(
-                hass.data[DOMAIN][config_entry.entry_id],
+                hass.data[DOMAIN][config_entry.entry_id].coordinator,
                 RAIN_DELAY_ENTITY_DESCRIPTION,
             )
         ]

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry for a Rain Bird irrigation switches."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
     async_add_entities(
         RainBirdSwitch(
             coordinator,

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -36,7 +36,7 @@ SERIAL_NUMBER = 0x12635436566
 # Get serial number Command 0x85. Serial is 0x12635436566
 SERIAL_RESPONSE = "850000012635436566"
 # Model and version command 0x82
-MODEL_AND_VERSION_RESPONSE = "820006090C"
+MODEL_AND_VERSION_RESPONSE = "820005090C"  # ESP-TM2
 # Get available stations command 0x83
 AVAILABLE_STATIONS_RESPONSE = "83017F000000"  # Mask for 7 zones
 EMPTY_STATIONS_RESPONSE = "830000000000"
@@ -176,8 +176,15 @@ def mock_rain_delay_response() -> str:
     return RAIN_DELAY_OFF
 
 
+@pytest.fixture(name="model_and_version_response")
+def mock_model_and_version_response() -> str:
+    """Mock response to return rain delay state."""
+    return MODEL_AND_VERSION_RESPONSE
+
+
 @pytest.fixture(name="api_responses")
 def mock_api_responses(
+    model_and_version_response: str,
     stations_response: str,
     zone_state_response: str,
     rain_response: str,
@@ -188,7 +195,7 @@ def mock_api_responses(
     These are returned in the order they are requested by the update coordinator.
     """
     return [
-        MODEL_AND_VERSION_RESPONSE,
+        model_and_version_response,
         stations_response,
         zone_state_response,
         rain_response,

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -176,6 +176,38 @@ def mock_rain_delay_response() -> str:
     return RAIN_DELAY_OFF
 
 
+@pytest.fixture(name="schedule_responses")
+def mock_schedule_responses() -> list[str]:
+    """Mock response to return the irrigation schedule."""
+    # Example schedule from TM2
+    return [
+        # Model and version
+        "820005090C",
+        # Current running program
+        "A0000000000400",
+        # Per-program information
+        "A00010060602006400",  # CYCLIC every 6 days
+        "A00011110602006400",
+        "A00012000300006400",
+        # Start times per program
+        "A0006000F0FFFFFFFFFFFF",  # 4am
+        "A00061FFFFFFFFFFFFFFFF",
+        "A00062FFFFFFFFFFFFFFFF",
+        # Run times for each zone
+        "A00080001900000000001400000000",  # zone1=25, zone2=20
+        "A00081000700000000001400000000",  # zone3=7, zone4=20
+        "A00082000A00000000000000000000",  # zone5=10
+        "A00083000000000000000000000000",
+        "A00084000000000000000000000000",
+        "A00085000000000000000000000000",
+        "A00086000000000000000000000000",
+        "A00087000000000000000000000000",
+        "A00088000000000000000000000000",
+        "A00089000000000000000000000000",
+        "A0008A000000000000000000000000",
+    ]
+
+
 @pytest.fixture(name="api_responses")
 def mock_api_responses(
     stations_response: str,

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -176,38 +176,6 @@ def mock_rain_delay_response() -> str:
     return RAIN_DELAY_OFF
 
 
-@pytest.fixture(name="schedule_responses")
-def mock_schedule_responses() -> list[str]:
-    """Mock response to return the irrigation schedule."""
-    # Example schedule from TM2
-    return [
-        # Model and version
-        "820005090C",
-        # Current running program
-        "A0000000000400",
-        # Per-program information
-        "A00010060602006400",  # CYCLIC every 6 days
-        "A00011110602006400",
-        "A00012000300006400",
-        # Start times per program
-        "A0006000F0FFFFFFFFFFFF",  # 4am
-        "A00061FFFFFFFFFFFFFFFF",
-        "A00062FFFFFFFFFFFFFFFF",
-        # Run times for each zone
-        "A00080001900000000001400000000",  # zone1=25, zone2=20
-        "A00081000700000000001400000000",  # zone3=7, zone4=20
-        "A00082000A00000000000000000000",  # zone5=10
-        "A00083000000000000000000000000",
-        "A00084000000000000000000000000",
-        "A00085000000000000000000000000",
-        "A00086000000000000000000000000",
-        "A00087000000000000000000000000",
-        "A00088000000000000000000000000",
-        "A00089000000000000000000000000",
-        "A0008A000000000000000000000000",
-    ]
-
-
 @pytest.fixture(name="api_responses")
 def mock_api_responses(
     stations_response: str,

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -130,7 +130,7 @@ async def test_get_events(
 
 
 @pytest.mark.parametrize(
-    "freeze_time,expected_state",
+    ("freeze_time", "expected_state"),
     [
         (
             datetime.datetime(2023, 1, 23, 3, 50, tzinfo=ZoneInfo("America/Regina")),

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -66,10 +66,7 @@ def mock_schedule_responses(responses: list[AiohttpClientMockResponse]) -> list[
     """Mock response to return the irrigation schedule."""
     # Example schedule from TM2
     responses.extend(
-        [
-            mock_response(api_response)
-            for api_response in [MODEL_VERSION_RESPONSE] + SCHEDULE_RESPONSES
-        ]
+        [mock_response(api_response) for api_response in SCHEDULE_RESPONSES]
     )
 
 

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -9,7 +9,6 @@ import urllib
 from zoneinfo import ZoneInfo
 
 from aiohttp import ClientSession
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -92,7 +91,7 @@ def get_events_fixture(
     return _fetch
 
 
-@freeze_time("2023-01-21 09:32:00")
+@pytest.mark.freeze_time("2023-01-21 09:32:00")
 async def test_get_events(
     hass: HomeAssistant, setup_integration: ComponentSetup, get_events: GetEventsFn
 ) -> None:

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -1,0 +1,146 @@
+"""Tests for rainbird calendar platform."""
+
+
+from collections.abc import Awaitable, Callable
+import datetime
+from http import HTTPStatus
+from typing import Any
+import urllib
+
+from aiohttp import ClientSession
+from freezegun import freeze_time
+import pytest
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import ComponentSetup, mock_response
+
+from tests.test_util.aiohttp import AiohttpClientMockResponse
+
+TEST_ENTITY = "calendar.rain_bird_controller"
+GetEventsFn = Callable[[str, str], Awaitable[dict[str, Any]]]
+
+MODEL_VERSION_RESPONSE = "820005090C"
+SCHEDULE_RESPONSES = [
+    # Current running program
+    "A0000000000400",
+    # Per-program information
+    "A00010060602006400",  # CYCLIC every 6 days, starting in 2 days
+    "A00011110602006400",
+    "A00012000300006400",
+    # Start times per program
+    "A0006000F0FFFFFFFFFFFF",  # 4am
+    "A00061FFFFFFFFFFFFFFFF",
+    "A00062FFFFFFFFFFFFFFFF",
+    # Run times for each zone
+    "A00080001900000000001400000000",  # zone1=25, zone2=20
+    "A00081000700000000001400000000",  # zone3=7, zone4=20
+    "A00082000A00000000000000000000",  # zone5=10
+    "A00083000000000000000000000000",
+    "A00084000000000000000000000000",
+    "A00085000000000000000000000000",
+    "A00086000000000000000000000000",
+    "A00087000000000000000000000000",
+    "A00088000000000000000000000000",
+    "A00089000000000000000000000000",
+    "A0008A000000000000000000000000",
+]
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.CALENDAR]
+
+
+@pytest.fixture(autouse=True)
+def set_time_zone(hass: HomeAssistant):
+    """Set the time zone for the tests."""
+    hass.config.set_time_zone("America/Regina")
+
+
+@pytest.fixture(autouse=True)
+def mock_schedule_responses(responses: list[AiohttpClientMockResponse]) -> list[str]:
+    """Mock response to return the irrigation schedule."""
+    # Example schedule from TM2
+    responses.extend(
+        [
+            mock_response(api_response)
+            for api_response in [MODEL_VERSION_RESPONSE] + SCHEDULE_RESPONSES
+        ]
+    )
+
+
+@pytest.fixture(name="get_events")
+def get_events_fixture(
+    hass_client: Callable[..., Awaitable[ClientSession]]
+) -> GetEventsFn:
+    """Fetch calendar events from the HTTP API."""
+
+    async def _fetch(start: str, end: str) -> list[dict[str, Any]]:
+        client = await hass_client()
+        response = await client.get(
+            f"/api/calendars/{TEST_ENTITY}?start={urllib.parse.quote(start)}&end={urllib.parse.quote(end)}"
+        )
+        assert response.status == HTTPStatus.OK
+        results = await response.json()
+        return [{k: event[k] for k in {"summary", "start", "end"}} for event in results]
+
+    return _fetch
+
+
+@freeze_time("2023-01-21 09:32:00")
+async def test_get_events(
+    hass: HomeAssistant, setup_integration: ComponentSetup, get_events: GetEventsFn
+) -> None:
+    """Test calendar event fetching APIs."""
+
+    assert await setup_integration()
+
+    events = await get_events("2023-01-20T00:00:00Z", "2023-02-05T00:00:00Z")
+    assert events == [
+        {
+            "summary": "PGM A",
+            "start": {"dateTime": "2023-01-24T04:00:00-06:00"},
+            "end": {"dateTime": "2023-01-24T05:22:00-06:00"},
+        },
+        {
+            "summary": "PGM A",
+            "start": {"dateTime": "2023-01-30T04:00:00-06:00"},
+            "end": {"dateTime": "2023-01-30T05:22:00-06:00"},
+        },
+        {
+            "summary": "PGM A",
+            "start": {"dateTime": "2023-01-31T04:00:00-06:00"},
+            "end": {"dateTime": "2023-01-31T05:22:00-06:00"},
+        },
+    ]
+
+
+async def test_event_state_off(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    get_events: GetEventsFn,
+    freezer,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test calendar upcoming event state."""
+
+    freezer.move_to(datetime.datetime(2023, 1, 21, 9, 32))
+
+    assert await setup_integration()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state is not None
+    assert state.attributes == {
+        "message": "PGM A",
+        "start_time": "2023-01-24 04:00:00",
+        "end_time": "2023-01-24 05:22:00",
+        "all_day": False,
+        "description": "",
+        "location": "",
+        "friendly_name": "Rain Bird Controller",
+        "icon": "mdi:sprinkler",
+    }
+    assert state.state == "off"

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -73,7 +73,7 @@ async def test_set_value(
     device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL_NUMBER)})
     assert device
     assert device.name == "Rain Bird Controller"
-    assert device.model == "ST8x-WiFi"
+    assert device.model == "ESP-TM2"
     assert device.sw_version == "9.12"
 
     aioclient_mock.mock_calls.clear()

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -57,7 +57,6 @@ async def test_no_zones(
 async def test_zones(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
-    responses: list[AiohttpClientMockResponse],
 ) -> None:
     """Test switch platform with fake data that creates 7 zones with one enabled."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an irrigation calendar for Rain Bird that can return the next irrigation time and full upcoming schedule.

This is meant to replicate the same calendar that is shown in the Rain Bird App, for devices that support program based scheduling.  Rain Bird devices support different scheduling modes: Custom (specific days of week), Cyclic (every N days) or Odd/Even days. These details are managed by `pyrainbird` library, which just returns the timeline of events.

The `pyrainbird` library shares calendar logic with `ical`  (similar to `gcal_sync`) to provide `Timeline` interface to a calendar that hides the details of recurring events which are managed behind the scenes by `dateutil.rrule`.  The `CalendarEntity` also works similarly to `google` where it has an update coordinator for fetching schedule data every 15 minutes, but then updates the `CalendarEntity` every minute to detect when an event actually starts/ends. 

This adds a separate update coordinator for managing the calendar because it changes rarely and sends a large number of RPCs. The storage of `hass.data` has been adjusted to hold a separate object for managing the coordinators.

See [Scheduling a Rain Bird WiFi Controller for Automatic Irrigation](https://wifi.rainbird.com/articles/how-do-i-program-my-wifi-controller-with-the-rain-bird-app/) for more details about what this looks like in the Rain Bird app.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26151

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
