### PR TITLE
Add studio mode switch to Elgato

### DIFF
--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import ElgatoDataUpdateCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/elgato/switch.py
+++ b/homeassistant/components/elgato/switch.py
@@ -1,0 +1,113 @@
+"""Support for Elgato switches."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from elgato import Elgato, ElgatoError
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import ElgatoData, ElgatoDataUpdateCoordinator
+from .entity import ElgatoEntity
+
+
+@dataclass
+class ElgatoEntityDescriptionMixin:
+    """Mixin values for Elgato entities."""
+
+    is_on_fn: Callable[[ElgatoData], bool | None]
+    set_fn: Callable[[Elgato, bool], Awaitable[Any]]
+
+
+@dataclass
+class ElgatoSwitchEntityDescription(
+    SwitchEntityDescription, ElgatoEntityDescriptionMixin
+):
+    """Class describing Elgato switch entities."""
+
+    has_fn: Callable[[ElgatoData], bool] = lambda _: True
+
+
+SWITCHES = [
+    ElgatoSwitchEntityDescription(
+        key="bypass",
+        name="Studio mode",
+        icon="mdi:battery-off-outline",
+        entity_category=EntityCategory.CONFIG,
+        has_fn=lambda x: x.battery is not None,
+        is_on_fn=lambda x: x.settings.battery.bypass if x.settings.battery else None,
+        set_fn=lambda client, on: client.battery_bypass(on=on),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Elgato switches based on a config entry."""
+    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        ElgatoSwitchEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SWITCHES
+        if description.has_fn(coordinator.data)
+    )
+
+
+class ElgatoSwitchEntity(ElgatoEntity, SwitchEntity):
+    """Representation of an Elgato switch."""
+
+    entity_description: ElgatoSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ElgatoDataUpdateCoordinator,
+        description: ElgatoSwitchEntityDescription,
+    ) -> None:
+        """Initiate Elgato switch."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.data.info.serial_number}_{description.key}"
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return state of the switch."""
+        return self.entity_description.is_on_fn(self.coordinator.data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        try:
+            await self.entity_description.set_fn(self.coordinator.client, True)
+        except ElgatoError as error:
+            raise HomeAssistantError(
+                "An error occurred while updating the Elgato Light"
+            ) from error
+        finally:
+            await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        try:
+            await self.entity_description.set_fn(self.coordinator.client, False)
+        except ElgatoError as error:
+            raise HomeAssistantError(
+                "An error occurred while updating the Elgato Light"
+            ) from error
+        finally:
+            await self.coordinator.async_refresh()

--- a/tests/components/elgato/test_switch.py
+++ b/tests/components/elgato/test_switch.py
@@ -1,0 +1,110 @@
+"""Tests for the Elgato switch platform."""
+from unittest.mock import MagicMock
+
+from elgato import ElgatoError
+import pytest
+
+from homeassistant.components.elgato.const import DOMAIN
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    STATE_OFF,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
+
+
+@pytest.mark.parametrize("device_fixtures", ["key-light-mini"])
+@pytest.mark.usefixtures(
+    "device_fixtures",
+    "entity_registry_enabled_by_default",
+    "init_integration",
+)
+async def test_battery_bypass(hass: HomeAssistant, mock_elgato: MagicMock) -> None:
+    """Test the Elgato battery bypass switch."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("switch.frenck_studio_mode")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frenck Studio mode"
+    assert state.attributes.get(ATTR_ICON) == "mdi:battery-off-outline"
+    assert not state.attributes.get(ATTR_DEVICE_CLASS)
+
+    entry = entity_registry.async_get("switch.frenck_studio_mode")
+    assert entry
+    assert entry.unique_id == "GW24L1A02987_bypass"
+    assert entry.entity_category == EntityCategory.CONFIG
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.configuration_url is None
+    assert device_entry.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")
+    }
+    assert device_entry.entry_type is None
+    assert device_entry.identifiers == {(DOMAIN, "GW24L1A02987")}
+    assert device_entry.manufacturer == "Elgato"
+    assert device_entry.model == "Elgato Key Light Mini"
+    assert device_entry.name == "Frenck"
+    assert device_entry.sw_version == "1.0.4 (229)"
+    assert device_entry.hw_version == "202"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.frenck_studio_mode"},
+        blocking=True,
+    )
+
+    assert len(mock_elgato.battery_bypass.mock_calls) == 1
+    mock_elgato.battery_bypass.assert_called_once_with(on=True)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.frenck_studio_mode"},
+        blocking=True,
+    )
+
+    assert len(mock_elgato.battery_bypass.mock_calls) == 2
+    mock_elgato.battery_bypass.assert_called_with(on=False)
+
+    mock_elgato.battery_bypass.side_effect = ElgatoError
+
+    with pytest.raises(
+        HomeAssistantError, match="An error occurred while updating the Elgato Light"
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.frenck_studio_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(mock_elgato.battery_bypass.mock_calls) == 3
+
+    with pytest.raises(
+        HomeAssistantError, match="An error occurred while updating the Elgato Light"
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.frenck_studio_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(mock_elgato.battery_bypass.mock_calls) == 4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the switch platform to Elgato, providing a single "Studio mode" switch (available on battery-powered Elgato lights, which bypasses the battery when mains powered). More switches and functionality will be added in follow-up PRs.

![image](https://user-images.githubusercontent.com/195327/217499796-ce76f20f-1d63-4b5b-90a1-174a9c3bec8f.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26164

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
