### PR TITLE
Add return type to async tests without arguments

### DIFF
--- a/script/scaffold/templates/significant_change/tests/test_significant_change.py
+++ b/script/scaffold/templates/significant_change/tests/test_significant_change.py
@@ -4,7 +4,7 @@ from homeassistant.components.NEW_DOMAIN.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect NEW_NAME significant changes."""
     attrs = {}
     assert not async_check_significant_change(None, "on", attrs, "on", attrs)

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -36,7 +36,7 @@ async def test_validating_password_invalid_user(data, hass):
         data.validate_login("non-existing", "pw")
 
 
-async def test_not_allow_set_id():
+async def test_not_allow_set_id() -> None:
     """Test we are not allowed to set an ID in config."""
     hass = Mock()
     with pytest.raises(vol.Invalid):

--- a/tests/components/auth/test_indieauth.py
+++ b/tests/components/auth/test_indieauth.py
@@ -106,7 +106,7 @@ def test_parse_url_path():
     assert indieauth._parse_url("http://ex.com").path == "/"
 
 
-async def test_verify_redirect_uri():
+async def test_verify_redirect_uri() -> None:
     """Test that we verify redirect uri correctly."""
     assert await indieauth.verify_redirect_uri(
         None, "http://ex.com", "http://ex.com/callback"

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -4,7 +4,7 @@ from homeassistant.components.binary_sensor.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect Binary Sensor significant changes."""
     old_attrs = {"attr_1": "value_1"}
     new_attrs = {"attr_1": "value_2"}

--- a/tests/components/config/test_auth_provider_homeassistant.py
+++ b/tests/components/config/test_auth_provider_homeassistant.py
@@ -61,7 +61,7 @@ async def test_create_auth_system_generated_user(hass, hass_ws_client):
     assert result["error"]["code"] == "system_generated"
 
 
-async def test_create_auth_user_already_credentials():
+async def test_create_auth_user_already_credentials() -> None:
     """Test we can't create auth for user with pre-existing credentials."""
     # assert False
 

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -153,12 +153,12 @@ class _Data:
 Data = _Data()
 
 
-async def test_v1_data():
+async def test_v1_data() -> None:
     """Test for version 1 api based on message."""
     assert dialogflow.get_api_version(Data.v1) == 1
 
 
-async def test_v2_data():
+async def test_v2_data() -> None:
     """Test for version 2 api based on message."""
     assert dialogflow.get_api_version(Data.v2) == 2
 

--- a/tests/components/ecobee/test_util.py
+++ b/tests/components/ecobee/test_util.py
@@ -5,14 +5,14 @@ import voluptuous as vol
 from homeassistant.components.ecobee.util import ecobee_date, ecobee_time
 
 
-async def test_ecobee_date_with_valid_input():
+async def test_ecobee_date_with_valid_input() -> None:
     """Test that the date function returns the expected result."""
     test_input = "2019-09-27"
 
     assert ecobee_date(test_input) == test_input
 
 
-async def test_ecobee_date_with_invalid_input():
+async def test_ecobee_date_with_invalid_input() -> None:
     """Test that the date function raises the expected exception."""
     test_input = "20190927"
 
@@ -20,14 +20,14 @@ async def test_ecobee_date_with_invalid_input():
         ecobee_date(test_input)
 
 
-async def test_ecobee_time_with_valid_input():
+async def test_ecobee_time_with_valid_input() -> None:
     """Test that the time function returns the expected result."""
     test_input = "20:55:15"
 
     assert ecobee_time(test_input) == test_input
 
 
-async def test_ecobee_time_with_invalid_input():
+async def test_ecobee_time_with_invalid_input() -> None:
     """Test that the time function raises the expected exception."""
     test_input = "20:55"
 

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -276,7 +276,7 @@ async def test_agent_user_id_storage(hass, hass_storage):
     )
 
 
-async def test_agent_user_id_connect():
+async def test_agent_user_id_connect() -> None:
     """Test the connection and disconnection of users."""
     config = MockConfig()
     store = config._store

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -23,18 +23,18 @@ class FilterTest:
     should_pass: bool
 
 
-async def test_datetime():
+async def test_datetime() -> None:
     """Test datetime encoding."""
     time = datetime(2019, 1, 13, 12, 30, 5)
     assert victim().encode(time) == '"2019-01-13T12:30:05"'
 
 
-async def test_no_datetime():
+async def test_no_datetime() -> None:
     """Test integer encoding."""
     assert victim().encode(42) == "42"
 
 
-async def test_nested():
+async def test_nested() -> None:
     """Test dictionary encoding."""
     assert victim().encode({"foo": "bar"}) == '{"foo": "bar"}'
 

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -38,13 +38,13 @@ async def test_connect_error(hass, config):
         assert result["errors"] == {CONF_IP_ADDRESS: "cannot_connect"}
 
 
-async def test_get_pin_from_discovery_hostname():
+async def test_get_pin_from_discovery_hostname() -> None:
     """Test getting a device PIN from the zeroconf-discovered hostname."""
     pin = async_get_pin_from_discovery_hostname("GVC1-3456.local.")
     assert pin == "3456"
 
 
-async def test_get_pin_from_uid():
+async def test_get_pin_from_uid() -> None:
     """Test getting a device PIN from its UID."""
     pin = async_get_pin_from_uid("ABCDEF123456")
     assert pin == "3456"

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -346,7 +346,7 @@ async def test_port_is_available_skips_existing_entries(hass):
         async_find_next_available_port(hass, 65530)
 
 
-async def test_format_version():
+async def test_format_version() -> None:
     """Test format_version method."""
     assert format_version("soho+3.6.8+soho-release-rt120+10") == "3.6.8"
     assert format_version("undefined-undefined-1.6.8") == "1.6.8"
@@ -362,14 +362,14 @@ async def test_format_version():
     assert format_version("unknown") is None
 
 
-async def test_coerce_int():
+async def test_coerce_int() -> None:
     """Test coerce_int method."""
     assert coerce_int("1") == 1
     assert coerce_int("") == 0
     assert coerce_int(0) == 0
 
 
-async def test_accessory_friendly_name():
+async def test_accessory_friendly_name() -> None:
     """Test we provide a helpful friendly name."""
 
     accessory = Mock()

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -88,7 +88,7 @@ async def test_hap_setup_works(hass):
     assert hap.home is home
 
 
-async def test_hap_setup_connection_error():
+async def test_hap_setup_connection_error() -> None:
     """Test a failed accesspoint setup."""
     hass = Mock()
     entry = Mock()

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -42,7 +42,7 @@ async def test_invalid_json(caplog):
     )
 
 
-async def test_nan_serialized_to_null():
+async def test_nan_serialized_to_null() -> None:
     """Test nan serialized to null JSON."""
     response = HomeAssistantView.json(float("NaN"))
     assert json.loads(response.body.decode("utf-8")) is None

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -12,7 +12,7 @@ from . import MockLocation
 from tests.common import MockConfigEntry, mock_registry
 
 
-async def test_show_config_form():
+async def test_show_config_form() -> None:
     """Test show configuration form."""
     hass = Mock()
     flow = config_flow.IpmaFlowHandler()
@@ -24,7 +24,7 @@ async def test_show_config_form():
     assert result["step_id"] == "user"
 
 
-async def test_show_config_form_default_values():
+async def test_show_config_form_default_values() -> None:
     """Test show configuration form."""
     hass = Mock()
     flow = config_flow.IpmaFlowHandler()
@@ -54,7 +54,7 @@ async def test_flow_with_home_location(hass):
     assert result["step_id"] == "user"
 
 
-async def test_flow_show_form():
+async def test_flow_show_form() -> None:
     """Test show form scenarios first time.
 
     Test when the form should show when no configurations exists
@@ -70,7 +70,7 @@ async def test_flow_show_form():
         assert len(config_form.mock_calls) == 1
 
 
-async def test_flow_entry_created_from_user_input():
+async def test_flow_entry_created_from_user_input() -> None:
     """Test that create data from user input.
 
     Test when the form should show when no configurations exists
@@ -97,7 +97,7 @@ async def test_flow_entry_created_from_user_input():
         assert not config_form.mock_calls
 
 
-async def test_flow_entry_config_entry_already_exists():
+async def test_flow_entry_config_entry_already_exists() -> None:
     """Test that create data from user input and config_entry already exists.
 
     Test when the form should show when user puts existing name

--- a/tests/components/light/test_significant_change.py
+++ b/tests/components/light/test_significant_change.py
@@ -10,7 +10,7 @@ from homeassistant.components.light.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect Light significant changes."""
     assert not async_check_significant_change(None, "on", {}, "on", {})
     assert async_check_significant_change(None, "on", {}, "off", {})

--- a/tests/components/lock/test_significant_change.py
+++ b/tests/components/lock/test_significant_change.py
@@ -4,7 +4,7 @@ from homeassistant.components.lock.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect Lock significant changes."""
     old_attrs = {"attr_1": "a"}
     new_attrs = {"attr_1": "b"}

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.components.media_source import const, models
 from homeassistant.setup import async_setup_component
 
 
-async def test_is_media_source_id():
+async def test_is_media_source_id() -> None:
     """Test media source validation."""
     assert media_source.is_media_source_id(media_source.URI_SCHEME)
     assert media_source.is_media_source_id(f"{media_source.URI_SCHEME}domain")
@@ -20,7 +20,7 @@ async def test_is_media_source_id():
     assert not media_source.is_media_source_id("test")
 
 
-async def test_generate_media_source_id():
+async def test_generate_media_source_id() -> None:
     """Test identifier generation."""
     tests = [
         (None, None),
@@ -258,7 +258,7 @@ async def test_websocket_resolve_media(hass, hass_ws_client, filename):
     assert msg["error"]["message"] == "test"
 
 
-async def test_browse_resolve_without_setup():
+async def test_browse_resolve_without_setup() -> None:
     """Test browse and resolve work without being setup."""
     with pytest.raises(BrowseError):
         await media_source.async_browse_media(Mock(data={}), None)

--- a/tests/components/media_source/test_models.py
+++ b/tests/components/media_source/test_models.py
@@ -3,7 +3,7 @@ from homeassistant.components.media_player import MediaClass, MediaType
 from homeassistant.components.media_source import const, models
 
 
-async def test_browse_media_as_dict():
+async def test_browse_media_as_dict() -> None:
     """Test BrowseMediaSource conversion to media player item dict."""
     base = models.BrowseMediaSource(
         domain=const.DOMAIN,
@@ -40,7 +40,7 @@ async def test_browse_media_as_dict():
     assert item["children"][0]["media_class"] == MediaClass.MUSIC
 
 
-async def test_browse_media_parent_no_children():
+async def test_browse_media_parent_no_children() -> None:
     """Test BrowseMediaSource conversion to media player item dict."""
     base = models.BrowseMediaSource(
         domain=const.DOMAIN,
@@ -63,7 +63,7 @@ async def test_browse_media_parent_no_children():
     assert item["children_media_class"] is None
 
 
-async def test_media_source_default_name():
+async def test_media_source_default_name() -> None:
     """Test MediaSource uses domain as default name."""
     source = models.MediaSource(const.DOMAIN)
     assert source.name == const.DOMAIN

--- a/tests/components/minio/test_minio.py
+++ b/tests/components/minio/test_minio.py
@@ -153,7 +153,7 @@ async def test_minio_listen(hass, caplog, minio_client_event):
     assert len(event.data["metadata"]) == 0
 
 
-async def test_queue_listener():
+async def test_queue_listener() -> None:
     """Tests QueueListener firing events on Home Assistant event bus."""
     hass = MagicMock()
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -118,7 +118,7 @@ async def mock_modbus_with_pymodbus_fixture(hass, caplog, do_config, mock_pymodb
     return mock_pymodbus
 
 
-async def test_number_validator():
+async def test_number_validator() -> None:
     """Test number validator."""
 
     for value, value_type in (

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -42,7 +42,7 @@ async def test_async_create_certificate_temp_files(
     )
 
 
-async def test_reading_non_exitisting_certificate_file():
+async def test_reading_non_exitisting_certificate_file() -> None:
     """Test reading a non existing certificate file."""
     assert (
         mqtt.util.migrate_certificate_file_to_content("/home/file_not_exists") is None

--- a/tests/components/nexia/test_util.py
+++ b/tests/components/nexia/test_util.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from homeassistant.components.nexia import util
 
 
-async def test_is_invalid_auth_code():
+async def test_is_invalid_auth_code() -> None:
     """Test for invalid auth."""
 
     assert util.is_invalid_auth_code(HTTPStatus.UNAUTHORIZED) is True
@@ -13,7 +13,7 @@ async def test_is_invalid_auth_code():
     assert util.is_invalid_auth_code(HTTPStatus.NOT_FOUND) is False
 
 
-async def test_percent_conv():
+async def test_percent_conv() -> None:
     """Test percentage conversion."""
 
     assert util.percent_conv(0.12) == 12.0

--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -37,7 +37,7 @@ async def test_setup_views_if_not_onboarded(hass):
     assert not onboarding.async_is_onboarded(hass)
 
 
-async def test_is_onboarded():
+async def test_is_onboarded() -> None:
     """Test the is onboarded function."""
     hass = Mock()
     hass.data = {}
@@ -51,7 +51,7 @@ async def test_is_onboarded():
     assert not onboarding.async_is_onboarded(hass)
 
 
-async def test_is_user_onboarded():
+async def test_is_user_onboarded() -> None:
     """Test the is onboarded function."""
     hass = Mock()
     hass.data = {}

--- a/tests/components/person/test_significant_change.py
+++ b/tests/components/person/test_significant_change.py
@@ -4,7 +4,7 @@ from homeassistant.components.person.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect Person significant changes and ensure that attribute changes do not trigger a significant change."""
     old_attrs = {"source": "device_tracker.wifi_device"}
     new_attrs = {"source": "device_tracker.gps_device"}

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -227,7 +227,7 @@ def test_states_from_native_invalid_entity_id():
     assert state.entity_id == "test.invalid__id"
 
 
-async def test_process_timestamp():
+async def test_process_timestamp() -> None:
     """Test processing time stamp to UTC."""
     datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
     datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
@@ -256,7 +256,7 @@ async def test_process_timestamp():
     assert process_timestamp(None) is None
 
 
-async def test_process_timestamp_to_utc_isoformat():
+async def test_process_timestamp_to_utc_isoformat() -> None:
     """Test processing time stamp to UTC isoformat."""
     datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
     datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
@@ -292,7 +292,7 @@ async def test_process_timestamp_to_utc_isoformat():
     assert process_timestamp_to_utc_isoformat(None) is None
 
 
-async def test_event_to_db_model():
+async def test_event_to_db_model() -> None:
     """Test we can round trip Event conversion."""
     event = ha.Event(
         "state_changed", {"some": "attr"}, ha.EventOrigin.local, dt_util.utcnow()

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -9,7 +9,7 @@ from homeassistant.components.recorder.const import DB_WORKER_PREFIX
 from homeassistant.components.recorder.pool import RecorderPool
 
 
-async def test_recorder_pool_called_from_event_loop():
+async def test_recorder_pool_called_from_event_loop() -> None:
     """Test we raise an exception when calling from the event loop."""
     engine = create_engine("sqlite://", poolclass=RecorderPool)
     with pytest.raises(RuntimeError):

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -60,7 +60,7 @@ from homeassistant.util import dt
 from tests.common import async_fire_time_changed
 
 
-async def test_climate_find_valid_targets():
+async def test_climate_find_valid_targets() -> None:
     """Test function to return temperature from valid targets."""
 
     valid_targets = [10, 16, 17, 18, 19, 20]

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -151,7 +151,7 @@ async def test_get_block_device_sleep_period(settings, sleep_period):
 
 
 @freeze_time("2019-01-10 18:43:00+00:00")
-async def test_get_device_uptime():
+async def test_get_device_uptime() -> None:
     """Test block test get device uptime."""
     assert get_device_uptime(
         55, dt.as_utc(dt.parse_datetime("2019-01-10 18:42:00+00:00"))

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -38,7 +38,7 @@ def filter_log_records(caplog: LogCaptureFixture) -> list[logging.LogRecord]:
     ]
 
 
-async def test_message_includes_default_emoji():
+async def test_message_includes_default_emoji() -> None:
     """Tests that default icon is used when no message icon is given."""
     mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
@@ -55,7 +55,7 @@ async def test_message_includes_default_emoji():
     assert kwargs["icon_emoji"] == expected_icon
 
 
-async def test_message_emoji_overrides_default():
+async def test_message_emoji_overrides_default() -> None:
     """Tests that overriding the default icon emoji when sending a message works."""
     mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
@@ -72,7 +72,7 @@ async def test_message_emoji_overrides_default():
     assert kwargs["icon_emoji"] == expected_icon
 
 
-async def test_message_includes_default_icon_url():
+async def test_message_includes_default_icon_url() -> None:
     """Tests that overriding the default icon url when sending a message works."""
     mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
@@ -89,7 +89,7 @@ async def test_message_includes_default_icon_url():
     assert kwargs["icon_url"] == expected_icon
 
 
-async def test_message_icon_url_overrides_default():
+async def test_message_icon_url_overrides_default() -> None:
     """Tests that overriding the default icon url when sending a message works."""
     mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import EntityCategory
 from .conftest import setup_platform
 
 
-async def test_mapping_integrity():
+async def test_mapping_integrity() -> None:
     """Test ensures the map dicts have proper integrity."""
     # Ensure every CAPABILITY_TO_ATTRIB key is in CAPABILITIES
     # Ensure every CAPABILITY_TO_ATTRIB value is in ATTRIB_TO_CLASS keys

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import EntityCategory
 from .conftest import setup_platform
 
 
-async def test_mapping_integrity():
+async def test_mapping_integrity() -> None:
     """Test ensures the map dicts have proper integrity."""
     for capability, maps in sensor.CAPABILITY_TO_SENSORS.items():
         assert capability in CAPABILITIES, capability

--- a/tests/components/sonos/test_helpers.py
+++ b/tests/components/sonos/test_helpers.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.components.sonos.helpers import hostname_to_uid
 
 
-async def test_uid_to_hostname():
+async def test_uid_to_hostname() -> None:
     """Test we can convert a hostname to a uid."""
     assert hostname_to_uid("Sonos-347E5C0CF1E3.local.") == "RINCON_347E5C0CF1E301400"
     assert hostname_to_uid("sonos5CAAFDE47AC8.local.") == "RINCON_5CAAFDE47AC801400"

--- a/tests/components/switch/test_significant_change.py
+++ b/tests/components/switch/test_significant_change.py
@@ -4,7 +4,7 @@ from homeassistant.components.switch.significant_change import (
 )
 
 
-async def test_significant_change():
+async def test_significant_change() -> None:
     """Detect Switch significant change."""
     attrs = {}
     assert not async_check_significant_change(None, "on", attrs, "on", attrs)

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -112,7 +112,7 @@ async def test_device_diagnostics_error(hass, integration):
         await async_get_device_diagnostics(hass, integration, device)
 
 
-async def test_empty_zwave_value_matcher():
+async def test_empty_zwave_value_matcher() -> None:
     """Test empty ZwaveValueMatcher is invalid."""
     with pytest.raises(ValueError):
         ZwaveValueMatcher()

--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -112,7 +112,7 @@ def test_id_manager():
     assert id_manager.generate_id("bla") == "bla"
 
 
-async def test_observable_collection():
+async def test_observable_collection() -> None:
     """Test observerable collection."""
     coll = collection.ObservableCollection(_LOGGER)
     assert coll.async_items() == []
@@ -127,7 +127,7 @@ async def test_observable_collection():
     assert changes[0] == ("mock_type", "mock_id", {"mock": "item"})
 
 
-async def test_yaml_collection():
+async def test_yaml_collection() -> None:
     """Test a YAML collection."""
     id_manager = collection.IDManager()
     coll = collection.YamlCollection(_LOGGER, id_manager)
@@ -171,7 +171,7 @@ async def test_yaml_collection():
     )
 
 
-async def test_yaml_collection_skipping_duplicate_ids():
+async def test_yaml_collection_skipping_duplicate_ids() -> None:
     """Test YAML collection skipping duplicate IDs."""
     id_manager = collection.IDManager()
     id_manager.add_collection({"existing": True})

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1934,7 +1934,7 @@ async def test_multiple_zones(hass):
     assert not test(hass)
 
 
-async def test_extract_entities():
+async def test_extract_entities() -> None:
     """Test extracting entities."""
     assert condition.async_extract_entities(
         {
@@ -2007,7 +2007,7 @@ async def test_extract_entities():
     }
 
 
-async def test_extract_devices():
+async def test_extract_devices() -> None:
     """Test extracting devices."""
     assert condition.async_extract_devices(
         {

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -876,7 +876,7 @@ def test_entity_category_schema_error(value):
         schema(value)
 
 
-async def test_entity_description_fallback():
+async def test_entity_description_fallback() -> None:
     """Test entity description has same defaults as entity."""
     ent = entity.Entity()
     ent_with_description = entity.Entity()
@@ -955,7 +955,7 @@ async def test_translation_key(hass):
     assert mock_entity2.translation_key == "from_entity_description"
 
 
-async def test_repr_using_stringify_state():
+async def test_repr_using_stringify_state() -> None:
     """Test that repr uses stringify state."""
 
     class MyEntity(MockEntity):

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.helpers import config_validation as cv, template
 
 
-async def test_static_vars():
+async def test_static_vars() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
@@ -13,7 +13,7 @@ async def test_static_vars():
     assert rendered == orig
 
 
-async def test_static_vars_run_args():
+async def test_static_vars_run_args() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     orig_copy = dict(orig)
@@ -24,7 +24,7 @@ async def test_static_vars_run_args():
     assert orig == orig_copy
 
 
-async def test_static_vars_no_default():
+async def test_static_vars_no_default() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
@@ -33,7 +33,7 @@ async def test_static_vars_no_default():
     assert rendered == orig
 
 
-async def test_static_vars_run_args_no_default():
+async def test_static_vars_run_args_no_default() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     orig_copy = dict(orig)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -975,7 +975,7 @@ async def test_serviceregistry_callback_service_raise_exception(hass):
     await hass.async_block_till_done()
 
 
-async def test_config_defaults():
+async def test_config_defaults() -> None:
     """Test config defaults."""
     hass = Mock()
     config = ha.Config(hass)
@@ -1003,21 +1003,21 @@ async def test_config_defaults():
     assert config.language == "en"
 
 
-async def test_config_path_with_file():
+async def test_config_path_with_file() -> None:
     """Test get_config_path method."""
     config = ha.Config(None)
     config.config_dir = "/test/ha-config"
     assert config.path("test.conf") == "/test/ha-config/test.conf"
 
 
-async def test_config_path_with_dir_and_file():
+async def test_config_path_with_dir_and_file() -> None:
     """Test get_config_path method."""
     config = ha.Config(None)
     config.config_dir = "/test/ha-config"
     assert config.path("dir", "test.conf") == "/test/ha-config/dir/test.conf"
 
 
-async def test_config_as_dict():
+async def test_config_as_dict() -> None:
     """Test as dict."""
     config = ha.Config(None)
     config.config_dir = "/test/ha-config"
@@ -1049,7 +1049,7 @@ async def test_config_as_dict():
     assert expected == config.as_dict()
 
 
-async def test_config_is_allowed_path():
+async def test_config_is_allowed_path() -> None:
     """Test is_allowed_path method."""
     config = ha.Config(None)
     with TemporaryDirectory() as tmp_dir:
@@ -1081,7 +1081,7 @@ async def test_config_is_allowed_path():
             config.is_allowed_path(None)
 
 
-async def test_config_is_allowed_external_url():
+async def test_config_is_allowed_external_url() -> None:
     """Test is_allowed_external_url method."""
     config = ha.Config(None)
     config.allowlist_external_urls = [
@@ -1507,7 +1507,7 @@ async def test_async_entity_ids_count(hass):
     assert hass.states.async_entity_ids_count("light") == 3
 
 
-async def test_hassjob_forbid_coroutine():
+async def test_hassjob_forbid_coroutine() -> None:
     """Test hassjob forbids coroutines."""
 
     async def bla():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,7 +15,7 @@ SUPERVISOR_HARD_TIMEOUT = 220
 TIMEOUT_SAFETY_MARGIN = 10
 
 
-async def test_cumulative_shutdown_timeout_less_than_supervisor():
+async def test_cumulative_shutdown_timeout_less_than_supervisor() -> None:
     """Verify the cumulative shutdown timeout is at least 10s less than the supervisor."""
     assert (
         core.STAGE_1_SHUTDOWN_TIMEOUT

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -4,7 +4,7 @@ import pytest
 from .aiohttp import AiohttpClientMocker
 
 
-async def test_matching_url():
+async def test_matching_url() -> None:
     """Test we can match urls."""
     mocker = AiohttpClientMocker()
     mocker.get("http://example.com")

--- a/tests/util/test_aiohttp.py
+++ b/tests/util/test_aiohttp.py
@@ -4,21 +4,21 @@ from aiohttp import web
 from homeassistant.util import aiohttp
 
 
-async def test_request_json():
+async def test_request_json() -> None:
     """Test a JSON request."""
     request = aiohttp.MockRequest(b'{"hello": 2}', mock_source="test")
     assert request.status == 200
     assert await request.json() == {"hello": 2}
 
 
-async def test_request_text():
+async def test_request_text() -> None:
     """Test a JSON request."""
     request = aiohttp.MockRequest(b"hello", status=201, mock_source="test")
     assert request.status == 201
     assert await request.text() == "hello"
 
 
-async def test_request_post_query():
+async def test_request_post_query() -> None:
     """Test a JSON request."""
     request = aiohttp.MockRequest(
         b"hello=2&post=true", query_string="get=true", method="POST", mock_source="test"

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -75,7 +75,7 @@ def banned_function():
     """Mock banned function."""
 
 
-async def test_check_loop_async():
+async def test_check_loop_async() -> None:
     """Test check_loop detects when called from event loop without integration context."""
     with pytest.raises(RuntimeError):
         hasync.check_loop(banned_function)
@@ -217,7 +217,7 @@ async def test_protect_loop_debugger_sleep(caplog):
     assert "Detected blocking call inside the event loop" not in caplog.text
 
 
-async def test_gather_with_concurrency():
+async def test_gather_with_concurrency() -> None:
     """Test gather_with_concurrency limits the number of running tasks."""
 
     runs = 0

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -214,7 +214,7 @@ def test_get_random_string(mock_random):
     assert util.get_random_string(length=3) == "ABC"
 
 
-async def test_throttle_async():
+async def test_throttle_async() -> None:
     """Test Throttle decorator with async method."""
 
     @util.Throttle(timedelta(seconds=2))

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -24,7 +24,7 @@ def test_sensitive_data_filter():
     assert sensitive_record.msg == "******* log"
 
 
-async def test_logging_with_queue_handler():
+async def test_logging_with_queue_handler() -> None:
     """Test logging with HomeAssistantQueueHandler."""
 
     simple_queue = queue.SimpleQueue()  # type: ignore

--- a/tests/util/test_percentage.py
+++ b/tests/util/test_percentage.py
@@ -28,7 +28,7 @@ SMALL_ORDERED_LIST = [SPEED_1, SPEED_2, SPEED_3, SPEED_4]
 LARGE_ORDERED_LIST = [SPEED_1, SPEED_2, SPEED_3, SPEED_4, SPEED_5, SPEED_6, SPEED_7]
 
 
-async def test_ordered_list_item_to_percentage():
+async def test_ordered_list_item_to_percentage() -> None:
     """Test percentage of an item in an ordered list."""
 
     assert ordered_list_item_to_percentage(LEGACY_ORDERED_LIST, SPEED_LOW) == 33
@@ -52,7 +52,7 @@ async def test_ordered_list_item_to_percentage():
         assert ordered_list_item_to_percentage([], SPEED_1)
 
 
-async def test_percentage_to_ordered_list_item():
+async def test_percentage_to_ordered_list_item() -> None:
     """Test item that most closely matches the percentage in an ordered list."""
 
     assert percentage_to_ordered_list_item(SMALL_ORDERED_LIST, 1) == SPEED_1
@@ -102,7 +102,7 @@ async def test_percentage_to_ordered_list_item():
         assert percentage_to_ordered_list_item([], 100)
 
 
-async def test_ranged_value_to_percentage_large():
+async def test_ranged_value_to_percentage_large() -> None:
     """Test a large range of low and high values convert a single value to a percentage."""
     range = (1, 255)
 
@@ -112,7 +112,7 @@ async def test_ranged_value_to_percentage_large():
     assert ranged_value_to_percentage(range, 1) == 0
 
 
-async def test_percentage_to_ranged_value_large():
+async def test_percentage_to_ranged_value_large() -> None:
     """Test a large range of low and high values convert a percentage to a single value."""
     range = (1, 255)
 
@@ -125,7 +125,7 @@ async def test_percentage_to_ranged_value_large():
     assert math.ceil(percentage_to_ranged_value(range, 4)) == 11
 
 
-async def test_ranged_value_to_percentage_small():
+async def test_ranged_value_to_percentage_small() -> None:
     """Test a small range of low and high values convert a single value to a percentage."""
     range = (1, 6)
 
@@ -137,7 +137,7 @@ async def test_ranged_value_to_percentage_small():
     assert ranged_value_to_percentage(range, 6) == 100
 
 
-async def test_percentage_to_ranged_value_small():
+async def test_percentage_to_ranged_value_small() -> None:
     """Test a small range of low and high values convert a percentage to a single value."""
     range = (1, 6)
 
@@ -149,7 +149,7 @@ async def test_percentage_to_ranged_value_small():
     assert math.ceil(percentage_to_ranged_value(range, 100)) == 6
 
 
-async def test_ranged_value_to_percentage_starting_at_one():
+async def test_ranged_value_to_percentage_starting_at_one() -> None:
     """Test a range that starts with 1."""
     range = (1, 4)
 
@@ -159,7 +159,7 @@ async def test_ranged_value_to_percentage_starting_at_one():
     assert ranged_value_to_percentage(range, 4) == 100
 
 
-async def test_ranged_value_to_percentage_starting_high():
+async def test_ranged_value_to_percentage_starting_high() -> None:
     """Test a range that does not start with 1."""
     range = (101, 255)
 
@@ -170,7 +170,7 @@ async def test_ranged_value_to_percentage_starting_high():
     assert ranged_value_to_percentage(range, 255) == 100
 
 
-async def test_ranged_value_to_percentage_starting_zero():
+async def test_ranged_value_to_percentage_starting_zero() -> None:
     """Test a range that starts with 0."""
     range = (0, 3)
 

--- a/tests/util/test_process.py
+++ b/tests/util/test_process.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.util import process
 
 
-async def test_kill_process():
+async def test_kill_process() -> None:
     """Test killing a process."""
     sleeper = subprocess.Popen(
         "sleep 1000",

--- a/tests/util/test_thread.py
+++ b/tests/util/test_thread.py
@@ -57,7 +57,7 @@ class _EmptyClass:
     """An empty class."""
 
 
-async def test_deadlock_safe_shutdown_no_threads():
+async def test_deadlock_safe_shutdown_no_threads() -> None:
     """Test we can shutdown without deadlock without any threads to join."""
 
     dead_thread_mock = Mock(
@@ -78,7 +78,7 @@ async def test_deadlock_safe_shutdown_no_threads():
     assert not daemon_thread_mock.join.called
 
 
-async def test_deadlock_safe_shutdown():
+async def test_deadlock_safe_shutdown() -> None:
     """Test we can shutdown without deadlock."""
 
     normal_thread_mock = Mock(

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.util.timeout import TimeoutManager
 
 
-async def test_simple_global_timeout():
+async def test_simple_global_timeout() -> None:
     """Test a simple global timeout."""
     timeout = TimeoutManager()
 
@@ -26,7 +26,7 @@ async def test_simple_global_timeout_with_executor_job(hass):
             await hass.async_add_executor_job(lambda: time.sleep(0.2))
 
 
-async def test_simple_global_timeout_freeze():
+async def test_simple_global_timeout_freeze() -> None:
     """Test a simple global timeout freeze."""
     timeout = TimeoutManager()
 
@@ -130,7 +130,7 @@ async def test_simple_global_timeout_freeze_with_executor_job(hass):
             await hass.async_add_executor_job(lambda: time.sleep(0.3))
 
 
-async def test_simple_global_timeout_freeze_reset():
+async def test_simple_global_timeout_freeze_reset() -> None:
     """Test a simple global timeout freeze reset."""
     timeout = TimeoutManager()
 
@@ -141,7 +141,7 @@ async def test_simple_global_timeout_freeze_reset():
             await asyncio.sleep(0.2)
 
 
-async def test_simple_zone_timeout():
+async def test_simple_zone_timeout() -> None:
     """Test a simple zone timeout."""
     timeout = TimeoutManager()
 
@@ -150,7 +150,7 @@ async def test_simple_zone_timeout():
             await asyncio.sleep(0.3)
 
 
-async def test_multiple_zone_timeout():
+async def test_multiple_zone_timeout() -> None:
     """Test a simple zone timeout."""
     timeout = TimeoutManager()
 
@@ -160,7 +160,7 @@ async def test_multiple_zone_timeout():
                 await asyncio.sleep(0.3)
 
 
-async def test_different_zone_timeout():
+async def test_different_zone_timeout() -> None:
     """Test a simple zone timeout."""
     timeout = TimeoutManager()
 
@@ -170,7 +170,7 @@ async def test_different_zone_timeout():
                 await asyncio.sleep(0.3)
 
 
-async def test_simple_zone_timeout_freeze():
+async def test_simple_zone_timeout_freeze() -> None:
     """Test a simple zone timeout freeze."""
     timeout = TimeoutManager()
 
@@ -179,7 +179,7 @@ async def test_simple_zone_timeout_freeze():
             await asyncio.sleep(0.3)
 
 
-async def test_simple_zone_timeout_freeze_without_timeout():
+async def test_simple_zone_timeout_freeze_without_timeout() -> None:
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
     timeout = TimeoutManager()
 
@@ -188,7 +188,7 @@ async def test_simple_zone_timeout_freeze_without_timeout():
             await asyncio.sleep(0.3)
 
 
-async def test_simple_zone_timeout_freeze_reset():
+async def test_simple_zone_timeout_freeze_reset() -> None:
     """Test a simple zone timeout freeze reset."""
     timeout = TimeoutManager()
 
@@ -199,7 +199,7 @@ async def test_simple_zone_timeout_freeze_reset():
             await asyncio.sleep(0.2, "test")
 
 
-async def test_mix_zone_timeout_freeze_and_global_freeze():
+async def test_mix_zone_timeout_freeze_and_global_freeze() -> None:
     """Test a mix zone timeout freeze and global freeze."""
     timeout = TimeoutManager()
 
@@ -209,7 +209,7 @@ async def test_mix_zone_timeout_freeze_and_global_freeze():
                 await asyncio.sleep(0.3)
 
 
-async def test_mix_global_and_zone_timeout_freeze_():
+async def test_mix_global_and_zone_timeout_freeze_() -> None:
     """Test a mix zone timeout freeze and global freeze."""
     timeout = TimeoutManager()
 
@@ -219,7 +219,7 @@ async def test_mix_global_and_zone_timeout_freeze_():
                 await asyncio.sleep(0.3)
 
 
-async def test_mix_zone_timeout_freeze():
+async def test_mix_zone_timeout_freeze() -> None:
     """Test a mix zone timeout global freeze."""
     timeout = TimeoutManager()
 
@@ -228,7 +228,7 @@ async def test_mix_zone_timeout_freeze():
             await asyncio.sleep(0.3)
 
 
-async def test_mix_zone_timeout():
+async def test_mix_zone_timeout() -> None:
     """Test a mix zone timeout global."""
     timeout = TimeoutManager()
 
@@ -238,7 +238,7 @@ async def test_mix_zone_timeout():
                 await asyncio.sleep(0.4)
 
 
-async def test_mix_zone_timeout_trigger_global():
+async def test_mix_zone_timeout_trigger_global() -> None:
     """Test a mix zone timeout global with trigger it."""
     timeout = TimeoutManager()
 
@@ -251,7 +251,7 @@ async def test_mix_zone_timeout_trigger_global():
             await asyncio.sleep(0.3)
 
 
-async def test_mix_zone_timeout_trigger_global_cool_down():
+async def test_mix_zone_timeout_trigger_global_cool_down() -> None:
     """Test a mix zone timeout global with trigger it with cool_down."""
     timeout = TimeoutManager()
 
@@ -290,7 +290,7 @@ async def test_simple_zone_timeout_freeze_without_timeout_cleanup2(hass):
             await asyncio.sleep(0.3)
 
 
-async def test_simple_zone_timeout_freeze_without_timeout_exeption():
+async def test_simple_zone_timeout_freeze_without_timeout_exeption() -> None:
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
     timeout = TimeoutManager()
 
@@ -303,7 +303,7 @@ async def test_simple_zone_timeout_freeze_without_timeout_exeption():
             await asyncio.sleep(0.4)
 
 
-async def test_simple_zone_timeout_zone_with_timeout_exeption():
+async def test_simple_zone_timeout_zone_with_timeout_exeption() -> None:
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
     timeout = TimeoutManager()
 

--- a/tests/util/test_ulid.py
+++ b/tests/util/test_ulid.py
@@ -5,12 +5,12 @@ import uuid
 import homeassistant.util.ulid as ulid_util
 
 
-async def test_ulid_util_uuid_hex():
+async def test_ulid_util_uuid_hex() -> None:
     """Verify we can generate a ulid in hex."""
     assert len(ulid_util.ulid_hex()) == 32
     assert uuid.UUID(ulid_util.ulid_hex())
 
 
-async def test_ulid_util_uuid():
+async def test_ulid_util_uuid() -> None:
     """Verify we can generate a ulid."""
     assert len(ulid_util.ulid()) == 26

--- a/tests/util/test_uuid.py
+++ b/tests/util/test_uuid.py
@@ -5,7 +5,7 @@ import uuid
 import homeassistant.util.uuid as uuid_util
 
 
-async def test_uuid_util_random_uuid_hex():
+async def test_uuid_util_random_uuid_hex() -> None:
     """Verify we can generate a random uuid."""
     assert len(uuid_util.random_uuid_hex()) == 32
     assert uuid.UUID(uuid_util.random_uuid_hex())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #87607

Ensure that all tests without argument have return type `None`

Regex replace `^async def test_(\w+)\(\):$` => `async def test_$1() -> None:`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
