### PR TITLE
Bump PyISY to 3.1.13, check portal for network buttons

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from aiohttp import CookieJar
 import async_timeout
 from pyisy import ISY, ISYConnectionError, ISYInvalidAuthError, ISYResponseParseError
+from pyisy.constants import CONFIG_NETWORKING, CONFIG_PORTAL
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -43,7 +44,6 @@ from .const import (
     ISY_CONF_FIRMWARE,
     ISY_CONF_MODEL,
     ISY_CONF_NAME,
-    ISY_CONF_NETWORKING,
     MANUFACTURER,
     PLATFORMS,
     SCHEME_HTTP,
@@ -220,9 +220,11 @@ async def async_setup_entry(
         numbers = isy_data.variables[Platform.NUMBER]
         for vtype, _, vid in isy.variables.children:
             numbers.append(isy.variables[vtype][vid])
-    if isy.conf[ISY_CONF_NETWORKING]:
+    if (
+        isy.conf[CONFIG_NETWORKING] or isy.conf[CONFIG_PORTAL]
+    ) and isy.networking.nobjs:
         isy_data.devices[CONF_NETWORK] = _create_service_device_info(
-            isy, name=ISY_CONF_NETWORKING, unique_id=CONF_NETWORK
+            isy, name=CONFIG_NETWORKING, unique_id=CONF_NETWORK
         )
         for resource in isy.networking.nobjs:
             isy_data.net_resources.append(resource)

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -118,7 +118,6 @@ SUPPORTED_BIN_SENS_CLASSES = ["moisture", "opening", "motion", "climate"]
 # (they can turn off, and report their state)
 ISY_GROUP_PLATFORM = Platform.SWITCH
 
-ISY_CONF_NETWORKING = "Networking Module"
 ISY_CONF_UUID = "uuid"
 ISY_CONF_NAME = "name"
 ISY_CONF_MODEL = "model"

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -3,7 +3,7 @@
   "name": "Universal Devices ISY/IoX",
   "integration_type": "hub",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==3.1.11"],
+  "requirements": ["pyisy==3.1.13"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -23,7 +23,7 @@ import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.service import entity_service_call
 
-from .const import _LOGGER, CONF_NETWORK, DOMAIN, ISY_CONF_NAME, ISY_CONF_NETWORKING
+from .const import _LOGGER, CONF_NETWORK, DOMAIN, ISY_CONF_NAME
 from .util import _async_cleanup_registry_entries
 
 # Common Services for All Platforms:
@@ -233,7 +233,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             isy = isy_data.root
             if isy_name and isy_name != isy.conf[ISY_CONF_NAME]:
                 continue
-            if isy.networking is None or not isy.conf[ISY_CONF_NETWORKING]:
+            if isy.networking is None:
                 continue
             command = None
             if address:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1705,7 +1705,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.11
+pyisy==3.1.13
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1224,7 +1224,7 @@ pyiqvia==2022.04.0
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==3.1.11
+pyisy==3.1.13
 
 # homeassistant.components.kaleidescape
 pykaleidescape==1.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump PyISY to 3.1.13 and check for either Networking Module or UDI Portal before loading Network Resources as `button` entities.

Currently, the module only checks if the Networking Module is enabled before loading resoures. This feature is also enabled if the UDI Portal has been enabled, but will not show as having the Networking Module installed if it wasn't installed before the Portal.

https://github.com/automicus/PyISY/compare/v3.1.11...v3.1.13

Note: v3.1.12 is skipped as it was an invalid release only inlcuding part of the change above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://forum.universal-devices.com/topic/39772-home-assistant-integration-updates-coming/page/3/#comment-359629
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
