### PR TITLE
Rename fixture function in stt tests

### DIFF
--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -24,8 +24,8 @@ from tests.common import mock_platform
 from tests.typing import ClientSessionGenerator
 
 
-class TestProvider(Provider):
-    """Test provider."""
+class MockProvider(Provider):
+    """Mock provider."""
 
     fail_process_audio = False
 
@@ -74,17 +74,17 @@ class TestProvider(Provider):
         return SpeechResult("test", SpeechResultState.SUCCESS)
 
 
-@pytest.fixture(name="test_provider")
-def get_test_provider() -> TestProvider:
+@pytest.fixture
+def mock_provider() -> MockProvider:
     """Test provider fixture."""
-    return TestProvider()
+    return MockProvider()
 
 
 @pytest.fixture(autouse=True)
-async def mock_setup(hass: HomeAssistant, test_provider: TestProvider) -> None:
+async def mock_setup(hass: HomeAssistant, mock_provider: MockProvider) -> None:
     """Set up a test provider."""
     mock_platform(
-        hass, "test.stt", Mock(async_get_engine=AsyncMock(return_value=test_provider))
+        hass, "test.stt", Mock(async_get_engine=AsyncMock(return_value=mock_provider))
     )
     assert await async_setup_component(hass, "stt", {"stt": {"platform": "test"}})
 
@@ -170,6 +170,6 @@ async def test_metadata_errors(
     assert await response.text() == error
 
 
-async def test_get_provider(hass: HomeAssistant, test_provider: TestProvider) -> None:
+async def test_get_provider(hass: HomeAssistant, mock_provider: MockProvider) -> None:
     """Test we can get STT providers."""
-    assert test_provider == async_get_provider(hass, "test")
+    assert mock_provider == async_get_provider(hass, "test")

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -17,9 +17,11 @@ from homeassistant.components.stt import (
     SpeechResultState,
     async_get_provider,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_platform
+from tests.typing import ClientSessionGenerator
 
 
 class TestProvider(Provider):
@@ -32,7 +34,7 @@ class TestProvider(Provider):
         self.calls = []
 
     @property
-    def supported_languages(self):
+    def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         return ["en"]
 
@@ -72,14 +74,14 @@ class TestProvider(Provider):
         return SpeechResult("test", SpeechResultState.SUCCESS)
 
 
-@pytest.fixture
-def test_provider():
+@pytest.fixture(name="test_provider")
+def get_test_provider() -> TestProvider:
     """Test provider fixture."""
     return TestProvider()
 
 
 @pytest.fixture(autouse=True)
-async def mock_setup(hass, test_provider):
+async def mock_setup(hass: HomeAssistant, test_provider: TestProvider) -> None:
     """Set up a test provider."""
     mock_platform(
         hass, "test.stt", Mock(async_get_engine=AsyncMock(return_value=test_provider))
@@ -87,7 +89,9 @@ async def mock_setup(hass, test_provider):
     assert await async_setup_component(hass, "stt", {"stt": {"platform": "test"}})
 
 
-async def test_get_provider_info(hass, hass_client):
+async def test_get_provider_info(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test engine that doesn't exist."""
     client = await hass_client()
     response = await client.get("/api/stt/test")
@@ -102,14 +106,18 @@ async def test_get_provider_info(hass, hass_client):
     }
 
 
-async def test_get_non_existing_provider_info(hass, hass_client):
+async def test_get_non_existing_provider_info(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test streaming to engine that doesn't exist."""
     client = await hass_client()
     response = await client.get("/api/stt/not_exist")
     assert response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_stream_audio(hass, hass_client):
+async def test_stream_audio(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test streaming audio and getting response."""
     client = await hass_client()
     response = await client.post(
@@ -144,10 +152,16 @@ async def test_stream_audio(hass, hass_client):
         ),
     ),
 )
-async def test_metadata_errors(hass, hass_client, header, status, error):
+async def test_metadata_errors(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    header: str | None,
+    status: int,
+    error: str,
+) -> None:
     """Test metadata errors."""
     client = await hass_client()
-    headers = {}
+    headers: dict[str, str] = {}
     if header:
         headers["X-Speech-Content"] = header
 
@@ -156,6 +170,6 @@ async def test_metadata_errors(hass, hass_client, header, status, error):
     assert await response.text() == error
 
 
-async def test_get_provider(hass, test_provider):
+async def test_get_provider(hass: HomeAssistant, test_provider: TestProvider) -> None:
     """Test we can get STT providers."""
     assert test_provider == async_get_provider(hass, "test")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As spotted by @jbouwh in #87613

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
