### PR TITLE
Add matching on quirk_classes to zha

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -240,6 +240,11 @@ class ChannelPool:
         return self._channels.zha_device.model
 
     @property
+    def quirk_class(self) -> str:
+        """Return device quirk class."""
+        return self._channels.zha_device.quirk_class
+
+    @property
     def skip_configuration(self) -> bool:
         """Return True if device does not require channel configuration."""
         return self._channels.zha_device.skip_configuration

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -95,7 +95,11 @@ class ProbeEndpoint:
         if component and component in zha_const.PLATFORMS:
             channels = channel_pool.unclaimed_channels()
             entity_class, claimed = zha_regs.ZHA_ENTITIES.get_entity(
-                component, channel_pool.manufacturer, channel_pool.model, channels
+                component,
+                channel_pool.manufacturer,
+                channel_pool.model,
+                channels,
+                channel_pool.quirk_class,
             )
             if entity_class is None:
                 return
@@ -145,7 +149,11 @@ class ProbeEndpoint:
         unique_id = f"{ep_channels.unique_id}-{channel.cluster.cluster_id}"
 
         entity_class, claimed = zha_regs.ZHA_ENTITIES.get_entity(
-            component, ep_channels.manufacturer, ep_channels.model, channel_list
+            component,
+            ep_channels.manufacturer,
+            ep_channels.model,
+            channel_list,
+            ep_channels.quirk_class,
         )
         if entity_class is None:
             return
@@ -190,12 +198,14 @@ class ProbeEndpoint:
                 channel_pool.manufacturer,
                 channel_pool.model,
                 list(channel_pool.all_channels.values()),
+                channel_pool.quirk_class,
             )
         else:
             matches, claimed = zha_regs.ZHA_ENTITIES.get_multi_entity(
                 channel_pool.manufacturer,
                 channel_pool.model,
                 channel_pool.unclaimed_channels(),
+                channel_pool.quirk_class,
             )
 
         channel_pool.claim_channels(claimed)
@@ -210,8 +220,7 @@ class ProbeEndpoint:
         for component, ent_n_chan_list in matches.items():
             for entity_and_channel in ent_n_chan_list:
                 if component == cmpt_by_dev_type:
-                    # for well known device types, like thermostats
-                    # we'll take only 1st class
+                    # for well known device types, like thermostats we'll take only 1st class
                     channel_pool.async_new_entity(
                         component,
                         entity_and_channel.entity_class,

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -152,8 +152,9 @@ class MatchRule:
     def weight(self) -> int:
         """Return the weight of the matching rule.
 
-        More specific matches should be preferred over less specific. Model matching
-        rules have a priority over manufacturer matching rules and rules matching a
+        More specific matches should be preferred over less specific. Quirk class
+        matching rules have priority over model matching rules
+        and have a priority over manufacturer matching rules and rules matching a
         single model/manufacturer get a better priority over rules matching multiple
         models/manufacturers. And any model or manufacturers matching rules get better
         priority over rules matching only channels.
@@ -161,16 +162,17 @@ class MatchRule:
         multiple channels a better priority over rules matching a single channel.
         """
         weight = 0
+        if self.quirk_classes:
+            weight += 501 - (
+                1 if callable(self.quirk_classes) else len(self.quirk_classes)
+            )
+
         if self.models:
             weight += 401 - (1 if callable(self.models) else len(self.models))
 
         if self.manufacturers:
             weight += 301 - (
                 1 if callable(self.manufacturers) else len(self.manufacturers)
-            )
-        if self.quirk_classes:
-            weight += 201 - (
-                1 if callable(self.quirk_classes) else len(self.quirk_classes)
             )
 
         weight += 10 * len(self.channel_names)

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -315,7 +315,12 @@ def entity_registry():
     ),
 )
 def test_weighted_match(
-    channel, entity_registry: er.EntityRegistry, manufacturer, model, quirk_class, match_name
+    channel,
+    entity_registry: er.EntityRegistry,
+    manufacturer,
+    model,
+    quirk_class,
+    match_name,
 ):
     """Test weightedd match."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change allow to match more easily the devices/cluster based on the zigpy quirk class.
It is very useful for Tuya devices since they are all need quirks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR will help fixing https://github.com/home-assistant/core/pull/87546 in a more elegant and easy way.
It will also alleviate the need for further PRs when additional TS0601 ZonnSmart TRVs are added in zha-device-handlers since it will already match the quirk class.
https://github.com/home-assistant/core/blob/589ff54e632fa420dcaa4883a24b0e900f211806/homeassistant/components/zha/climate.py#L762-L771

The above can be replaced by `quirk_classes={"ts0601_trv.ZonnsmartTV01_ZG"}` and be future proof.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
 
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
