### PR TITLE
Replace global test markers with fixtures in Devolo home control tests

### DIFF
--- a/tests/components/devolo_home_control/conftest.py
+++ b/tests/components/devolo_home_control/conftest.py
@@ -1,31 +1,34 @@
 """Fixtures for tests."""
 
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 
 
-def pytest_configure(config):
-    """Define custom markers."""
-    config.addinivalue_line(
-        "markers",
-        "credentials_invalid: Treat credentials as invalid.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "maintenance: Set maintenance mode to on.",
-    )
+@pytest.fixture
+def credentials_valid() -> bool:
+    """Mark test as credentials invalid."""
+    return True
+
+
+@pytest.fixture
+def maintenance() -> bool:
+    """Mark test as maintenance mode on."""
+    return False
 
 
 @pytest.fixture(autouse=True)
-def patch_mydevolo(request):
+def patch_mydevolo(
+    credentials_valid: bool, maintenance: bool
+) -> Generator[None, None, None]:
     """Fixture to patch mydevolo into a desired state."""
     with patch(
         "homeassistant.components.devolo_home_control.Mydevolo.credentials_valid",
-        return_value=not bool(request.node.get_closest_marker("credentials_invalid")),
+        return_value=credentials_valid,
     ), patch(
         "homeassistant.components.devolo_home_control.Mydevolo.maintenance",
-        return_value=bool(request.node.get_closest_marker("maintenance")),
+        return_value=maintenance,
     ), patch(
         "homeassistant.components.devolo_home_control.Mydevolo.get_gateway_ids",
         return_value=["1400000000000001", "1400000000000002"],

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_form(hass: HomeAssistant) -> None:
     await _setup(hass, result)
 
 
-@pytest.mark.credentials_invalid
+@pytest.mark.parametrize("credentials_valid", [False])
 async def test_form_invalid_credentials_user(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
 
@@ -116,7 +116,7 @@ async def test_form_zeroconf(hass: HomeAssistant) -> None:
     await _setup(hass, result)
 
 
-@pytest.mark.credentials_invalid
+@pytest.mark.parametrize("credentials_valid", [False])
 async def test_form_invalid_credentials_zeroconf(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
 
@@ -195,7 +195,7 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.credentials_invalid
+@pytest.mark.parametrize("credentials_valid", [False])
 async def test_form_invalid_credentials_reauth(hass: HomeAssistant) -> None:
     """Test if we get the error message on invalid credentials."""
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id="123456", data={})

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -25,7 +25,7 @@ async def test_setup_entry(hass: HomeAssistant, mock_zeroconf):
         assert entry.state is ConfigEntryState.LOADED
 
 
-@pytest.mark.credentials_invalid
+@pytest.mark.parametrize("credentials_valid", [False])
 async def test_setup_entry_credentials_invalid(hass: HomeAssistant):
     """Test setup entry fails if credentials are invalid."""
     entry = configure_integration(hass)
@@ -33,7 +33,7 @@ async def test_setup_entry_credentials_invalid(hass: HomeAssistant):
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-@pytest.mark.maintenance
+@pytest.mark.parametrize("maintenance", [True])
 async def test_setup_entry_maintenance(hass: HomeAssistant):
     """Test setup entry fails if mydevolo is in maintenance mode."""
     entry = configure_integration(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I noticed that the Devolo Home Control registered global test markers, which are actually only used the pass flags around inside tests themselves (and have no global function either, as it is specific to Devolo Home Control).

This PR removes those markers and replaces them with regular fixtures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
