### PR TITLE
Keep sleepy xiaomi-ble devices that don't broadcast regularly available

### DIFF
--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from xiaomi_ble import SensorUpdate, XiaomiBluetoothDeviceData
-from xiaomi_ble.parser import EncryptionScheme
+from xiaomi_ble import EncryptionScheme, SensorUpdate, XiaomiBluetoothDeviceData
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import (

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Xiaomi binary sensors."""
 from __future__ import annotations
 
+from xiaomi_ble import SLEEPY_DEVICE_MODELS
 from xiaomi_ble.parser import (
     BinarySensorDeviceClass as XiaomiBinarySensorDeviceClass,
     ExtendedBinarySensorDeviceClass,
@@ -19,6 +20,7 @@ from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
     PassiveBluetoothProcessorEntity,
 )
+from homeassistant.const import ATTR_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
@@ -128,3 +130,13 @@ class XiaomiBluetoothSensorEntity(
     def is_on(self) -> bool | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self.device_info:
+            if self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
+                # These devices sleep for an indeterminate amount of time
+                # so there is no way to track their availability.
+                return True
+        return super().available

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -134,9 +134,8 @@ class XiaomiBluetoothSensorEntity(
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.device_info:
-            if self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
-                # These devices sleep for an indeterminate amount of time
-                # so there is no way to track their availability.
-                return True
+        if self.device_info and self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
+            # These devices sleep for an indeterminate amount of time
+            # so there is no way to track their availability.
+            return True
         return super().available

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -16,5 +16,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_ble",
   "iot_class": "local_push",
-  "requirements": ["xiaomi-ble==0.16.1"]
+  "requirements": ["xiaomi-ble==0.16.3"]
 }

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -174,9 +174,8 @@ class XiaomiBluetoothSensorEntity(
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.device_info:
-            if self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
-                # These devices sleep for an indeterminate amount of time
-                # so there is no way to track their availability.
-                return True
+        if self.device_info and self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
+            # These devices sleep for an indeterminate amount of time
+            # so there is no way to track their availability.
+            return True
         return super().available

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -1,7 +1,7 @@
 """Support for xiaomi ble sensors."""
 from __future__ import annotations
 
-from xiaomi_ble import DeviceClass, SensorUpdate, Units
+from xiaomi_ble import SLEEPY_DEVICE_MODELS, DeviceClass, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -17,6 +17,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    ATTR_MODEL,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     CONDUCTIVITY,
     LIGHT_LUX,
@@ -169,3 +170,13 @@ class XiaomiBluetoothSensorEntity(
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self.device_info:
+            if self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
+                # These devices sleep for an indeterminate amount of time
+                # so there is no way to track their availability.
+                return True
+        return super().available

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -1,7 +1,7 @@
 """Support for xiaomi ble sensors."""
 from __future__ import annotations
 
-from xiaomi_ble import SLEEPY_DEVICE_MODELS, DeviceClass, SensorUpdate, Units
+from xiaomi_ble import DeviceClass, SensorUpdate, Units
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_MODEL,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     CONDUCTIVITY,
     LIGHT_LUX,
@@ -170,12 +169,3 @@ class XiaomiBluetoothSensorEntity(
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        if self.device_info and self.device_info[ATTR_MODEL] in SLEEPY_DEVICE_MODELS:
-            # These devices sleep for an indeterminate amount of time
-            # so there is no way to track their availability.
-            return True
-        return super().available

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2644,7 +2644,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.16.2
+xiaomi-ble==0.16.3
 
 # homeassistant.components.knx
 xknx==2.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2644,7 +2644,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.16.1
+xiaomi-ble==0.16.2
 
 # homeassistant.components.knx
 xknx==2.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1869,7 +1869,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.16.1
+xiaomi-ble==0.16.2
 
 # homeassistant.components.knx
 xknx==2.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1869,7 +1869,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==0.16.2
+xiaomi-ble==0.16.3
 
 # homeassistant.components.knx
 xknx==2.4.0

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -297,7 +297,7 @@ async def test_unavailable(hass):
     with patch(
         "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
         return_value=monotonic_now,
-    ), patch_all_discovered_devices([MagicMock(address="A4:C1:38:66:E5:67")]):
+    ), patch_all_discovered_devices([]):
         async_fire_time_changed(
             hass,
             dt_util.utcnow()
@@ -348,7 +348,7 @@ async def test_sleepy_device(hass):
     with patch(
         "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
         return_value=monotonic_now,
-    ), patch_all_discovered_devices([MagicMock(address="A4:C1:38:66:E5:67")]):
+    ), patch_all_discovered_devices([]):
         async_fire_time_changed(
             hass,
             dt_util.utcnow()

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -1,11 +1,20 @@
 """Test Xiaomi binary sensors."""
+
+from datetime import timedelta
+
 from homeassistant.components.xiaomi_ble.const import DOMAIN
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import make_advertisement
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
@@ -34,19 +43,19 @@ async def test_door_problem_sensors(hass: HomeAssistant) -> None:
 
     door_sensor = hass.states.get("binary_sensor.door_lock_be98_door")
     door_sensor_attribtes = door_sensor.attributes
-    assert door_sensor.state == "off"
+    assert door_sensor.state == STATE_OFF
     assert door_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Door"
 
     door_left_open = hass.states.get("binary_sensor.door_lock_be98_door_left_open")
     door_left_open_attribtes = door_left_open.attributes
-    assert door_left_open.state == "off"
+    assert door_left_open.state == STATE_OFF
     assert (
         door_left_open_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Door left open"
     )
 
     pry_the_door = hass.states.get("binary_sensor.door_lock_be98_pry_the_door")
     pry_the_door_attribtes = pry_the_door.attributes
-    assert pry_the_door.state == "off"
+    assert pry_the_door.state == STATE_OFF
     assert pry_the_door_attribtes[ATTR_FRIENDLY_NAME] == "Door Lock BE98 Pry the door"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -77,12 +86,12 @@ async def test_light_motion(hass: HomeAssistant) -> None:
 
     motion_sensor = hass.states.get("binary_sensor.nightlight_9321_motion")
     motion_sensor_attribtes = motion_sensor.attributes
-    assert motion_sensor.state == "on"
+    assert motion_sensor.state == STATE_ON
     assert motion_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Nightlight 9321 Motion"
 
     light_sensor = hass.states.get("binary_sensor.nightlight_9321_light")
     light_sensor_attribtes = light_sensor.attributes
-    assert light_sensor.state == "off"
+    assert light_sensor.state == STATE_OFF
     assert light_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Nightlight 9321 Light"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -116,7 +125,7 @@ async def test_moisture(hass: HomeAssistant) -> None:
 
     sensor = hass.states.get("binary_sensor.smart_flower_pot_3e7a_moisture")
     sensor_attr = sensor.attributes
-    assert sensor.state == "on"
+    assert sensor.state == STATE_ON
     assert sensor_attr[ATTR_FRIENDLY_NAME] == "Smart Flower Pot 3E7A Moisture"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -148,12 +157,12 @@ async def test_opening(hass: HomeAssistant) -> None:
 
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
     opening_sensor_attribtes = opening_sensor.attributes
-    assert opening_sensor.state == "on"
+
+    assert opening_sensor.state == STATE_ON
     assert (
         opening_sensor_attribtes[ATTR_FRIENDLY_NAME]
         == "Door/Window Sensor E567 Opening"
     )
-
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -183,7 +192,7 @@ async def test_opening_problem_sensors(hass: HomeAssistant) -> None:
 
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
     opening_sensor_attribtes = opening_sensor.attributes
-    assert opening_sensor.state == "off"
+    assert opening_sensor.state == STATE_OFF
     assert (
         opening_sensor_attribtes[ATTR_FRIENDLY_NAME]
         == "Door/Window Sensor E567 Opening"
@@ -193,7 +202,7 @@ async def test_opening_problem_sensors(hass: HomeAssistant) -> None:
         "binary_sensor.door_window_sensor_e567_door_left_open"
     )
     door_left_open_attribtes = door_left_open.attributes
-    assert door_left_open.state == "off"
+    assert door_left_open.state == STATE_OFF
     assert (
         door_left_open_attribtes[ATTR_FRIENDLY_NAME]
         == "Door/Window Sensor E567 Door left open"
@@ -203,7 +212,7 @@ async def test_opening_problem_sensors(hass: HomeAssistant) -> None:
         "binary_sensor.door_window_sensor_e567_device_forcibly_removed"
     )
     device_forcibly_removed_attribtes = device_forcibly_removed.attributes
-    assert device_forcibly_removed.state == "off"
+    assert device_forcibly_removed.state == STATE_OFF
     assert (
         device_forcibly_removed_attribtes[ATTR_FRIENDLY_NAME]
         == "Door/Window Sensor E567 Device forcibly removed"
@@ -238,8 +247,93 @@ async def test_smoke(hass: HomeAssistant) -> None:
 
     smoke_sensor = hass.states.get("binary_sensor.thermometer_9cbc_smoke")
     smoke_sensor_attribtes = smoke_sensor.attributes
-    assert smoke_sensor.state == "on"
+    assert smoke_sensor.state == STATE_ON
     assert smoke_sensor_attribtes[ATTR_FRIENDLY_NAME] == "Thermometer 9CBC Smoke"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_unavailable(hass):
+    """Test normal device goes to unavailable after 60 minutes."""
+    now = dt_util.utcnow()
+    future = now + timedelta(minutes=60)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:66:E5:67",
+        data={"bindkey": "0fdcc30fe9289254876b5ef7c11ef1f0"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "A4:C1:38:66:E5:67",
+            b"XY\x89\x18\x9ag\xe5f8\xc1\xa4\x9d\xd9z\xf3&\x00\x00\xc8\xa6\x0b\xd5",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+
+    assert opening_sensor.state == STATE_ON
+
+    # Fastforward time without BLE advertisements
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+
+    # Normal devices should go to unavailable after a while
+    assert opening_sensor.state == STATE_UNAVAILABLE
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_sleepy_device(hass):
+    """Test sleepy device does not go to unavailable after 60 minutes."""
+    now = dt_util.utcnow()
+    future = now + timedelta(minutes=60)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:66:E5:67",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "A4:C1:38:66:E5:67",
+            b"@0\xd6\x03$\x19\x10\x01\x00",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+
+    assert opening_sensor.state == STATE_ON
+
+    # Fastforward time without BLE advertisements
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
+
+    # Sleepy devices should keep their state over time
+    assert opening_sensor.state == STATE_ON
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -258,6 +258,7 @@ async def test_unavailable(hass):
     """Test normal device goes to unavailable after 60 minutes."""
     now = dt_util.utcnow()
     future = now + timedelta(minutes=60)
+    later = future + timedelta(seconds=1)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -288,9 +289,13 @@ async def test_unavailable(hass):
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 
+    # Wait a second to let the state change to unavailable
+    async_fire_time_changed(hass, later)
+    await hass.async_block_till_done()
+
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
 
-    # Normal devices should go to unavailable after a while
+    # Normal devices should go to unavailable
     assert opening_sensor.state == STATE_UNAVAILABLE
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -301,6 +306,7 @@ async def test_sleepy_device(hass):
     """Test sleepy device does not go to unavailable after 60 minutes."""
     now = dt_util.utcnow()
     future = now + timedelta(minutes=60)
+    later = future + timedelta(seconds=1)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -328,6 +334,10 @@ async def test_sleepy_device(hass):
 
     # Fastforward time without BLE advertisements
     async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    # Wait a second to let the state change to unavailable
+    async_fire_time_changed(hass, later)
     await hass.async_block_till_done()
 
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -297,7 +297,7 @@ async def test_unavailable(hass):
     with patch(
         "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
         return_value=monotonic_now,
-    ), patch_all_discovered_devices([]):
+    ), patch_all_discovered_devices([MagicMock(address="A4:C1:38:66:E5:67")]):
         async_fire_time_changed(
             hass,
             dt_util.utcnow()

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -257,8 +257,7 @@ async def test_smoke(hass: HomeAssistant) -> None:
 async def test_unavailable(hass):
     """Test normal device goes to unavailable after 60 minutes."""
     now = dt_util.utcnow()
-    future = now + timedelta(minutes=60)
-    later = future + timedelta(seconds=1)
+    future_interval = timedelta(minutes=60)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -286,12 +285,10 @@ async def test_unavailable(hass):
     assert opening_sensor.state == STATE_ON
 
     # Fastforward time without BLE advertisements
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    # Wait a second to let the state change to unavailable
-    async_fire_time_changed(hass, later)
-    await hass.async_block_till_done()
+    for i in range(1, 3):
+        future = now + (future_interval * i)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
 
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
 
@@ -305,8 +302,7 @@ async def test_unavailable(hass):
 async def test_sleepy_device(hass):
     """Test sleepy device does not go to unavailable after 60 minutes."""
     now = dt_util.utcnow()
-    future = now + timedelta(minutes=60)
-    later = future + timedelta(seconds=1)
+    future_interval = timedelta(minutes=60)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -333,12 +329,10 @@ async def test_sleepy_device(hass):
     assert opening_sensor.state == STATE_ON
 
     # Fastforward time without BLE advertisements
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    # Wait a second to let the state change to unavailable
-    async_fire_time_changed(hass, later)
-    await hass.async_block_till_done()
+    for i in range(1, 3):
+        future = now + (future_interval * i)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
 
     opening_sensor = hass.states.get("binary_sensor.door_window_sensor_e567_opening")
 

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -297,7 +297,7 @@ async def test_unavailable(hass):
     with patch(
         "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
         return_value=monotonic_now,
-    ), patch_all_discovered_devices([MagicMock(address="A4:C1:38:66:E5:67")]):
+    ), patch_all_discovered_devices([]):
         async_fire_time_changed(
             hass,
             dt_util.utcnow()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Xiaomi-BLE devices, like the CGH1 and MCCGQ02HL door/window sensors stop broadcasting, after 30 minutes of no movement. RTCGQ02LM also broadcasts very rarely (once per 50 minutes) during periods without motion. This will cause these devices to go to unavailable after a certain time. This PR will set the availability to True for these devices.

https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v0.16.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87296
- This PR is related to issue: #87296
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
