### PR TITLE
Extend energyzero sensors to use data of tomorrow

### DIFF
--- a/homeassistant/components/energyzero/const.py
+++ b/homeassistant/components/energyzero/const.py
@@ -12,5 +12,6 @@ THRESHOLD_HOUR: Final = 14
 
 SERVICE_TYPE_DEVICE_NAMES = {
     "today_energy": "Energy market price",
+    "tomorrow_energy": "Energy market price of tomorrow",
     "today_gas": "Gas market price",
 }

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Any
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -29,6 +30,7 @@ class EnergyZeroSensorEntityDescriptionMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[EnergyZeroData], float | datetime | None]
+    prices_fn: Callable[[EnergyZeroData], float | datetime | None]
     service_type: str
 
 
@@ -47,6 +49,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfVolume.CUBIC_METERS}",
         value_fn=lambda data: data.gas_today.current_price if data.gas_today else None,
+        prices_fn=lambda data: data.energy_today.timestamp_prices
     ),
     EnergyZeroSensorEntityDescription(
         key="next_hour_price",
@@ -54,6 +57,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_gas",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfVolume.CUBIC_METERS}",
         value_fn=lambda data: get_gas_price(data, 1),
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="current_hour_price",
@@ -62,6 +66,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.current_price,
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="next_hour_price",
@@ -71,6 +76,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         value_fn=lambda data: data.energy_today.price_at_time(
             data.energy_today.utcnow() + timedelta(hours=1)
         ),
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="average_price",
@@ -78,6 +84,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.average_price,
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="max_price",
@@ -85,6 +92,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.extreme_prices[1],
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="min_price",
@@ -92,6 +100,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.extreme_prices[0],
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="highest_price_time",
@@ -99,6 +108,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_today.highest_price_time,
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="lowest_price_time",
@@ -106,6 +116,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_today.lowest_price_time,
+        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="percentage_of_max",
@@ -114,7 +125,48 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:percent",
         value_fn=lambda data: data.energy_today.pct_of_max_price,
+        prices_fn=None
     ),
+    EnergyZeroSensorEntityDescription(
+        key="average_price",
+        name="Average - tomorrow",
+        service_type="tomorrow_energy",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
+        value_fn=lambda data: data.energy_tomorrow.average_price,
+        prices_fn=None
+    ),
+    EnergyZeroSensorEntityDescription(
+        key="max_price",
+        name="Highest price - tomorrow",
+        service_type="tomorrow_energy",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[1],
+        prices_fn=None
+    ),
+    EnergyZeroSensorEntityDescription(
+        key="min_price",
+        name="Lowest price - tomorrow",
+        service_type="tomorrow_energy",
+        native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[0],
+        prices_fn=None
+    ),
+    EnergyZeroSensorEntityDescription(
+        key="highest_price_time",
+        name="Time of highest price - tomorrow",
+        service_type="tomorrow_energy",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda data: data.energy_tomorrow.highest_price_time,
+        prices_fn=None
+    ),
+    EnergyZeroSensorEntityDescription(
+        key="lowest_price_time",
+        name="Time of lowest price - tomorrow",
+        service_type="tomorrow_energy",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda data: data.energy_tomorrow.lowest_price_time,
+        prices_fn=None
+    )
 )
 
 
@@ -187,3 +239,10 @@ class EnergyZeroSensorEntity(
     def native_value(self) -> float | datetime | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the optional state attributes."""
+        if self.entity_description.prices_fn is not None:
+            return {"prices": self.entity_description.prices_fn(self.coordinator.data)} 
+        return None

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -30,7 +29,6 @@ class EnergyZeroSensorEntityDescriptionMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[EnergyZeroData], float | datetime | None]
-    prices_fn: Callable[[EnergyZeroData], float | datetime | None]
     service_type: str
 
 
@@ -49,7 +47,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfVolume.CUBIC_METERS}",
         value_fn=lambda data: data.gas_today.current_price if data.gas_today else None,
-        prices_fn=lambda data: data.energy_today.timestamp_prices
     ),
     EnergyZeroSensorEntityDescription(
         key="next_hour_price",
@@ -57,7 +54,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_gas",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfVolume.CUBIC_METERS}",
         value_fn=lambda data: get_gas_price(data, 1),
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="current_hour_price",
@@ -66,7 +62,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.current_price,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="next_hour_price",
@@ -76,7 +71,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         value_fn=lambda data: data.energy_today.price_at_time(
             data.energy_today.utcnow() + timedelta(hours=1)
         ),
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="average_price",
@@ -84,7 +78,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.average_price,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="max_price",
@@ -92,7 +85,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.extreme_prices[1],
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="min_price",
@@ -100,7 +92,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_today.extreme_prices[0],
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="highest_price_time",
@@ -108,7 +99,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_today.highest_price_time,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="lowest_price_time",
@@ -116,7 +106,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_today.lowest_price_time,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="percentage_of_max",
@@ -125,7 +114,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:percent",
         value_fn=lambda data: data.energy_today.pct_of_max_price,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="average_price",
@@ -133,7 +121,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_tomorrow.average_price,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="max_price",
@@ -141,7 +128,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_tomorrow.extreme_prices[1],
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="min_price",
@@ -149,7 +135,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         value_fn=lambda data: data.energy_tomorrow.extreme_prices[0],
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="highest_price_time",
@@ -157,7 +142,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_tomorrow.highest_price_time,
-        prices_fn=None
     ),
     EnergyZeroSensorEntityDescription(
         key="lowest_price_time",
@@ -165,7 +149,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: data.energy_tomorrow.lowest_price_time,
-        prices_fn=None
     )
 )
 
@@ -239,10 +222,3 @@ class EnergyZeroSensorEntity(
     def native_value(self) -> float | datetime | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the optional state attributes."""
-        if self.entity_description.prices_fn is not None:
-            return {"prices": self.entity_description.prices_fn(self.coordinator.data)} 
-        return None

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -120,35 +120,35 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         name="Average - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.average_price,
+        value_fn=lambda data: data.energy_tomorrow.average_price if data.energy_tomorrow else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="max_price",
         name="Highest price - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.extreme_prices[1],
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[1] if data.energy_tomorrow else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="min_price",
         name="Lowest price - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.extreme_prices[0],
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[0] if data.energy_tomorrow else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="highest_price_time",
         name="Time of highest price - tomorrow",
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data.energy_tomorrow.highest_price_time,
+        value_fn=lambda data: data.energy_tomorrow.highest_price_time if data.energy_tomorrow else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="lowest_price_time",
         name="Time of lowest price - tomorrow",
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data.energy_tomorrow.lowest_price_time,
+        value_fn=lambda data: data.energy_tomorrow.lowest_price_time if data.energy_tomorrow else None,
     )
 )
 

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -118,36 +118,46 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         name="Average - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.average_price if data.energy_tomorrow else None,
+        value_fn=lambda data: data.energy_tomorrow.average_price
+        if data.energy_tomorrow
+        else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="max_price",
         name="Highest price - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.extreme_prices[1] if data.energy_tomorrow else None,
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[1]
+        if data.energy_tomorrow
+        else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="min_price",
         name="Lowest price - tomorrow",
         service_type="tomorrow_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
-        value_fn=lambda data: data.energy_tomorrow.extreme_prices[0] if data.energy_tomorrow else None,
+        value_fn=lambda data: data.energy_tomorrow.extreme_prices[0]
+        if data.energy_tomorrow
+        else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="highest_price_time",
         name="Time of highest price - tomorrow",
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data.energy_tomorrow.highest_price_time if data.energy_tomorrow else None,
+        value_fn=lambda data: data.energy_tomorrow.highest_price_time
+        if data.energy_tomorrow
+        else None,
     ),
     EnergyZeroSensorEntityDescription(
         key="lowest_price_time",
         name="Time of lowest price - tomorrow",
         service_type="tomorrow_energy",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data.energy_tomorrow.lowest_price_time if data.energy_tomorrow else None,
-    )
+        value_fn=lambda data: data.energy_tomorrow.lowest_price_time
+        if data.energy_tomorrow
+        else None,
+    ),
 )
 
 
@@ -178,9 +188,18 @@ def get_next_energy_price(data: EnergyZeroData, hours: int) -> float | None:
     Returns:
         The next energy market price.
     """
-    price = data.energy_today.price_at_time(data.energy_today.utcnow() + timedelta(hours=hours))
+    price = data.energy_today.price_at_time(
+        data.energy_today.utcnow() + timedelta(hours=hours)
+    )
     if price is None and data.energy_tomorrow is not None:
-        return data.energy_tomorrow.price_at_time(data.energy_today.utcnow() + timedelta(hours=hours))
+        return data.energy_tomorrow.price_at_time(
+            data.energy_today.utcnow()
+            + timedelta(
+                hours=24 - (data.energy_today.utcnow().hour + hours)
+                if data.energy_today.utcnow().hour + hours >= 24
+                else hours
+            )
+        )
     return price
 
 

--- a/tests/components/energyzero/conftest.py
+++ b/tests/components/energyzero/conftest.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, date
 from energyzero import Electricity, Gas
 import pytest
-from freezegun.api import FakeDate
 
 from homeassistant.components.energyzero.const import DOMAIN
 from homeassistant.core import HomeAssistant

--- a/tests/components/energyzero/fixtures/tomorrow_energy.json
+++ b/tests/components/energyzero/fixtures/tomorrow_energy.json
@@ -1,0 +1,104 @@
+{
+    "Prices": [
+     {
+      "price": 0.32,
+      "readingDate": "2022-12-07T23:00:00Z"
+     },
+     {
+      "price": 0.31,
+      "readingDate": "2022-12-08T00:00:00Z"
+     },
+     {
+      "price": 0.29,
+      "readingDate": "2022-12-08T01:00:00Z"
+     },
+     {
+      "price": 0.29,
+      "readingDate": "2022-12-08T02:00:00Z"
+     },
+     {
+      "price": 0.31,
+      "readingDate": "2022-12-08T03:00:00Z"
+     },
+     {
+      "price": 0.33,
+      "readingDate": "2022-12-08T04:00:00Z"
+     },
+     {
+      "price": 0.34,
+      "readingDate": "2022-12-08T05:00:00Z"
+     },
+     {
+      "price": 0.39,
+      "readingDate": "2022-12-08T06:00:00Z"
+     },
+     {
+      "price": 0.46,
+      "readingDate": "2022-12-08T07:00:00Z"
+     },
+     {
+      "price": 0.5,
+      "readingDate": "2022-12-08T08:00:00Z"
+     },
+     {
+      "price": 0.46,
+      "readingDate": "2022-12-08T09:00:00Z"
+     },
+     {
+      "price": 0.44,
+      "readingDate": "2022-12-08T10:00:00Z"
+     },
+     {
+      "price": 0.4,
+      "readingDate": "2022-12-08T11:00:00Z"
+     },
+     {
+      "price": 0.43,
+      "readingDate": "2022-12-08T12:00:00Z"
+     },
+     {
+      "price": 0.49,
+      "readingDate": "2022-12-08T13:00:00Z"
+     },
+     {
+      "price": 0.5,
+      "readingDate": "2022-12-08T14:00:00Z"
+     },
+     {
+      "price": 0.5,
+      "readingDate": "2022-12-08T15:00:00Z"
+     },
+     {
+      "price": 0.55,
+      "readingDate": "2022-12-08T16:00:00Z"
+     },
+     {
+      "price": 0.44,
+      "readingDate": "2022-12-08T17:00:00Z"
+     },
+     {
+      "price": 0.43,
+      "readingDate": "2022-12-08T18:00:00Z"
+     },
+     {
+      "price": 0.44,
+      "readingDate": "2022-12-08T19:00:00Z"
+     },
+     {
+      "price": 0.37,
+      "readingDate": "2022-12-08T20:00:00Z"
+     },
+     {
+      "price": 0.36,
+      "readingDate": "2022-12-08T21:00:00Z"
+     },
+     {
+      "price": 0.33,
+      "readingDate": "2022-12-08T22:00:00Z"
+     }
+    ],
+    "intervalType": 4,
+    "average": 0.4,
+    "fromDate": "2022-12-07T23:00:00Z",
+    "tillDate": "2022-12-08T22:59:59.999Z"
+   }

--- a/tests/components/energyzero/snapshots/test_sensor_tomorrow.ambr
+++ b/tests/components/energyzero/snapshots/test_sensor_tomorrow.ambr
@@ -1,0 +1,193 @@
+# serializer version: 1
+# name: test_sensor[sensor.energyzero_tomorrow_energy_average_price-tomorrow_energy_average_price-tomorrow_energy]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by EnergyZero',
+      'friendly_name': 'Energy market price of tomorrow Average - tomorrow',
+      'unit_of_measurement': '€/kWh',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_average_price',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.4',
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_average_price-tomorrow_energy_average_price-tomorrow_energy].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_average_price',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Average - tomorrow',
+    'platform': 'energyzero',
+    'supported_features': 0,
+    'translation_key': None,
+    'unit_of_measurement': '€/kWh',
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_average_price-tomorrow_energy_average_price-tomorrow_energy].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': None,
+    'id': <ANY>,
+    'is_new': False,
+    'manufacturer': 'EnergyZero',
+    'model': None,
+    'name': 'Energy market price of tomorrow',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_highest_price_time-tomorrow_energy_highest_price_time-tomorrow_energy]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by EnergyZero',
+      'device_class': 'timestamp',
+      'friendly_name': 'Energy market price of tomorrow Time of highest price - tomorrow',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_highest_price_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2022-12-08T16:00:00+00:00',
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_highest_price_time-tomorrow_energy_highest_price_time-tomorrow_energy].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_highest_price_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Time of highest price - tomorrow',
+    'platform': 'energyzero',
+    'supported_features': 0,
+    'translation_key': None,
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_highest_price_time-tomorrow_energy_highest_price_time-tomorrow_energy].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': None,
+    'id': <ANY>,
+    'is_new': False,
+    'manufacturer': 'EnergyZero',
+    'model': None,
+    'name': 'Energy market price of tomorrow',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_max_price-tomorrow_energy_max_price-tomorrow_energy]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by EnergyZero',
+      'friendly_name': 'Energy market price of tomorrow Highest price - tomorrow',
+      'unit_of_measurement': '€/kWh',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_max_price',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.55',
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_max_price-tomorrow_energy_max_price-tomorrow_energy].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.energyzero_tomorrow_energy_max_price',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Highest price - tomorrow',
+    'platform': 'energyzero',
+    'supported_features': 0,
+    'translation_key': None,
+    'unit_of_measurement': '€/kWh',
+  })
+# ---
+# name: test_sensor[sensor.energyzero_tomorrow_energy_max_price-tomorrow_energy_max_price-tomorrow_energy].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': None,
+    'id': <ANY>,
+    'is_new': False,
+    'manufacturer': 'EnergyZero',
+    'model': None,
+    'name': 'Energy market price of tomorrow',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/energyzero/test_energy_last_hour.py
+++ b/tests/components/energyzero/test_energy_last_hour.py
@@ -27,7 +27,7 @@ async def test_last_hour_price(hass: HomeAssistant, mock_energyzero: MagicMock) 
     await hass.services.async_call(
         "homeassistant",
         SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: ["sensor.energyzero_today_gas_current_hour_price"]},
+        {ATTR_ENTITY_ID: ["sensor.energyzero_today_energy_next_hour_price"]},
         blocking=True,
     )
     await hass.async_block_till_done()

--- a/tests/components/energyzero/test_energy_last_hour.py
+++ b/tests/components/energyzero/test_energy_last_hour.py
@@ -1,0 +1,36 @@
+"""Tests for the sensors provided by the EnergyZero integration."""
+
+from unittest.mock import MagicMock
+
+from energyzero import EnergyZeroNoDataError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.components.energyzero.const import DOMAIN
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+pytestmark = [pytest.mark.freeze_time("2022-12-07 23:15:00")]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_last_hour_price(hass: HomeAssistant, mock_energyzero: MagicMock) -> None:
+    """Test the EnergyZero - Validate the next hour price on the last hour of the day."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    await hass.services.async_call(
+        "homeassistant",
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ["sensor.energyzero_today_gas_current_hour_price"]},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.energyzero_today_energy_next_hour_price"))
+    assert state.state == "0.32"

--- a/tests/components/energyzero/test_sensor_tomorrow.py
+++ b/tests/components/energyzero/test_sensor_tomorrow.py
@@ -1,0 +1,62 @@
+"""Tests for the sensors provided by the EnergyZero integration."""
+from unittest.mock import MagicMock
+
+from energyzero import EnergyZeroNoDataError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.components.energyzero.const import DOMAIN
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+pytestmark = [pytest.mark.freeze_time("2022-12-07 15:00:00")]
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "entity_unique_id", "device_identifier"),
+    [
+        (
+            "sensor.energyzero_tomorrow_energy_average_price",
+            "tomorrow_energy_average_price",
+            "tomorrow_energy",
+        ),
+        (
+            "sensor.energyzero_tomorrow_energy_max_price",
+            "tomorrow_energy_max_price",
+            "tomorrow_energy",
+        ),
+        (
+            "sensor.energyzero_tomorrow_energy_highest_price_time",
+            "tomorrow_energy_highest_price_time",
+            "tomorrow_energy",
+        ),
+    ],
+)
+async def test_sensor(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+    entity_unique_id: str,
+    device_identifier: str,
+) -> None:
+    """Test the EnergyZero - Energy sensors."""
+    entry_id = init_integration.entry_id
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
+    assert (entity_entry := entity_registry.async_get(entity_id))
+    assert entity_entry == snapshot(exclude=props("unique_id"))
+    assert entity_entry.unique_id == f"{entry_id}_{entity_unique_id}"
+
+    assert entity_entry.device_id
+    assert (device_entry := device_registry.async_get(entity_entry.device_id))
+    assert device_entry == snapshot(exclude=props("identifiers"))
+    assert device_entry.identifiers == {(DOMAIN, f"{entry_id}_{device_identifier}")}


### PR DESCRIPTION
Extended with a number of sensors to use data of tomorrow
Extended the current_hour_price sensor with an attribute 'prices' to show in a graph

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sensors added for tomorrow's prices, so that you can also steer on these prices within ha
Furthermore, the possibility to display today's prices in a graph was missing. This data can now be retrieved via an attribute on the current price
This data was already available, but has now been made available in various (new) sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
