### PR TITLE
Round value in state_with_unit template function

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -833,8 +833,8 @@ def async_update_suggested_units(hass: HomeAssistant) -> None:
 
 
 @callback
-def async_state_with_unit(hass: HomeAssistant, entity_id: str, state: State) -> str:
-    """Return the state concatenated with the unit if available."""
+def async_rounded_state(hass: HomeAssistant, entity_id: str, state: State) -> str:
+    """Return the state rounded for presentation."""
 
     def display_precision() -> int | None:
         """Return the display precision."""
@@ -847,14 +847,14 @@ def async_state_with_unit(hass: HomeAssistant, entity_id: str, state: State) -> 
         return sensor_options.get("suggested_display_precision")
 
     value = state.state
-    precision = display_precision()
+    if (precision := display_precision()) is None:
+        return value
+
     with suppress(TypeError, ValueError):
-        numerical_value = int(value)
+        numerical_value = float(value)
         value = f"{numerical_value:.{precision}f}"
         # This can be replaced with adding the z option when we drop support for
         # Python 3.10
         value = NEGATIVE_ZERO_PATTERN.sub(r"\1", value)
 
-    unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-
-    return f"{value} {unit}" if unit else value
+    return value

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -737,14 +737,12 @@ class AllStates:
         self,
         entity_id: str,
         rounded: bool | object = _SENTINEL,
-        with_unit: bool | object = _SENTINEL,
+        with_unit: bool = False,
     ) -> str:
         """Return the states."""
         state = _get_state(self._hass, entity_id)
         if state is None:
             return STATE_UNKNOWN
-        if with_unit is _SENTINEL:
-            with_unit = False
         if rounded is _SENTINEL:
             rounded = with_unit
         if rounded or with_unit:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -794,7 +794,7 @@ class DomainStates:
 class TemplateStateBase(State):
     """Class to represent a state object in a template."""
 
-    __slots__ = ("_hass", "_collect", "_entity_id")
+    __slots__ = ("_hass", "_collect", "_entity_id", "__dict__")
 
     _state: State
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -734,14 +734,21 @@ class AllStates:
         return self._hass.states.async_entity_ids_count()
 
     def __call__(
-        self, entity_id: str, rounded: bool = False, with_unit: bool = False
+        self,
+        entity_id: str,
+        rounded: bool | object = _SENTINEL,
+        with_unit: bool | object = _SENTINEL,
     ) -> str:
         """Return the states."""
         state = _get_state(self._hass, entity_id)
         if state is None:
             return STATE_UNKNOWN
+        if with_unit is _SENTINEL:
+            with_unit = False
+        if rounded is _SENTINEL:
+            rounded = with_unit
         if rounded or with_unit:
-            return state.format_state(rounded, with_unit)
+            return state.format_state(rounded, with_unit)  # type: ignore[arg-type]
         return state.state
 
     def __repr__(self) -> str:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3688,10 +3688,22 @@ def test_state_with_unit_and_rounding(hass: HomeAssistant) -> None:
     tpl3 = template.Template("{{ states('sensor.test') }}", hass)
     tpl4 = template.Template("{{ states('sensor.test2') }}", hass)
 
+    # AllStates.__call__ and with_unit=True
+    tpl5 = template.Template("{{ states('sensor.test', with_unit=True) }}", hass)
+    tpl6 = template.Template("{{ states('sensor.test2', with_unit=True) }}", hass)
+
+    # AllStates.__call__ and rounded=True
+    tpl7 = template.Template("{{ states('sensor.test', rounded=True) }}", hass)
+    tpl8 = template.Template("{{ states('sensor.test2', rounded=True) }}", hass)
+
     assert tpl.async_render() == "23.00 beers"
     assert tpl2.async_render() == "23 beers"
     assert tpl3.async_render() == 23
     assert tpl4.async_render() == 23
+    assert tpl5.async_render() == "23.00 beers"
+    assert tpl6.async_render() == "23 beers"
+    assert tpl7.async_render() == 23.0
+    assert tpl8.async_render() == 23
 
     hass.states.async_set("sensor.test", "23.015", {ATTR_UNIT_OF_MEASUREMENT: "beers"})
     hass.states.async_set("sensor.test2", "23.015", {ATTR_UNIT_OF_MEASUREMENT: "beers"})
@@ -3700,6 +3712,10 @@ def test_state_with_unit_and_rounding(hass: HomeAssistant) -> None:
     assert tpl2.async_render() == "23.015 beers"
     assert tpl3.async_render() == 23.015
     assert tpl4.async_render() == 23.015
+    assert tpl5.async_render() == "23.02 beers"
+    assert tpl6.async_render() == "23.015 beers"
+    assert tpl7.async_render() == 23.02
+    assert tpl8.async_render() == 23.015
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Round value in state_with_unit template state property

Allow rounding and suffixing with unit when calling the `states` function

Example template output for a sensor.test: `state=1.000000001, uom=A, display_precision=2`:
```
"{{ states.sensor.test.state }}" -> 1.000000001
"{{ states.sensor.test.state_with_unit }}" -> "1.00 A"
"{{ states("sensor.test") }}" -> 1.000000001
"{{ states("sensor.test, with_unit=True") }}" -> "1.00 A"
"{{ states("sensor.test, with_unit=True, rounded=False") }}" -> "1.000000001 A"
"{{ states("sensor.test, rounded=True") }}" -> 1.00
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26175

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
