### PR TITLE
Add type hints to integration tests (a)

### DIFF
--- a/tests/components/accuweather/test_config_flow.py
+++ b/tests/components/accuweather/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.accuweather.const import CONF_FORECAST, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -19,7 +20,7 @@ VALID_CONFIG = {
 }
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -29,7 +30,7 @@ async def test_show_form(hass):
     assert result["step_id"] == SOURCE_USER
 
 
-async def test_api_key_too_short(hass):
+async def test_api_key_too_short(hass: HomeAssistant) -> None:
     """Test that errors are shown when API key is too short."""
     # The API key length check is done by the library without polling the AccuWeather
     # server so we don't need to patch the library method.
@@ -47,7 +48,7 @@ async def test_api_key_too_short(hass):
     assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
-async def test_invalid_api_key(hass):
+async def test_invalid_api_key(hass: HomeAssistant) -> None:
     """Test that errors are shown when API key is invalid."""
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
@@ -62,7 +63,7 @@ async def test_invalid_api_key(hass):
         assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
-async def test_api_error(hass):
+async def test_api_error(hass: HomeAssistant) -> None:
     """Test API error."""
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
@@ -77,7 +78,7 @@ async def test_api_error(hass):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_requests_exceeded_error(hass):
+async def test_requests_exceeded_error(hass: HomeAssistant) -> None:
     """Test requests exceeded error."""
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
@@ -94,7 +95,7 @@ async def test_requests_exceeded_error(hass):
         assert result["errors"] == {CONF_API_KEY: "requests_exceeded"}
 
 
-async def test_integration_already_exists(hass):
+async def test_integration_already_exists(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
@@ -116,7 +117,7 @@ async def test_integration_already_exists(hass):
         assert result["reason"] == "single_instance_allowed"
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
@@ -138,7 +139,7 @@ async def test_create_entry(hass):
         assert result["data"][CONF_API_KEY] == "32-character-string-1234567890qw"
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/accuweather/test_diagnostics.py
+++ b/tests/components/accuweather/test_diagnostics.py
@@ -1,13 +1,18 @@
 """Test AccuWeather diagnostics."""
 import json
 
+from homeassistant.core import HomeAssistant
+
 from . import init_integration
 
 from tests.common import load_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, hass_client):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test config entry diagnostics."""
     entry = await init_integration(hass)
 

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -8,6 +8,7 @@ from accuweather import ApiError
 from homeassistant.components.accuweather.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from . import init_integration
@@ -15,7 +16,7 @@ from . import init_integration
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
-async def test_async_setup_entry(hass):
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test a successful setup entry."""
     await init_integration(hass)
 
@@ -25,7 +26,7 @@ async def test_async_setup_entry(hass):
     assert state.state == "sunny"
 
 
-async def test_config_not_ready(hass):
+async def test_config_not_ready(hass: HomeAssistant) -> None:
     """Test for setup failure if connection to AccuWeather is missing."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -48,7 +49,7 @@ async def test_config_not_ready(hass):
         assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 
@@ -62,7 +63,7 @@ async def test_unload_entry(hass):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_update_interval(hass):
+async def test_update_interval(hass: HomeAssistant) -> None:
     """Test correct update interval."""
     entry = await init_integration(hass)
 
@@ -83,7 +84,7 @@ async def test_update_interval(hass):
         assert mock_current.call_count == 1
 
 
-async def test_update_interval_forecast(hass):
+async def test_update_interval_forecast(hass: HomeAssistant) -> None:
     """Test correct update interval when forecast is True."""
     entry = await init_integration(hass, forecast=True)
 

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolumetricFlux,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -37,7 +38,7 @@ from . import init_integration
 from tests.common import async_fire_time_changed, load_fixture
 
 
-async def test_sensor_without_forecast(hass):
+async def test_sensor_without_forecast(hass: HomeAssistant) -> None:
     """Test states of the sensor without forecast."""
     await init_integration(hass)
     registry = er.async_get(hass)
@@ -115,7 +116,7 @@ async def test_sensor_without_forecast(hass):
     assert entry.unique_id == "0123456-uvindex"
 
 
-async def test_sensor_with_forecast(hass):
+async def test_sensor_with_forecast(hass: HomeAssistant) -> None:
     """Test states of the sensor with forecast."""
     await init_integration(hass, forecast=True)
     registry = er.async_get(hass)
@@ -193,7 +194,7 @@ async def test_sensor_with_forecast(hass):
     assert entry.unique_id == "0123456-uvindex-0"
 
 
-async def test_sensor_disabled(hass):
+async def test_sensor_disabled(hass: HomeAssistant) -> None:
     """Test sensor disabled by default."""
     await init_integration(hass)
     registry = er.async_get(hass)
@@ -213,7 +214,7 @@ async def test_sensor_disabled(hass):
     assert updated_entry.disabled is False
 
 
-async def test_sensor_enabled_without_forecast(hass):
+async def test_sensor_enabled_without_forecast(hass: HomeAssistant) -> None:
     """Test enabling an advanced sensor."""
     registry = er.async_get(hass)
 
@@ -659,7 +660,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert entry.unique_id == "0123456-windgustnight-0"
 
 
-async def test_availability(hass):
+async def test_availability(hass: HomeAssistant) -> None:
     """Ensure that we mark the entities unavailable correctly when service is offline."""
     await init_integration(hass)
 
@@ -700,7 +701,7 @@ async def test_availability(hass):
         assert state.state == "3200.0"
 
 
-async def test_manual_update_entity(hass):
+async def test_manual_update_entity(hass: HomeAssistant) -> None:
     """Test manual update entity via service homeassistant/update_entity."""
     await init_integration(hass, forecast=True)
 
@@ -730,7 +731,7 @@ async def test_manual_update_entity(hass):
         assert mock_forecast.call_count == 1
 
 
-async def test_sensor_imperial_units(hass):
+async def test_sensor_imperial_units(hass: HomeAssistant) -> None:
     """Test states of the sensor without forecast."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     await init_integration(hass)
@@ -743,7 +744,7 @@ async def test_sensor_imperial_units(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.FEET
 
 
-async def test_state_update(hass):
+async def test_state_update(hass: HomeAssistant) -> None:
     """Ensure the sensor state changes after updating the data."""
     await init_integration(hass)
 

--- a/tests/components/accuweather/test_system_health.py
+++ b/tests/components/accuweather/test_system_health.py
@@ -5,12 +5,16 @@ from unittest.mock import Mock
 from aiohttp import ClientError
 
 from homeassistant.components.accuweather.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_accuweather_system_health(hass, aioclient_mock):
+async def test_accuweather_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test AccuWeather system health."""
     aioclient_mock.get("https://dataservice.accuweather.com/", text="")
     hass.config.components.add(DOMAIN)
@@ -32,7 +36,9 @@ async def test_accuweather_system_health(hass, aioclient_mock):
     }
 
 
-async def test_accuweather_system_health_fail(hass, aioclient_mock):
+async def test_accuweather_system_health_fail(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test AccuWeather system health."""
     aioclient_mock.get("https://dataservice.accuweather.com/", exc=ClientError)
     hass.config.components.add(DOMAIN)

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -23,6 +23,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -32,7 +33,7 @@ from . import init_integration
 from tests.common import async_fire_time_changed, load_fixture
 
 
-async def test_weather_without_forecast(hass):
+async def test_weather_without_forecast(hass: HomeAssistant) -> None:
     """Test states of the weather without forecast."""
     await init_integration(hass)
     registry = er.async_get(hass)
@@ -55,7 +56,7 @@ async def test_weather_without_forecast(hass):
     assert entry.unique_id == "0123456"
 
 
-async def test_weather_with_forecast(hass):
+async def test_weather_with_forecast(hass: HomeAssistant) -> None:
     """Test states of the weather with forecast."""
     await init_integration(hass, forecast=True)
     registry = er.async_get(hass)
@@ -86,7 +87,7 @@ async def test_weather_with_forecast(hass):
     assert entry.unique_id == "0123456"
 
 
-async def test_availability(hass):
+async def test_availability(hass: HomeAssistant) -> None:
     """Ensure that we mark the entities unavailable correctly when service is offline."""
     await init_integration(hass)
 
@@ -127,7 +128,7 @@ async def test_availability(hass):
         assert state.state == "sunny"
 
 
-async def test_manual_update_entity(hass):
+async def test_manual_update_entity(hass: HomeAssistant) -> None:
     """Test manual update entity via service homeassistant/update_entity."""
     await init_integration(hass, forecast=True)
 
@@ -157,7 +158,7 @@ async def test_manual_update_entity(hass):
     assert mock_forecast.call_count == 1
 
 
-async def test_unsupported_condition_icon_data(hass):
+async def test_unsupported_condition_icon_data(hass: HomeAssistant) -> None:
     """Test with unsupported condition icon data."""
     await init_integration(hass, forecast=True, unsupported_icon=True)
 

--- a/tests/components/adax/test_config_flow.py
+++ b/tests/components/adax/test_config_flow.py
@@ -127,7 +127,7 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
 # local API:
 
 
-async def test_local_create_entry(hass):
+async def test_local_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -175,7 +175,7 @@ async def test_local_create_entry(hass):
     }
 
 
-async def test_local_flow_entry_already_exists(hass):
+async def test_local_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
 
     test_data = {
@@ -225,7 +225,7 @@ async def test_local_flow_entry_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_local_connection_error(hass):
+async def test_local_connection_error(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     result = await hass.config_entries.flow.async_init(
@@ -260,7 +260,7 @@ async def test_local_connection_error(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_local_heater_not_available(hass):
+async def test_local_heater_not_available(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     result = await hass.config_entries.flow.async_init(
@@ -295,7 +295,7 @@ async def test_local_heater_not_available(hass):
     assert result["reason"] == "heater_not_available"
 
 
-async def test_local_heater_not_found(hass):
+async def test_local_heater_not_found(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     result = await hass.config_entries.flow.async_init(
@@ -330,7 +330,7 @@ async def test_local_heater_not_found(hass):
     assert result["reason"] == "heater_not_found"
 
 
-async def test_local_invalid_wifi_cred(hass):
+async def test_local_invalid_wifi_cred(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -15,9 +16,12 @@ from . import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
+async def test_binary_sensor_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test binary sensor setup."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -22,6 +22,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -33,8 +34,12 @@ from . import (
     add_mock_config,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_climate_async_setup_entry(hass, aioclient_mock):
+
+async def test_climate_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test climate platform."""
 
     aioclient_mock.get(
@@ -172,7 +177,9 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
 
 
-async def test_climate_async_failed_update(hass, aioclient_mock):
+async def test_climate_async_failed_update(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test climate change failure."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_config_flow.py
+++ b/tests/components/advantage_air/test_config_flow.py
@@ -1,14 +1,16 @@
 """Test the Advantage Air config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.advantage_air.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from . import TEST_SYSTEM_DATA, TEST_SYSTEM_URL, USER_INPUT
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_form(hass, aioclient_mock):
+
+async def test_form(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test that form shows up."""
 
     aioclient_mock.get(
@@ -50,7 +52,9 @@ async def test_form(hass, aioclient_mock):
     assert result4["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_form_cannot_connect(hass, aioclient_mock):
+async def test_form_cannot_connect(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we handle cannot connect error."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_cover.py
+++ b/tests/components/advantage_air/test_cover.py
@@ -1,5 +1,4 @@
 """Test the Advantage Air Cover Platform."""
-
 from json import loads
 
 from homeassistant.components.advantage_air.const import (
@@ -15,6 +14,7 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OPEN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
@@ -25,8 +25,12 @@ from . import (
     add_mock_config,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_cover_async_setup_entry(hass, aioclient_mock):
+
+async def test_cover_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test cover platform."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -1,11 +1,15 @@
 """Test the Advantage Air Initialization."""
-
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from . import TEST_SYSTEM_DATA, TEST_SYSTEM_URL, add_mock_config
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_async_setup_entry(hass, aioclient_mock):
+
+async def test_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a successful setup entry and unload."""
 
     aioclient_mock.get(
@@ -21,7 +25,9 @@ async def test_async_setup_entry(hass, aioclient_mock):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_async_setup_entry_failure(hass, aioclient_mock):
+async def test_async_setup_entry_failure(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a unsuccessful setup entry."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_light.py
+++ b/tests/components/advantage_air/test_light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
@@ -22,8 +23,12 @@ from . import (
     add_mock_config,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_light_async_setup_entry(hass, aioclient_mock):
+
+async def test_light_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test light setup."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_select.py
+++ b/tests/components/advantage_air/test_select.py
@@ -7,6 +7,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
@@ -17,8 +18,12 @@ from . import (
     add_mock_config,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_select_async_setup_entry(hass, aioclient_mock):
+
+async def test_select_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test select platform."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,5 +1,4 @@
 """Test the Advantage Air Sensor Platform."""
-
 from datetime import timedelta
 from json import loads
 
@@ -10,6 +9,7 @@ from homeassistant.components.advantage_air.sensor import (
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -22,9 +22,12 @@ from . import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_sensor_platform(hass, aioclient_mock):
+async def test_sensor_platform(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sensor platform."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_switch.py
+++ b/tests/components/advantage_air/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
@@ -21,8 +22,12 @@ from . import (
     add_mock_config,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_cover_async_setup_entry(hass, aioclient_mock):
+
+async def test_cover_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test switch platform."""
 
     aioclient_mock.get(

--- a/tests/components/advantage_air/test_update.py
+++ b/tests/components/advantage_air/test_update.py
@@ -1,14 +1,17 @@
 """Test the Advantage Air Update Platform."""
-
 from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import TEST_SYSTEM_URL, add_mock_config
 
 from tests.common import load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_update_platform(hass, aioclient_mock):
+async def test_update_platform(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test update platform."""
 
     aioclient_mock.get(

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -1,5 +1,4 @@
 """Define tests for the AEMET OpenData config flow."""
-
 from unittest.mock import MagicMock, patch
 
 import requests_mock
@@ -8,6 +7,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.aemet.const import CONF_STATION_UPDATES, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .util import aemet_requests_mock
@@ -22,7 +22,7 @@ CONFIG = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test that the form is served with valid input."""
 
     with patch(
@@ -58,7 +58,7 @@ async def test_form(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_options(hass):
+async def test_form_options(hass: HomeAssistant) -> None:
     """Test the form options."""
 
     now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
@@ -114,7 +114,7 @@ async def test_form_options(hass):
         assert entry.state is ConfigEntryState.LOADED
 
 
-async def test_form_duplicated_id(hass):
+async def test_form_duplicated_id(hass: HomeAssistant) -> None:
     """Test setting up duplicated entry."""
 
     now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
@@ -136,7 +136,7 @@ async def test_form_duplicated_id(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_form_api_offline(hass):
+async def test_form_api_offline(hass: HomeAssistant) -> None:
     """Test setting up with api call error."""
     mocked_aemet = MagicMock()
 

--- a/tests/components/aemet/test_init.py
+++ b/tests/components/aemet/test_init.py
@@ -1,5 +1,4 @@
 """Define tests for the AEMET OpenData init."""
-
 from unittest.mock import patch
 
 import requests_mock
@@ -7,6 +6,7 @@ import requests_mock
 from homeassistant.components.aemet.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .util import aemet_requests_mock
@@ -21,7 +21,7 @@ CONFIG = {
 }
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test that the options form."""
 
     now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")

--- a/tests/components/aemet/test_sensor.py
+++ b/tests/components/aemet/test_sensor.py
@@ -1,5 +1,4 @@
 """The sensor tests for the AEMET OpenData platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.weather import (
@@ -7,12 +6,13 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SNOWY,
 )
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .util import async_init_integration
 
 
-async def test_aemet_forecast_create_sensors(hass):
+async def test_aemet_forecast_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of forecast sensors."""
 
     hass.config.set_time_zone("UTC")
@@ -73,7 +73,7 @@ async def test_aemet_forecast_create_sensors(hass):
     assert state is None
 
 
-async def test_aemet_weather_create_sensors(hass):
+async def test_aemet_weather_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of weather sensors."""
 
     now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")

--- a/tests/components/aemet/test_weather.py
+++ b/tests/components/aemet/test_weather.py
@@ -1,5 +1,4 @@
 """The sensor tests for the AEMET OpenData platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.aemet.const import ATTRIBUTION
@@ -22,12 +21,13 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .util import async_init_integration
 
 
-async def test_aemet_weather(hass):
+async def test_aemet_weather(hass: HomeAssistant) -> None:
     """Test states of the weather."""
 
     hass.config.set_time_zone("UTC")

--- a/tests/components/air_quality/test_air_quality.py
+++ b/tests/components/air_quality/test_air_quality.py
@@ -5,10 +5,11 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_state(hass):
+async def test_state(hass: HomeAssistant) -> None:
     """Test Air Quality state."""
     config = {"air_quality": {"platform": "demo"}}
 
@@ -21,7 +22,7 @@ async def test_state(hass):
     assert state.state == "14"
 
 
-async def test_attributes(hass):
+async def test_attributes(hass: HomeAssistant) -> None:
     """Test Air Quality attributes."""
     config = {"air_quality": {"platform": "demo"}}
 

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -7,10 +7,12 @@ from homeassistant import data_entry_flow
 from homeassistant.components.airly.const import CONF_USE_NEAREST, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
 
 from . import API_NEAREST_URL, API_POINT_URL
 
 from tests.common import MockConfigEntry, load_fixture, patch
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONFIG = {
     CONF_NAME: "Home",
@@ -20,7 +22,7 @@ CONFIG = {
 }
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -30,7 +32,9 @@ async def test_show_form(hass):
     assert result["step_id"] == SOURCE_USER
 
 
-async def test_invalid_api_key(hass, aioclient_mock):
+async def test_invalid_api_key(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that errors are shown when API key is invalid."""
     aioclient_mock.get(
         API_POINT_URL,
@@ -46,7 +50,9 @@ async def test_invalid_api_key(hass, aioclient_mock):
     assert result["errors"] == {"base": "invalid_api_key"}
 
 
-async def test_invalid_location(hass, aioclient_mock):
+async def test_invalid_location(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that errors are shown when location is invalid."""
     aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
 
@@ -62,7 +68,9 @@ async def test_invalid_location(hass, aioclient_mock):
     assert result["errors"] == {"base": "wrong_location"}
 
 
-async def test_invalid_location_for_point_and_nearest(hass, aioclient_mock):
+async def test_invalid_location_for_point_and_nearest(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test an abort when the location is wrong for the point and nearest methods."""
 
     aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
@@ -78,7 +86,9 @@ async def test_invalid_location_for_point_and_nearest(hass, aioclient_mock):
     assert result["reason"] == "wrong_location"
 
 
-async def test_duplicate_error(hass, aioclient_mock):
+async def test_duplicate_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that errors are shown when duplicates are added."""
     aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
     MockConfigEntry(domain=DOMAIN, unique_id="123-456", data=CONFIG).add_to_hass(hass)
@@ -91,7 +101,9 @@ async def test_duplicate_error(hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_create_entry(hass, aioclient_mock):
+async def test_create_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that the user step works."""
     aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
 
@@ -108,7 +120,9 @@ async def test_create_entry(hass, aioclient_mock):
     assert result["data"][CONF_USE_NEAREST] is False
 
 
-async def test_create_entry_with_nearest_method(hass, aioclient_mock):
+async def test_create_entry_with_nearest_method(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that the user step works with nearest method."""
 
     aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))

--- a/tests/components/airly/test_init.py
+++ b/tests/components/airly/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.components.airly import set_update_interval
 from homeassistant.components.airly.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -19,9 +20,12 @@ from tests.common import (
     load_fixture,
     mock_device_registry,
 )
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_async_setup_entry(hass, aioclient_mock):
+async def test_async_setup_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a successful setup entry."""
     await init_integration(hass, aioclient_mock)
 
@@ -31,7 +35,9 @@ async def test_async_setup_entry(hass, aioclient_mock):
     assert state.state == "4.37"
 
 
-async def test_config_not_ready(hass, aioclient_mock):
+async def test_config_not_ready(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test for setup failure if connection to Airly is missing."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -52,7 +58,9 @@ async def test_config_not_ready(hass, aioclient_mock):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_config_without_unique_id(hass, aioclient_mock):
+async def test_config_without_unique_id(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test for setup entry without unique_id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -72,7 +80,9 @@ async def test_config_without_unique_id(hass, aioclient_mock):
     assert entry.unique_id == "123-456"
 
 
-async def test_config_with_turned_off_station(hass, aioclient_mock):
+async def test_config_with_turned_off_station(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test for setup entry for a turned off measuring station."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -92,7 +102,9 @@ async def test_config_with_turned_off_station(hass, aioclient_mock):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_update_interval(hass, aioclient_mock):
+async def test_update_interval(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test correct update interval when the number of configured instances changes."""
     REMAINING_REQUESTS = 15
     HEADERS = {
@@ -173,7 +185,9 @@ async def test_update_interval(hass, aioclient_mock):
         assert aioclient_mock.call_count == 5
 
 
-async def test_unload_entry(hass, aioclient_mock):
+async def test_unload_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass, aioclient_mock)
 
@@ -219,7 +233,9 @@ async def test_migrate_device_entry(hass, aioclient_mock, old_identifier):
     assert device_entry.id == migrated_device_entry.id
 
 
-async def test_remove_air_quality_entities(hass, aioclient_mock):
+async def test_remove_air_quality_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test remove air_quality entities from registry."""
     registry = er.async_get(hass)
 

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -29,9 +30,10 @@ from homeassistant.util.dt import utcnow
 from . import API_POINT_URL, init_integration
 
 from tests.common import async_fire_time_changed, load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_sensor(hass, aioclient_mock):
+async def test_sensor(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test states of the sensor."""
     await init_integration(hass, aioclient_mock)
     registry = er.async_get(hass)
@@ -199,7 +201,9 @@ async def test_sensor(hass, aioclient_mock):
     assert entry.options["sensor"] == {"suggested_display_precision": 1}
 
 
-async def test_availability(hass, aioclient_mock):
+async def test_availability(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Ensure that we mark the entities unavailable correctly when service is offline."""
     await init_integration(hass, aioclient_mock)
 
@@ -232,7 +236,9 @@ async def test_availability(hass, aioclient_mock):
     assert state.state == "68.35"
 
 
-async def test_manual_update_entity(hass, aioclient_mock):
+async def test_manual_update_entity(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test manual update entity via service homeassistant/update_entity."""
     await init_integration(hass, aioclient_mock)
 

--- a/tests/components/airly/test_system_health.py
+++ b/tests/components/airly/test_system_health.py
@@ -5,12 +5,16 @@ from unittest.mock import Mock
 from aiohttp import ClientError
 
 from homeassistant.components.airly.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_airly_system_health(hass, aioclient_mock):
+async def test_airly_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test Airly system health."""
     aioclient_mock.get("https://airapi.airly.eu/v2/", text="")
     hass.config.components.add(DOMAIN)
@@ -36,7 +40,9 @@ async def test_airly_system_health(hass, aioclient_mock):
     assert info["requests_per_day"] == 100
 
 
-async def test_airly_system_health_fail(hass, aioclient_mock):
+async def test_airly_system_health_fail(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test Airly system health."""
     aioclient_mock.get("https://airapi.airly.eu/v2/", exc=ClientError)
     hass.config.components.add(DOMAIN)

--- a/tests/components/airtouch4/test_config_flow.py
+++ b/tests/components/airtouch4/test_config_flow.py
@@ -5,9 +5,10 @@ from airtouch4pyapi.airtouch import AirTouch, AirTouchAc, AirTouchGroup, AirTouc
 
 from homeassistant import config_entries
 from homeassistant.components.airtouch4.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -42,7 +43,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_timeout(hass):
+async def test_form_timeout(hass: HomeAssistant) -> None:
     """Test we handle a connection timeout."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -61,7 +62,7 @@ async def test_form_timeout(hass):
         assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_library_error_message(hass):
+async def test_form_library_error_message(hass: HomeAssistant) -> None:
     """Test we handle an unknown error message from the library."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -80,7 +81,7 @@ async def test_form_library_error_message(hass):
         assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_connection_refused(hass):
+async def test_form_connection_refused(hass: HomeAssistant) -> None:
     """Test we handle a connection error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -99,7 +100,7 @@ async def test_form_connection_refused(hass):
         assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_no_units(hass):
+async def test_form_no_units(hass: HomeAssistant) -> None:
     """Test we handle no units found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/alarm_control_panel/test_reproduce_state.py
+++ b/tests/components/alarm_control_panel/test_reproduce_state.py
@@ -1,4 +1,6 @@
 """Test reproduce state for Alarm control panel."""
+import pytest
+
 from homeassistant.const import (
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_CUSTOM_BYPASS,
@@ -15,13 +17,15 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Alarm control panel states."""
     hass.states.async_set(
         "alarm_control_panel.entity_armed_away", STATE_ALARM_ARMED_AWAY, {}

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -79,7 +79,7 @@ def mock_notifier(hass: HomeAssistant) -> list[ServiceCall]:
     return async_mock_service(hass, notify.DOMAIN, NOTIFIER)
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setup method."""
     assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     assert hass.states.get(ENTITY_ID).state == STATE_IDLE
@@ -305,7 +305,7 @@ async def test_skipfirst(hass: HomeAssistant, mock_notifier: list[ServiceCall]) 
     assert len(mock_notifier) == 0
 
 
-async def test_done_message_state_tracker_reset_on_cancel(hass):
+async def test_done_message_state_tracker_reset_on_cancel(hass: HomeAssistant) -> None:
     """Test that the done message is reset when canceled."""
     entity = alert.Alert(hass, *TEST_NOACK)
     entity._cancel = lambda *args: None

--- a/tests/components/alert/test_reproduce_state.py
+++ b/tests/components/alert/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Alert."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Alert states."""
     hass.states.async_set("alert.entity_off", "off", {})
     hass.states.async_set("alert.entity_on", "on", {})

--- a/tests/components/alexa/test_auth.py
+++ b/tests/components/alexa/test_auth.py
@@ -1,8 +1,11 @@
 """Test Alexa auth endpoints."""
 from homeassistant.components.alexa.auth import Auth
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 
 from .test_common import TEST_TOKEN_URL
+
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def run_auth_get_access_token(
@@ -29,7 +32,9 @@ async def run_auth_get_access_token(
     await auth.async_get_access_token()
 
 
-async def test_auth_get_access_token_expired(hass, aioclient_mock):
+async def test_auth_get_access_token_expired(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the auth get access token function."""
     client_id = "client123"
     client_secret = "shhhhh"
@@ -63,7 +68,9 @@ async def test_auth_get_access_token_expired(hass, aioclient_mock):
     assert token_call_json[CONF_CLIENT_SECRET] == client_secret
 
 
-async def test_auth_get_access_token_not_expired(hass, aioclient_mock):
+async def test_auth_get_access_token_not_expired(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the auth get access token function."""
     client_id = "client123"
     client_secret = "shhhhh"

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_UNLOCKED,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_common import (
     assert_request_calls_service,
@@ -61,7 +62,7 @@ async def test_api_adjust_brightness(hass, adjust):
     assert msg["header"]["name"] == "Response"
 
 
-async def test_api_set_color_rgb(hass):
+async def test_api_set_color_rgb(hass: HomeAssistant) -> None:
     """Test api set color process."""
     request = get_new_request("Alexa.ColorController", "SetColor", "light#test")
 
@@ -91,7 +92,7 @@ async def test_api_set_color_rgb(hass):
     assert msg["header"]["name"] == "Response"
 
 
-async def test_api_set_color_temperature(hass):
+async def test_api_set_color_temperature(hass: HomeAssistant) -> None:
     """Test api set color temperature process."""
     request = get_new_request(
         "Alexa.ColorTemperatureController", "SetColorTemperature", "light#test"
@@ -217,7 +218,7 @@ async def test_api_select_input(hass, domain, payload, source_list, idx):
     assert call.data["source"] == source_list[idx]
 
 
-async def test_report_lock_state(hass):
+async def test_report_lock_state(hass: HomeAssistant) -> None:
     """Test LockController implements lockState property."""
     hass.states.async_set("lock.locked", STATE_LOCKED, {})
     hass.states.async_set("lock.unlocked", STATE_UNLOCKED, {})
@@ -310,7 +311,7 @@ async def test_report_colored_light_state(hass, supported_color_modes):
     )
 
 
-async def test_report_colored_temp_light_state(hass):
+async def test_report_colored_temp_light_state(hass: HomeAssistant) -> None:
     """Test ColorTemperatureController reports color temp correctly."""
     hass.states.async_set(
         "light.test_on",
@@ -338,7 +339,7 @@ async def test_report_colored_temp_light_state(hass):
     )
 
 
-async def test_report_fan_speed_state(hass):
+async def test_report_fan_speed_state(hass: HomeAssistant) -> None:
     """Test PercentageController, PowerLevelController reports fan speed correctly."""
     hass.states.async_set(
         "fan.off",
@@ -411,7 +412,7 @@ async def test_report_fan_speed_state(hass):
     properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
 
 
-async def test_report_humidifier_humidity_state(hass):
+async def test_report_humidifier_humidity_state(hass: HomeAssistant) -> None:
     """Test PercentageController, PowerLevelController humidifier humidity reporting."""
     hass.states.async_set(
         "humidifier.dry",
@@ -442,7 +443,7 @@ async def test_report_humidifier_humidity_state(hass):
     properties.assert_equal("Alexa.RangeController", "rangeValue", 80)
 
 
-async def test_report_humidifier_mode(hass):
+async def test_report_humidifier_mode(hass: HomeAssistant) -> None:
     """Test ModeController reports humidifier mode correctly."""
     hass.states.async_set(
         "humidifier.auto",
@@ -477,7 +478,7 @@ async def test_report_humidifier_mode(hass):
     properties.assert_equal("Alexa.ModeController", "mode", "mode.Medium")
 
 
-async def test_report_fan_preset_mode(hass):
+async def test_report_fan_preset_mode(hass: HomeAssistant) -> None:
     """Test ModeController reports fan preset_mode correctly."""
     hass.states.async_set(
         "fan.preset_mode",
@@ -531,7 +532,7 @@ async def test_report_fan_preset_mode(hass):
     properties = await reported_properties(hass, "fan.preset_mode")
 
 
-async def test_report_fan_oscillating(hass):
+async def test_report_fan_oscillating(hass: HomeAssistant) -> None:
     """Test ToggleController reports fan oscillating correctly."""
     hass.states.async_set(
         "fan.oscillating_off",
@@ -555,7 +556,7 @@ async def test_report_fan_oscillating(hass):
     properties.assert_equal("Alexa.ToggleController", "toggleState", "ON")
 
 
-async def test_report_fan_direction(hass):
+async def test_report_fan_direction(hass: HomeAssistant) -> None:
     """Test ModeController reports fan direction correctly."""
     hass.states.async_set(
         "fan.off", "off", {"friendly_name": "Off fan", "supported_features": 4}
@@ -589,7 +590,7 @@ async def test_report_fan_direction(hass):
     properties.assert_equal("Alexa.ModeController", "mode", "direction.forward")
 
 
-async def test_report_cover_range_value(hass):
+async def test_report_cover_range_value(hass: HomeAssistant) -> None:
     """Test RangeController reports cover position correctly."""
     hass.states.async_set(
         "cover.fully_open",
@@ -629,7 +630,7 @@ async def test_report_cover_range_value(hass):
     properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
 
 
-async def test_report_climate_state(hass):
+async def test_report_climate_state(hass: HomeAssistant) -> None:
     """Test ThermostatController reports state correctly."""
     for auto_modes in (HVACMode.AUTO, HVACMode.HEAT_COOL):
         hass.states.async_set(
@@ -761,7 +762,7 @@ async def test_report_climate_state(hass):
     assert msg["event"]["payload"]["type"] == "INTERNAL_ERROR"
 
 
-async def test_temperature_sensor_sensor(hass):
+async def test_temperature_sensor_sensor(hass: HomeAssistant) -> None:
     """Test TemperatureSensor reports sensor temperature correctly."""
     for bad_value in (STATE_UNKNOWN, STATE_UNAVAILABLE, "not-number"):
         hass.states.async_set(
@@ -784,7 +785,7 @@ async def test_temperature_sensor_sensor(hass):
     )
 
 
-async def test_temperature_sensor_climate(hass):
+async def test_temperature_sensor_climate(hass: HomeAssistant) -> None:
     """Test TemperatureSensor reports climate temperature correctly."""
     for bad_value in (STATE_UNKNOWN, STATE_UNAVAILABLE, "not-number"):
         hass.states.async_set(
@@ -807,7 +808,7 @@ async def test_temperature_sensor_climate(hass):
     )
 
 
-async def test_report_alarm_control_panel_state(hass):
+async def test_report_alarm_control_panel_state(hass: HomeAssistant) -> None:
     """Test SecurityPanelController implements armState property."""
     hass.states.async_set("alarm_control_panel.armed_away", STATE_ALARM_ARMED_AWAY, {})
     hass.states.async_set(
@@ -837,7 +838,7 @@ async def test_report_alarm_control_panel_state(hass):
     properties.assert_equal("Alexa.SecurityPanelController", "armState", "DISARMED")
 
 
-async def test_report_playback_state(hass):
+async def test_report_playback_state(hass: HomeAssistant) -> None:
     """Test PlaybackStateReporter implements playbackState property."""
     hass.states.async_set(
         "media_player.test",
@@ -858,7 +859,7 @@ async def test_report_playback_state(hass):
     )
 
 
-async def test_report_speaker_volume(hass):
+async def test_report_speaker_volume(hass: HomeAssistant) -> None:
     """Test Speaker reports volume correctly."""
     hass.states.async_set(
         "media_player.test_speaker",
@@ -890,7 +891,7 @@ async def test_report_speaker_volume(hass):
         properties.assert_equal("Alexa.Speaker", "volume", good_value)
 
 
-async def test_report_image_processing(hass):
+async def test_report_image_processing(hass: HomeAssistant) -> None:
     """Test EventDetectionSensor implements humanPresenceDetectionState property."""
     hass.states.async_set(
         "image_processing.test_face",
@@ -986,7 +987,9 @@ async def test_toggle_entities_report_contact_events(hass, domain):
     )
 
 
-async def test_get_property_blowup(hass, caplog):
+async def test_get_property_blowup(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle a property blowing up."""
     hass.states.async_set(
         "climate.downstairs",

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -1,15 +1,18 @@
 """Test Alexa entity representation."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.alexa import smart_home
 from homeassistant.const import __version__
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
 from .test_common import get_default_config, get_new_request
 
 
-async def test_unsupported_domain(hass):
+async def test_unsupported_domain(hass: HomeAssistant) -> None:
     """Discovery ignores entities of unknown domains."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -23,7 +26,7 @@ async def test_unsupported_domain(hass):
     assert not msg["payload"]["endpoints"]
 
 
-async def test_categorized_hidden_entities(hass):
+async def test_categorized_hidden_entities(hass: HomeAssistant) -> None:
     """Discovery ignores hidden and categorized entities."""
     entity_registry = er.async_get(hass)
     request = get_new_request("Alexa.Discovery", "Discover")
@@ -71,7 +74,7 @@ async def test_categorized_hidden_entities(hass):
     assert not msg["payload"]["endpoints"]
 
 
-async def test_serialize_discovery(hass):
+async def test_serialize_discovery(hass: HomeAssistant) -> None:
     """Test we handle an interface raising unexpectedly during serialize discovery."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -91,7 +94,9 @@ async def test_serialize_discovery(hass):
     }
 
 
-async def test_serialize_discovery_recovers(hass, caplog):
+async def test_serialize_discovery_recovers(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle an interface raising unexpectedly during serialize discovery."""
     request = get_new_request("Alexa.Discovery", "Discover")
 

--- a/tests/components/alexa/test_init.py
+++ b/tests/components/alexa/test_init.py
@@ -1,11 +1,12 @@
 """Tests for alexa."""
 from homeassistant.components.alexa.const import EVENT_ALEXA_SMART_HOME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_alexa_event(hass):
+async def test_humanify_alexa_event(hass: HomeAssistant) -> None:
     """Test humanifying Alexa event."""
     hass.config.components.add("recorder")
     await async_setup_component(hass, "alexa", {})

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1,5 +1,4 @@
 """Test for smart home alexa support."""
-
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -102,7 +101,7 @@ def test_create_api_message_special() -> None:
     assert "endpoint" not in msg
 
 
-async def test_wrong_version(hass):
+async def test_wrong_version(hass: HomeAssistant) -> None:
     """Test with wrong version."""
     msg = get_new_request("Alexa.PowerController", "TurnOn")
     msg["directive"]["header"]["payloadVersion"] = "2"
@@ -214,7 +213,7 @@ async def test_outlet(hass, events):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_light(hass):
+async def test_light(hass: HomeAssistant) -> None:
     """Test light discovery."""
     device = ("light.test_1", "on", {"friendly_name": "Test light 1"})
     appliance = await discovery_test(device, hass)
@@ -231,7 +230,7 @@ async def test_light(hass):
     )
 
 
-async def test_dimmable_light(hass):
+async def test_dimmable_light(hass: HomeAssistant) -> None:
     """Test dimmable light discovery."""
     device = (
         "light.test_2",
@@ -308,7 +307,7 @@ async def test_color_light(hass, supported_color_modes):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_script(hass):
+async def test_script(hass: HomeAssistant) -> None:
     """Test script discovery."""
     device = ("script.test", "off", {"friendly_name": "Test script"})
     appliance = await discovery_test(device, hass)
@@ -329,7 +328,7 @@ async def test_script(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_input_boolean(hass):
+async def test_input_boolean(hass: HomeAssistant) -> None:
     """Test input boolean discovery."""
     device = ("input_boolean.test", "off", {"friendly_name": "Test input boolean"})
     appliance = await discovery_test(device, hass)
@@ -366,7 +365,7 @@ async def test_input_boolean(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_scene(hass):
+async def test_scene(hass: HomeAssistant) -> None:
     """Test scene discovery."""
     device = ("scene.test", "off", {"friendly_name": "Test scene"})
     appliance = await discovery_test(device, hass)
@@ -387,7 +386,7 @@ async def test_scene(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_fan(hass):
+async def test_fan(hass: HomeAssistant) -> None:
     """Test fan discovery."""
     device = ("fan.test_1", "off", {"friendly_name": "Test fan 1"})
     appliance = await discovery_test(device, hass)
@@ -433,7 +432,7 @@ async def test_fan(hass):
     )
 
 
-async def test_fan2(hass):
+async def test_fan2(hass: HomeAssistant) -> None:
     """Test fan discovery with percentage_step."""
 
     # Test fan discovery with percentage_step
@@ -467,7 +466,7 @@ async def test_fan2(hass):
     assert "configuration" not in power_capability
 
 
-async def test_variable_fan(hass):
+async def test_variable_fan(hass: HomeAssistant) -> None:
     """Test fan discovery.
 
     This one has variable speed.
@@ -565,7 +564,9 @@ async def test_variable_fan(hass):
     )
 
 
-async def test_variable_fan_no_current_speed(hass, caplog):
+async def test_variable_fan_no_current_speed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test fan discovery.
 
     This one has variable speed, but no current speed.
@@ -619,7 +620,7 @@ async def test_variable_fan_no_current_speed(hass, caplog):
     caplog.clear()
 
 
-async def test_oscillating_fan(hass):
+async def test_oscillating_fan(hass: HomeAssistant) -> None:
     """Test oscillating fan with ToggleController."""
     device = (
         "fan.test_3",
@@ -677,7 +678,7 @@ async def test_oscillating_fan(hass):
     assert not call.data["oscillating"]
 
 
-async def test_direction_fan(hass):
+async def test_direction_fan(hass: HomeAssistant) -> None:
     """Test fan direction with modeController."""
     device = (
         "fan.test_4",
@@ -783,7 +784,9 @@ async def test_direction_fan(hass):
         assert call.data
 
 
-async def test_preset_mode_fan(hass, caplog):
+async def test_preset_mode_fan(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test fan discovery.
 
     This one has preset modes.
@@ -866,7 +869,9 @@ async def test_preset_mode_fan(hass, caplog):
     caplog.clear()
 
 
-async def test_single_preset_mode_fan(hass, caplog):
+async def test_single_preset_mode_fan(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test fan discovery.
 
     This one has only preset mode.
@@ -939,7 +944,9 @@ async def test_single_preset_mode_fan(hass, caplog):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_humidifier(hass, caplog):
+async def test_humidifier(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test humidifier controller."""
     device = (
         "humidifier.test_1",
@@ -1010,7 +1017,7 @@ async def test_humidifier(hass, caplog):
     assert call.data["humidity"] == 33
 
 
-async def test_humidifier_without_modes(hass):
+async def test_humidifier_without_modes(hass: HomeAssistant) -> None:
     """Test humidifier discovery without modes."""
 
     device = (
@@ -1042,7 +1049,7 @@ async def test_humidifier_without_modes(hass):
     assert "configuration" not in power_capability
 
 
-async def test_humidifier_with_modes(hass):
+async def test_humidifier_with_modes(hass: HomeAssistant) -> None:
     """Test humidifier discovery with modes."""
 
     device = (
@@ -1077,7 +1084,7 @@ async def test_humidifier_with_modes(hass):
     assert "configuration" not in power_capability
 
 
-async def test_lock(hass):
+async def test_lock(hass: HomeAssistant) -> None:
     """Test lock discovery."""
     device = ("lock.test", "off", {"friendly_name": "Test lock"})
     appliance = await discovery_test(device, hass)
@@ -1109,7 +1116,7 @@ async def test_lock(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_media_player(hass):
+async def test_media_player(hass: HomeAssistant) -> None:
     """Test media player discovery."""
     device = (
         "media_player.test",
@@ -1271,7 +1278,7 @@ async def test_media_player(hass):
     )
 
 
-async def test_media_player_power(hass):
+async def test_media_player_power(hass: HomeAssistant) -> None:
     """Test media player discovery with mapped on/off."""
     device = (
         "media_player.test",
@@ -1317,7 +1324,7 @@ async def test_media_player_power(hass):
     )
 
 
-async def test_media_player_inputs(hass):
+async def test_media_player_inputs(hass: HomeAssistant) -> None:
     """Test media player discovery with source list inputs."""
     device = (
         "media_player.test",
@@ -1421,7 +1428,7 @@ async def test_media_player_inputs(hass):
     assert call.data["source"] == "tv"
 
 
-async def test_media_player_no_supported_inputs(hass):
+async def test_media_player_no_supported_inputs(hass: HomeAssistant) -> None:
     """Test media player discovery with no supported inputs."""
     device = (
         "media_player.test_no_inputs",
@@ -1456,7 +1463,7 @@ async def test_media_player_no_supported_inputs(hass):
     )
 
 
-async def test_media_player_speaker(hass):
+async def test_media_player_speaker(hass: HomeAssistant) -> None:
     """Test media player with speaker interface."""
     device = (
         "media_player.test_speaker",
@@ -1533,7 +1540,7 @@ async def test_media_player_speaker(hass):
     )
 
 
-async def test_media_player_step_speaker(hass):
+async def test_media_player_step_speaker(hass: HomeAssistant) -> None:
     """Test media player with step speaker interface."""
     device = (
         "media_player.test_step_speaker",
@@ -1602,7 +1609,7 @@ async def test_media_player_step_speaker(hass):
     )
 
 
-async def test_media_player_seek(hass):
+async def test_media_player_seek(hass: HomeAssistant) -> None:
     """Test media player seek capability."""
     device = (
         "media_player.test_seek",
@@ -1689,7 +1696,7 @@ async def test_media_player_seek(hass):
     assert {"name": "positionMilliseconds", "value": 600000} in properties
 
 
-async def test_media_player_seek_error(hass):
+async def test_media_player_seek_error(hass: HomeAssistant) -> None:
     """Test media player seek capability for media_position Error."""
     device = (
         "media_player.test_seek",
@@ -1721,7 +1728,7 @@ async def test_media_player_seek_error(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_alert(hass):
+async def test_alert(hass: HomeAssistant) -> None:
     """Test alert discovery."""
     device = ("alert.test", "off", {"friendly_name": "Test alert"})
     appliance = await discovery_test(device, hass)
@@ -1739,7 +1746,7 @@ async def test_alert(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_automation(hass):
+async def test_automation(hass: HomeAssistant) -> None:
     """Test automation discovery."""
     device = ("automation.test", "off", {"friendly_name": "Test automation"})
     appliance = await discovery_test(device, hass)
@@ -1761,7 +1768,7 @@ async def test_automation(hass):
 
 
 @freeze_time("2022-04-19 07:53:05")
-async def test_group(hass):
+async def test_group(hass: HomeAssistant) -> None:
     """Test group discovery."""
     device = ("group.test", "off", {"friendly_name": "Test group"})
     appliance = await discovery_test(device, hass)
@@ -1782,7 +1789,7 @@ async def test_group(hass):
     )
 
 
-async def test_cover_position_range(hass):
+async def test_cover_position_range(hass: HomeAssistant) -> None:
     """Test cover discovery and position using rangeController."""
     device = (
         "cover.test_range",
@@ -1981,7 +1988,7 @@ async def assert_range_changes(
             assert call.data[changed_parameter] == result_range
 
 
-async def test_temp_sensor(hass):
+async def test_temp_sensor(hass: HomeAssistant) -> None:
     """Test temperature sensor discovery."""
     device = (
         "sensor.test_temp",
@@ -2013,7 +2020,7 @@ async def test_temp_sensor(hass):
     )
 
 
-async def test_contact_sensor(hass):
+async def test_contact_sensor(hass: HomeAssistant) -> None:
     """Test contact sensor discovery."""
     device = (
         "binary_sensor.test_contact",
@@ -2042,7 +2049,7 @@ async def test_contact_sensor(hass):
     properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
 
 
-async def test_forced_contact_sensor(hass):
+async def test_forced_contact_sensor(hass: HomeAssistant) -> None:
     """Test contact sensor discovery with specified display_category."""
     device = (
         "binary_sensor.test_contact_forced",
@@ -2071,7 +2078,7 @@ async def test_forced_contact_sensor(hass):
     properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
 
 
-async def test_motion_sensor(hass):
+async def test_motion_sensor(hass: HomeAssistant) -> None:
     """Test motion sensor discovery."""
     device = (
         "binary_sensor.test_motion",
@@ -2098,7 +2105,7 @@ async def test_motion_sensor(hass):
     properties.assert_equal("Alexa.MotionSensor", "detectionState", "DETECTED")
 
 
-async def test_forced_motion_sensor(hass):
+async def test_forced_motion_sensor(hass: HomeAssistant) -> None:
     """Test motion sensor discovery with specified display_category."""
     device = (
         "binary_sensor.test_motion_forced",
@@ -2127,7 +2134,7 @@ async def test_forced_motion_sensor(hass):
     properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
 
 
-async def test_doorbell_sensor(hass):
+async def test_doorbell_sensor(hass: HomeAssistant) -> None:
     """Test doorbell sensor discovery."""
     device = (
         "binary_sensor.test_doorbell",
@@ -2149,7 +2156,7 @@ async def test_doorbell_sensor(hass):
     assert doorbell_capability["proactivelyReported"] is True
 
 
-async def test_unknown_sensor(hass):
+async def test_unknown_sensor(hass: HomeAssistant) -> None:
     """Test sensors of unknown quantities are not discovered."""
     device = (
         "sensor.test_sickness",
@@ -2159,7 +2166,7 @@ async def test_unknown_sensor(hass):
     await discovery_test(device, hass, expected_endpoints=0)
 
 
-async def test_thermostat(hass):
+async def test_thermostat(hass: HomeAssistant) -> None:
     """Test thermostat discovery."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     device = (
@@ -2430,7 +2437,7 @@ async def test_thermostat(hass):
     assert call.data["preset_mode"] == "eco"
 
 
-async def test_exclude_filters(hass):
+async def test_exclude_filters(hass: HomeAssistant) -> None:
     """Test exclusion filters."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -2457,7 +2464,7 @@ async def test_exclude_filters(hass):
     assert len(msg["payload"]["endpoints"]) == 1
 
 
-async def test_include_filters(hass):
+async def test_include_filters(hass: HomeAssistant) -> None:
     """Test inclusion filters."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -2488,7 +2495,7 @@ async def test_include_filters(hass):
     assert len(msg["payload"]["endpoints"]) == 3
 
 
-async def test_never_exposed_entities(hass):
+async def test_never_exposed_entities(hass: HomeAssistant) -> None:
     """Test never exposed locks do not get discovered."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -2513,7 +2520,7 @@ async def test_never_exposed_entities(hass):
     assert len(msg["payload"]["endpoints"]) == 1
 
 
-async def test_api_entity_not_exists(hass):
+async def test_api_entity_not_exists(hass: HomeAssistant) -> None:
     """Test api turn on process without entity."""
     request = get_new_request("Alexa.PowerController", "TurnOn", "switch#test")
 
@@ -2531,7 +2538,7 @@ async def test_api_entity_not_exists(hass):
     assert msg["payload"]["type"] == "NO_SUCH_ENDPOINT"
 
 
-async def test_api_function_not_implemented(hass):
+async def test_api_function_not_implemented(hass: HomeAssistant) -> None:
     """Test api call that is not implemented to us."""
     request = get_new_request("Alexa.HAHAAH", "Sweet")
     msg = await smart_home.async_handle_message(hass, get_default_config(hass), request)
@@ -2544,7 +2551,7 @@ async def test_api_function_not_implemented(hass):
     assert msg["payload"]["type"] == "INTERNAL_ERROR"
 
 
-async def test_api_accept_grant(hass):
+async def test_api_accept_grant(hass: HomeAssistant) -> None:
     """Test api AcceptGrant process."""
     request = get_new_request("Alexa.Authorization", "AcceptGrant")
 
@@ -2567,7 +2574,7 @@ async def test_api_accept_grant(hass):
     assert msg["header"]["name"] == "AcceptGrant.Response"
 
 
-async def test_entity_config(hass):
+async def test_entity_config(hass: HomeAssistant) -> None:
     """Test that we can configure things via entity config."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
@@ -2653,7 +2660,7 @@ async def test_logging_request_with_entity(hass, events):
     assert event.context == context
 
 
-async def test_disabled(hass):
+async def test_disabled(hass: HomeAssistant) -> None:
     """When enabled=False, everything fails."""
     hass.states.async_set("switch.test", "on", {"friendly_name": "Test switch"})
     request = get_new_request("Alexa.PowerController", "TurnOn", "switch#test")
@@ -2674,7 +2681,7 @@ async def test_disabled(hass):
     assert msg["payload"]["type"] == "BRIDGE_UNREACHABLE"
 
 
-async def test_endpoint_good_health(hass):
+async def test_endpoint_good_health(hass: HomeAssistant) -> None:
     """Test endpoint health reporting."""
     device = (
         "binary_sensor.test_contact",
@@ -2686,7 +2693,7 @@ async def test_endpoint_good_health(hass):
     properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
 
 
-async def test_endpoint_bad_health(hass):
+async def test_endpoint_bad_health(hass: HomeAssistant) -> None:
     """Test endpoint health reporting."""
     device = (
         "binary_sensor.test_contact",
@@ -2700,7 +2707,7 @@ async def test_endpoint_bad_health(hass):
     )
 
 
-async def test_alarm_control_panel_disarmed(hass):
+async def test_alarm_control_panel_disarmed(hass: HomeAssistant) -> None:
     """Test alarm_control_panel discovery."""
     device = (
         "alarm_control_panel.test_1",
@@ -2772,7 +2779,7 @@ async def test_alarm_control_panel_disarmed(hass):
     properties.assert_equal("Alexa.SecurityPanelController", "armState", "ARMED_NIGHT")
 
 
-async def test_alarm_control_panel_armed(hass):
+async def test_alarm_control_panel_armed(hass: HomeAssistant) -> None:
     """Test alarm_control_panel discovery."""
     device = (
         "alarm_control_panel.test_2",
@@ -2820,7 +2827,7 @@ async def test_alarm_control_panel_armed(hass):
     assert msg["event"]["payload"]["type"] == "AUTHORIZATION_REQUIRED"
 
 
-async def test_alarm_control_panel_code_arm_required(hass):
+async def test_alarm_control_panel_code_arm_required(hass: HomeAssistant) -> None:
     """Test alarm_control_panel with code_arm_required not in discovery."""
     device = (
         "alarm_control_panel.test_3",
@@ -2834,7 +2841,7 @@ async def test_alarm_control_panel_code_arm_required(hass):
     await discovery_test(device, hass, expected_endpoints=0)
 
 
-async def test_range_unsupported_domain(hass):
+async def test_range_unsupported_domain(hass: HomeAssistant) -> None:
     """Test rangeController with unsupported domain."""
     device = ("switch.test", "on", {"friendly_name": "Test switch"})
     await discovery_test(device, hass)
@@ -2855,7 +2862,7 @@ async def test_range_unsupported_domain(hass):
     assert msg["payload"]["type"] == "INVALID_DIRECTIVE"
 
 
-async def test_mode_unsupported_domain(hass):
+async def test_mode_unsupported_domain(hass: HomeAssistant) -> None:
     """Test modeController with unsupported domain."""
     device = ("switch.test", "on", {"friendly_name": "Test switch"})
     await discovery_test(device, hass)
@@ -2876,7 +2883,7 @@ async def test_mode_unsupported_domain(hass):
     assert msg["payload"]["type"] == "INVALID_DIRECTIVE"
 
 
-async def test_cover_garage_door(hass):
+async def test_cover_garage_door(hass: HomeAssistant) -> None:
     """Test garage door cover discovery."""
     device = (
         "cover.test_garage_door",
@@ -2898,7 +2905,7 @@ async def test_cover_garage_door(hass):
     )
 
 
-async def test_cover_gate(hass):
+async def test_cover_gate(hass: HomeAssistant) -> None:
     """Test gate cover discovery."""
     device = (
         "cover.test_gate",
@@ -2920,7 +2927,7 @@ async def test_cover_gate(hass):
     )
 
 
-async def test_cover_position_mode(hass):
+async def test_cover_position_mode(hass: HomeAssistant) -> None:
     """Test cover discovery and position using modeController."""
     device = (
         "cover.test_mode",
@@ -3061,7 +3068,7 @@ async def test_cover_position_mode(hass):
     assert properties["value"] == "position.custom"
 
 
-async def test_image_processing(hass):
+async def test_image_processing(hass: HomeAssistant) -> None:
     """Test image_processing discovery as event detection."""
     device = (
         "image_processing.test_face",
@@ -3084,7 +3091,7 @@ async def test_image_processing(hass):
     )
 
 
-async def test_motion_sensor_event_detection(hass):
+async def test_motion_sensor_event_detection(hass: HomeAssistant) -> None:
     """Test motion sensor with EventDetectionSensor discovery."""
     device = (
         "binary_sensor.test_motion_camera_event",
@@ -3115,7 +3122,7 @@ async def test_motion_sensor_event_detection(hass):
     assert {"name": "humanPresenceDetectionState"} in properties["supported"]
 
 
-async def test_presence_sensor(hass):
+async def test_presence_sensor(hass: HomeAssistant) -> None:
     """Test presence sensor."""
     device = (
         "binary_sensor.test_presence_sensor",
@@ -3142,7 +3149,7 @@ async def test_presence_sensor(hass):
     assert {"name": "humanPresenceDetectionState"} in properties["supported"]
 
 
-async def test_cover_tilt_position_range(hass):
+async def test_cover_tilt_position_range(hass: HomeAssistant) -> None:
     """Test cover discovery and tilt position using rangeController."""
     device = (
         "cover.test_tilt_range",
@@ -3260,7 +3267,7 @@ async def test_cover_tilt_position_range(hass):
     )
 
 
-async def test_cover_semantics_position_and_tilt(hass):
+async def test_cover_semantics_position_and_tilt(hass: HomeAssistant) -> None:
     """Test cover discovery and semantics with position and tilt support."""
     device = (
         "cover.test_semantics",
@@ -3518,7 +3525,7 @@ async def test_input_number_float(hass, domain: str):
     )
 
 
-async def test_media_player_eq_modes(hass):
+async def test_media_player_eq_modes(hass: HomeAssistant) -> None:
     """Test media player discovery with sound mode list."""
     device = (
         "media_player.test",
@@ -3566,7 +3573,7 @@ async def test_media_player_eq_modes(hass):
         assert call.data["sound_mode"] == mode.lower()
 
 
-async def test_media_player_sound_mode_list_unsupported(hass):
+async def test_media_player_sound_mode_list_unsupported(hass: HomeAssistant) -> None:
     """Test EqualizerController with unsupported sound modes."""
     device = (
         "media_player.test",
@@ -3588,7 +3595,7 @@ async def test_media_player_sound_mode_list_unsupported(hass):
     )
 
 
-async def test_media_player_eq_bands_not_supported(hass):
+async def test_media_player_eq_bands_not_supported(hass: HomeAssistant) -> None:
     """Test EqualizerController bands directive not supported."""
     device = (
         "media_player.test_bands",
@@ -3654,7 +3661,7 @@ async def test_media_player_eq_bands_not_supported(hass):
     assert msg["payload"]["type"] == "INVALID_DIRECTIVE"
 
 
-async def test_timer_hold(hass):
+async def test_timer_hold(hass: HomeAssistant) -> None:
     """Test timer hold."""
     device = (
         "timer.laundry",
@@ -3681,7 +3688,7 @@ async def test_timer_hold(hass):
     )
 
 
-async def test_timer_resume(hass):
+async def test_timer_resume(hass: HomeAssistant) -> None:
     """Test timer resume."""
     device = (
         "timer.laundry",
@@ -3698,7 +3705,7 @@ async def test_timer_resume(hass):
     )
 
 
-async def test_timer_start(hass):
+async def test_timer_start(hass: HomeAssistant) -> None:
     """Test timer start."""
     device = (
         "timer.laundry",
@@ -3715,7 +3722,7 @@ async def test_timer_start(hass):
     )
 
 
-async def test_timer_cancel(hass):
+async def test_timer_cancel(hass: HomeAssistant) -> None:
     """Test timer cancel."""
     device = (
         "timer.laundry",
@@ -3732,7 +3739,7 @@ async def test_timer_cancel(hass):
     )
 
 
-async def test_vacuum_discovery(hass):
+async def test_vacuum_discovery(hass: HomeAssistant) -> None:
     """Test vacuum discovery."""
     device = (
         "vacuum.test_1",
@@ -3773,7 +3780,7 @@ async def test_vacuum_discovery(hass):
     )
 
 
-async def test_vacuum_fan_speed(hass):
+async def test_vacuum_fan_speed(hass: HomeAssistant) -> None:
     """Test vacuum fan speed with rangeController."""
     device = (
         "vacuum.test_2",
@@ -3902,7 +3909,7 @@ async def test_vacuum_fan_speed(hass):
     )
 
 
-async def test_vacuum_pause(hass):
+async def test_vacuum_pause(hass: HomeAssistant) -> None:
     """Test vacuum pause with TimeHoldController."""
     device = (
         "vacuum.test_3",
@@ -3940,7 +3947,7 @@ async def test_vacuum_pause(hass):
     )
 
 
-async def test_vacuum_resume(hass):
+async def test_vacuum_resume(hass: HomeAssistant) -> None:
     """Test vacuum resume with TimeHoldController."""
     device = (
         "vacuum.test_4",
@@ -3968,7 +3975,7 @@ async def test_vacuum_resume(hass):
     )
 
 
-async def test_vacuum_discovery_no_turn_on(hass):
+async def test_vacuum_discovery_no_turn_on(hass: HomeAssistant) -> None:
     """Test vacuum discovery for vacuums without turn_on."""
     device = (
         "vacuum.test_5",
@@ -3998,7 +4005,7 @@ async def test_vacuum_discovery_no_turn_on(hass):
     )
 
 
-async def test_vacuum_discovery_no_turn_off(hass):
+async def test_vacuum_discovery_no_turn_off(hass: HomeAssistant) -> None:
     """Test vacuum discovery for vacuums without turn_off."""
     device = (
         "vacuum.test_6",
@@ -4029,7 +4036,7 @@ async def test_vacuum_discovery_no_turn_off(hass):
     )
 
 
-async def test_vacuum_discovery_no_turn_on_or_off(hass):
+async def test_vacuum_discovery_no_turn_on_or_off(hass: HomeAssistant) -> None:
     """Test vacuum discovery vacuums without on or off."""
     device = (
         "vacuum.test_7",
@@ -4089,7 +4096,7 @@ async def test_camera_discovery(hass, mock_stream):
     assert "AAC" in configuration["audioCodecs"]
 
 
-async def test_camera_discovery_without_stream(hass):
+async def test_camera_discovery_without_stream(hass: HomeAssistant) -> None:
     """Test camera discovery without stream integration."""
     device = (
         "camera.test",
@@ -4220,7 +4227,7 @@ async def test_button(hass, domain):
     )
 
 
-async def test_api_message_sets_authorized(hass):
+async def test_api_message_sets_authorized(hass: HomeAssistant) -> None:
     """Test an incoming API messages sets the authorized flag."""
     msg = get_new_request("Alexa.PowerController", "TurnOn", "switch#xy")
     async_mock_service(hass, "switch", "turn_on")

--- a/tests/components/alexa/test_smart_home_http.py
+++ b/tests/components/alexa/test_smart_home_http.py
@@ -4,9 +4,12 @@ import json
 
 from homeassistant.components.alexa import DOMAIN, smart_home_http
 from homeassistant.const import CONTENT_TYPE_JSON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import get_new_request
+
+from tests.typing import ClientSessionGenerator
 
 
 async def do_http_discovery(config, hass, hass_client):
@@ -23,7 +26,9 @@ async def do_http_discovery(config, hass, hass_client):
     return response
 
 
-async def test_http_api(hass, hass_client):
+async def test_http_api(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """With `smart_home:` HTTP API is exposed."""
     config = {"alexa": {"smart_home": None}}
 
@@ -35,7 +40,9 @@ async def test_http_api(hass, hass_client):
     assert response_data["event"]["header"]["name"] == "Discover.Response"
 
 
-async def test_http_api_disabled(hass, hass_client):
+async def test_http_api_disabled(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Without `smart_home:`, the HTTP API is disabled."""
     config = {"alexa": {}}
     response = await do_http_discovery(config, hass, hass_client)

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -9,11 +9,16 @@ from homeassistant import core
 from homeassistant.components.alexa import errors, state_report
 from homeassistant.components.alexa.resources import AlexaGlobalCatalog
 from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTemperature
+from homeassistant.core import HomeAssistant
 
 from .test_common import TEST_URL, get_default_config
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_report_state(hass, aioclient_mock):
+
+async def test_report_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test proactive state reports."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
@@ -122,7 +127,9 @@ async def test_report_state_timeout(hass, aioclient_mock, caplog):
     )
 
 
-async def test_report_state_retry(hass, aioclient_mock):
+async def test_report_state_retry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test proactive state retries once."""
     aioclient_mock.post(
         TEST_URL,
@@ -150,7 +157,9 @@ async def test_report_state_retry(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 2
 
 
-async def test_report_state_unsets_authorized_on_error(hass, aioclient_mock):
+async def test_report_state_unsets_authorized_on_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test proactive state unsets authorized on error."""
     aioclient_mock.post(
         TEST_URL,
@@ -211,7 +220,9 @@ async def test_report_state_unsets_authorized_on_access_token_error(
         config._store.set_authorized.assert_called_once_with(False)
 
 
-async def test_report_state_fan(hass, aioclient_mock):
+async def test_report_state_fan(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test proactive state reports with fan instance."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
@@ -277,7 +288,9 @@ async def test_report_state_fan(hass, aioclient_mock):
     assert call_json["event"]["endpoint"]["endpointId"] == "fan#test_fan"
 
 
-async def test_report_state_humidifier(hass, aioclient_mock):
+async def test_report_state_humidifier(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test proactive state reports with humidifier instance."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
@@ -425,7 +438,9 @@ async def test_report_state_number(hass, aioclient_mock, domain, value, unit, la
     assert call_json["event"]["endpoint"]["endpointId"] == f"{domain}#test_{domain}"
 
 
-async def test_send_add_or_update_message(hass, aioclient_mock):
+async def test_send_add_or_update_message(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sending an AddOrUpdateReport message."""
     aioclient_mock.post(TEST_URL, text="")
 
@@ -462,7 +477,9 @@ async def test_send_add_or_update_message(hass, aioclient_mock):
     )
 
 
-async def test_send_delete_message(hass, aioclient_mock):
+async def test_send_delete_message(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sending an AddOrUpdateReport message."""
     aioclient_mock.post(TEST_URL, json={"data": "is irrelevant"})
 
@@ -489,7 +506,9 @@ async def test_send_delete_message(hass, aioclient_mock):
     )
 
 
-async def test_doorbell_event(hass, aioclient_mock):
+async def test_doorbell_event(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test doorbell press reports."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
@@ -554,7 +573,9 @@ async def test_doorbell_event(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 2
 
 
-async def test_doorbell_event_from_unknown(hass, aioclient_mock):
+async def test_doorbell_event_from_unknown(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test doorbell press reports."""
     aioclient_mock.post(TEST_URL, text="", status=202)
 
@@ -658,7 +679,9 @@ async def test_doorbell_event_timeout(hass, aioclient_mock, caplog):
     )
 
 
-async def test_proactive_mode_filter_states(hass, aioclient_mock):
+async def test_proactive_mode_filter_states(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test all the cases that filter states."""
     aioclient_mock.post(TEST_URL, text="", status=202)
     config = get_default_config(hass)

--- a/tests/components/ambiclimate/test_config_flow.py
+++ b/tests/components/ambiclimate/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.ambiclimate import config_flow
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import aiohttp
 
@@ -29,7 +30,7 @@ async def init_config_flow(hass):
     return flow
 
 
-async def test_abort_if_no_implementation_registered(hass):
+async def test_abort_if_no_implementation_registered(hass: HomeAssistant) -> None:
     """Test we abort if no implementation is registered."""
     flow = config_flow.AmbiclimateFlowHandler()
     flow.hass = hass
@@ -39,7 +40,7 @@ async def test_abort_if_no_implementation_registered(hass):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_abort_if_already_setup(hass):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if Ambiclimate is already setup."""
     flow = await init_config_flow(hass)
 
@@ -57,7 +58,7 @@ async def test_abort_if_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_full_flow_implementation(hass):
+async def test_full_flow_implementation(hass: HomeAssistant) -> None:
     """Test registering an implementation and finishing flow works."""
     config_flow.register_flow_implementation(hass, None, None)
     flow = await init_config_flow(hass)
@@ -96,7 +97,7 @@ async def test_full_flow_implementation(hass):
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_abort_invalid_code(hass):
+async def test_abort_invalid_code(hass: HomeAssistant) -> None:
     """Test if no code is given to step_code."""
     config_flow.register_flow_implementation(hass, None, None)
     flow = await init_config_flow(hass)
@@ -107,7 +108,7 @@ async def test_abort_invalid_code(hass):
     assert result["reason"] == "access_token"
 
 
-async def test_already_setup(hass):
+async def test_already_setup(hass: HomeAssistant) -> None:
     """Test when already setup."""
     MockConfigEntry(domain=config_flow.DOMAIN).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
@@ -119,7 +120,7 @@ async def test_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_view(hass):
+async def test_view(hass: HomeAssistant) -> None:
     """Test view."""
     hass.config_entries.flow.async_init = AsyncMock()
 

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -14,8 +14,11 @@ from homeassistant.components.analytics.const import (
     ATTR_USAGE,
 )
 from homeassistant.const import ATTR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.loader import IntegrationNotFound
 from homeassistant.setup import async_setup_component
+
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_UUID = "abcdefg"
 MOCK_VERSION = "1970.1.0"
@@ -38,7 +41,7 @@ async def test_no_send(hass, caplog, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 0
 
 
-async def test_load_with_supervisor_diagnostics(hass):
+async def test_load_with_supervisor_diagnostics(hass: HomeAssistant) -> None:
     """Test loading with a supervisor that has diagnostics enabled."""
     analytics = Analytics(hass)
     assert not analytics.preferences[ATTR_DIAGNOSTICS]
@@ -53,7 +56,7 @@ async def test_load_with_supervisor_diagnostics(hass):
     assert analytics.preferences[ATTR_DIAGNOSTICS]
 
 
-async def test_load_with_supervisor_without_diagnostics(hass):
+async def test_load_with_supervisor_without_diagnostics(hass: HomeAssistant) -> None:
     """Test loading with a supervisor that has not diagnostics enabled."""
     analytics = Analytics(hass)
     analytics._data.preferences[ATTR_DIAGNOSTICS] = True
@@ -343,7 +346,9 @@ async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
     assert "'integrations':" not in caplog.text
 
 
-async def test_reusing_uuid(hass, aioclient_mock):
+async def test_reusing_uuid(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test reusing the stored UUID."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
@@ -376,7 +381,9 @@ async def test_custom_integrations(hass, aioclient_mock, enable_custom_integrati
     assert payload["custom_integrations"][0][ATTR_DOMAIN] == "test_package"
 
 
-async def test_dev_url(hass, aioclient_mock):
+async def test_dev_url(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sending payload to dev url."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
@@ -410,7 +417,9 @@ async def test_dev_url_error(hass, aioclient_mock, caplog):
     ) in caplog.text
 
 
-async def test_nightly_endpoint(hass, aioclient_mock):
+async def test_nightly_endpoint(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sending payload to production url when running nightly."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
@@ -425,7 +434,9 @@ async def test_nightly_endpoint(hass, aioclient_mock):
     assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
 
 
-async def test_send_with_no_energy(hass, aioclient_mock):
+async def test_send_with_no_energy(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -2,12 +2,13 @@
 from unittest.mock import patch
 
 from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 MOCK_VERSION = "1970.1.0"
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setup of the integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -34,6 +34,7 @@ from homeassistant.components.androidtv.const import (
 )
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from .patchers import PATCH_ACCESS, PATCH_ISFILE, PATCH_SETUP_ENTRY
 
@@ -116,7 +117,7 @@ async def test_user(hass, config, eth_mac, wifi_mac):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_adbkey(hass):
+async def test_user_adbkey(hass: HomeAssistant) -> None:
     """Test user step with adbkey file."""
     config_data = CONFIG_PYTHON_ADB.copy()
     config_data[CONF_ADBKEY] = ADBKEY
@@ -139,7 +140,7 @@ async def test_user_adbkey(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_error_both_key_server(hass):
+async def test_error_both_key_server(hass: HomeAssistant) -> None:
     """Test we abort if both adb key and server are provided."""
     config_data = CONFIG_ADB_SERVER.copy()
 
@@ -167,7 +168,7 @@ async def test_error_both_key_server(hass):
         assert result2["data"] == CONFIG_ADB_SERVER
 
 
-async def test_error_invalid_key(hass):
+async def test_error_invalid_key(hass: HomeAssistant) -> None:
     """Test we abort if component is already setup."""
     config_data = CONFIG_PYTHON_ADB.copy()
     config_data[CONF_ADBKEY] = ADBKEY
@@ -221,7 +222,7 @@ async def test_invalid_mac(hass, config, eth_mac, wifi_mac):
         assert result["reason"] == "invalid_unique_id"
 
 
-async def test_abort_if_host_exist(hass):
+async def test_abort_if_host_exist(hass: HomeAssistant) -> None:
     """Test we abort if component is already setup."""
     MockConfigEntry(
         domain=DOMAIN, data=CONFIG_ADB_SERVER, unique_id=ETH_MAC
@@ -239,7 +240,7 @@ async def test_abort_if_host_exist(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_abort_if_unique_exist(hass):
+async def test_abort_if_unique_exist(hass: HomeAssistant) -> None:
     """Test we abort if component is already setup."""
     config_data = CONFIG_ADB_SERVER.copy()
     config_data[CONF_HOST] = "127.0.0.2"
@@ -262,7 +263,7 @@ async def test_abort_if_unique_exist(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_on_connect_failed(hass):
+async def test_on_connect_failed(hass: HomeAssistant) -> None:
     """Test when we have errors connecting the router."""
     flow_result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -300,7 +301,7 @@ async def test_on_connect_failed(hass):
         assert result3["data"] == CONFIG_ADB_SERVER
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -66,6 +66,7 @@ from homeassistant.const import (
     STATE_STANDBY,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import slugify
 
@@ -304,7 +305,7 @@ async def test_adb_shell_returns_none(hass, config):
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_setup_with_adbkey(hass):
+async def test_setup_with_adbkey(hass: HomeAssistant) -> None:
     """Test that setup succeeds when using an ADB key."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_PYTHON_ADB_KEY)
     config_entry.add_to_hass(hass)
@@ -496,7 +497,7 @@ async def test_select_source_androidtv(hass, source, expected_arg, method_patch)
     )
 
 
-async def test_androidtv_select_source_overridden_app_name(hass):
+async def test_androidtv_select_source_overridden_app_name(hass: HomeAssistant) -> None:
     """Test that when an app name is overridden via the `apps` configuration parameter, the app is launched correctly."""
     # Evidence that the default YouTube app ID will be overridden
     conf_apps = {
@@ -564,7 +565,7 @@ async def test_setup_fail(hass, config, connect):
         assert state is None
 
 
-async def test_adb_command(hass):
+async def test_adb_command(hass: HomeAssistant) -> None:
     """Test sending a command via the `androidtv.adb_command` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -593,7 +594,7 @@ async def test_adb_command(hass):
             assert state.attributes["adb_response"] == response
 
 
-async def test_adb_command_unicode_decode_error(hass):
+async def test_adb_command_unicode_decode_error(hass: HomeAssistant) -> None:
     """Test sending a command via the `androidtv.adb_command` service that raises a UnicodeDecodeError exception."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -622,7 +623,7 @@ async def test_adb_command_unicode_decode_error(hass):
             assert state.attributes["adb_response"] is None
 
 
-async def test_adb_command_key(hass):
+async def test_adb_command_key(hass: HomeAssistant) -> None:
     """Test sending a key command via the `androidtv.adb_command` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -651,7 +652,7 @@ async def test_adb_command_key(hass):
             assert state.attributes["adb_response"] is None
 
 
-async def test_adb_command_get_properties(hass):
+async def test_adb_command_get_properties(hass: HomeAssistant) -> None:
     """Test sending the "GET_PROPERTIES" command via the `androidtv.adb_command` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -681,7 +682,7 @@ async def test_adb_command_get_properties(hass):
             assert state.attributes["adb_response"] == str(response)
 
 
-async def test_learn_sendevent(hass):
+async def test_learn_sendevent(hass: HomeAssistant) -> None:
     """Test the `androidtv.learn_sendevent` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -710,7 +711,7 @@ async def test_learn_sendevent(hass):
             assert state.attributes["adb_response"] == response
 
 
-async def test_update_lock_not_acquired(hass):
+async def test_update_lock_not_acquired(hass: HomeAssistant) -> None:
     """Test that the state does not get updated when a `LockNotAcquiredException` is raised."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -743,7 +744,7 @@ async def test_update_lock_not_acquired(hass):
         assert state.state == STATE_STANDBY
 
 
-async def test_download(hass):
+async def test_download(hass: HomeAssistant) -> None:
     """Test the `androidtv.download` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -789,7 +790,7 @@ async def test_download(hass):
             patch_pull.assert_called_with(local_path, device_path)
 
 
-async def test_upload(hass):
+async def test_upload(hass: HomeAssistant) -> None:
     """Test the `androidtv.upload` service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -835,7 +836,7 @@ async def test_upload(hass):
             patch_push.assert_called_with(local_path, device_path)
 
 
-async def test_androidtv_volume_set(hass):
+async def test_androidtv_volume_set(hass: HomeAssistant) -> None:
     """Test setting the volume for an Android TV device."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -904,7 +905,7 @@ async def test_get_image_http(hass, hass_client_no_auth):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_get_image_disabled(hass):
+async def test_get_image_disabled(hass: HomeAssistant) -> None:
     """Test that the screencap option can disable entity_picture."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -959,7 +960,7 @@ async def _test_service(
         assert service_call.called
 
 
-async def test_services_androidtv(hass):
+async def test_services_androidtv(hass: HomeAssistant) -> None:
     """Test media player services for an Android TV device."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -1000,7 +1001,7 @@ async def test_services_androidtv(hass):
             )
 
 
-async def test_services_firetv(hass):
+async def test_services_firetv(hass: HomeAssistant) -> None:
     """Test media player services for a Fire TV device."""
     patch_key, entity_id, config_entry = _setup(CONFIG_FIRETV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -1023,7 +1024,7 @@ async def test_services_firetv(hass):
             await _test_service(hass, entity_id, SERVICE_TURN_ON, "adb_shell")
 
 
-async def test_volume_mute(hass):
+async def test_volume_mute(hass: HomeAssistant) -> None:
     """Test the volume mute service."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -1066,7 +1067,7 @@ async def test_volume_mute(hass):
                     assert mute_volume.called
 
 
-async def test_connection_closed_on_ha_stop(hass):
+async def test_connection_closed_on_ha_stop(hass: HomeAssistant) -> None:
     """Test that the ADB socket connection is closed when HA stops."""
     patch_key, _, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)
@@ -1083,7 +1084,7 @@ async def test_connection_closed_on_ha_stop(hass):
             assert adb_close.called
 
 
-async def test_exception(hass):
+async def test_exception(hass: HomeAssistant) -> None:
     """Test that the ADB connection gets closed when there is an unforeseen exception.
 
     HA will attempt to reconnect on the next update.
@@ -1116,7 +1117,7 @@ async def test_exception(hass):
         assert state.state == STATE_OFF
 
 
-async def test_options_reload(hass):
+async def test_options_reload(hass: HomeAssistant) -> None:
     """Test changing an option that will cause integration reload."""
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_DEFAULT)
     config_entry.add_to_hass(hass)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -73,6 +73,7 @@ from homeassistant.util import slugify
 from . import patchers
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 HOST = "127.0.0.1"
 
@@ -860,7 +861,9 @@ async def test_androidtv_volume_set(hass: HomeAssistant) -> None:
         patch_set_volume_level.assert_called_with(0.5)
 
 
-async def test_get_image_http(hass, hass_client_no_auth):
+async def test_get_image_http(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test taking a screen capture.
 
     This is based on `test_get_image_http` in tests/components/media_player/test_init.py.

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test config flow."""
-
 from ipaddress import IPv4Address
 from unittest.mock import ANY, patch
 
@@ -15,6 +14,7 @@ from homeassistant.components.apple_tv.const import (
     CONF_START_OFF,
     DOMAIN,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import airplay_service, create_conf, mrp_service, raop_service
 
@@ -526,7 +526,7 @@ async def test_ignores_disabled_service(hass, airplay_with_disabled_mrp, pairing
 # Zeroconf
 
 
-async def test_zeroconf_unsupported_service_aborts(hass):
+async def test_zeroconf_unsupported_service_aborts(hass: HomeAssistant) -> None:
     """Test discovering unsupported zeroconf service."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -1050,7 +1050,7 @@ async def test_reconfigure_update_credentials(hass, mrp_device, pairing):
 # Options
 
 
-async def test_option_start_off(hass):
+async def test_option_start_off(hass: HomeAssistant) -> None:
     """Test start off-option flag."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, unique_id="dmapid", options={"start_off": False}
@@ -1068,7 +1068,7 @@ async def test_option_start_off(hass):
     assert config_entry.options[CONF_START_OFF]
 
 
-async def test_zeroconf_rejects_ipv6(hass):
+async def test_zeroconf_rejects_ipv6(hass: HomeAssistant) -> None:
     """Test zeroconf discovery rejects ipv6."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -414,7 +414,7 @@ async def test_import_named_credential(
     ]
 
 
-async def test_config_flow_no_credentials(hass):
+async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     """Test config flow base case with no credentials registered."""
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,12 +1,13 @@
 """The tests for the apprise notification platform."""
 from unittest.mock import MagicMock, patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 BASE_COMPONENT = "notify"
 
 
-async def test_apprise_config_load_fail01(hass):
+async def test_apprise_config_load_fail01(hass: HomeAssistant) -> None:
     """Test apprise configuration failures 1."""
 
     config = {
@@ -21,7 +22,7 @@ async def test_apprise_config_load_fail01(hass):
         assert not hass.services.has_service(BASE_COMPONENT, "test")
 
 
-async def test_apprise_config_load_fail02(hass):
+async def test_apprise_config_load_fail02(hass: HomeAssistant) -> None:
     """Test apprise configuration failures 2."""
 
     config = {
@@ -56,7 +57,7 @@ async def test_apprise_config_load_okay(hass, tmp_path):
     assert hass.services.has_service(BASE_COMPONENT, "test")
 
 
-async def test_apprise_url_load_fail(hass):
+async def test_apprise_url_load_fail(hass: HomeAssistant) -> None:
     """Test apprise url failure."""
 
     config = {
@@ -74,7 +75,7 @@ async def test_apprise_url_load_fail(hass):
         assert not hass.services.has_service(BASE_COMPONENT, "test")
 
 
-async def test_apprise_notification(hass):
+async def test_apprise_notification(hass: HomeAssistant) -> None:
     """Test apprise notification."""
 
     config = {

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -5,6 +5,7 @@ import aprslib
 import pytest
 
 import homeassistant.components.aprs.device_tracker as device_tracker
+from homeassistant.core import HomeAssistant
 
 DEFAULT_PORT = 14580
 
@@ -297,7 +298,7 @@ def test_aprs_listener_rx_msg_no_position() -> None:
         see.assert_not_called()
 
 
-async def test_setup_scanner(hass):
+async def test_setup_scanner(hass: HomeAssistant) -> None:
     """Test setup_scanner."""
     with patch(
         "homeassistant.components.aprs.device_tracker.AprsListenerThread"
@@ -321,7 +322,7 @@ async def test_setup_scanner(hass):
         )
 
 
-async def test_setup_scanner_timeout(hass):
+async def test_setup_scanner_timeout(hass: HomeAssistant) -> None:
     """Test setup_scanner failure from timeout."""
     with patch("aprslib.IS.connect", side_effect=TimeoutError):
         config = {

--- a/tests/components/aranet/test_config_flow.py
+++ b/tests/components/aranet/test_config_flow.py
@@ -16,7 +16,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -35,7 +35,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_aranet4(hass):
+async def test_async_step_bluetooth_not_aranet4(hass: HomeAssistant) -> None:
     """Test that we reject discovery via Bluetooth for an unrelated device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -45,7 +45,7 @@ async def test_async_step_bluetooth_not_aranet4(hass):
     assert result["type"] == FlowResultType.ABORT
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -62,7 +62,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -81,7 +81,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the Aranet sensors."""
-
-
 from homeassistant.components.aranet.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import DISABLED_INTEGRATIONS_SERVICE_INFO, VALID_DATA_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -66,7 +65,7 @@ async def test_sensors(hass):
     await hass.async_block_till_done()
 
 
-async def test_smart_home_integration_disabled(hass):
+async def test_smart_home_integration_disabled(hass: HomeAssistant) -> None:
     """Test disabling smart home integration marks entities as unavailable."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/arcam_fmj/test_config_flow.py
+++ b/tests/components/arcam_fmj/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Arcam FMJ config flow module."""
-
 from dataclasses import replace
 from unittest.mock import AsyncMock, patch
 
@@ -12,6 +11,7 @@ from homeassistant.components.arcam_fmj.config_flow import get_entry_client
 from homeassistant.components.arcam_fmj.const import DOMAIN, DOMAIN_DATA_ENTRIES
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE
+from homeassistant.core import HomeAssistant
 
 from .conftest import (
     MOCK_CONFIG_ENTRY,
@@ -23,6 +23,7 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_UPNP_DEVICE = f"""
 <root xmlns="urn:schemas-upnp-org:device-1-0">
@@ -75,7 +76,7 @@ async def test_ssdp(hass, dummy_client):
     assert result["data"] == MOCK_CONFIG_ENTRY
 
 
-async def test_ssdp_abort(hass):
+async def test_ssdp_abort(hass: HomeAssistant) -> None:
     """Test a ssdp import flow."""
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG_ENTRY, title=MOCK_NAME, unique_id=MOCK_UUID
@@ -123,7 +124,7 @@ async def test_ssdp_invalid_id(hass, dummy_client):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_ssdp_update(hass):
+async def test_ssdp_update(hass: HomeAssistant) -> None:
     """Test a ssdp import flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -144,7 +145,7 @@ async def test_ssdp_update(hass):
     assert entry.data[CONF_HOST] == MOCK_HOST
 
 
-async def test_user(hass, aioclient_mock):
+async def test_user(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test a manual user configuration flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -171,7 +172,9 @@ async def test_user(hass, aioclient_mock):
     assert result["result"].unique_id == MOCK_UUID
 
 
-async def test_invalid_ssdp(hass, aioclient_mock):
+async def test_invalid_ssdp(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a a config flow where ssdp fails."""
     user_input = {
         CONF_HOST: MOCK_HOST,
@@ -190,7 +193,9 @@ async def test_invalid_ssdp(hass, aioclient_mock):
     assert result["result"].unique_id is None
 
 
-async def test_user_wrong(hass, aioclient_mock):
+async def test_user_wrong(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a manual user configuration flow with no ssdp response."""
     user_input = {
         CONF_HOST: MOCK_HOST,
@@ -208,7 +213,7 @@ async def test_user_wrong(hass, aioclient_mock):
     assert result["result"].unique_id is None
 
 
-async def test_get_entry_client(hass):
+async def test_get_entry_client(hass: HomeAssistant) -> None:
     """Test helper for configuration."""
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG_ENTRY, title=MOCK_NAME, unique_id=MOCK_UUID

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -122,7 +122,7 @@ async def test_error_wrong_password_ssh(hass, config, error):
     assert result["errors"] == {"base": error}
 
 
-async def test_error_invalid_ssh(hass):
+async def test_error_invalid_ssh(hass: HomeAssistant) -> None:
     """Test we abort if invalid ssh file is provided."""
     config_data = CONFIG_DATA.copy()
     config_data.pop(CONF_PASSWORD)
@@ -142,7 +142,7 @@ async def test_error_invalid_ssh(hass):
         assert result["errors"] == {"base": "ssh_not_file"}
 
 
-async def test_error_invalid_host(hass):
+async def test_error_invalid_host(hass: HomeAssistant) -> None:
     """Test we abort if host name is invalid."""
     with patch(
         "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
@@ -158,7 +158,7 @@ async def test_error_invalid_host(hass):
         assert result["errors"] == {"base": "invalid_host"}
 
 
-async def test_abort_if_not_unique_id_setup(hass):
+async def test_abort_if_not_unique_id_setup(hass: HomeAssistant) -> None:
     """Test we abort if component without uniqueid is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -202,7 +202,7 @@ async def test_update_uniqueid_exist(hass, mock_unique_id):
 
 
 @pytest.mark.usefixtures("connect")
-async def test_abort_invalid_unique_id(hass):
+async def test_abort_invalid_unique_id(hass: HomeAssistant) -> None:
     """Test we abort if uniqueid not available."""
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 import homeassistant.util.dt as dt_util
 
@@ -32,7 +33,7 @@ def _timetoken():
     return str(time.time_ns())[:-2]
 
 
-async def test_doorsense(hass):
+async def test_doorsense(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_lock_from_fixture(
         hass, "get_lock.online_with_doorsense.json"
@@ -66,7 +67,7 @@ async def test_doorsense(hass):
     assert binary_sensor_online_with_doorsense_name.state == STATE_OFF
 
 
-async def test_lock_bridge_offline(hass):
+async def test_lock_bridge_offline(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that goes offline."""
     lock_one = await _mock_lock_from_fixture(
         hass, "get_lock.online_with_doorsense.json"
@@ -82,7 +83,7 @@ async def test_lock_bridge_offline(hass):
     assert binary_sensor_online_with_doorsense_name.state == STATE_UNAVAILABLE
 
 
-async def test_create_doorbell(hass):
+async def test_create_doorbell(hass: HomeAssistant) -> None:
     """Test creation of a doorbell."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
     await _create_august_with_devices(hass, [doorbell_one])
@@ -113,7 +114,7 @@ async def test_create_doorbell(hass):
     assert binary_sensor_k98gidt45gul_name_image_capture.state == STATE_OFF
 
 
-async def test_create_doorbell_offline(hass):
+async def test_create_doorbell_offline(hass: HomeAssistant) -> None:
     """Test creation of a doorbell that is offline."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
@@ -130,7 +131,7 @@ async def test_create_doorbell_offline(hass):
     assert binary_sensor_tmt100_name_ding.state == STATE_UNAVAILABLE
 
 
-async def test_create_doorbell_with_motion(hass):
+async def test_create_doorbell_with_motion(hass: HomeAssistant) -> None:
     """Test creation of a doorbell."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
     activities = await _mock_activities_from_fixture(
@@ -164,7 +165,7 @@ async def test_create_doorbell_with_motion(hass):
     assert binary_sensor_k98gidt45gul_name_motion.state == STATE_OFF
 
 
-async def test_doorbell_update_via_pubnub(hass):
+async def test_doorbell_update_via_pubnub(hass: HomeAssistant) -> None:
     """Test creation of a doorbell that can be updated via pubnub."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
     pubnub = AugustPubNub()
@@ -294,7 +295,7 @@ async def test_doorbell_update_via_pubnub(hass):
     assert binary_sensor_k98gidt45gul_name_ding.state == STATE_OFF
 
 
-async def test_doorbell_device_registry(hass):
+async def test_doorbell_device_registry(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge ands up in the registry."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
@@ -308,7 +309,7 @@ async def test_doorbell_device_registry(hass):
     assert reg_device.sw_version == "3.1.0-HYDRC75+201909251139"
 
 
-async def test_door_sense_update_via_pubnub(hass):
+async def test_door_sense_update_via_pubnub(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     assert lock_one.pubsub_channel == "pubsub"

--- a/tests/components/august/test_button.py
+++ b/tests/components/august/test_button.py
@@ -1,12 +1,12 @@
 """The button tests for the august platform."""
-
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 
 from .mocks import _create_august_api_with_devices, _mock_lock_from_fixture
 
 
-async def test_wake_lock(hass):
+async def test_wake_lock(hass: HomeAssistant) -> None:
     """Test creation of a lock and wake it."""
     lock_one = await _mock_lock_from_fixture(
         hass, "get_lock.online_with_doorsense.json"

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -1,14 +1,18 @@
 """The camera tests for the august platform."""
-
 from http import HTTPStatus
 from unittest.mock import patch
 
 from homeassistant.const import STATE_IDLE
+from homeassistant.core import HomeAssistant
 
 from .mocks import _create_august_with_devices, _mock_doorbell_from_fixture
 
+from tests.typing import ClientSessionGenerator
 
-async def test_create_doorbell(hass, hass_client_no_auth):
+
+async def test_create_doorbell(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test creation of a doorbell."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
 

--- a/tests/components/august/test_config_flow.py
+++ b/tests/components/august/test_config_flow.py
@@ -17,11 +17,12 @@ from homeassistant.components.august.exceptions import (
     RequireValidation,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -58,7 +59,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -81,7 +82,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_unexpected_exception(hass):
+async def test_user_unexpected_exception(hass: HomeAssistant) -> None:
     """Test we handle an unexpected exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -104,7 +105,7 @@ async def test_user_unexpected_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -127,7 +128,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_needs_validate(hass):
+async def test_form_needs_validate(hass: HomeAssistant) -> None:
     """Test we present validation when we need to validate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -212,7 +213,7 @@ async def test_form_needs_validate(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_reauth(hass):
+async def test_form_reauth(hass: HomeAssistant) -> None:
     """Test reauthenticate."""
 
     entry = MockConfigEntry(
@@ -255,7 +256,7 @@ async def test_form_reauth(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_reauth_with_2fa(hass):
+async def test_form_reauth_with_2fa(hass: HomeAssistant) -> None:
     """Test reauthenticate with 2fa."""
 
     entry = MockConfigEntry(

--- a/tests/components/august/test_diagnostics.py
+++ b/tests/components/august/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test august diagnostics."""
+from homeassistant.core import HomeAssistant
 
 from .mocks import (
     _create_august_api_with_devices,
@@ -7,9 +8,12 @@ from .mocks import (
 )
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_diagnostics(hass, hass_client):
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test generating diagnostics for a config entry."""
     lock_one = await _mock_lock_from_fixture(
         hass, "get_lock.online_with_doorsense.json"

--- a/tests/components/august/test_gateway.py
+++ b/tests/components/august/test_gateway.py
@@ -5,11 +5,12 @@ from yalexs.authenticator_common import AuthenticationState
 
 from homeassistant.components.august.const import DOMAIN
 from homeassistant.components.august.gateway import AugustGateway
+from homeassistant.core import HomeAssistant
 
 from .mocks import _mock_august_authentication, _mock_get_config
 
 
-async def test_refresh_access_token(hass):
+async def test_refresh_access_token(hass: HomeAssistant) -> None:
     """Test token refreshes."""
     await _patched_refresh_access_token(hass, "new_token", 5678)
 

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_LOCKED,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -35,7 +36,7 @@ from .mocks import (
 from tests.common import MockConfigEntry
 
 
-async def test_august_api_is_failing(hass):
+async def test_august_api_is_failing(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_RETRY when august api is failing."""
 
     config_entry = MockConfigEntry(
@@ -55,7 +56,7 @@ async def test_august_api_is_failing(hass):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_august_is_offline(hass):
+async def test_august_is_offline(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_RETRY when august is offline."""
 
     config_entry = MockConfigEntry(
@@ -75,7 +76,7 @@ async def test_august_is_offline(hass):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unlock_throws_august_api_http_error(hass):
+async def test_unlock_throws_august_api_http_error(hass: HomeAssistant) -> None:
     """Test unlock throws correct error on http error."""
     mocked_lock_detail = await _mock_operative_august_lock_detail(hass)
 
@@ -101,7 +102,7 @@ async def test_unlock_throws_august_api_http_error(hass):
     )
 
 
-async def test_lock_throws_august_api_http_error(hass):
+async def test_lock_throws_august_api_http_error(hass: HomeAssistant) -> None:
     """Test lock throws correct error on http error."""
     mocked_lock_detail = await _mock_operative_august_lock_detail(hass)
 
@@ -127,7 +128,7 @@ async def test_lock_throws_august_api_http_error(hass):
     )
 
 
-async def test_inoperative_locks_are_filtered_out(hass):
+async def test_inoperative_locks_are_filtered_out(hass: HomeAssistant) -> None:
     """Ensure inoperative locks do not get setup."""
     august_operative_lock = await _mock_operative_august_lock_detail(hass)
     august_inoperative_lock = await _mock_inoperative_august_lock_detail(hass)
@@ -143,7 +144,7 @@ async def test_inoperative_locks_are_filtered_out(hass):
     assert lock_a6697750d607098bae8d6baa11ef8063_name.state == STATE_LOCKED
 
 
-async def test_lock_has_doorsense(hass):
+async def test_lock_has_doorsense(hass: HomeAssistant) -> None:
     """Check to see if a lock has doorsense."""
     doorsenselock = await _mock_doorsense_enabled_august_lock_detail(hass)
     nodoorsenselock = await _mock_doorsense_missing_august_lock_detail(hass)
@@ -159,7 +160,7 @@ async def test_lock_has_doorsense(hass):
     assert binary_sensor_missing_doorsense_id_name_open is None
 
 
-async def test_auth_fails(hass):
+async def test_auth_fails(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_ERROR when auth fails."""
 
     config_entry = MockConfigEntry(
@@ -184,7 +185,7 @@ async def test_auth_fails(hass):
     assert flows[0]["step_id"] == "reauth_validate"
 
 
-async def test_bad_password(hass):
+async def test_bad_password(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_ERROR when the password has been changed."""
 
     config_entry = MockConfigEntry(
@@ -211,7 +212,7 @@ async def test_bad_password(hass):
     assert flows[0]["step_id"] == "reauth_validate"
 
 
-async def test_http_failure(hass):
+async def test_http_failure(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_RETRY when august is offline."""
 
     config_entry = MockConfigEntry(
@@ -234,7 +235,7 @@ async def test_http_failure(hass):
     assert hass.config_entries.flow.async_progress() == []
 
 
-async def test_unknown_auth_state(hass):
+async def test_unknown_auth_state(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_ERROR when august is in an unknown auth state."""
 
     config_entry = MockConfigEntry(
@@ -259,7 +260,7 @@ async def test_unknown_auth_state(hass):
     assert flows[0]["step_id"] == "reauth_validate"
 
 
-async def test_requires_validation_state(hass):
+async def test_requires_validation_state(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_ERROR when august requires validation."""
 
     config_entry = MockConfigEntry(
@@ -285,7 +286,7 @@ async def test_requires_validation_state(hass):
     assert hass.config_entries.flow.async_progress()[0]["context"]["source"] == "reauth"
 
 
-async def test_unknown_auth_http_401(hass):
+async def test_unknown_auth_http_401(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_ERROR when august gets an http."""
 
     config_entry = MockConfigEntry(
@@ -310,7 +311,7 @@ async def test_unknown_auth_http_401(hass):
     assert flows[0]["step_id"] == "reauth_validate"
 
 
-async def test_load_unload(hass):
+async def test_load_unload(hass: HomeAssistant) -> None:
     """Config entry can be unloaded."""
 
     august_operative_lock = await _mock_operative_august_lock_detail(hass)
@@ -325,7 +326,7 @@ async def test_load_unload(hass):
     await hass.async_block_till_done()
 
 
-async def test_load_triggers_ble_discovery(hass):
+async def test_load_triggers_ble_discovery(hass: HomeAssistant) -> None:
     """Test that loading a lock that supports offline ble operation passes the keys to yalexe_ble."""
 
     august_lock_with_key = await _mock_lock_with_offline_key(hass)

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -34,6 +34,7 @@ from .mocks import (
 )
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_august_api_is_failing(hass: HomeAssistant) -> None:
@@ -365,7 +366,9 @@ async def remove_device(ws_client, device_id, config_entry_id):
     return response["success"]
 
 
-async def test_device_remove_devices(hass, hass_ws_client):
+async def test_device_remove_devices(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can only remove a device that no longer exists."""
     assert await async_setup_component(hass, "config", {})
     august_operative_lock = await _mock_operative_august_lock_detail(hass)

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -34,7 +35,7 @@ from .mocks import (
 from tests.common import async_fire_time_changed
 
 
-async def test_lock_device_registry(hass):
+async def test_lock_device_registry(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge ands up in the registry."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     await _create_august_with_devices(hass, [lock_one])
@@ -50,7 +51,7 @@ async def test_lock_device_registry(hass):
     assert reg_device.manufacturer == "August Home Inc."
 
 
-async def test_lock_changed_by(hass):
+async def test_lock_changed_by(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -67,7 +68,7 @@ async def test_lock_changed_by(hass):
     )
 
 
-async def test_state_locking(hass):
+async def test_state_locking(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that is locking."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -79,7 +80,7 @@ async def test_state_locking(hass):
     assert lock_online_with_doorsense_name.state == STATE_LOCKING
 
 
-async def test_state_unlocking(hass):
+async def test_state_unlocking(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that is unlocking."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -93,7 +94,7 @@ async def test_state_unlocking(hass):
     assert lock_online_with_doorsense_name.state == STATE_UNLOCKING
 
 
-async def test_state_jammed(hass):
+async def test_state_jammed(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that is jammed."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -105,7 +106,7 @@ async def test_state_jammed(hass):
     assert lock_online_with_doorsense_name.state == STATE_JAMMED
 
 
-async def test_one_lock_operation(hass):
+async def test_one_lock_operation(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     await _create_august_with_devices(hass, [lock_one])
@@ -155,7 +156,7 @@ async def test_one_lock_operation(hass):
     )
 
 
-async def test_one_lock_operation_pubnub_connected(hass):
+async def test_one_lock_operation_pubnub_connected(hass: HomeAssistant) -> None:
     """Test lock and unlock operations are async when pubnub is connected."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     assert lock_one.pubsub_channel == "pubsub"
@@ -235,7 +236,7 @@ async def test_one_lock_operation_pubnub_connected(hass):
     )
 
 
-async def test_lock_jammed(hass):
+async def test_lock_jammed(hass: HomeAssistant) -> None:
     """Test lock gets jammed on unlock."""
 
     def _unlock_return_activities_side_effect(access_token, device_id):
@@ -270,7 +271,9 @@ async def test_lock_jammed(hass):
     assert lock_online_with_doorsense_name.state == STATE_JAMMED
 
 
-async def test_lock_throws_exception_on_unknown_status_code(hass):
+async def test_lock_throws_exception_on_unknown_status_code(
+    hass: HomeAssistant,
+) -> None:
     """Test lock throws exception."""
 
     def _unlock_return_activities_side_effect(access_token, device_id):
@@ -303,7 +306,7 @@ async def test_lock_throws_exception_on_unknown_status_code(hass):
         await hass.async_block_till_done()
 
 
-async def test_one_lock_unknown_state(hass):
+async def test_one_lock_unknown_state(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_lock_from_fixture(
         hass,
@@ -316,7 +319,7 @@ async def test_one_lock_unknown_state(hass):
     assert lock_brokenid_name.state == STATE_UNKNOWN
 
 
-async def test_lock_bridge_offline(hass):
+async def test_lock_bridge_offline(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that goes offline."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -330,7 +333,7 @@ async def test_lock_bridge_offline(hass):
     assert lock_online_with_doorsense_name.state == STATE_UNAVAILABLE
 
 
-async def test_lock_bridge_online(hass):
+async def test_lock_bridge_online(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge that goes offline."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -344,7 +347,7 @@ async def test_lock_bridge_online(hass):
     assert lock_online_with_doorsense_name.state == STATE_LOCKED
 
 
-async def test_lock_update_via_pubnub(hass):
+async def test_lock_update_via_pubnub(hass: HomeAssistant) -> None:
     """Test creation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     assert lock_one.pubsub_channel == "pubsub"

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -1,5 +1,6 @@
 """The sensor tests for the august platform."""
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .mocks import (
@@ -11,7 +12,7 @@ from .mocks import (
 )
 
 
-async def test_create_doorbell(hass):
+async def test_create_doorbell(hass: HomeAssistant) -> None:
     """Test creation of a doorbell."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
     await _create_august_with_devices(hass, [doorbell_one])
@@ -25,7 +26,7 @@ async def test_create_doorbell(hass):
     )
 
 
-async def test_create_doorbell_offline(hass):
+async def test_create_doorbell_offline(hass: HomeAssistant) -> None:
     """Test creation of a doorbell that is offline."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
@@ -40,7 +41,7 @@ async def test_create_doorbell_offline(hass):
     assert entry.unique_id == "tmt100_device_battery"
 
 
-async def test_create_doorbell_hardwired(hass):
+async def test_create_doorbell_hardwired(hass: HomeAssistant) -> None:
     """Test creation of a doorbell that is hardwired without a battery."""
     doorbell_one = await _mock_doorbell_from_fixture(
         hass, "get_doorbell.nobattery.json"
@@ -51,7 +52,7 @@ async def test_create_doorbell_hardwired(hass):
     assert sensor_tmt100_name_battery is None
 
 
-async def test_create_lock_with_linked_keypad(hass):
+async def test_create_lock_with_linked_keypad(hass: HomeAssistant) -> None:
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.doorsense_init.json")
     await _create_august_with_devices(hass, [lock_one])
@@ -81,7 +82,7 @@ async def test_create_lock_with_linked_keypad(hass):
     assert entry.unique_id == "5bc65c24e6ef2a263e1450a8_linked_keypad_battery"
 
 
-async def test_create_lock_with_low_battery_linked_keypad(hass):
+async def test_create_lock_with_low_battery_linked_keypad(hass: HomeAssistant) -> None:
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.low_keypad_battery.json")
     await _create_august_with_devices(hass, [lock_one])
@@ -124,7 +125,7 @@ async def test_create_lock_with_low_battery_linked_keypad(hass):
     )
 
 
-async def test_lock_operator_bluetooth(hass):
+async def test_lock_operator_bluetooth(hass: HomeAssistant) -> None:
     """Test operation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -168,7 +169,7 @@ async def test_lock_operator_bluetooth(hass):
     )
 
 
-async def test_lock_operator_keypad(hass):
+async def test_lock_operator_keypad(hass: HomeAssistant) -> None:
     """Test operation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -212,7 +213,7 @@ async def test_lock_operator_keypad(hass):
     )
 
 
-async def test_lock_operator_remote(hass):
+async def test_lock_operator_remote(hass: HomeAssistant) -> None:
     """Test operation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 
@@ -254,7 +255,7 @@ async def test_lock_operator_remote(hass):
     )
 
 
-async def test_lock_operator_autorelock(hass):
+async def test_lock_operator_autorelock(hass: HomeAssistant) -> None:
     """Test operation of a lock with doorsense and bridge."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
 

--- a/tests/components/aurora/test_config_flow.py
+++ b/tests/components/aurora/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Aurora config flow."""
-
 from unittest.mock import patch
 
 from aiohttp import ClientError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.aurora.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -16,7 +16,7 @@ DATA = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -44,7 +44,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test if invalid response or no connection returned from the API."""
 
     result = await hass.config_entries.flow.async_init(
@@ -65,7 +65,7 @@ async def test_form_cannot_connect(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_with_unknown_error(hass):
+async def test_with_unknown_error(hass: HomeAssistant) -> None:
     """Test with unknown error response from the API."""
 
     result = await hass.config_entries.flow.async_init(
@@ -86,7 +86,7 @@ async def test_with_unknown_error(hass):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_option_flow(hass):
+async def test_option_flow(hass: HomeAssistant) -> None:
     """Test option flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=DATA)
     entry.add_to_hass(hass)

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -13,11 +13,12 @@ from homeassistant.components.aurora_abb_powerone.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 TEST_DATA = {"device": "/dev/ttyUSB7", "address": 3, "name": "MyAuroraPV"}
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -75,7 +76,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_no_comports(hass):
+async def test_form_no_comports(hass: HomeAssistant) -> None:
     """Test we display correct info when there are no com ports.."""
 
     fakecomports = []
@@ -90,7 +91,7 @@ async def test_form_no_comports(hass):
     assert result["reason"] == "no_serial_ports"
 
 
-async def test_form_invalid_com_ports(hass):
+async def test_form_invalid_com_ports(hass: HomeAssistant) -> None:
     """Test we display correct info when the comport is invalid.."""
 
     fakecomports = []

--- a/tests/components/aurora_abb_powerone/test_init.py
+++ b/tests/components/aurora_abb_powerone/test_init.py
@@ -8,12 +8,13 @@ from homeassistant.components.aurora_abb_powerone.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unloading the aurora_abb_powerone entry."""
 
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.aurora_abb_powerone.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -54,7 +55,7 @@ def _mock_config_entry():
     )
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test data coming back from inverter."""
     mock_entry = _mock_config_entry()
 
@@ -94,7 +95,7 @@ async def test_sensors(hass):
         assert energy.state == "12.35"
 
 
-async def test_sensor_dark(hass):
+async def test_sensor_dark(hass: HomeAssistant) -> None:
     """Test that darkness (no comms) is handled correctly."""
     mock_entry = _mock_config_entry()
 
@@ -152,7 +153,7 @@ async def test_sensor_dark(hass):
         assert power.state == "unknown"  # should this be 'available'?
 
 
-async def test_sensor_unknown_error(hass):
+async def test_sensor_unknown_error(hass: HomeAssistant) -> None:
     """Test other comms error is handled correctly."""
     mock_entry = _mock_config_entry()
 

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -1,6 +1,7 @@
 """Aussie Broadband sensor platform tests."""
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 
 from .common import setup_platform
 
@@ -39,7 +40,7 @@ MOCK_VOIP_USAGE = {
 }
 
 
-async def test_nbn_sensor_states(hass):
+async def test_nbn_sensor_states(hass: HomeAssistant) -> None:
     """Tests that the sensors are correct."""
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_NBN_USAGE)
@@ -57,7 +58,7 @@ async def test_nbn_sensor_states(hass):
     )
 
 
-async def test_phone_sensor_states(hass):
+async def test_phone_sensor_states(hass: HomeAssistant) -> None:
     """Tests that the sensors are correct."""
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_MOBILE_USAGE)
@@ -76,7 +77,7 @@ async def test_phone_sensor_states(hass):
     )
 
 
-async def test_voip_sensor_states(hass):
+async def test_voip_sensor_states(hass: HomeAssistant) -> None:
     """Tests that the sensors are correct."""
 
     await setup_platform(hass, [SENSOR_DOMAIN], usage=MOCK_VOIP_USAGE)

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -8,12 +8,14 @@ import pytest
 from homeassistant.auth import InvalidAuthError
 from homeassistant.auth.models import Credentials
 from homeassistant.components import auth
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, MockUser
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -46,7 +48,9 @@ async def async_setup_user_refresh_token(hass):
     )
 
 
-async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
+async def test_login_new_user_and_trying_refresh_token(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in with new user and refreshing tokens."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     resp = await client.post(
@@ -114,7 +118,9 @@ async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
     assert resp.status == HTTPStatus.OK
 
 
-async def test_auth_code_checks_local_only_user(hass, aiohttp_client):
+async def test_auth_code_checks_local_only_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test local only user cannot exchange auth code for refresh tokens when external."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     resp = await client.post(
@@ -220,7 +226,9 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
     assert "data" not in hass_cred
 
 
-async def test_cors_on_token(hass, aiohttp_client):
+async def test_cors_on_token(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in with new user and refreshing tokens."""
     client = await async_setup_auth(hass, aiohttp_client)
 
@@ -238,7 +246,9 @@ async def test_cors_on_token(hass, aiohttp_client):
     assert resp.headers["Access-Control-Allow-Origin"] == "http://example.com"
 
 
-async def test_refresh_token_system_generated(hass, aiohttp_client):
+async def test_refresh_token_system_generated(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test that we can get access tokens for system generated user."""
     client = await async_setup_auth(hass, aiohttp_client)
     user = await hass.auth.async_create_system_user("Test System")
@@ -269,7 +279,9 @@ async def test_refresh_token_system_generated(hass, aiohttp_client):
     )
 
 
-async def test_refresh_token_different_client_id(hass, aiohttp_client):
+async def test_refresh_token_different_client_id(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test that we verify client ID."""
     client = await async_setup_auth(hass, aiohttp_client)
     refresh_token = await async_setup_user_refresh_token(hass)
@@ -315,7 +327,9 @@ async def test_refresh_token_different_client_id(hass, aiohttp_client):
     )
 
 
-async def test_refresh_token_checks_local_only_user(hass, aiohttp_client):
+async def test_refresh_token_checks_local_only_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test that we can't refresh token for a local only user when external."""
     client = await async_setup_auth(hass, aiohttp_client)
     refresh_token = await async_setup_user_refresh_token(hass)

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -2,9 +2,12 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
+
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
+from tests.typing import ClientSessionGenerator
 
 
 async def async_get_code(hass, aiohttp_client):
@@ -64,7 +67,9 @@ async def async_get_code(hass, aiohttp_client):
     }
 
 
-async def test_link_user(hass, aiohttp_client):
+async def test_link_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to new credentials."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
@@ -81,7 +86,9 @@ async def test_link_user(hass, aiohttp_client):
     assert len(info["user"].credentials) == 1
 
 
-async def test_link_user_invalid_client_id(hass, aiohttp_client):
+async def test_link_user_invalid_client_id(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to new credentials."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
@@ -98,7 +105,9 @@ async def test_link_user_invalid_client_id(hass, aiohttp_client):
     assert len(info["user"].credentials) == 0
 
 
-async def test_link_user_invalid_code(hass, aiohttp_client):
+async def test_link_user_invalid_code(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to new credentials."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
@@ -114,7 +123,9 @@ async def test_link_user_invalid_code(hass, aiohttp_client):
     assert len(info["user"].credentials) == 0
 
 
-async def test_link_user_invalid_auth(hass, aiohttp_client):
+async def test_link_user_invalid_auth(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to new credentials."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
@@ -131,7 +142,9 @@ async def test_link_user_invalid_auth(hass, aiohttp_client):
     assert len(info["user"].credentials) == 0
 
 
-async def test_link_user_already_linked_same_user(hass, aiohttp_client):
+async def test_link_user_already_linked_same_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to a credential it's already linked to."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
@@ -152,7 +165,9 @@ async def test_link_user_already_linked_same_user(hass, aiohttp_client):
     assert len(info["user"].credentials) == 0
 
 
-async def test_link_user_already_linked_other_user(hass, aiohttp_client):
+async def test_link_user_already_linked_other_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test linking a user to a credential already linked to other user."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -2,12 +2,17 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
+
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
+from tests.typing import ClientSessionGenerator
 
 
-async def test_fetch_auth_providers(hass, aiohttp_client):
+async def test_fetch_auth_providers(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test fetching auth providers."""
     client = await async_setup_auth(hass, aiohttp_client)
     resp = await client.get("/auth/providers")
@@ -17,7 +22,9 @@ async def test_fetch_auth_providers(hass, aiohttp_client):
     ]
 
 
-async def test_fetch_auth_providers_onboarding(hass, aiohttp_client):
+async def test_fetch_auth_providers_onboarding(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test fetching auth providers."""
     client = await async_setup_auth(hass, aiohttp_client)
     with patch(
@@ -32,14 +39,18 @@ async def test_fetch_auth_providers_onboarding(hass, aiohttp_client):
     }
 
 
-async def test_cannot_get_flows_in_progress(hass, aiohttp_client):
+async def test_cannot_get_flows_in_progress(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test we cannot get flows in progress."""
     client = await async_setup_auth(hass, aiohttp_client, [])
     resp = await client.get("/auth/login_flow")
     assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-async def test_invalid_username_password(hass, aiohttp_client):
+async def test_invalid_username_password(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test we cannot get flows in progress."""
     client = await async_setup_auth(hass, aiohttp_client)
     resp = await client.post(
@@ -114,7 +125,9 @@ async def test_invalid_username_password(hass, aiohttp_client):
     assert step["errors"]["base"] == "invalid_auth"
 
 
-async def test_invalid_redirect_uri(hass, aiohttp_client):
+async def test_invalid_redirect_uri(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test invalid redirect URI."""
     client = await async_setup_auth(hass, aiohttp_client)
     resp = await client.post(
@@ -149,7 +162,9 @@ async def test_invalid_redirect_uri(hass, aiohttp_client):
     assert data["message"] == "Invalid redirect URI"
 
 
-async def test_login_exist_user(hass, aiohttp_client):
+async def test_login_exist_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in with exist user."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     cred = await hass.auth.auth_providers[0].async_get_or_create_credentials(
@@ -187,7 +202,9 @@ async def test_login_exist_user(hass, aiohttp_client):
     assert len(mock_process_success_login.mock_calls) == 1
 
 
-async def test_login_local_only_user(hass, aiohttp_client):
+async def test_login_local_only_user(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in with local only user."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     cred = await hass.auth.auth_providers[0].async_get_or_create_credentials(
@@ -225,7 +242,9 @@ async def test_login_local_only_user(hass, aiohttp_client):
     assert await resp.json() == {"message": "Login blocked: User is local only"}
 
 
-async def test_login_exist_user_ip_changes(hass, aiohttp_client):
+async def test_login_exist_user_ip_changes(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in and the ip address changes results in an rejection."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     cred = await hass.auth.auth_providers[0].async_get_or_create_credentials(
@@ -270,7 +289,9 @@ async def test_login_exist_user_ip_changes(hass, aiohttp_client):
     assert response == {"message": "IP address changed"}
 
 
-async def test_well_known_auth_info(hass, aiohttp_client):
+async def test_well_known_auth_info(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test logging in and the ip address changes results in an rejection."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
     resp = await client.get(

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -2,12 +2,16 @@
 from homeassistant import data_entry_flow
 from homeassistant.auth import auth_manager_from_config
 from homeassistant.components.auth import mfa_setup_flow
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import CLIENT_ID, MockUser, ensure_auth_manager_loaded
+from tests.typing import WebSocketGenerator
 
 
-async def test_ws_setup_depose_mfa(hass, hass_ws_client):
+async def test_ws_setup_depose_mfa(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test set up mfa module for current user."""
     hass.auth = await auth_manager_from_config(
         hass,

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, yaml
 
@@ -40,7 +40,7 @@ def patch_blueprint(blueprint_path: str, data_path):
         yield
 
 
-async def test_notify_leaving_zone(hass):
+async def test_notify_leaving_zone(hass: HomeAssistant) -> None:
     """Test notifying leaving a zone blueprint."""
 
     def set_person_state(state, extra={}):
@@ -128,7 +128,7 @@ async def test_notify_leaving_zone(hass):
         assert len(mock_call_action.mock_calls) == 3
 
 
-async def test_motion_light(hass):
+async def test_motion_light(hass: HomeAssistant) -> None:
     """Test motion light blueprint."""
     hass.states.async_set("binary_sensor.kitchen", "off")
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1098,7 +1098,7 @@ async def test_reload_automation_when_blueprint_changes(hass, calls, extra_confi
         assert len(calls) == 3
 
 
-async def test_automation_restore_state(hass):
+async def test_automation_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     time = dt_util.utcnow()
 
@@ -1153,7 +1153,7 @@ async def test_automation_restore_state(hass):
     assert len(calls) == 1
 
 
-async def test_initial_value_off(hass):
+async def test_initial_value_off(hass: HomeAssistant) -> None:
     """Test initial value off."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1176,7 +1176,7 @@ async def test_initial_value_off(hass):
     assert len(calls) == 0
 
 
-async def test_initial_value_on(hass):
+async def test_initial_value_on(hass: HomeAssistant) -> None:
     """Test initial value on."""
     hass.state = CoreState.not_running
     calls = async_mock_service(hass, "test", "automation")
@@ -1205,7 +1205,7 @@ async def test_initial_value_on(hass):
     assert len(calls) == 1
 
 
-async def test_initial_value_off_but_restore_on(hass):
+async def test_initial_value_off_but_restore_on(hass: HomeAssistant) -> None:
     """Test initial value off and restored state is turned on."""
     hass.state = CoreState.not_running
     calls = async_mock_service(hass, "test", "automation")
@@ -1231,7 +1231,7 @@ async def test_initial_value_off_but_restore_on(hass):
     assert len(calls) == 0
 
 
-async def test_initial_value_on_but_restore_off(hass):
+async def test_initial_value_on_but_restore_off(hass: HomeAssistant) -> None:
     """Test initial value on and restored state is turned off."""
     calls = async_mock_service(hass, "test", "automation")
     mock_restore_cache(hass, (State("automation.hello", STATE_OFF),))
@@ -1255,7 +1255,7 @@ async def test_initial_value_on_but_restore_off(hass):
     assert len(calls) == 1
 
 
-async def test_no_initial_value_and_restore_off(hass):
+async def test_no_initial_value_and_restore_off(hass: HomeAssistant) -> None:
     """Test initial value off and restored state is turned on."""
     calls = async_mock_service(hass, "test", "automation")
     mock_restore_cache(hass, (State("automation.hello", STATE_OFF),))
@@ -1278,7 +1278,9 @@ async def test_no_initial_value_and_restore_off(hass):
     assert len(calls) == 0
 
 
-async def test_automation_is_on_if_no_initial_state_or_restore(hass):
+async def test_automation_is_on_if_no_initial_state_or_restore(
+    hass: HomeAssistant,
+) -> None:
     """Test initial value is on when no initial state or restored state."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1300,7 +1302,7 @@ async def test_automation_is_on_if_no_initial_state_or_restore(hass):
     assert len(calls) == 1
 
 
-async def test_automation_not_trigger_on_bootstrap(hass):
+async def test_automation_not_trigger_on_bootstrap(hass: HomeAssistant) -> None:
     """Test if automation is not trigger on bootstrap."""
     hass.state = CoreState.not_running
     calls = async_mock_service(hass, "test", "automation")
@@ -1438,7 +1440,9 @@ async def test_automation_with_error_in_script(
     assert issues[0]["issue_id"] == "automation.hello_service_not_found_test.automation"
 
 
-async def test_automation_with_error_in_script_2(hass, caplog):
+async def test_automation_with_error_in_script_2(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with an error in script."""
     assert await async_setup_component(
         hass,
@@ -1457,7 +1461,9 @@ async def test_automation_with_error_in_script_2(hass, caplog):
     assert "string value is None" in caplog.text
 
 
-async def test_automation_restore_last_triggered_with_initial_state(hass):
+async def test_automation_restore_last_triggered_with_initial_state(
+    hass: HomeAssistant,
+) -> None:
     """Ensure last_triggered is restored, even when initial state is set."""
     time = dt_util.utcnow()
 
@@ -1511,7 +1517,7 @@ async def test_automation_restore_last_triggered_with_initial_state(hass):
     assert state.attributes["last_triggered"] == time
 
 
-async def test_extraction_functions(hass):
+async def test_extraction_functions(hass: HomeAssistant) -> None:
     """Test extraction functions."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     assert await async_setup_component(
@@ -1682,7 +1688,7 @@ async def test_extraction_functions(hass):
     }
 
 
-async def test_logbook_humanify_automation_triggered_event(hass):
+async def test_logbook_humanify_automation_triggered_event(hass: HomeAssistant) -> None:
     """Test humanifying Automation Trigger event."""
     hass.config.components.add("recorder")
     await async_setup_component(hass, automation.DOMAIN, {})
@@ -1717,7 +1723,9 @@ async def test_logbook_humanify_automation_triggered_event(hass):
     assert event2["entity_id"] == "automation.bye"
 
 
-async def test_automation_variables(hass, caplog):
+async def test_automation_variables(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation variables."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1798,7 +1806,9 @@ async def test_automation_variables(hass, caplog):
     assert len(calls) == 3
 
 
-async def test_automation_trigger_variables(hass, caplog):
+async def test_automation_trigger_variables(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation trigger variables."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1864,7 +1874,9 @@ async def test_automation_trigger_variables(hass, caplog):
     assert "Error rendering variables" not in caplog.text
 
 
-async def test_automation_bad_trigger_variables(hass, caplog):
+async def test_automation_bad_trigger_variables(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation trigger variables accessing hass is rejected."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1892,7 +1904,9 @@ async def test_automation_bad_trigger_variables(hass, caplog):
     assert len(calls) == 0
 
 
-async def test_automation_this_var_always(hass, caplog):
+async def test_automation_this_var_always(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation always has reference to this, even with no variable or trigger variables configured."""
     calls = async_mock_service(hass, "test", "automation")
 
@@ -1997,7 +2011,9 @@ async def test_blueprint_automation_bad_config(
     assert details in caplog.text
 
 
-async def test_blueprint_automation_fails_substitution(hass, caplog):
+async def test_blueprint_automation_fails_substitution(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test blueprint automation with bad inputs."""
     with patch(
         "homeassistant.components.blueprint.models.BlueprintInputs.async_substitute",

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -58,6 +58,7 @@ from tests.common import (
 )
 from tests.components.logbook.common import MockRow, mock_humanify
 from tests.components.repairs import get_repairs
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -2351,7 +2352,9 @@ async def test_recursive_automation(hass: HomeAssistant, automation_mode, caplog
         assert "Disallowed recursion detected" not in caplog.text
 
 
-async def test_websocket_config(hass, hass_ws_client):
+async def test_websocket_config(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test config command."""
     config = {
         "alias": "hello",

--- a/tests/components/automation/test_logbook.py
+++ b/tests/components/automation/test_logbook.py
@@ -1,12 +1,12 @@
 """Test automation logbook."""
 from homeassistant.components import automation
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_automation_trigger_event(hass):
+async def test_humanify_automation_trigger_event(hass: HomeAssistant) -> None:
     """Test humanifying Shelly click event."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "automation", {})

--- a/tests/components/automation/test_reproduce_state.py
+++ b/tests/components/automation/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Automation."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Automation states."""
     hass.states.async_set("automation.entity_off", "off", {})
     hass.states.async_set("automation.entity_on", "on", {})

--- a/tests/components/aws/test_init.py
+++ b/tests/components/aws/test_init.py
@@ -2,6 +2,7 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, call, patch as async_patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -36,7 +37,7 @@ class MockAioSession:
         return ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
 
 
-async def test_empty_config(hass):
+async def test_empty_config(hass: HomeAssistant) -> None:
     """Test a default config will be create for empty config."""
     mock_session = MockAioSession()
     with async_patch(
@@ -49,7 +50,7 @@ async def test_empty_config(hass):
     mock_session.get_user.assert_not_awaited()
 
 
-async def test_empty_credential(hass):
+async def test_empty_credential(hass: HomeAssistant) -> None:
     """Test a default config will be create for empty credential section."""
     mock_session = MockAioSession()
     with async_patch(
@@ -79,7 +80,7 @@ async def test_empty_credential(hass):
     mock_session.invoke.assert_awaited_once()
 
 
-async def test_profile_credential(hass):
+async def test_profile_credential(hass: HomeAssistant) -> None:
     """Test credentials with profile name."""
     mock_session = MockAioSession()
     with async_patch(
@@ -114,7 +115,7 @@ async def test_profile_credential(hass):
     mock_session.publish.assert_awaited_once()
 
 
-async def test_access_key_credential(hass):
+async def test_access_key_credential(hass: HomeAssistant) -> None:
     """Test credentials with access key."""
     mock_session = MockAioSession()
     with async_patch(
@@ -156,7 +157,7 @@ async def test_access_key_credential(hass):
     mock_session.publish.assert_awaited_once()
 
 
-async def test_notify_credential(hass):
+async def test_notify_credential(hass: HomeAssistant) -> None:
     """Test notify service can use access key directly."""
     mock_session = MockAioSession()
     with async_patch(
@@ -190,7 +191,7 @@ async def test_notify_credential(hass):
     )
 
 
-async def test_notify_credential_profile(hass):
+async def test_notify_credential_profile(hass: HomeAssistant) -> None:
     """Test notify service can use profile directly."""
     mock_session = MockAioSession()
     with async_patch(
@@ -222,7 +223,7 @@ async def test_notify_credential_profile(hass):
     )
 
 
-async def test_credential_skip_validate(hass):
+async def test_credential_skip_validate(hass: HomeAssistant) -> None:
     """Test credential can skip validate."""
     mock_session = MockAioSession()
     with async_patch(
@@ -249,7 +250,7 @@ async def test_credential_skip_validate(hass):
     mock_session.get_user.assert_not_awaited()
 
 
-async def test_service_call_extra_data(hass):
+async def test_service_call_extra_data(hass: HomeAssistant) -> None:
     """Test service call extra data are parsed properly."""
     mock_session = MockAioSession()
     with async_patch(
@@ -293,7 +294,7 @@ async def test_service_call_extra_data(hass):
     )
 
 
-async def test_events_service_call(hass):
+async def test_events_service_call(hass: HomeAssistant) -> None:
     """Test events service (EventBridge) call works as expected."""
     mock_session = MockAioSession()
     with async_patch(
@@ -346,7 +347,7 @@ async def test_events_service_call(hass):
     )
 
 
-async def test_events_service_call_10_targets(hass):
+async def test_events_service_call_10_targets(hass: HomeAssistant) -> None:
     """Test events service (EventBridge) call works with more than 10 targets."""
     mock_session = MockAioSession()
     with async_patch(

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -1,17 +1,17 @@
 """Axis binary sensor platform tests."""
-
 from homeassistant.components.axis.const import DOMAIN as AXIS_DOMAIN
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import NAME
 
 
-async def test_platform_manually_configured(hass):
+async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     """Test that nothing happens when platform is manually configured."""
     assert (
         await async_setup_component(

--- a/tests/components/axis/test_camera.py
+++ b/tests/components/axis/test_camera.py
@@ -1,5 +1,4 @@
 """Axis camera platform tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -11,12 +10,13 @@ from homeassistant.components.axis.const import (
 )
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.const import STATE_IDLE
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import NAME
 
 
-async def test_platform_manually_configured(hass):
+async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     """Test that nothing happens when platform is manually configured."""
     assert (
         await async_setup_component(

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .const import DEFAULT_HOST, MAC, MODEL, NAME
@@ -108,7 +109,7 @@ async def test_manual_configuration_update_configuration(
     assert mock_config_entry.data[CONF_HOST] == "2.3.4.5"
 
 
-async def test_flow_fails_faulty_credentials(hass):
+async def test_flow_fails_faulty_credentials(hass: HomeAssistant) -> None:
     """Test that config flow fails on faulty credentials."""
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, context={"source": SOURCE_USER}
@@ -134,7 +135,7 @@ async def test_flow_fails_faulty_credentials(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_flow_fails_cannot_connect(hass):
+async def test_flow_fails_cannot_connect(hass: HomeAssistant) -> None:
     """Test that config flow fails on cannot connect."""
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/axis/test_light.py
+++ b/tests/components/axis/test_light.py
@@ -1,5 +1,4 @@
 """Axis light platform tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import DEFAULT_HOST, NAME
@@ -57,7 +57,7 @@ def light_control_fixture(light_control_items):
     )
 
 
-async def test_platform_manually_configured(hass):
+async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     """Test that nothing happens when platform is manually configured."""
     assert await async_setup_component(
         hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": AXIS_DOMAIN}}

--- a/tests/components/axis/test_switch.py
+++ b/tests/components/axis/test_switch.py
@@ -1,5 +1,4 @@
 """Axis switch platform tests."""
-
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,12 +12,13 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import API_DISCOVERY_PORT_MANAGEMENT, NAME
 
 
-async def test_platform_manually_configured(hass):
+async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     """Test that nothing happens when platform is manually configured."""
     assert await async_setup_component(
         hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: {"platform": AXIS_DOMAIN}}

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components import azure_event_hub
 from homeassistant.components.azure_event_hub.const import CONF_SEND_INTERVAL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -21,7 +22,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test the popping of the filter and further import of the config."""
     config = {
         DOMAIN: {
@@ -41,7 +42,7 @@ async def test_import(hass):
     assert await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_filter_only_config(hass):
+async def test_filter_only_config(hass: HomeAssistant) -> None:
     """Test the popping of the filter and further import of the config."""
     config = {
         DOMAIN: {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests (a):
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
