### PR TITLE
Do not return cached values for entity states in emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -843,10 +843,18 @@ def create_config_model(config: Config, request: web.Request) -> dict[str, Any]:
 
 def create_list_of_entities(config: Config, request: web.Request) -> dict[str, Any]:
     """Create a list of all entities."""
-    json_response: dict[str, Any] = {
-        config.entity_id_to_number(state.entity_id): state_to_json(config, state)
-        for state in config.get_exposed_states()
-    }
+    hass: core.HomeAssistant = request.app["hass"]
+
+    json_response: dict[str, Any] = {}
+    for cached_state in config.get_exposed_states():
+        entity_id = cached_state.entity_id
+        state = hass.states.get(entity_id)
+        assert state is not None
+
+        json_response[config.entity_id_to_number(entity_id)] = state_to_json(
+            config, state
+        )
+
     return json_response
 
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -301,6 +301,7 @@ async def test_discover_lights(hass, hue_client):
     await hass.async_block_till_done()
 
     result_json = await async_get_lights(hue_client)
+    assert "1" not in result_json.keys()
     devices = {val["uniqueid"] for val in result_json.values()}
     assert "00:2f:d2:31:ce:c5:55:cc-ee" not in devices  # light.ceiling_lights
 
@@ -308,8 +309,16 @@ async def test_discover_lights(hass, hue_client):
     hass.states.async_set("light.ceiling_lights", STATE_ON)
     await hass.async_block_till_done()
     result_json = await async_get_lights(hue_client)
-    devices = {val["uniqueid"] for val in result_json.values()}
-    assert "00:2f:d2:31:ce:c5:55:cc-ee" in devices  # light.ceiling_lights
+    device = result_json["1"]  # Test that light ID did not change
+    assert device["uniqueid"] == "00:2f:d2:31:ce:c5:55:cc-ee"  # light.ceiling_lights
+    assert device["state"][HUE_API_STATE_ON] is True
+
+    # Test that returned value is fresh and not cached
+    hass.states.async_set("light.ceiling_lights", STATE_OFF)
+    await hass.async_block_till_done()
+    result_json = await async_get_lights(hue_client)
+    device = result_json["1"]
+    assert device["state"][HUE_API_STATE_ON] is False
 
 
 async def test_light_without_brightness_supported(hass_hue, hue_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Always return current instead of cached states for emulated_hue `/api/nouser/lights` requests.

Previously the request to `/api/nouser/lights` would always return the entities' states that were cached upon HA start, in most cases `{ "state": { "on": false, "bri": 1 } }` for dimmable lights. This state would not change even when a light was turned on, be it through emulated_hue or the Home Assistant UI.

After this change, the correct state will always be fetched live and returned.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

I have a smart home system by Busch-Jaeger (free@home) that integrates with Home Assistant via `emulated_hue`. The system would periodically poll the `/api/nouser/lights` route for all lights' state. All lights would always appear as "off", even when switched on afterwards. My PR fixes that.

This _may_ be related to #75057, since Alexa may possibly set a device to "unresponsive" when turning it on, but not seeing a state change in the `/api/nouser/lights` route. (This is speculative.)

- This PR fixes or closes issue: fixes #75057
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
