### PR TITLE
Replace global test markers with fixtures in Synology DSM tests

### DIFF
--- a/tests/components/synology_dsm/conftest.py
+++ b/tests/components/synology_dsm/conftest.py
@@ -1,26 +1,17 @@
 """Configure Synology DSM tests."""
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 
-def pytest_configure(config):
-    """Register custom marker for tests."""
-    config.addinivalue_line(
-        "markers", "no_bypass_setup: mark test to disable bypass_setup_fixture"
-    )
-
-
-@pytest.fixture(name="bypass_setup", autouse=True)
-def bypass_setup_fixture(request):
-    """Mock component setup."""
-    if "no_bypass_setup" in request.keywords:
-        yield
-    else:
-        with patch(
-            "homeassistant.components.synology_dsm.async_setup_entry", return_value=True
-        ):
-            yield
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.synology_dsm.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
 
 
 @pytest.fixture(name="mock_dsm")

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -146,6 +146,7 @@ def mock_controller_service_failed():
         yield dsm
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user(hass: HomeAssistant, service: MagicMock):
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
@@ -217,6 +218,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
     assert result["data"].get(CONF_VOLUMES) is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
     """Test user with 2sa authentication config."""
     with patch(
@@ -269,6 +271,7 @@ async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
     assert result["data"].get(CONF_VOLUMES) is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
     """Test user config."""
     with patch(
@@ -313,6 +316,7 @@ async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
     assert result["data"].get(CONF_VOLUMES) is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reauth(hass: HomeAssistant, service: MagicMock):
     """Test reauthentication."""
     entry = MockConfigEntry(
@@ -362,6 +366,7 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock):
     assert result["reason"] == "reauth_successful"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
     """Test re-configuration of already existing entry by user."""
     MockConfigEntry(
@@ -390,6 +395,7 @@ async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
         assert result["reason"] == "reconfigure_successful"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_login_failed(hass: HomeAssistant, service: MagicMock):
     """Test when we have errors during login."""
     service.return_value.login = Mock(
@@ -405,6 +411,7 @@ async def test_login_failed(hass: HomeAssistant, service: MagicMock):
     assert result["errors"] == {CONF_USERNAME: "invalid_auth"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_connection_failed(hass: HomeAssistant, service: MagicMock):
     """Test when we have errors during connection."""
     service.return_value.login = Mock(
@@ -421,6 +428,7 @@ async def test_connection_failed(hass: HomeAssistant, service: MagicMock):
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_unknown_failed(hass: HomeAssistant, service: MagicMock):
     """Test when we have an unknown error."""
     service.return_value.login = Mock(side_effect=SynologyDSMException(None, None))
@@ -435,6 +443,7 @@ async def test_unknown_failed(hass: HomeAssistant, service: MagicMock):
     assert result["errors"] == {"base": "unknown"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_missing_data_after_login(hass: HomeAssistant, service_failed: MagicMock):
     """Test when we have errors during connection."""
     with patch(
@@ -450,6 +459,7 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
     assert result["errors"] == {"base": "missing_data"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test we can setup from ssdp."""
 
@@ -493,6 +503,7 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
     assert result["data"].get(CONF_VOLUMES) is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test re-configuration of already existing entry by ssdp."""
 
@@ -525,6 +536,7 @@ async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
     assert result["reason"] == "reconfigure_successful"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test re-configuration of already existing entry by ssdp."""
 
@@ -557,6 +569,7 @@ async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test abort of already existing entry by ssdp."""
 
@@ -589,6 +602,7 @@ async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_flow(hass: HomeAssistant, service: MagicMock):
     """Test config flow options."""
     config_entry = MockConfigEntry(
@@ -632,6 +646,7 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
     assert config_entry.options[CONF_SNAPSHOT_QUALITY] == 0
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock):
     """Test we can setup from zeroconf."""
 
@@ -677,6 +692,7 @@ async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock):
     assert result["data"].get(CONF_VOLUMES) is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_discovered_via_zeroconf_missing_mac(
     hass: HomeAssistant, service: MagicMock
 ):

--- a/tests/components/synology_dsm/test_init.py
+++ b/tests/components/synology_dsm/test_init.py
@@ -1,7 +1,6 @@
 """Tests for the Synology DSM component."""
 from unittest.mock import MagicMock, patch
 
-import pytest
 from synology_dsm.exceptions import SynologyDSMLoginInvalidException
 
 from homeassistant import data_entry_flow
@@ -21,7 +20,6 @@ from .consts import HOST, MACS, PASSWORD, PORT, USE_SSL, USERNAME
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.no_bypass_setup
 async def test_services_registered(hass: HomeAssistant, mock_dsm: MagicMock):
     """Test if all services are registered."""
     with patch(
@@ -45,7 +43,6 @@ async def test_services_registered(hass: HomeAssistant, mock_dsm: MagicMock):
             assert hass.services.has_service(DOMAIN, service)
 
 
-@pytest.mark.no_bypass_setup
 async def test_reauth_triggered(hass: HomeAssistant):
     """Test if reauthentication flow is triggered."""
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I noticed how the Synology DSM integration registered a global test marker, however, it is merely used to turn an auto fixture into a no-op. This PR removes the marker and removes the auto-use from the fixture to be more in inline with the rest of the codebase. Also removed the need for no-oping a fixture :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
