### PR TITLE
Add type hints to integration tests (d-e)

### DIFF
--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components import zeroconf
 from homeassistant.components.daikin.const import KEY_MAC
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
@@ -100,7 +101,7 @@ async def test_device_abort(hass, mock_daikin, s_effect, reason):
     assert result["step_id"] == "user"
 
 
-async def test_api_password_abort(hass):
+async def test_api_password_abort(hass: HomeAssistant) -> None:
     """Test device abort."""
     result = await hass.config_entries.flow.async_init(
         "daikin",

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import forecastio
 from requests.exceptions import ConnectionError as ConnectError
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
@@ -77,7 +78,7 @@ async def test_setup_with_config(hass, requests_mock):
         assert state is not None
 
 
-async def test_setup_with_invalid_config(hass):
+async def test_setup_with_invalid_config(hass: HomeAssistant) -> None:
     """Test the platform setup with invalid configuration."""
     assert await async_setup_component(hass, "sensor", INVALID_CONFIG_MINIMAL)
     await hass.async_block_till_done()
@@ -86,7 +87,7 @@ async def test_setup_with_invalid_config(hass):
     assert state is None
 
 
-async def test_setup_with_language_config(hass):
+async def test_setup_with_language_config(hass: HomeAssistant) -> None:
     """Test the platform setup with language configuration."""
     with patch("homeassistant.components.darksky.sensor.forecastio.load_forecast"):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_LANG_DE)
@@ -96,7 +97,7 @@ async def test_setup_with_language_config(hass):
         assert state is not None
 
 
-async def test_setup_with_invalid_language_config(hass):
+async def test_setup_with_invalid_language_config(hass: HomeAssistant) -> None:
     """Test the platform setup with language configuration."""
     assert await async_setup_component(hass, "sensor", INVALID_CONFIG_LANG)
     await hass.async_block_till_done()
@@ -123,7 +124,7 @@ async def test_setup_bad_api_key(hass, requests_mock):
     assert hass.states.get("sensor.dark_sky_summary") is None
 
 
-async def test_connection_error(hass):
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test setting up with a connection error."""
     with patch(
         "homeassistant.components.darksky.sensor.forecastio.load_forecast",

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -6,6 +6,7 @@ import forecastio
 from requests.exceptions import ConnectionError as ConnectError
 
 from homeassistant.components import weather
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
@@ -36,7 +37,7 @@ async def test_setup(hass, requests_mock):
         assert state.state == "sunny"
 
 
-async def test_failed_setup(hass):
+async def test_failed_setup(hass: HomeAssistant) -> None:
     """Test to ensure that a network error does not break component state."""
     with patch("forecastio.load_forecast", side_effect=ConnectError()):
         assert await async_setup_component(

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -10,12 +10,13 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
 
 
-async def test_invalid_config(hass):
+async def test_invalid_config(hass: HomeAssistant) -> None:
     """Test invalid configuration."""
     with assert_setup_component(0):
         assert not await async_setup_component(
@@ -23,7 +24,7 @@ async def test_invalid_config(hass):
         )
 
 
-async def test_datadog_setup_full(hass):
+async def test_datadog_setup_full(hass: HomeAssistant) -> None:
     """Test setup with all data."""
     config = {datadog.DOMAIN: {"host": "host", "port": 123, "rate": 1, "prefix": "foo"}}
     hass.bus.listen = MagicMock()
@@ -41,7 +42,7 @@ async def test_datadog_setup_full(hass):
     assert hass.bus.listen.call_args_list[1][0][0] == EVENT_STATE_CHANGED
 
 
-async def test_datadog_setup_defaults(hass):
+async def test_datadog_setup_defaults(hass: HomeAssistant) -> None:
     """Test setup with defaults."""
     hass.bus.listen = mock.MagicMock()
 
@@ -65,7 +66,7 @@ async def test_datadog_setup_defaults(hass):
     assert hass.bus.listen.called
 
 
-async def test_logbook_entry(hass):
+async def test_logbook_entry(hass: HomeAssistant) -> None:
     """Test event listener."""
     hass.bus.listen = mock.MagicMock()
 
@@ -99,7 +100,7 @@ async def test_logbook_entry(hass):
         mock_statsd.event.reset_mock()
 
 
-async def test_state_changed(hass):
+async def test_state_changed(hass: HomeAssistant) -> None:
     """Test event listener."""
     hass.bus.listen = mock.MagicMock()
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -1,5 +1,4 @@
 """deCONZ alarm control panel platform tests."""
-
 from unittest.mock import patch
 
 from pydeconz.models.sensor.ancillary_control import AncillaryControlPanel
@@ -24,6 +23,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -31,8 +31,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_sensors(hass, aioclient_mock):
+
+async def test_no_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no climate entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -1,5 +1,4 @@
 """deCONZ binary sensor platform tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +17,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
@@ -28,8 +28,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_binary_sensors(hass, aioclient_mock):
+
+async def test_no_binary_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no sensor entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -541,7 +545,9 @@ async def test_binary_sensors(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_not_allow_clip_sensor(hass, aioclient_mock):
+async def test_not_allow_clip_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that CLIP sensors are not allowed."""
     data = {
         "sensors": {
@@ -563,7 +569,9 @@ async def test_not_allow_clip_sensor(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_allow_clip_sensor(hass, aioclient_mock):
+async def test_allow_clip_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that CLIP sensors can be allowed."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_button.py
+++ b/tests/components/deconz/test_button.py
@@ -1,11 +1,11 @@
 """deCONZ button platform tests."""
-
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
@@ -15,8 +15,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_binary_sensors(hass, aioclient_mock):
+
+async def test_no_binary_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no sensor entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -47,8 +48,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_sensors(hass, aioclient_mock):
+
+async def test_no_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no climate entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -725,7 +730,9 @@ async def test_climate_device_with_preset(hass, aioclient_mock, mock_deconz_webs
         )
 
 
-async def test_clip_climate_device(hass, aioclient_mock):
+async def test_clip_climate_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test successful creation of sensor entities."""
     data = {
         "sensors": {
@@ -871,7 +878,9 @@ async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocke
     )
 
 
-async def test_not_allow_clip_thermostat(hass, aioclient_mock):
+async def test_not_allow_clip_thermostat(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that CLIP thermostats are not allowed."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for deCONZ config flow."""
-
 import asyncio
 from unittest.mock import patch
 
@@ -29,14 +28,19 @@ from homeassistant.config_entries import (
     SOURCE_USER,
 )
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .test_gateway import API_KEY, BRIDGEID, setup_deconz_integration
 
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 BAD_BRIDGEID = "0000000000000000"
 
 
-async def test_flow_discovered_bridges(hass, aioclient_mock):
+async def test_flow_discovered_bridges(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that config flow works for discovered bridges."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -80,7 +84,9 @@ async def test_flow_discovered_bridges(hass, aioclient_mock):
     }
 
 
-async def test_flow_manual_configuration_decision(hass, aioclient_mock):
+async def test_flow_manual_configuration_decision(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that config flow for one discovered bridge works."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -132,7 +138,9 @@ async def test_flow_manual_configuration_decision(hass, aioclient_mock):
     }
 
 
-async def test_flow_manual_configuration(hass, aioclient_mock):
+async def test_flow_manual_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that config flow works with manual configuration after no discovered bridges."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -180,7 +188,9 @@ async def test_flow_manual_configuration(hass, aioclient_mock):
     }
 
 
-async def test_manual_configuration_after_discovery_timeout(hass, aioclient_mock):
+async def test_manual_configuration_after_discovery_timeout(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test failed discovery fallbacks to manual configuration."""
     aioclient_mock.get(pydeconz.utils.URL_DISCOVER, exc=asyncio.TimeoutError)
 
@@ -193,7 +203,9 @@ async def test_manual_configuration_after_discovery_timeout(hass, aioclient_mock
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
 
-async def test_manual_configuration_after_discovery_ResponseError(hass, aioclient_mock):
+async def test_manual_configuration_after_discovery_ResponseError(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test failed discovery fallbacks to manual configuration."""
     aioclient_mock.get(pydeconz.utils.URL_DISCOVER, exc=pydeconz.errors.ResponseError)
 
@@ -206,7 +218,9 @@ async def test_manual_configuration_after_discovery_ResponseError(hass, aioclien
     assert not hass.config_entries.flow._progress[result["flow_id"]].bridges
 
 
-async def test_manual_configuration_update_configuration(hass, aioclient_mock):
+async def test_manual_configuration_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that manual configuration can update existing config entry."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -252,7 +266,9 @@ async def test_manual_configuration_update_configuration(hass, aioclient_mock):
     assert config_entry.data[CONF_HOST] == "2.3.4.5"
 
 
-async def test_manual_configuration_dont_update_configuration(hass, aioclient_mock):
+async def test_manual_configuration_dont_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that _create_entry work and that bridgeid can be requested."""
     await setup_deconz_integration(hass, aioclient_mock)
 
@@ -297,7 +313,9 @@ async def test_manual_configuration_dont_update_configuration(hass, aioclient_mo
     assert result["reason"] == "already_configured"
 
 
-async def test_manual_configuration_timeout_get_bridge(hass, aioclient_mock):
+async def test_manual_configuration_timeout_get_bridge(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that _create_entry handles a timeout."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -377,7 +395,9 @@ async def test_link_step_fails(hass, aioclient_mock, raised_error, error_string)
     assert result["errors"] == {"base": error_string}
 
 
-async def test_reauth_flow_update_configuration(hass, aioclient_mock):
+async def test_reauth_flow_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify reauth flow can update gateway API key."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -413,7 +433,9 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
     assert config_entry.data[CONF_API_KEY] == new_api_key
 
 
-async def test_flow_ssdp_discovery(hass, aioclient_mock):
+async def test_flow_ssdp_discovery(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that config flow for one discovered bridge works."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
@@ -455,7 +477,9 @@ async def test_flow_ssdp_discovery(hass, aioclient_mock):
     }
 
 
-async def test_ssdp_discovery_update_configuration(hass, aioclient_mock):
+async def test_ssdp_discovery_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test if a discovered bridge is configured but updates with new attributes."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -484,7 +508,9 @@ async def test_ssdp_discovery_update_configuration(hass, aioclient_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_ssdp_discovery_dont_update_configuration(hass, aioclient_mock):
+async def test_ssdp_discovery_dont_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test if a discovered bridge has already been configured."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -534,7 +560,7 @@ async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
     assert config_entry.data[CONF_HOST] == "1.2.3.4"
 
 
-async def test_flow_hassio_discovery(hass):
+async def test_flow_hassio_discovery(hass: HomeAssistant) -> None:
     """Test hassio discovery flow works."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
@@ -579,7 +605,9 @@ async def test_flow_hassio_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_hassio_discovery_update_configuration(hass, aioclient_mock):
+async def test_hassio_discovery_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we can update an existing config entry."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -611,7 +639,9 @@ async def test_hassio_discovery_update_configuration(hass, aioclient_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_hassio_discovery_dont_update_configuration(hass, aioclient_mock):
+async def test_hassio_discovery_dont_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we can update an existing config entry."""
     await setup_deconz_integration(hass, aioclient_mock)
 
@@ -634,7 +664,9 @@ async def test_hassio_discovery_dont_update_configuration(hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_option_flow(hass, aioclient_mock):
+async def test_option_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow options."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -1,5 +1,4 @@
 """deCONZ cover platform tests."""
-
 from unittest.mock import patch
 
 from homeassistant.components.cover import (
@@ -23,6 +22,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -30,8 +30,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_covers(hass, aioclient_mock):
+
+async def test_no_covers(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no cover entities are created."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -137,7 +141,9 @@ async def test_cover(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_tilt_cover(hass, aioclient_mock):
+async def test_tilt_cover(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that tilting a cover works."""
     data = {
         "lights": {
@@ -215,7 +221,9 @@ async def test_tilt_cover(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[4][2] == {"stop": True}
 
 
-async def test_level_controllable_output_cover(hass, aioclient_mock):
+async def test_level_controllable_output_cover(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that tilting a cover works."""
     data = {
         "lights": {

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,5 +1,4 @@
 """Test deCONZ remote events."""
-
 from unittest.mock import patch
 
 from pydeconz.models.sensor.ancillary_control import (
@@ -25,11 +24,13 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.common import async_capture_events
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
@@ -618,7 +619,9 @@ async def test_deconz_relative_rotary_events(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_events_bad_unique_id(hass, aioclient_mock):
+async def test_deconz_events_bad_unique_id(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no devices are created if unique id is bad or missing."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -1,5 +1,4 @@
 """deCONZ device automation tests."""
-
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,6 +24,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -37,6 +37,7 @@ from tests.common import (
     async_mock_service,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -45,7 +46,9 @@ def automation_calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, aioclient_mock):
+async def test_get_triggers(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test triggers work."""
     data = {
         "sensors": {
@@ -144,7 +147,9 @@ async def test_get_triggers(hass, aioclient_mock):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
+async def test_get_triggers_for_alarm_event(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test triggers work."""
     data = {
         "sensors": {
@@ -234,7 +239,9 @@ async def test_get_triggers_for_alarm_event(hass, aioclient_mock):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_manage_unsupported_remotes(hass, aioclient_mock):
+async def test_get_triggers_manage_unsupported_remotes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no triggers for an unsupported remote."""
     data = {
         "sensors": {
@@ -350,7 +357,9 @@ async def test_functional_device_trigger(
 
 
 @pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
-async def test_validate_trigger_unknown_device(hass, aioclient_mock):
+async def test_validate_trigger_unknown_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test unknown device does not return a trigger config."""
     await setup_deconz_integration(hass, aioclient_mock)
 
@@ -380,7 +389,9 @@ async def test_validate_trigger_unknown_device(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 0
 
 
-async def test_validate_trigger_unsupported_device(hass, aioclient_mock):
+async def test_validate_trigger_unsupported_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test unsupported device doesn't return a trigger config."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -417,7 +428,9 @@ async def test_validate_trigger_unsupported_device(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 0
 
 
-async def test_validate_trigger_unsupported_trigger(hass, aioclient_mock):
+async def test_validate_trigger_unsupported_trigger(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test unsupported trigger does not return a trigger config."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -456,7 +469,9 @@ async def test_validate_trigger_unsupported_trigger(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 0
 
 
-async def test_attach_trigger_no_matching_event(hass, aioclient_mock):
+async def test_attach_trigger_no_matching_event(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no matching event for device doesn't return a trigger config."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -1,5 +1,4 @@
 """deCONZ fan platform tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +12,7 @@ from homeassistant.components.fan import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -20,8 +20,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_fans(hass, aioclient_mock):
+
+async def test_no_fans(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no fan entities are created."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -1,5 +1,4 @@
 """Test deCONZ gateway."""
-
 import asyncio
 from copy import deepcopy
 from unittest.mock import patch
@@ -46,9 +45,11 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 API_KEY = "1234567890ABCDEF"
 BRIDGEID = "01234E56789A"
@@ -137,7 +138,9 @@ async def setup_deconz_integration(
     return config_entry
 
 
-async def test_gateway_setup(hass, aioclient_mock):
+async def test_gateway_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Successful setup."""
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
@@ -184,7 +187,9 @@ async def test_gateway_setup(hass, aioclient_mock):
     assert gateway_entry.entry_type is dr.DeviceEntryType.SERVICE
 
 
-async def test_gateway_device_configuration_url_when_addon(hass, aioclient_mock):
+async def test_gateway_device_configuration_url_when_addon(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Successful setup."""
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
@@ -236,7 +241,9 @@ async def test_connection_status_signalling(
     assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
 
-async def test_update_address(hass, aioclient_mock):
+async def test_update_address(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Make sure that connection status triggers a dispatcher send."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     gateway = get_gateway_from_config_entry(hass, config_entry)
@@ -266,7 +273,9 @@ async def test_update_address(hass, aioclient_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reset_after_successful_setup(hass, aioclient_mock):
+async def test_reset_after_successful_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Make sure that connection status triggers a dispatcher send."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     gateway = get_gateway_from_config_entry(hass, config_entry)
@@ -277,7 +286,7 @@ async def test_reset_after_successful_setup(hass, aioclient_mock):
     assert result is True
 
 
-async def test_get_deconz_session(hass):
+async def test_get_deconz_session(hass: HomeAssistant) -> None:
     """Successful call."""
     with patch("pydeconz.DeconzSession.refresh_state", return_value=True):
         assert await get_deconz_session(hass, ENTRY_CONFIG)

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -1,5 +1,4 @@
 """Test deCONZ component setup process."""
-
 from unittest.mock import patch
 
 from homeassistant.components.deconz import (
@@ -15,11 +14,13 @@ from homeassistant.components.deconz.const import (
 from homeassistant.components.deconz.errors import AuthenticationRequired, CannotConnect
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 ENTRY1_HOST = "1.2.3.4"
 ENTRY1_PORT = 80
@@ -42,7 +43,9 @@ async def setup_entry(hass, entry):
         assert await async_setup_entry(hass, entry) is True
 
 
-async def test_setup_entry_successful(hass, aioclient_mock):
+async def test_setup_entry_successful(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup entry is successful."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -51,7 +54,7 @@ async def test_setup_entry_successful(hass, aioclient_mock):
     assert hass.data[DECONZ_DOMAIN][config_entry.entry_id].master
 
 
-async def test_setup_entry_fails_config_entry_not_ready(hass):
+async def test_setup_entry_fails_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.deconz.get_deconz_session",
@@ -62,7 +65,7 @@ async def test_setup_entry_fails_config_entry_not_ready(hass):
     assert hass.data[DECONZ_DOMAIN] == {}
 
 
-async def test_setup_entry_fails_trigger_reauth_flow(hass):
+async def test_setup_entry_fails_trigger_reauth_flow(hass: HomeAssistant) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.deconz.get_deconz_session",
@@ -74,7 +77,9 @@ async def test_setup_entry_fails_trigger_reauth_flow(hass):
     assert hass.data[DECONZ_DOMAIN] == {}
 
 
-async def test_setup_entry_multiple_gateways(hass, aioclient_mock):
+async def test_setup_entry_multiple_gateways(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup entry is successful with multiple gateways."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
@@ -93,7 +98,9 @@ async def test_setup_entry_multiple_gateways(hass, aioclient_mock):
     assert not hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
 
 
-async def test_unload_entry(hass, aioclient_mock):
+async def test_unload_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test being able to unload an entry."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     assert hass.data[DECONZ_DOMAIN]
@@ -102,7 +109,9 @@ async def test_unload_entry(hass, aioclient_mock):
     assert not hass.data[DECONZ_DOMAIN]
 
 
-async def test_unload_entry_multiple_gateways(hass, aioclient_mock):
+async def test_unload_entry_multiple_gateways(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test being able to unload an entry and master gateway gets moved."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
@@ -124,7 +133,7 @@ async def test_unload_entry_multiple_gateways(hass, aioclient_mock):
     assert hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
 
 
-async def test_update_group_unique_id(hass):
+async def test_update_group_unique_id(hass: HomeAssistant) -> None:
     """Test successful migration of entry data."""
     old_unique_id = "123"
     new_unique_id = "1234"
@@ -164,7 +173,7 @@ async def test_update_group_unique_id(hass):
     assert registry.async_get(f"{LIGHT_DOMAIN}.new").unique_id == f"{new_unique_id}-NEW"
 
 
-async def test_update_group_unique_id_no_legacy_group_id(hass):
+async def test_update_group_unique_id_no_legacy_group_id(hass: HomeAssistant) -> None:
     """Test migration doesn't trigger without old legacy group id in entry data."""
     old_unique_id = "123"
     new_unique_id = "1234"

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -42,8 +43,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_lights_or_groups(hass, aioclient_mock):
+
+async def test_no_lights_or_groups(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no lights or groups entities are created."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -550,7 +555,9 @@ async def test_light_service_calls(hass, aioclient_mock, input, expected):
         assert len(aioclient_mock.mock_calls) == 1  # not called
 
 
-async def test_ikea_default_transition_time(hass, aioclient_mock):
+async def test_ikea_default_transition_time(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify that service calls to IKEA lights always extend with transition tinme 0 if absent."""
     data = {
         "lights": {
@@ -616,7 +623,9 @@ async def test_ikea_default_transition_time(hass, aioclient_mock):
     }
 
 
-async def test_lidl_christmas_light(hass, aioclient_mock):
+async def test_lidl_christmas_light(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that lights or groups entities are created."""
     data = {
         "lights": {
@@ -663,7 +672,9 @@ async def test_lidl_christmas_light(hass, aioclient_mock):
     assert hass.states.get("light.lidl_xmas_light")
 
 
-async def test_configuration_tool(hass, aioclient_mock):
+async def test_configuration_tool(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify that configuration tool is not created."""
     data = {
         "lights": {
@@ -964,7 +975,9 @@ async def test_group_service_calls(hass, aioclient_mock, input, expected):
         assert len(aioclient_mock.mock_calls) == 1  # not called
 
 
-async def test_empty_group(hass, aioclient_mock):
+async def test_empty_group(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify that a group without a list of lights is not created."""
     data = {
         "groups": {
@@ -986,7 +999,9 @@ async def test_empty_group(hass, aioclient_mock):
     assert not hass.states.get("light.empty_group")
 
 
-async def test_disable_light_groups(hass, aioclient_mock):
+async def test_disable_light_groups(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test disallowing light groups work."""
     data = {
         "groups": {
@@ -1164,7 +1179,9 @@ async def test_non_color_light_reports_color(
         assert hass.states.get("light.group").attributes[ATTR_HS_COLOR]
 
 
-async def test_verify_group_supported_features(hass, aioclient_mock):
+async def test_verify_group_supported_features(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that group supported features reflect what included lights support."""
     data = {
         "groups": {

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -1,5 +1,4 @@
 """deCONZ lock platform tests."""
-
 from unittest.mock import patch
 
 from homeassistant.components.lock import (
@@ -13,6 +12,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNLOCKED,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -20,8 +20,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_locks(hass, aioclient_mock):
+
+async def test_no_locks(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no lock entities are created."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -1,5 +1,4 @@
 """The tests for deCONZ logbook."""
-
 from unittest.mock import patch
 
 from homeassistant.components.deconz.const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
@@ -16,6 +15,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     STATE_ALARM_ARMED_AWAY,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
@@ -23,9 +23,12 @@ from homeassistant.util import slugify
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.components.logbook.common import MockRow, mock_humanify
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
+async def test_humanifying_deconz_alarm_event(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test humanifying deCONZ event."""
     data = {
         "sensors": {
@@ -108,7 +111,9 @@ async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
     assert events[1]["message"] == "fired event 'armed_away'"
 
 
-async def test_humanifying_deconz_event(hass, aioclient_mock):
+async def test_humanifying_deconz_event(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test humanifying deCONZ event."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -1,5 +1,4 @@
 """deCONZ number platform tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +10,7 @@ from homeassistant.components.number import (
     SERVICE_SET_VALUE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
@@ -20,8 +20,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_number_entities(hass, aioclient_mock):
+
+async def test_no_number_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no number entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -1,11 +1,11 @@
 """deCONZ scene platform tests."""
-
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, SERVICE_TURN_ON
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .test_gateway import (
@@ -14,8 +14,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_scenes(hass, aioclient_mock):
+
+async def test_no_scenes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that scenes can be loaded without scenes being available."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_select.py
+++ b/tests/components/deconz/test_select.py
@@ -1,5 +1,4 @@
 """deCONZ select platform tests."""
-
 from unittest.mock import patch
 
 from pydeconz.models.sensor.presence import (
@@ -14,6 +13,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 
@@ -23,8 +23,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_select_entities(hass, aioclient_mock):
+
+async def test_no_select_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no sensor entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -1,5 +1,4 @@
 """deCONZ sensor platform tests."""
-
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -16,6 +15,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.util import dt
@@ -23,9 +23,12 @@ from homeassistant.util import dt
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_no_sensors(hass, aioclient_mock):
+async def test_no_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no sensors in deconz results in no sensor entities."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -693,7 +696,9 @@ async def test_sensors(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_not_allow_clip_sensor(hass, aioclient_mock):
+async def test_not_allow_clip_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that CLIP sensors are not allowed."""
     data = {
         "sensors": {
@@ -715,7 +720,9 @@ async def test_not_allow_clip_sensor(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_allow_clip_sensors(hass, aioclient_mock):
+async def test_allow_clip_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that CLIP sensors can be allowed."""
     data = {
         "sensors": {
@@ -839,7 +846,9 @@ async def test_dont_add_sensor_if_state_is_none(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_air_quality_sensor_without_ppb(hass, aioclient_mock):
+async def test_air_quality_sensor_without_ppb(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test sensor with scaled data is not created if state is None."""
     data = {
         "sensors": {
@@ -1065,7 +1074,9 @@ async def test_special_danfoss_battery_creation(hass, aioclient_mock, model_id):
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 5
 
 
-async def test_unsupported_sensor(hass, aioclient_mock):
+async def test_unsupported_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that unsupported sensors doesn't break anything."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -20,6 +20,7 @@ from homeassistant.components.deconz.services import (
     SUPPORTED_SERVICES,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 
@@ -32,9 +33,12 @@ from .test_gateway import (
 )
 
 from tests.common import async_capture_events
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_service_setup_and_unload(hass, aioclient_mock):
+async def test_service_setup_and_unload(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify service setup works."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     for service in SUPPORTED_SERVICES:
@@ -63,7 +67,9 @@ async def test_service_setup_and_unload_not_called_if_multiple_integrations_dete
     assert remove_service_mock.call_count == 3
 
 
-async def test_configure_service_with_field(hass, aioclient_mock):
+async def test_configure_service_with_field(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service invokes pydeconz with the correct path and data."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -81,7 +87,9 @@ async def test_configure_service_with_field(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
-async def test_configure_service_with_entity(hass, aioclient_mock):
+async def test_configure_service_with_entity(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service invokes pydeconz with the correct path and data."""
     data = {
         "lights": {
@@ -109,7 +117,9 @@ async def test_configure_service_with_entity(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
-async def test_configure_service_with_entity_and_field(hass, aioclient_mock):
+async def test_configure_service_with_entity_and_field(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service invokes pydeconz with the correct path and data."""
     data = {
         "lights": {
@@ -138,7 +148,9 @@ async def test_configure_service_with_entity_and_field(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
-async def test_configure_service_with_faulty_bridgeid(hass, aioclient_mock):
+async def test_configure_service_with_faulty_bridgeid(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service fails on a bad bridge id."""
     await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
@@ -157,7 +169,9 @@ async def test_configure_service_with_faulty_bridgeid(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 0
 
 
-async def test_configure_service_with_faulty_field(hass, aioclient_mock):
+async def test_configure_service_with_faulty_field(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service fails on a bad field."""
     await setup_deconz_integration(hass, aioclient_mock)
 
@@ -170,7 +184,9 @@ async def test_configure_service_with_faulty_field(hass, aioclient_mock):
         await hass.async_block_till_done()
 
 
-async def test_configure_service_with_faulty_entity(hass, aioclient_mock):
+async def test_configure_service_with_faulty_entity(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service on a non existing entity."""
     await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
@@ -188,7 +204,9 @@ async def test_configure_service_with_faulty_entity(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 0
 
 
-async def test_calling_service_with_no_master_gateway_fails(hass, aioclient_mock):
+async def test_calling_service_with_no_master_gateway_fails(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service call fails when no master gateway exist."""
     await setup_deconz_integration(
         hass, aioclient_mock, options={CONF_MASTER_GATEWAY: False}
@@ -208,7 +226,9 @@ async def test_calling_service_with_no_master_gateway_fails(hass, aioclient_mock
     assert len(aioclient_mock.mock_calls) == 0
 
 
-async def test_service_refresh_devices(hass, aioclient_mock):
+async def test_service_refresh_devices(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that service can refresh devices."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
@@ -258,7 +278,9 @@ async def test_service_refresh_devices(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 5
 
 
-async def test_service_refresh_devices_trigger_no_state_update(hass, aioclient_mock):
+async def test_service_refresh_devices_trigger_no_state_update(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify that gateway.ignore_state_updates are honored."""
     data = {
         "sensors": {
@@ -323,7 +345,9 @@ async def test_service_refresh_devices_trigger_no_state_update(hass, aioclient_m
     assert len(captured_events) == 0
 
 
-async def test_remove_orphaned_entries_service(hass, aioclient_mock):
+async def test_remove_orphaned_entries_service(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service works and also don't remove more than expected."""
     data = {
         "lights": {

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -1,5 +1,4 @@
 """deCONZ switch platform tests."""
-
 from unittest.mock import patch
 
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
@@ -10,6 +9,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .test_gateway import (
@@ -18,8 +18,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_no_switches(hass, aioclient_mock):
+
+async def test_no_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that no switch entities are created."""
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
@@ -112,7 +116,9 @@ async def test_power_plugs(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_remove_legacy_on_off_output_as_light(hass, aioclient_mock):
+async def test_remove_legacy_on_off_output_as_light(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that switch platform cleans up legacy light entities."""
     unique_id = "00:00:00:00:00:00:00:00-00"
 

--- a/tests/components/demo/test_camera.py
+++ b/tests/components/demo/test_camera.py
@@ -15,6 +15,7 @@ from homeassistant.components.camera import (
 )
 from homeassistant.components.demo import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -30,7 +31,7 @@ async def demo_camera(hass):
     await hass.async_block_till_done()
 
 
-async def test_init_state_is_streaming(hass):
+async def test_init_state_is_streaming(hass: HomeAssistant) -> None:
     """Demo camera initialize as streaming."""
     state = hass.states.get(ENTITY_CAMERA)
     assert state.state == STATE_STREAMING
@@ -43,7 +44,7 @@ async def test_init_state_is_streaming(hass):
         assert image.content == b"ON"
 
 
-async def test_turn_on_state_back_to_streaming(hass):
+async def test_turn_on_state_back_to_streaming(hass: HomeAssistant) -> None:
     """After turn on state back to streaming."""
     state = hass.states.get(ENTITY_CAMERA)
     assert state.state == STATE_STREAMING
@@ -63,7 +64,7 @@ async def test_turn_on_state_back_to_streaming(hass):
     assert state.state == STATE_STREAMING
 
 
-async def test_turn_off_image(hass):
+async def test_turn_off_image(hass: HomeAssistant) -> None:
     """After turn off, Demo camera raise error."""
     await hass.services.async_call(
         CAMERA_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_CAMERA}, blocking=True
@@ -74,7 +75,7 @@ async def test_turn_off_image(hass):
         assert error.args[0] == "Camera is off"
 
 
-async def test_turn_off_invalid_camera(hass):
+async def test_turn_off_invalid_camera(hass: HomeAssistant) -> None:
     """Turn off non-exist camera should quietly fail."""
     state = hass.states.get(ENTITY_CAMERA)
     assert state.state == STATE_STREAMING
@@ -90,7 +91,7 @@ async def test_turn_off_invalid_camera(hass):
     assert state.state == STATE_STREAMING
 
 
-async def test_motion_detection(hass):
+async def test_motion_detection(hass: HomeAssistant) -> None:
     """Test motion detection services."""
 
     # Fetch state and check motion detection attribute

--- a/tests/components/demo/test_climate.py
+++ b/tests/components/demo/test_climate.py
@@ -88,7 +88,7 @@ def test_default_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_MAX_HUMIDITY) == 99
 
 
-async def test_set_only_target_temp_bad_attr(hass):
+async def test_set_only_target_temp_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the target temperature without required attribute."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_TEMPERATURE) == 21
@@ -105,7 +105,7 @@ async def test_set_only_target_temp_bad_attr(hass):
     assert state.attributes.get(ATTR_TEMPERATURE) == 21
 
 
-async def test_set_only_target_temp(hass):
+async def test_set_only_target_temp(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_TEMPERATURE) == 21
@@ -121,7 +121,7 @@ async def test_set_only_target_temp(hass):
     assert state.attributes.get(ATTR_TEMPERATURE) == 30.0
 
 
-async def test_set_only_target_temp_with_convert(hass):
+async def test_set_only_target_temp_with_convert(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature."""
     state = hass.states.get(ENTITY_HEATPUMP)
     assert state.attributes.get(ATTR_TEMPERATURE) == 20
@@ -137,7 +137,7 @@ async def test_set_only_target_temp_with_convert(hass):
     assert state.attributes.get(ATTR_TEMPERATURE) == 21.0
 
 
-async def test_set_target_temp_range(hass):
+async def test_set_target_temp_range(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature with range."""
     state = hass.states.get(ENTITY_ECOBEE)
     assert state.attributes.get(ATTR_TEMPERATURE) is None
@@ -161,7 +161,7 @@ async def test_set_target_temp_range(hass):
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 25.0
 
 
-async def test_set_target_temp_range_bad_attr(hass):
+async def test_set_target_temp_range_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the target temperature range without attribute."""
     state = hass.states.get(ENTITY_ECOBEE)
     assert state.attributes.get(ATTR_TEMPERATURE) is None
@@ -186,7 +186,7 @@ async def test_set_target_temp_range_bad_attr(hass):
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 24.0
 
 
-async def test_set_target_humidity_bad_attr(hass):
+async def test_set_target_humidity_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the target humidity without required attribute."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_HUMIDITY) == 67
@@ -203,7 +203,7 @@ async def test_set_target_humidity_bad_attr(hass):
     assert state.attributes.get(ATTR_HUMIDITY) == 67
 
 
-async def test_set_target_humidity(hass):
+async def test_set_target_humidity(hass: HomeAssistant) -> None:
     """Test the setting of the target humidity."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_HUMIDITY) == 67
@@ -219,7 +219,7 @@ async def test_set_target_humidity(hass):
     assert state.attributes.get(ATTR_HUMIDITY) == 64.0
 
 
-async def test_set_fan_mode_bad_attr(hass):
+async def test_set_fan_mode_bad_attr(hass: HomeAssistant) -> None:
     """Test setting fan mode without required attribute."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_FAN_MODE) == "On High"
@@ -236,7 +236,7 @@ async def test_set_fan_mode_bad_attr(hass):
     assert state.attributes.get(ATTR_FAN_MODE) == "On High"
 
 
-async def test_set_fan_mode(hass):
+async def test_set_fan_mode(hass: HomeAssistant) -> None:
     """Test setting of new fan mode."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_FAN_MODE) == "On High"
@@ -252,7 +252,7 @@ async def test_set_fan_mode(hass):
     assert state.attributes.get(ATTR_FAN_MODE) == "On Low"
 
 
-async def test_set_swing_mode_bad_attr(hass):
+async def test_set_swing_mode_bad_attr(hass: HomeAssistant) -> None:
     """Test setting swing mode without required attribute."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_SWING_MODE) == "Off"
@@ -269,7 +269,7 @@ async def test_set_swing_mode_bad_attr(hass):
     assert state.attributes.get(ATTR_SWING_MODE) == "Off"
 
 
-async def test_set_swing(hass):
+async def test_set_swing(hass: HomeAssistant) -> None:
     """Test setting of new swing mode."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_SWING_MODE) == "Off"
@@ -285,7 +285,7 @@ async def test_set_swing(hass):
     assert state.attributes.get(ATTR_SWING_MODE) == "Auto"
 
 
-async def test_set_hvac_bad_attr_and_state(hass):
+async def test_set_hvac_bad_attr_and_state(hass: HomeAssistant) -> None:
     """Test setting hvac mode without required attribute.
 
     Also check the state.
@@ -307,7 +307,7 @@ async def test_set_hvac_bad_attr_and_state(hass):
     assert state.state == HVACMode.COOL
 
 
-async def test_set_hvac(hass):
+async def test_set_hvac(hass: HomeAssistant) -> None:
     """Test setting of new hvac mode."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == HVACMode.COOL
@@ -323,7 +323,7 @@ async def test_set_hvac(hass):
     assert state.state == HVACMode.HEAT
 
 
-async def test_set_hold_mode_away(hass):
+async def test_set_hold_mode_away(hass: HomeAssistant) -> None:
     """Test setting the hold mode away."""
     await hass.services.async_call(
         DOMAIN,
@@ -336,7 +336,7 @@ async def test_set_hold_mode_away(hass):
     assert state.attributes.get(ATTR_PRESET_MODE) == PRESET_AWAY
 
 
-async def test_set_hold_mode_eco(hass):
+async def test_set_hold_mode_eco(hass: HomeAssistant) -> None:
     """Test setting the hold mode eco."""
     await hass.services.async_call(
         DOMAIN,
@@ -349,7 +349,7 @@ async def test_set_hold_mode_eco(hass):
     assert state.attributes.get(ATTR_PRESET_MODE) == PRESET_ECO
 
 
-async def test_set_aux_heat_bad_attr(hass):
+async def test_set_aux_heat_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the auxiliary heater without required attribute."""
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get(ATTR_AUX_HEAT) == STATE_OFF
@@ -366,7 +366,7 @@ async def test_set_aux_heat_bad_attr(hass):
     assert state.attributes.get(ATTR_AUX_HEAT) == STATE_OFF
 
 
-async def test_set_aux_heat_on(hass):
+async def test_set_aux_heat_on(hass: HomeAssistant) -> None:
     """Test setting the axillary heater on/true."""
     await hass.services.async_call(
         DOMAIN,
@@ -379,7 +379,7 @@ async def test_set_aux_heat_on(hass):
     assert state.attributes.get(ATTR_AUX_HEAT) == STATE_ON
 
 
-async def test_set_aux_heat_off(hass):
+async def test_set_aux_heat_off(hass: HomeAssistant) -> None:
     """Test setting the auxiliary heater off/false."""
     await hass.services.async_call(
         DOMAIN,
@@ -392,7 +392,7 @@ async def test_set_aux_heat_off(hass):
     assert state.attributes.get(ATTR_AUX_HEAT) == STATE_OFF
 
 
-async def test_turn_on(hass):
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test turn on device."""
     await hass.services.async_call(
         DOMAIN,
@@ -411,7 +411,7 @@ async def test_turn_on(hass):
     assert state.state == HVACMode.HEAT
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test turn on device."""
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/demo/test_geo_location.py
+++ b/tests/components/demo/test_geo_location.py
@@ -1,5 +1,4 @@
 """The tests for the demo platform."""
-
 from freezegun import freeze_time
 
 from homeassistant.components import geo_location
@@ -13,6 +12,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     UnitOfLength,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -21,7 +21,7 @@ from tests.common import assert_setup_component, async_fire_time_changed
 CONFIG = {geo_location.DOMAIN: [{"platform": "demo"}]}
 
 
-async def test_setup_platform(hass):
+async def test_setup_platform(hass: HomeAssistant) -> None:
     """Test setup of demo platform via configuration."""
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.

--- a/tests/components/demo/test_humidifier.py
+++ b/tests/components/demo/test_humidifier.py
@@ -52,7 +52,7 @@ def test_default_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_MAX_HUMIDITY) == 100
 
 
-async def test_set_target_humidity_bad_attr(hass):
+async def test_set_target_humidity_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the target humidity without required attribute."""
     state = hass.states.get(ENTITY_DEHUMIDIFIER)
     assert state.attributes.get(ATTR_HUMIDITY) == 54
@@ -70,7 +70,7 @@ async def test_set_target_humidity_bad_attr(hass):
     assert state.attributes.get(ATTR_HUMIDITY) == 54
 
 
-async def test_set_target_humidity(hass):
+async def test_set_target_humidity(hass: HomeAssistant) -> None:
     """Test the setting of the target humidity."""
     state = hass.states.get(ENTITY_DEHUMIDIFIER)
     assert state.attributes.get(ATTR_HUMIDITY) == 54
@@ -87,7 +87,7 @@ async def test_set_target_humidity(hass):
     assert state.attributes.get(ATTR_HUMIDITY) == 64
 
 
-async def test_set_hold_mode_away(hass):
+async def test_set_hold_mode_away(hass: HomeAssistant) -> None:
     """Test setting the hold mode away."""
     await hass.services.async_call(
         DOMAIN,
@@ -101,7 +101,7 @@ async def test_set_hold_mode_away(hass):
     assert state.attributes.get(ATTR_MODE) == MODE_AWAY
 
 
-async def test_set_hold_mode_eco(hass):
+async def test_set_hold_mode_eco(hass: HomeAssistant) -> None:
     """Test setting the hold mode eco."""
     await hass.services.async_call(
         DOMAIN,
@@ -115,7 +115,7 @@ async def test_set_hold_mode_eco(hass):
     assert state.attributes.get(ATTR_MODE) == "eco"
 
 
-async def test_turn_on(hass):
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test turn on device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_DEHUMIDIFIER}, blocking=True
@@ -130,7 +130,7 @@ async def test_turn_on(hass):
     assert state.state == STATE_ON
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test turn off device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_DEHUMIDIFIER}, blocking=True
@@ -145,7 +145,7 @@ async def test_turn_off(hass):
     assert state.state == STATE_OFF
 
 
-async def test_toggle(hass):
+async def test_toggle(hass: HomeAssistant) -> None:
     """Test toggle device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_DEHUMIDIFIER}, blocking=True

--- a/tests/components/demo/test_light.py
+++ b/tests/components/demo/test_light.py
@@ -17,6 +17,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 ENTITY_LIGHT = "light.bed_light"
@@ -31,7 +32,7 @@ async def setup_comp(hass):
     await hass.async_block_till_done()
 
 
-async def test_state_attributes(hass):
+async def test_state_attributes(hass: HomeAssistant) -> None:
     """Test light state attributes."""
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -86,7 +87,7 @@ async def test_state_attributes(hass):
     assert state.attributes.get(ATTR_BRIGHTNESS) == 128
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test light turn off method."""
     await hass.services.async_call(
         LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_LIGHT}, blocking=True
@@ -103,7 +104,7 @@ async def test_turn_off(hass):
     assert state.state == STATE_OFF
 
 
-async def test_turn_off_without_entity_id(hass):
+async def test_turn_off_without_entity_id(hass: HomeAssistant) -> None:
     """Test light turn off all lights."""
     await hass.services.async_call(
         LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "all"}, blocking=True

--- a/tests/components/demo/test_lock.py
+++ b/tests/components/demo/test_lock.py
@@ -16,6 +16,7 @@ from homeassistant.components.lock import (
     STATE_UNLOCKING,
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, async_mock_service
@@ -36,7 +37,7 @@ async def setup_comp(hass):
 
 
 @patch.object(demo_lock, "LOCK_UNLOCK_DELAY", 0)
-async def test_locking(hass):
+async def test_locking(hass: HomeAssistant) -> None:
     """Test the locking of a lock."""
     state = hass.states.get(KITCHEN)
     assert state.state == STATE_UNLOCKED
@@ -56,7 +57,7 @@ async def test_locking(hass):
 
 
 @patch.object(demo_lock, "LOCK_UNLOCK_DELAY", 0)
-async def test_unlocking(hass):
+async def test_unlocking(hass: HomeAssistant) -> None:
     """Test the unlocking of a lock."""
     state = hass.states.get(FRONT)
     assert state.state == STATE_LOCKED
@@ -76,7 +77,7 @@ async def test_unlocking(hass):
 
 
 @patch.object(demo_lock, "LOCK_UNLOCK_DELAY", 0)
-async def test_jammed_when_locking(hass):
+async def test_jammed_when_locking(hass: HomeAssistant) -> None:
     """Test the locking of a lock jams."""
     state = hass.states.get(POORLY_INSTALLED)
     assert state.state == STATE_UNLOCKED
@@ -95,7 +96,7 @@ async def test_jammed_when_locking(hass):
     assert state_changes[1].data["new_state"].state == STATE_JAMMED
 
 
-async def test_opening_mocked(hass):
+async def test_opening_mocked(hass: HomeAssistant) -> None:
     """Test the opening of a lock."""
     calls = async_mock_service(hass, LOCK_DOMAIN, SERVICE_OPEN)
     await hass.services.async_call(
@@ -104,7 +105,7 @@ async def test_opening_mocked(hass):
     assert len(calls) == 1
 
 
-async def test_opening(hass):
+async def test_opening(hass: HomeAssistant) -> None:
     """Test the opening of a lock."""
     await hass.services.async_call(
         LOCK_DOMAIN, SERVICE_OPEN, {ATTR_ENTITY_ID: OPENABLE_LOCK}, blocking=True

--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -14,8 +14,11 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_PLAYING,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import DATA_CLIENTSESSION
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 TEST_ENTITY_ID = "media_player.walkman"
 
@@ -30,7 +33,7 @@ def media_player_media_seek_fixture():
         yield seek
 
 
-async def test_source_select(hass):
+async def test_source_select(hass: HomeAssistant) -> None:
     """Test the input source service."""
     entity_id = "media_player.lounge_room"
 
@@ -61,7 +64,7 @@ async def test_source_select(hass):
     assert state.attributes.get(mp.ATTR_INPUT_SOURCE) == "xbox"
 
 
-async def test_repeat_set(hass):
+async def test_repeat_set(hass: HomeAssistant) -> None:
     """Test the repeat set service."""
     entity_id = "media_player.walkman"
 
@@ -82,7 +85,7 @@ async def test_repeat_set(hass):
     assert state.attributes.get(mp.ATTR_MEDIA_REPEAT) == mp.const.REPEAT_MODE_ALL
 
 
-async def test_clear_playlist(hass):
+async def test_clear_playlist(hass: HomeAssistant) -> None:
     """Test clear playlist."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -102,7 +105,7 @@ async def test_clear_playlist(hass):
     assert state.state == STATE_OFF
 
 
-async def test_volume_services(hass):
+async def test_volume_services(hass: HomeAssistant) -> None:
     """Test the volume service."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -174,7 +177,7 @@ async def test_volume_services(hass):
     assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_MUTED) is True
 
 
-async def test_turning_off_and_on(hass):
+async def test_turning_off_and_on(hass: HomeAssistant) -> None:
     """Test turn_on and turn_off."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -215,7 +218,7 @@ async def test_turning_off_and_on(hass):
     assert not mp.is_on(hass, TEST_ENTITY_ID)
 
 
-async def test_playing_pausing(hass):
+async def test_playing_pausing(hass: HomeAssistant) -> None:
     """Test media_pause."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -262,7 +265,7 @@ async def test_playing_pausing(hass):
     assert state.state == STATE_PLAYING
 
 
-async def test_prev_next_track(hass):
+async def test_prev_next_track(hass: HomeAssistant) -> None:
     """Test media_next_track and media_previous_track ."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -327,7 +330,7 @@ async def test_prev_next_track(hass):
     assert state.attributes.get(mp.ATTR_MEDIA_EPISODE) == "1"
 
 
-async def test_play_media(hass):
+async def test_play_media(hass: HomeAssistant) -> None:
     """Test play_media ."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -413,7 +416,7 @@ async def test_seek(hass, mock_media_seek):
     assert mock_media_seek.called
 
 
-async def test_stop(hass):
+async def test_stop(hass: HomeAssistant) -> None:
     """Test stop."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -433,7 +436,9 @@ async def test_stop(hass):
     assert state.state == STATE_OFF
 
 
-async def test_media_image_proxy(hass, hass_client):
+async def test_media_image_proxy(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the media server image proxy server ."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
@@ -477,7 +482,7 @@ async def test_media_image_proxy(hass, hass_client):
     assert await req.text() == fake_picture_data
 
 
-async def test_grouping(hass):
+async def test_grouping(hass: HomeAssistant) -> None:
     """Test the join/unjoin services."""
     walkman = "media_player.walkman"
     kitchen = "media_player.kitchen"

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -1,5 +1,4 @@
 """The tests for the notify demo platform."""
-
 import logging
 from unittest.mock import patch
 
@@ -8,7 +7,7 @@ import voluptuous as vol
 
 import homeassistant.components.demo.notify as demo
 import homeassistant.components.notify as notify
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -173,7 +172,7 @@ async def test_calling_notify_from_script_loaded_from_yaml_with_title(hass, even
     } == events[0].data
 
 
-async def test_targets_are_services(hass):
+async def test_targets_are_services(hass: HomeAssistant) -> None:
     """Test that all targets are exposed as individual services."""
     await setup_notify(hass)
     assert hass.services.has_service("notify", "demo") is not None

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -62,7 +62,7 @@ def test_default_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_MODE) == NumberMode.AUTO
 
 
-async def test_set_value_bad_attr(hass):
+async def test_set_value_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the value without required attribute."""
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "42.0"
@@ -80,7 +80,7 @@ async def test_set_value_bad_attr(hass):
     assert state.state == "42.0"
 
 
-async def test_set_value_bad_range(hass):
+async def test_set_value_bad_range(hass: HomeAssistant) -> None:
     """Test setting the value out of range."""
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "42.0"
@@ -98,7 +98,7 @@ async def test_set_value_bad_range(hass):
     assert state.state == "42.0"
 
 
-async def test_set_set_value(hass):
+async def test_set_set_value(hass: HomeAssistant) -> None:
     """Test the setting of the value."""
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "42.0"

--- a/tests/components/demo/test_remote.py
+++ b/tests/components/demo/test_remote.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 ENTITY_ID = "remote.remote_one"
@@ -25,7 +26,7 @@ async def setup_component(hass):
     await hass.async_block_till_done()
 
 
-async def test_methods(hass):
+async def test_methods(hass: HomeAssistant) -> None:
     """Test if services call the entity methods as expected."""
     await hass.services.async_call(
         remote.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}

--- a/tests/components/demo/test_siren.py
+++ b/tests/components/demo/test_siren.py
@@ -44,7 +44,7 @@ def test_all_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_AVAILABLE_TONES) == ["fire", "alarm"]
 
 
-async def test_turn_on(hass):
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test turn on device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_SIREN}, blocking=True
@@ -68,7 +68,7 @@ async def test_turn_on(hass):
         )
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test turn off device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_SIREN}, blocking=True
@@ -83,7 +83,7 @@ async def test_turn_off(hass):
     assert state.state == STATE_OFF
 
 
-async def test_toggle(hass):
+async def test_toggle(hass: HomeAssistant) -> None:
     """Test toggle device."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_SIREN}, blocking=True
@@ -104,7 +104,7 @@ async def test_toggle(hass):
     assert state.state == STATE_ON
 
 
-async def test_turn_on_strip_attributes(hass):
+async def test_turn_on_strip_attributes(hass: HomeAssistant) -> None:
     """Test attributes are stripped from turn_on service call when not supported."""
     with patch(
         "homeassistant.components.demo.siren.DemoSiren.async_turn_on"

--- a/tests/components/demo/test_text.py
+++ b/tests/components/demo/test_text.py
@@ -33,7 +33,7 @@ def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_MODE] == "text"
 
 
-async def test_set_value(hass):
+async def test_set_value(hass: HomeAssistant) -> None:
     """Test set value service."""
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -57,7 +58,7 @@ async def setup_demo_vacuum(hass):
     await hass.async_block_till_done()
 
 
-async def test_supported_features(hass):
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test vacuum supported features."""
     state = hass.states.get(ENTITY_VACUUM_COMPLETE)
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 2047
@@ -107,7 +108,7 @@ async def test_supported_features(hass):
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == FAN_SPEEDS
 
 
-async def test_methods(hass):
+async def test_methods(hass: HomeAssistant) -> None:
     """Test if methods call the services as expected."""
     hass.states.async_set(ENTITY_VACUUM_BASIC, STATE_ON)
     await hass.async_block_till_done()
@@ -194,7 +195,7 @@ async def test_methods(hass):
     assert state.state == STATE_CLEANING
 
 
-async def test_unsupported_methods(hass):
+async def test_unsupported_methods(hass: HomeAssistant) -> None:
     """Test service calls for unsupported vacuums."""
     hass.states.async_set(ENTITY_VACUUM_NONE, STATE_ON)
     await hass.async_block_till_done()
@@ -266,7 +267,7 @@ async def test_unsupported_methods(hass):
     assert state.state != STATE_CLEANING
 
 
-async def test_services(hass):
+async def test_services(hass: HomeAssistant) -> None:
     """Test vacuum services."""
     # Test send_command
     send_command_calls = async_mock_service(hass, DOMAIN, SERVICE_SEND_COMMAND)
@@ -299,7 +300,7 @@ async def test_services(hass):
     assert call.data[ATTR_FAN_SPEED] == FAN_SPEEDS[0]
 
 
-async def test_set_fan_speed(hass):
+async def test_set_fan_speed(hass: HomeAssistant) -> None:
     """Test vacuum service to set the fan speed."""
     group_vacuums = ",".join(
         [ENTITY_VACUUM_BASIC, ENTITY_VACUUM_COMPLETE, ENTITY_VACUUM_STATE]
@@ -326,7 +327,7 @@ async def test_set_fan_speed(hass):
     assert new_state_state.attributes[ATTR_FAN_SPEED] == FAN_SPEEDS[0]
 
 
-async def test_send_command(hass):
+async def test_send_command(hass: HomeAssistant) -> None:
     """Test vacuum service to send a command."""
     group_vacuums = ",".join([ENTITY_VACUUM_BASIC, ENTITY_VACUUM_COMPLETE])
     old_state_basic = hass.states.get(ENTITY_VACUUM_BASIC)

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -3,6 +3,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import water_heater
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -22,7 +23,7 @@ async def setup_comp(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_params(hass):
+async def test_setup_params(hass: HomeAssistant) -> None:
     """Test the initial parameters."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("temperature") == 119
@@ -30,14 +31,14 @@ async def test_setup_params(hass):
     assert state.attributes.get("operation_mode") == "eco"
 
 
-async def test_default_setup_params(hass):
+async def test_default_setup_params(hass: HomeAssistant) -> None:
     """Test the setup with default parameters."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("min_temp") == 110
     assert state.attributes.get("max_temp") == 140
 
 
-async def test_set_only_target_temp_bad_attr(hass):
+async def test_set_only_target_temp_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the target temperature without required attribute."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("temperature") == 119
@@ -46,7 +47,7 @@ async def test_set_only_target_temp_bad_attr(hass):
     assert state.attributes.get("temperature") == 119
 
 
-async def test_set_only_target_temp(hass):
+async def test_set_only_target_temp(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("temperature") == 119
@@ -55,7 +56,7 @@ async def test_set_only_target_temp(hass):
     assert state.attributes.get("temperature") == 110
 
 
-async def test_set_operation_bad_attr_and_state(hass):
+async def test_set_operation_bad_attr_and_state(hass: HomeAssistant) -> None:
     """Test setting operation mode without required attribute.
 
     Also check the state.
@@ -70,7 +71,7 @@ async def test_set_operation_bad_attr_and_state(hass):
     assert state.state == "eco"
 
 
-async def test_set_operation(hass):
+async def test_set_operation(hass: HomeAssistant) -> None:
     """Test setting of new operation mode."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("operation_mode") == "eco"
@@ -81,7 +82,7 @@ async def test_set_operation(hass):
     assert state.state == "electric"
 
 
-async def test_set_away_mode_bad_attr(hass):
+async def test_set_away_mode_bad_attr(hass: HomeAssistant) -> None:
     """Test setting the away mode without required attribute."""
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("away_mode") == "off"
@@ -90,21 +91,21 @@ async def test_set_away_mode_bad_attr(hass):
     assert state.attributes.get("away_mode") == "off"
 
 
-async def test_set_away_mode_on(hass):
+async def test_set_away_mode_on(hass: HomeAssistant) -> None:
     """Test setting the away mode on/true."""
     await common.async_set_away_mode(hass, True, ENTITY_WATER_HEATER)
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.attributes.get("away_mode") == "on"
 
 
-async def test_set_away_mode_off(hass):
+async def test_set_away_mode_off(hass: HomeAssistant) -> None:
     """Test setting the away mode off/false."""
     await common.async_set_away_mode(hass, False, ENTITY_WATER_HEATER_CELSIUS)
     state = hass.states.get(ENTITY_WATER_HEATER_CELSIUS)
     assert state.attributes.get("away_mode") == "off"
 
 
-async def test_set_only_target_temp_with_convert(hass):
+async def test_set_only_target_temp_with_convert(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature."""
     state = hass.states.get(ENTITY_WATER_HEATER_CELSIUS)
     assert state.attributes.get("temperature") == 113

--- a/tests/components/demo/test_weather.py
+++ b/tests/components/demo/test_weather.py
@@ -15,11 +15,12 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
 
-async def test_attributes(hass):
+async def test_attributes(hass: HomeAssistant) -> None:
     """Test weather attributes."""
     assert await async_setup_component(
         hass, weather.DOMAIN, {"weather": {"platform": "demo"}}

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.denonavr.config_flow import (
     AvrTimoutError,
 )
 from homeassistant.const import CONF_HOST, CONF_MODEL
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -68,7 +69,7 @@ def denonavr_connect_fixture():
         yield
 
 
-async def test_config_flow_manual_host_success(hass):
+async def test_config_flow_manual_host_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user.
 
     Host specified.
@@ -97,7 +98,7 @@ async def test_config_flow_manual_host_success(hass):
     }
 
 
-async def test_config_flow_manual_discover_1_success(hass):
+async def test_config_flow_manual_discover_1_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user.
 
     Without the host specified and 1 receiver discovered.
@@ -130,7 +131,7 @@ async def test_config_flow_manual_discover_1_success(hass):
     }
 
 
-async def test_config_flow_manual_discover_2_success(hass):
+async def test_config_flow_manual_discover_2_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user.
 
     Without the host specified and 2 receiver discovered.
@@ -172,7 +173,7 @@ async def test_config_flow_manual_discover_2_success(hass):
     }
 
 
-async def test_config_flow_manual_discover_error(hass):
+async def test_config_flow_manual_discover_error(hass: HomeAssistant) -> None:
     """Failed flow manually initialized by the user.
 
     Without the host specified and no receiver discovered.
@@ -199,7 +200,7 @@ async def test_config_flow_manual_discover_error(hass):
     assert result["errors"] == {"base": "discovery_error"}
 
 
-async def test_config_flow_manual_host_no_serial(hass):
+async def test_config_flow_manual_host_no_serial(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user.
 
     Host specified and an error getting the serial number.
@@ -232,7 +233,7 @@ async def test_config_flow_manual_host_no_serial(hass):
     }
 
 
-async def test_config_flow_manual_host_connection_error(hass):
+async def test_config_flow_manual_host_connection_error(hass: HomeAssistant) -> None:
     """Failed flow manually initialized by the user.
 
     Host specified and a connection error.
@@ -261,7 +262,7 @@ async def test_config_flow_manual_host_connection_error(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_config_flow_manual_host_no_device_info(hass):
+async def test_config_flow_manual_host_no_device_info(hass: HomeAssistant) -> None:
     """Failed flow manually initialized by the user.
 
     Host specified and no device info (due to receiver power off).
@@ -287,7 +288,7 @@ async def test_config_flow_manual_host_no_device_info(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_config_flow_ssdp(hass):
+async def test_config_flow_ssdp(hass: HomeAssistant) -> None:
     """Successful flow initialized by ssdp discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -323,7 +324,7 @@ async def test_config_flow_ssdp(hass):
     }
 
 
-async def test_config_flow_ssdp_not_denon(hass):
+async def test_config_flow_ssdp_not_denon(hass: HomeAssistant) -> None:
     """Failed flow initialized by ssdp discovery.
 
     Not supported manufacturer.
@@ -347,7 +348,7 @@ async def test_config_flow_ssdp_not_denon(hass):
     assert result["reason"] == "not_denonavr_manufacturer"
 
 
-async def test_config_flow_ssdp_missing_info(hass):
+async def test_config_flow_ssdp_missing_info(hass: HomeAssistant) -> None:
     """Failed flow initialized by ssdp discovery.
 
     Missing information.
@@ -369,7 +370,7 @@ async def test_config_flow_ssdp_missing_info(hass):
     assert result["reason"] == "not_denonavr_missing"
 
 
-async def test_config_flow_ssdp_ignored_model(hass):
+async def test_config_flow_ssdp_ignored_model(hass: HomeAssistant) -> None:
     """Failed flow initialized by ssdp discovery.
 
     Model in the ignored models list.
@@ -393,7 +394,7 @@ async def test_config_flow_ssdp_ignored_model(hass):
     assert result["reason"] == "not_denonavr_manufacturer"
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -432,7 +433,9 @@ async def test_options_flow(hass):
     }
 
 
-async def test_config_flow_manual_host_no_serial_double_config(hass):
+async def test_config_flow_manual_host_no_serial_double_config(
+    hass: HomeAssistant,
+) -> None:
     """Failed flow manually initialized by the user twice.
 
     Host specified and an error getting the serial number.

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -5,11 +5,12 @@ import random
 from unittest.mock import patch
 
 from homeassistant.const import UnitOfPower, UnitOfTime
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 
-async def test_state(hass):
+async def test_state(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     config = {
         "sensor": {
@@ -81,7 +82,7 @@ async def setup_tests(hass, config, times, values, expected_state):
     return state
 
 
-async def test_dataSet1(hass):
+async def test_dataSet1(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     await setup_tests(
         hass,
@@ -92,7 +93,7 @@ async def test_dataSet1(hass):
     )
 
 
-async def test_dataSet2(hass):
+async def test_dataSet2(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     await setup_tests(
         hass,
@@ -103,7 +104,7 @@ async def test_dataSet2(hass):
     )
 
 
-async def test_dataSet3(hass):
+async def test_dataSet3(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     state = await setup_tests(
         hass,
@@ -116,7 +117,7 @@ async def test_dataSet3(hass):
     assert state.attributes.get("unit_of_measurement") == f"/{UnitOfTime.SECONDS}"
 
 
-async def test_dataSet4(hass):
+async def test_dataSet4(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     await setup_tests(
         hass,
@@ -127,7 +128,7 @@ async def test_dataSet4(hass):
     )
 
 
-async def test_dataSet5(hass):
+async def test_dataSet5(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     await setup_tests(
         hass,
@@ -138,12 +139,12 @@ async def test_dataSet5(hass):
     )
 
 
-async def test_dataSet6(hass):
+async def test_dataSet6(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     await setup_tests(hass, {}, times=[0, 60], values=[0, 1 / 60], expected_state=1)
 
 
-async def test_data_moving_average_for_discrete_sensor(hass):
+async def test_data_moving_average_for_discrete_sensor(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     # We simulate the following situation:
     # The temperature rises 1 °C per minute for 30 minutes long.
@@ -182,7 +183,7 @@ async def test_data_moving_average_for_discrete_sensor(hass):
             assert abs(1 - derivative) <= 0.1 + 1e-6
 
 
-async def test_data_moving_average_for_irregular_times(hass):
+async def test_data_moving_average_for_irregular_times(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     # We simulate the following situation:
     # The temperature rises 1 °C per minute for 30 minutes long.
@@ -225,7 +226,7 @@ async def test_data_moving_average_for_irregular_times(hass):
             assert abs(0.1 - derivative) <= 0.01 + 1e-6
 
 
-async def test_double_signal_after_delay(hass):
+async def test_double_signal_after_delay(hass: HomeAssistant) -> None:
     """Test derivative sensor state."""
     # The old algorithm would produce extreme values if, after a delay longer than the time window
     # there would be two signals, a large spike would be produced. Check explicitly for this situation
@@ -266,7 +267,7 @@ async def test_double_signal_after_delay(hass):
         previous = derivative
 
 
-async def test_prefix(hass):
+async def test_prefix(hass: HomeAssistant) -> None:
     """Test derivative sensor state using a power source."""
     config = {
         "sensor": {
@@ -309,7 +310,7 @@ async def test_prefix(hass):
     assert state.attributes.get("unit_of_measurement") == f"kW/{UnitOfTime.HOURS}"
 
 
-async def test_suffix(hass):
+async def test_suffix(hass: HomeAssistant) -> None:
     """Test derivative sensor state using a network counter source."""
     config = {
         "sensor": {

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -29,6 +29,7 @@ from tests.common import (
     mock_registry,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -813,7 +814,9 @@ async def test_websocket_get_trigger_capabilities_bad_trigger(
     module.async_get_trigger_capabilities.assert_called_once()
 
 
-async def test_automation_with_non_existing_integration(hass, caplog):
+async def test_automation_with_non_existing_integration(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test device automation trigger with non existing integration."""
     assert await async_setup_component(
         hass,
@@ -898,7 +901,9 @@ async def test_automation_with_dynamically_validated_action(
     module.async_validate_action_config.assert_awaited_once()
 
 
-async def test_automation_with_integration_without_device_action(hass, caplog):
+async def test_automation_with_integration_without_device_action(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test device automation action with integration without device action support."""
     mock_integration(hass, MockModule(domain="test"))
     assert await async_setup_component(
@@ -984,7 +989,9 @@ async def test_automation_with_dynamically_validated_condition(
     module.async_validate_condition_config.assert_awaited_once()
 
 
-async def test_automation_with_integration_without_device_condition(hass, caplog):
+async def test_automation_with_integration_without_device_condition(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test device automation condition with integration without device condition support."""
     mock_integration(hass, MockModule(domain="test"))
     assert await async_setup_component(
@@ -1079,7 +1086,9 @@ async def test_automation_with_dynamically_validated_trigger(
     module.async_attach_trigger.assert_awaited_once()
 
 
-async def test_automation_with_integration_without_device_trigger(hass, caplog):
+async def test_automation_with_integration_without_device_trigger(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test device automation trigger with integration without device trigger support."""
     mock_integration(hass, MockModule(domain="test"))
     assert await async_setup_component(
@@ -1103,7 +1112,9 @@ async def test_automation_with_integration_without_device_trigger(hass, caplog):
     )
 
 
-async def test_automation_with_bad_action(hass, caplog):
+async def test_automation_with_bad_action(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device action."""
     assert await async_setup_component(
         hass,
@@ -1120,7 +1131,9 @@ async def test_automation_with_bad_action(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_condition_action(hass, caplog):
+async def test_automation_with_bad_condition_action(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device action."""
     assert await async_setup_component(
         hass,
@@ -1137,7 +1150,9 @@ async def test_automation_with_bad_condition_action(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_condition_missing_domain(hass, caplog):
+async def test_automation_with_bad_condition_missing_domain(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device condition."""
     assert await async_setup_component(
         hass,
@@ -1155,7 +1170,9 @@ async def test_automation_with_bad_condition_missing_domain(hass, caplog):
     assert "required key not provided @ data['condition'][0]['domain']" in caplog.text
 
 
-async def test_automation_with_bad_condition(hass, caplog):
+async def test_automation_with_bad_condition(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device condition."""
     assert await async_setup_component(
         hass,
@@ -1289,7 +1306,9 @@ async def test_automation_with_sub_condition(hass, calls, enable_custom_integrat
     )
 
 
-async def test_automation_with_bad_sub_condition(hass, caplog):
+async def test_automation_with_bad_sub_condition(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device condition under and/or conditions."""
     assert await async_setup_component(
         hass,
@@ -1310,7 +1329,9 @@ async def test_automation_with_bad_sub_condition(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_automation_with_bad_trigger(hass, caplog):
+async def test_automation_with_bad_trigger(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test automation with bad device trigger."""
     assert await async_setup_component(
         hass,
@@ -1327,7 +1348,9 @@ async def test_automation_with_bad_trigger(hass, caplog):
     assert "required key not provided" in caplog.text
 
 
-async def test_websocket_device_not_found(hass, hass_ws_client):
+async def test_websocket_device_not_found(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test calling command with unknown device."""
     await async_setup_component(hass, "device_automation", {})
     client = await hass_ws_client(hass)

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -1,5 +1,4 @@
 """The tests device sun light trigger component."""
-
 from datetime import datetime
 from unittest.mock import patch
 
@@ -21,7 +20,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -220,7 +219,7 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
         assert hass.states.get("person.me").state == "home"
 
 
-async def test_initialize_start(hass):
+async def test_initialize_start(hass: HomeAssistant) -> None:
     """Test we initialize when HA starts."""
     hass.state = CoreState.not_running
     assert await async_setup_component(

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -1,6 +1,6 @@
 """Test Device Tracker config entry things."""
 from homeassistant.components.device_tracker import DOMAIN, config_entry as ce
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -104,7 +104,7 @@ async def test_cleanup_legacy(hass, enable_custom_integrations):
     assert dev_reg.async_get(device2.id) is None
 
 
-async def test_register_mac(hass):
+async def test_register_mac(hass: HomeAssistant) -> None:
     """Test registering a mac."""
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -137,7 +137,7 @@ async def test_register_mac(hass):
     assert entity_entry_1.disabled_by is None
 
 
-async def test_register_mac_ignored(hass):
+async def test_register_mac_ignored(hass: HomeAssistant) -> None:
     """Test ignoring registering a mac."""
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -170,7 +170,7 @@ async def test_register_mac_ignored(hass):
     assert entity_entry_1.disabled_by == er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_connected_device_registered(hass):
+async def test_connected_device_registered(hass: HomeAssistant) -> None:
     """Test dispatch on connected device being registered."""
 
     registry = mock_registry(hass)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
-from homeassistant.core import State, callback
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.helpers.json import JSONEncoder
@@ -54,7 +54,7 @@ def mock_yaml_devices(hass):
         os.remove(yaml_devices)
 
 
-async def test_is_on(hass):
+async def test_is_on(hass: HomeAssistant) -> None:
     """Test is_on method."""
     entity_id = f"{const.DOMAIN}.test"
 
@@ -67,7 +67,7 @@ async def test_is_on(hass):
     assert not device_tracker.is_on(hass, entity_id)
 
 
-async def test_reading_broken_yaml_config(hass):
+async def test_reading_broken_yaml_config(hass: HomeAssistant) -> None:
     """Test when known devices contains invalid data."""
     files = {
         "empty.yaml": "",
@@ -169,7 +169,7 @@ async def test_setup_without_yaml_file(hass, yaml_devices, enable_custom_integra
         await hass.async_block_till_done()
 
 
-async def test_gravatar(hass):
+async def test_gravatar(hass: HomeAssistant) -> None:
     """Test the Gravatar generation."""
     dev_id = "test"
     device = legacy.Device(
@@ -188,7 +188,7 @@ async def test_gravatar(hass):
     assert device.config_picture == gravatar_url
 
 
-async def test_gravatar_and_picture(hass):
+async def test_gravatar_and_picture(hass: HomeAssistant) -> None:
     """Test that Gravatar overrides picture."""
     dev_id = "test"
     device = legacy.Device(
@@ -542,7 +542,7 @@ async def test_see_failures(mock_warning, hass, mock_device_tracker_conf):
     assert len(devices) == 4
 
 
-async def test_async_added_to_hass(hass):
+async def test_async_added_to_hass(hass: HomeAssistant) -> None:
     """Test restoring state."""
     attr = {
         ATTR_LONGITUDE: 18,
@@ -568,7 +568,7 @@ async def test_async_added_to_hass(hass):
         assert atr == val, f"{key}={atr} expected: {val}"
 
 
-async def test_bad_platform(hass):
+async def test_bad_platform(hass: HomeAssistant) -> None:
     """Test bad platform."""
     config = {"device_tracker": [{"platform": "bad_platform"}]}
     with assert_setup_component(0, device_tracker.DOMAIN):

--- a/tests/components/dexcom/test_config_flow.py
+++ b/tests/components/dexcom/test_config_flow.py
@@ -6,13 +6,14 @@ from pydexcom import AccountError, SessionError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dexcom.const import DOMAIN, MG_DL, MMOL_L
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from . import CONFIG
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -40,7 +41,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_account_error(hass):
+async def test_form_account_error(hass: HomeAssistant) -> None:
     """Test we handle account error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -59,7 +60,7 @@ async def test_form_account_error(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_session_error(hass):
+async def test_form_session_error(hass: HomeAssistant) -> None:
     """Test we handle session error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -78,7 +79,7 @@ async def test_form_session_error(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -97,7 +98,7 @@ async def test_form_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_option_flow_default(hass):
+async def test_option_flow_default(hass: HomeAssistant) -> None:
     """Test config flow options."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -121,7 +122,7 @@ async def test_option_flow_default(hass):
     }
 
 
-async def test_option_flow(hass):
+async def test_option_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/dexcom/test_init.py
+++ b/tests/components/dexcom/test_init.py
@@ -5,13 +5,14 @@ from pydexcom import AccountError, SessionError
 
 from homeassistant.components.dexcom.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from . import CONFIG, init_integration
 
 from tests.common import MockConfigEntry
 
 
-async def test_setup_entry_account_error(hass):
+async def test_setup_entry_account_error(hass: HomeAssistant) -> None:
     """Test entry setup failed due to account error."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -31,7 +32,7 @@ async def test_setup_entry_account_error(hass):
     assert result is False
 
 
-async def test_setup_entry_session_error(hass):
+async def test_setup_entry_session_error(hass: HomeAssistant) -> None:
     """Test entry setup failed due to session error."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -51,7 +52,7 @@ async def test_setup_entry_session_error(hass):
     assert result is False
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 

--- a/tests/components/dexcom/test_sensor.py
+++ b/tests/components/dexcom/test_sensor.py
@@ -1,5 +1,4 @@
 """The sensor tests for the griddy platform."""
-
 from unittest.mock import patch
 
 from pydexcom import SessionError
@@ -10,12 +9,13 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
 from . import GLUCOSE_READING, init_integration
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test we get sensor data."""
     await init_integration(hass)
 
@@ -29,7 +29,7 @@ async def test_sensors(hass):
     assert test_username_glucose_trend.state == GLUCOSE_READING.trend_description
 
 
-async def test_sensors_unknown(hass):
+async def test_sensors_unknown(hass: HomeAssistant) -> None:
     """Test we handle sensor state unknown."""
     await init_integration(hass)
 
@@ -50,7 +50,7 @@ async def test_sensors_unknown(hass):
     assert test_username_glucose_trend.state == STATE_UNKNOWN
 
 
-async def test_sensors_update_failed(hass):
+async def test_sensors_update_failed(hass: HomeAssistant) -> None:
     """Test we handle sensor update failed."""
     await init_integration(hass)
 
@@ -71,7 +71,7 @@ async def test_sensors_update_failed(hass):
     assert test_username_glucose_trend.state == STATE_UNAVAILABLE
 
 
-async def test_sensors_options_changed(hass):
+async def test_sensors_options_changed(hass: HomeAssistant) -> None:
     """Test we handle sensor unavailable."""
     entry = await init_integration(hass)
 

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -3,6 +3,7 @@ import datetime
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
 from scapy import arch  # pylint: disable=unused-import  # noqa: F401
 from scapy.error import Scapy_Exception
 from scapy.layers.dhcp import DHCP
@@ -25,6 +26,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
@@ -156,7 +158,7 @@ async def _async_get_handle_dhcp_packet(hass, integration_matchers):
     return async_handle_dhcp_packet
 
 
-async def test_dhcp_match_hostname_and_macaddress(hass):
+async def test_dhcp_match_hostname_and_macaddress(hass: HomeAssistant) -> None:
     """Test matching based on hostname and macaddress."""
     integration_matchers = [
         {"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}
@@ -183,7 +185,7 @@ async def test_dhcp_match_hostname_and_macaddress(hass):
     )
 
 
-async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
+async def test_dhcp_renewal_match_hostname_and_macaddress(hass: HomeAssistant) -> None:
     """Test renewal matching based on hostname and macaddress."""
     integration_matchers = [
         {"domain": "mock-domain", "hostname": "irobot-*", "macaddress": "501479*"}
@@ -211,7 +213,7 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
     )
 
 
-async def test_registered_devices(hass):
+async def test_registered_devices(hass: HomeAssistant) -> None:
     """Test discovery flows are created for registered devices."""
     integration_matchers = [
         {"domain": "not-matching", "registered_devices": True},
@@ -257,7 +259,7 @@ async def test_registered_devices(hass):
     )
 
 
-async def test_dhcp_match_hostname(hass):
+async def test_dhcp_match_hostname(hass: HomeAssistant) -> None:
     """Test matching based on hostname only."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "connect"}]
 
@@ -281,7 +283,7 @@ async def test_dhcp_match_hostname(hass):
     )
 
 
-async def test_dhcp_match_macaddress(hass):
+async def test_dhcp_match_macaddress(hass: HomeAssistant) -> None:
     """Test matching based on macaddress only."""
     integration_matchers = [{"domain": "mock-domain", "macaddress": "B8B7F1*"}]
 
@@ -305,7 +307,7 @@ async def test_dhcp_match_macaddress(hass):
     )
 
 
-async def test_dhcp_multiple_match_only_one_flow(hass):
+async def test_dhcp_multiple_match_only_one_flow(hass: HomeAssistant) -> None:
     """Test matching the domain multiple times only generates one flow."""
     integration_matchers = [
         {"domain": "mock-domain", "macaddress": "B8B7F1*"},
@@ -332,7 +334,7 @@ async def test_dhcp_multiple_match_only_one_flow(hass):
     )
 
 
-async def test_dhcp_match_macaddress_without_hostname(hass):
+async def test_dhcp_match_macaddress_without_hostname(hass: HomeAssistant) -> None:
     """Test matching based on macaddress only."""
     integration_matchers = [{"domain": "mock-domain", "macaddress": "606BBD*"}]
 
@@ -356,7 +358,7 @@ async def test_dhcp_match_macaddress_without_hostname(hass):
     )
 
 
-async def test_dhcp_nomatch(hass):
+async def test_dhcp_nomatch(hass: HomeAssistant) -> None:
     """Test not matching based on macaddress only."""
     integration_matchers = [{"domain": "mock-domain", "macaddress": "ABC123*"}]
 
@@ -371,7 +373,7 @@ async def test_dhcp_nomatch(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_nomatch_hostname(hass):
+async def test_dhcp_nomatch_hostname(hass: HomeAssistant) -> None:
     """Test not matching based on hostname only."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -386,7 +388,7 @@ async def test_dhcp_nomatch_hostname(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_nomatch_non_dhcp_packet(hass):
+async def test_dhcp_nomatch_non_dhcp_packet(hass: HomeAssistant) -> None:
     """Test matching does not throw on a non-dhcp packet."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -401,7 +403,7 @@ async def test_dhcp_nomatch_non_dhcp_packet(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
+async def test_dhcp_nomatch_non_dhcp_request_packet(hass: HomeAssistant) -> None:
     """Test nothing happens with the wrong message-type."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -425,7 +427,7 @@ async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_invalid_hostname(hass):
+async def test_dhcp_invalid_hostname(hass: HomeAssistant) -> None:
     """Test we ignore invalid hostnames."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -449,7 +451,7 @@ async def test_dhcp_invalid_hostname(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_missing_hostname(hass):
+async def test_dhcp_missing_hostname(hass: HomeAssistant) -> None:
     """Test we ignore missing hostnames."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -473,7 +475,7 @@ async def test_dhcp_missing_hostname(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_dhcp_invalid_option(hass):
+async def test_dhcp_invalid_option(hass: HomeAssistant) -> None:
     """Test we ignore invalid hostname option."""
     integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
@@ -497,7 +499,7 @@ async def test_dhcp_invalid_option(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_setup_and_stop(hass):
+async def test_setup_and_stop(hass: HomeAssistant) -> None:
     """Test we can setup and stop."""
 
     assert await async_setup_component(
@@ -521,7 +523,9 @@ async def test_setup_and_stop(hass):
     start_call.assert_called_once()
 
 
-async def test_setup_fails_as_root(hass, caplog):
+async def test_setup_fails_as_root(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle sniff setup failing as root."""
 
     assert await async_setup_component(
@@ -546,7 +550,9 @@ async def test_setup_fails_as_root(hass, caplog):
     assert "Cannot watch for dhcp packets" in caplog.text
 
 
-async def test_setup_fails_non_root(hass, caplog):
+async def test_setup_fails_non_root(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle sniff setup failing as non-root."""
 
     assert await async_setup_component(
@@ -568,7 +574,9 @@ async def test_setup_fails_non_root(hass, caplog):
     assert "Cannot watch for dhcp packets without root or CAP_NET_RAW" in caplog.text
 
 
-async def test_setup_fails_with_broken_libpcap(hass, caplog):
+async def test_setup_fails_with_broken_libpcap(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we abort if libpcap is missing or broken."""
 
     assert await async_setup_component(
@@ -597,7 +605,9 @@ async def test_setup_fails_with_broken_libpcap(hass, caplog):
     )
 
 
-async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
+async def test_device_tracker_hostname_and_macaddress_exists_before_start(
+    hass: HomeAssistant,
+) -> None:
     """Test matching based on hostname and macaddress before start."""
     hass.states.async_set(
         "device_tracker.august_connect",
@@ -633,7 +643,7 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
     )
 
 
-async def test_device_tracker_registered(hass):
+async def test_device_tracker_registered(hass: HomeAssistant) -> None:
     """Test matching based on hostname and macaddress when registered."""
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerRegisteredWatcher(
@@ -664,7 +674,7 @@ async def test_device_tracker_registered(hass):
     await hass.async_block_till_done()
 
 
-async def test_device_tracker_registered_hostname_none(hass):
+async def test_device_tracker_registered_hostname_none(hass: HomeAssistant) -> None:
     """Test handle None hostname."""
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerRegisteredWatcher(
@@ -686,7 +696,9 @@ async def test_device_tracker_registered_hostname_none(hass):
     await hass.async_block_till_done()
 
 
-async def test_device_tracker_hostname_and_macaddress_after_start(hass):
+async def test_device_tracker_hostname_and_macaddress_after_start(
+    hass: HomeAssistant,
+) -> None:
     """Test matching based on hostname and macaddress after start."""
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
@@ -723,7 +735,9 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
     )
 
 
-async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass):
+async def test_device_tracker_hostname_and_macaddress_after_start_not_home(
+    hass: HomeAssistant,
+) -> None:
     """Test matching based on hostname and macaddress after start but not home."""
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
@@ -751,7 +765,9 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass)
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_device_tracker_hostname_and_macaddress_after_start_not_router(hass):
+async def test_device_tracker_hostname_and_macaddress_after_start_not_router(
+    hass: HomeAssistant,
+) -> None:
     """Test matching based on hostname and macaddress after start but not router."""
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
@@ -808,7 +824,9 @@ async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missi
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_device_tracker_ignore_self_assigned_ips_before_start(hass):
+async def test_device_tracker_ignore_self_assigned_ips_before_start(
+    hass: HomeAssistant,
+) -> None:
     """Test matching ignores self assigned ip address."""
     hass.states.async_set(
         "device_tracker.august_connect",
@@ -835,7 +853,7 @@ async def test_device_tracker_ignore_self_assigned_ips_before_start(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_aiodiscover_finds_new_hosts(hass):
+async def test_aiodiscover_finds_new_hosts(hass: HomeAssistant) -> None:
     """Test aiodiscover finds new host."""
     with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",
@@ -869,7 +887,9 @@ async def test_aiodiscover_finds_new_hosts(hass):
     )
 
 
-async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
+async def test_aiodiscover_does_not_call_again_on_shorter_hostname(
+    hass: HomeAssistant,
+) -> None:
     """Verify longer hostnames generate a new flow but shorter ones do not.
 
     Some routers will truncate hostnames so we want to accept
@@ -933,7 +953,7 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
     )
 
 
-async def test_aiodiscover_finds_new_hosts_after_interval(hass):
+async def test_aiodiscover_finds_new_hosts_after_interval(hass: HomeAssistant) -> None:
     """Test aiodiscover finds new host after interval."""
     with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.setup import async_setup_component
@@ -12,6 +13,7 @@ from homeassistant.setup import async_setup_component
 from . import _get_diagnostics_for_config_entry, _get_diagnostics_for_device
 
 from tests.common import MockConfigEntry, mock_platform
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +44,9 @@ async def mock_diagnostics_integration(hass):
     assert await async_setup_component(hass, "diagnostics", {})
 
 
-async def test_websocket(hass, hass_ws_client):
+async def test_websocket(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test websocket command."""
     client = await hass_ws_client(hass)
     await client.send_json({"id": 5, "type": "diagnostics/list"})
@@ -74,7 +78,9 @@ async def test_websocket(hass, hass_ws_client):
     }
 
 
-async def test_download_diagnostics(hass, hass_client):
+async def test_download_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test download diagnostics."""
     config_entry = MockConfigEntry(domain="fake_integration")
     config_entry.add_to_hass(hass)
@@ -118,7 +124,9 @@ async def test_download_diagnostics(hass, hass_client):
     }
 
 
-async def test_failure_scenarios(hass, hass_client):
+async def test_failure_scenarios(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test failure scenarios."""
     client = await hass_client()
 

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed, mock_coro
@@ -53,7 +54,7 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
     return mock_discover, mock_platform
 
 
-async def test_unknown_service(hass):
+async def test_unknown_service(hass: HomeAssistant) -> None:
     """Test that unknown service is ignored."""
 
     def discover(netdisco, zeroconf_instance, suppress_mdns_types):
@@ -66,7 +67,7 @@ async def test_unknown_service(hass):
     assert not mock_platform.called
 
 
-async def test_load_platform(hass):
+async def test_load_platform(hass: HomeAssistant) -> None:
     """Test load a platform."""
 
     def discover(netdisco, zeroconf_instance, suppress_mdns_types):
@@ -82,7 +83,7 @@ async def test_load_platform(hass):
     )
 
 
-async def test_discover_config_flow(hass):
+async def test_discover_config_flow(hass: HomeAssistant) -> None:
     """Test discovery triggering a config flow."""
     discovery_info = {"hello": "world"}
 

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
 from homeassistant.components.doorbird.const import CONF_EVENTS, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -37,7 +38,7 @@ def _get_mock_doorbirdapi_side_effects(ready=None, info=None):
     return doorbirdapi_mock
 
 
-async def test_user_form(hass):
+async def test_user_form(hass: HomeAssistant) -> None:
     """Test we get the user form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -76,7 +77,7 @@ async def test_user_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_zeroconf_wrong_oui(hass):
+async def test_form_zeroconf_wrong_oui(hass: HomeAssistant) -> None:
     """Test we abort when we get the wrong OUI via zeroconf."""
 
     result = await hass.config_entries.flow.async_init(
@@ -96,7 +97,7 @@ async def test_form_zeroconf_wrong_oui(hass):
     assert result["reason"] == "not_doorbird_device"
 
 
-async def test_form_zeroconf_link_local_ignored(hass):
+async def test_form_zeroconf_link_local_ignored(hass: HomeAssistant) -> None:
     """Test we abort when we get a link local address via zeroconf."""
 
     result = await hass.config_entries.flow.async_init(
@@ -116,7 +117,7 @@ async def test_form_zeroconf_link_local_ignored(hass):
     assert result["reason"] == "link_local_address"
 
 
-async def test_form_zeroconf_ipv4_address(hass):
+async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
     """Test we abort and update the ip address from zeroconf with an ipv4 address."""
 
     config_entry = MockConfigEntry(
@@ -144,7 +145,7 @@ async def test_form_zeroconf_ipv4_address(hass):
     assert config_entry.data[CONF_HOST] == "4.4.4.4"
 
 
-async def test_form_zeroconf_non_ipv4_ignored(hass):
+async def test_form_zeroconf_non_ipv4_ignored(hass: HomeAssistant) -> None:
     """Test we abort when we get a non ipv4 address via zeroconf."""
 
     result = await hass.config_entries.flow.async_init(
@@ -164,7 +165,7 @@ async def test_form_zeroconf_non_ipv4_ignored(hass):
     assert result["reason"] == "not_ipv4_address"
 
 
-async def test_form_zeroconf_correct_oui(hass):
+async def test_form_zeroconf_correct_oui(hass: HomeAssistant) -> None:
     """Test we can setup from zeroconf with the correct OUI source."""
     doorbirdapi = _get_mock_doorbirdapi_return_values(
         ready=[True], info={"WIFI_MAC_ADDR": "macaddr"}
@@ -255,7 +256,7 @@ async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_
     assert result["reason"] == "not_doorbird_device"
 
 
-async def test_form_user_cannot_connect(hass):
+async def test_form_user_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -275,7 +276,7 @@ async def test_form_user_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_user_invalid_auth(hass):
+async def test_form_user_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle cannot invalid auth error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -296,7 +297,7 @@ async def test_form_user_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -9,6 +9,7 @@ import serial.tools.list_ports
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dsmr import DOMAIN, config_flow
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -530,7 +531,7 @@ async def test_setup_serial_wrong_telegram(
     assert result["errors"] == {"base": "cannot_communicate"}
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options flow."""
 
     entry_data = {

--- a/tests/components/dte_energy_bridge/test_sensor.py
+++ b/tests/components/dte_energy_bridge/test_sensor.py
@@ -1,12 +1,13 @@
 """The tests for the DTE Energy Bridge."""
 import requests_mock
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 DTE_ENERGY_BRIDGE_CONFIG = {"platform": "dte_energy_bridge", "ip": "192.168.1.1"}
 
 
-async def test_setup_with_config(hass):
+async def test_setup_with_config(hass: HomeAssistant) -> None:
     """Test the platform setup with configuration."""
     assert await async_setup_component(
         hass, "sensor", {"dte_energy_bridge": DTE_ENERGY_BRIDGE_CONFIG}
@@ -14,7 +15,7 @@ async def test_setup_with_config(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_correct_reading(hass):
+async def test_setup_correct_reading(hass: HomeAssistant) -> None:
     """Test DTE Energy bridge returns a correct value."""
     with requests_mock.Mocker() as mock_req:
         mock_req.get(
@@ -28,7 +29,7 @@ async def test_setup_correct_reading(hass):
     assert hass.states.get("sensor.current_energy_usage").state == "0.411"
 
 
-async def test_setup_incorrect_units_reading(hass):
+async def test_setup_incorrect_units_reading(hass: HomeAssistant) -> None:
     """Test DTE Energy bridge handles a value with incorrect units."""
     with requests_mock.Mocker() as mock_req:
         mock_req.get(
@@ -42,7 +43,7 @@ async def test_setup_incorrect_units_reading(hass):
     assert hass.states.get("sensor.current_energy_usage").state == "0.411"
 
 
-async def test_setup_bad_format_reading(hass):
+async def test_setup_bad_format_reading(hass: HomeAssistant) -> None:
     """Test DTE Energy bridge handles an invalid value."""
     with requests_mock.Mocker() as mock_req:
         mock_req.get(

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -6,11 +6,13 @@ import pytest
 
 from homeassistant.components import duckdns
 from homeassistant.components.duckdns import async_track_time_interval_backoff
+from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 DOMAIN = "bla"
 TOKEN = "abcdefgh"
@@ -43,7 +45,7 @@ def setup_duckdns(hass, aioclient_mock):
     )
 
 
-async def test_setup(hass, aioclient_mock):
+async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup works if update passes."""
     aioclient_mock.get(
         duckdns.UPDATE_URL, params={"domains": DOMAIN, "token": TOKEN}, text="OK"
@@ -63,7 +65,9 @@ async def test_setup(hass, aioclient_mock):
     assert aioclient_mock.call_count == 2
 
 
-async def test_setup_backoff(hass, aioclient_mock):
+async def test_setup_backoff(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup fails if first update fails."""
     aioclient_mock.get(
         duckdns.UPDATE_URL, params={"domains": DOMAIN, "token": TOKEN}, text="KO"
@@ -128,7 +132,7 @@ async def test_service_clear_txt(hass, aioclient_mock, setup_duckdns):
     assert aioclient_mock.call_count == 1
 
 
-async def test_async_track_time_interval_backoff(hass):
+async def test_async_track_time_interval_backoff(hass: HomeAssistant) -> None:
     """Test setup fails if first update fails."""
     ret_val = False
     call_count = 0

--- a/tests/components/dunehd/test_config_flow.py
+++ b/tests/components/dunehd/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.dunehd.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -14,7 +15,7 @@ CONFIG_IP = {CONF_HOST: "10.10.10.12"}
 DUNEHD_STATE = {"protocol_version": "4", "player_state": "navigator"}
 
 
-async def test_user_invalid_host(hass):
+async def test_user_invalid_host(hass: HomeAssistant) -> None:
     """Test that errors are shown when the host is invalid."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: "invalid/host"}
@@ -23,7 +24,7 @@ async def test_user_invalid_host(hass):
     assert result["errors"] == {CONF_HOST: "invalid_host"}
 
 
-async def test_user_very_long_host(hass):
+async def test_user_very_long_host(hass: HomeAssistant) -> None:
     """Test that errors are shown when the host is longer than 253 chars."""
     long_host = (
         "very_long_host_very_long_host_very_long_host_very_long_host_very_long_"
@@ -38,7 +39,7 @@ async def test_user_very_long_host(hass):
     assert result["errors"] == {CONF_HOST: "invalid_host"}
 
 
-async def test_user_cannot_connect(hass):
+async def test_user_cannot_connect(hass: HomeAssistant) -> None:
     """Test that errors are shown when cannot connect to the host."""
     with patch("pdunehd.DuneHDPlayer.update_state", return_value={}):
         result = await hass.config_entries.flow.async_init(
@@ -48,7 +49,7 @@ async def test_user_cannot_connect(hass):
         assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
-async def test_duplicate_error(hass):
+async def test_duplicate_error(hass: HomeAssistant) -> None:
     """Test that errors are shown when duplicates are added."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -65,7 +66,7 @@ async def test_duplicate_error(hass):
         assert result["errors"] == {CONF_HOST: "already_configured"}
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     with patch("homeassistant.components.dunehd.async_setup_entry"), patch(
         "pdunehd.DuneHDPlayer.update_state", return_value=DUNEHD_STATE
@@ -79,7 +80,7 @@ async def test_create_entry(hass):
         assert result["data"] == {CONF_HOST: "dunehd-host"}
 
 
-async def test_create_entry_with_ipv6_address(hass):
+async def test_create_entry_with_ipv6_address(hass: HomeAssistant) -> None:
     """Test that the user step works with device IPv6 address.."""
     with patch("homeassistant.components.dunehd.async_setup_entry"), patch(
         "pdunehd.DuneHDPlayer.update_state", return_value=DUNEHD_STATE

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -1,6 +1,4 @@
 """Test Dynalite bridge."""
-
-
 from unittest.mock import AsyncMock, Mock, patch
 
 from dynalite_devices_lib.dynalite_devices import (
@@ -18,12 +16,13 @@ from homeassistant.components.dynalite.const import (
     ATTR_PACKET,
     ATTR_PRESET,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from tests.common import MockConfigEntry
 
 
-async def test_update_device(hass):
+async def test_update_device(hass: HomeAssistant) -> None:
     """Test that update works."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
@@ -53,7 +52,7 @@ async def test_update_device(hass):
     specific_func.assert_called_once()
 
 
-async def test_add_devices_then_register(hass):
+async def test_add_devices_then_register(hass: HomeAssistant) -> None:
     """Test that add_devices work."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
@@ -88,7 +87,7 @@ async def test_add_devices_then_register(hass):
     assert hass.states.get("switch.name3")
 
 
-async def test_register_then_add_devices(hass):
+async def test_register_then_add_devices(hass: HomeAssistant) -> None:
     """Test that add_devices work after register_add_entities."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
@@ -117,7 +116,7 @@ async def test_register_then_add_devices(hass):
     assert hass.states.get("switch.name2")
 
 
-async def test_notifications(hass):
+async def test_notifications(hass: HomeAssistant) -> None:
     """Test that update works."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test Dynalite config flow."""
-
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import dynalite
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -38,7 +38,7 @@ async def test_flow(hass, first_con, second_con, exp_type, exp_result, exp_reaso
         assert result["reason"] == exp_reason
 
 
-async def test_existing(hass):
+async def test_existing(hass: HomeAssistant) -> None:
     """Test when the entry exists with the same config."""
     host = "1.2.3.4"
     MockConfigEntry(
@@ -57,7 +57,7 @@ async def test_existing(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_existing_update(hass):
+async def test_existing_update(hass: HomeAssistant) -> None:
     """Test when the entry exists with a different config."""
     host = "1.2.3.4"
     port1 = 7777
@@ -87,7 +87,7 @@ async def test_existing_update(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_two_entries(hass):
+async def test_two_entries(hass: HomeAssistant) -> None:
     """Test when two different entries exist with different hosts."""
     host1 = "1.2.3.4"
     host2 = "5.6.7.8"

--- a/tests/components/dynalite/test_init.py
+++ b/tests/components/dynalite/test_init.py
@@ -1,6 +1,4 @@
 """Test Dynalite __init__."""
-
-
 from unittest.mock import call, patch
 
 import pytest
@@ -8,19 +6,20 @@ from voluptuous import MultipleInvalid
 
 import homeassistant.components.dynalite.const as dynalite
 from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_ROOM
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_empty_config(hass):
+async def test_empty_config(hass: HomeAssistant) -> None:
     """Test with an empty config."""
     assert await async_setup_component(hass, dynalite.DOMAIN, {}) is True
     assert len(hass.config_entries.flow.async_progress()) == 0
     assert len(hass.config_entries.async_entries(dynalite.DOMAIN)) == 0
 
 
-async def test_async_setup(hass):
+async def test_async_setup(hass: HomeAssistant) -> None:
     """Test a successful setup with all of the different options."""
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -83,7 +82,7 @@ async def test_async_setup(hass):
     assert len(hass.config_entries.async_entries(dynalite.DOMAIN)) == 1
 
 
-async def test_service_request_area_preset(hass):
+async def test_service_request_area_preset(hass: HomeAssistant) -> None:
     """Test requesting and area preset via service call."""
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -155,7 +154,7 @@ async def test_service_request_area_preset(hass):
         mock_req_area_pres.assert_called_once_with(7, 1)
 
 
-async def test_service_request_channel_level(hass):
+async def test_service_request_channel_level(hass: HomeAssistant) -> None:
     """Test requesting the level of a channel via service call."""
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -206,7 +205,7 @@ async def test_service_request_channel_level(hass):
         assert mock_req_chan_lvl.mock_calls == [call(4, 5), call(4, 5)]
 
 
-async def test_async_setup_bad_config1(hass):
+async def test_async_setup_bad_config1(hass: HomeAssistant) -> None:
     """Test a successful with bad config on templates."""
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -235,7 +234,7 @@ async def test_async_setup_bad_config1(hass):
         await hass.async_block_till_done()
 
 
-async def test_async_setup_bad_config2(hass):
+async def test_async_setup_bad_config2(hass: HomeAssistant) -> None:
     """Test a successful with bad config on numbers."""
     host = "1.2.3.4"
     with patch(
@@ -260,7 +259,7 @@ async def test_async_setup_bad_config2(hass):
     assert len(hass.config_entries.async_entries(dynalite.DOMAIN)) == 0
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test being able to unload an entry."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={CONF_HOST: host})

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -12,11 +12,12 @@ from homeassistant.components.ecobee.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, mock_coro
 
 
-async def test_abort_if_already_setup(hass):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if ecobee is already setup."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -29,7 +30,7 @@ async def test_abort_if_already_setup(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_user_step_without_user_input(hass):
+async def test_user_step_without_user_input(hass: HomeAssistant) -> None:
     """Test expected result if user step is called."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -40,7 +41,7 @@ async def test_user_step_without_user_input(hass):
     assert result["step_id"] == "user"
 
 
-async def test_pin_request_succeeds(hass):
+async def test_pin_request_succeeds(hass: HomeAssistant) -> None:
     """Test expected result if pin request succeeds."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -58,7 +59,7 @@ async def test_pin_request_succeeds(hass):
         assert result["description_placeholders"] == {"pin": "test-pin"}
 
 
-async def test_pin_request_fails(hass):
+async def test_pin_request_fails(hass: HomeAssistant) -> None:
     """Test expected result if pin request fails."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -75,7 +76,7 @@ async def test_pin_request_fails(hass):
         assert result["errors"]["base"] == "pin_request_failed"
 
 
-async def test_token_request_succeeds(hass):
+async def test_token_request_succeeds(hass: HomeAssistant) -> None:
     """Test expected result if token request succeeds."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -99,7 +100,7 @@ async def test_token_request_succeeds(hass):
         }
 
 
-async def test_token_request_fails(hass):
+async def test_token_request_fails(hass: HomeAssistant) -> None:
     """Test expected result if token request fails."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -121,7 +122,7 @@ async def test_token_request_fails(hass):
 
 
 @pytest.mark.skip(reason="Flaky/slow")
-async def test_import_flow_triggered_but_no_ecobee_conf(hass):
+async def test_import_flow_triggered_but_no_ecobee_conf(hass: HomeAssistant) -> None:
     """Test expected result if import flow triggers but ecobee.conf doesn't exist."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -161,7 +162,9 @@ async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_valid_t
         }
 
 
-async def test_import_flow_triggered_with_ecobee_conf_and_invalid_data(hass):
+async def test_import_flow_triggered_with_ecobee_conf_and_invalid_data(
+    hass: HomeAssistant,
+) -> None:
     """Test expected result if import flow triggers and ecobee.conf exists with invalid data."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass

--- a/tests/components/ecobee/test_humidifier.py
+++ b/tests/components/ecobee/test_humidifier.py
@@ -29,13 +29,14 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import setup_platform
 
 DEVICE_ID = "humidifier.ecobee"
 
 
-async def test_attributes(hass):
+async def test_attributes(hass: HomeAssistant) -> None:
     """Test the humidifier attributes are correct."""
     await setup_platform(hass, HUMIDIFIER_DOMAIN)
 
@@ -56,7 +57,7 @@ async def test_attributes(hass):
     )
 
 
-async def test_turn_on(hass):
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test the humidifier can be turned on."""
     with patch("pyecobee.Ecobee.set_humidifier_mode") as mock_turn_on:
         await setup_platform(hass, HUMIDIFIER_DOMAIN)
@@ -71,7 +72,7 @@ async def test_turn_on(hass):
         mock_turn_on.assert_called_once_with(0, "manual")
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test the humidifier can be turned off."""
     with patch("pyecobee.Ecobee.set_humidifier_mode") as mock_turn_off:
         await setup_platform(hass, HUMIDIFIER_DOMAIN)
@@ -86,7 +87,7 @@ async def test_turn_off(hass):
         mock_turn_off.assert_called_once_with(0, STATE_OFF)
 
 
-async def test_set_mode(hass):
+async def test_set_mode(hass: HomeAssistant) -> None:
     """Test the humidifier can change modes."""
     with patch("pyecobee.Ecobee.set_humidifier_mode") as mock_set_mode:
         await setup_platform(hass, HUMIDIFIER_DOMAIN)
@@ -118,7 +119,7 @@ async def test_set_mode(hass):
             )
 
 
-async def test_set_humidity(hass):
+async def test_set_humidity(hass: HomeAssistant) -> None:
     """Test the humidifier can set humidity level."""
     with patch("pyecobee.Ecobee.set_humidity") as mock_set_humidity:
         await setup_platform(hass, HUMIDIFIER_DOMAIN)

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -12,7 +12,7 @@ VENTILATOR_MIN_AWAY_ID = "number.ecobee_ventilator_min_time_away"
 THERMOSTAT_ID = 0
 
 
-async def test_ventilator_min_on_home_attributes(hass):
+async def test_ventilator_min_on_home_attributes(hass: HomeAssistant) -> None:
     """Test the ventilator number on home attributes are correct."""
     await setup_platform(hass, DOMAIN)
 
@@ -25,7 +25,7 @@ async def test_ventilator_min_on_home_attributes(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
 
 
-async def test_ventilator_min_on_away_attributes(hass):
+async def test_ventilator_min_on_away_attributes(hass: HomeAssistant) -> None:
     """Test the ventilator number on away attributes are correct."""
     await setup_platform(hass, DOMAIN)
 

--- a/tests/components/econet/test_config_flow.py
+++ b/tests/components/econet/test_config_flow.py
@@ -7,12 +7,13 @@ from pyeconet.errors import InvalidCredentialsError, PyeconetError
 from homeassistant.components.econet import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
 
-async def test_bad_credentials(hass):
+async def test_bad_credentials(hass: HomeAssistant) -> None:
     """Test when provided credentials are rejected."""
 
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +43,7 @@ async def test_bad_credentials(hass):
         }
 
 
-async def test_generic_error_from_library(hass):
+async def test_generic_error_from_library(hass: HomeAssistant) -> None:
     """Test when connection fails."""
 
     result = await hass.config_entries.flow.async_init(
@@ -72,7 +73,7 @@ async def test_generic_error_from_library(hass):
         }
 
 
-async def test_auth_worked(hass):
+async def test_auth_worked(hass: HomeAssistant) -> None:
     """Test when provided credentials are accepted."""
 
     result = await hass.config_entries.flow.async_init(
@@ -102,7 +103,7 @@ async def test_auth_worked(hass):
         }
 
 
-async def test_already_configured(hass):
+async def test_already_configured(hass: HomeAssistant) -> None:
     """Test when provided credentials are already configured."""
     config = {
         CONF_EMAIL: "admin@localhost.com",

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.elkm1.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -31,7 +32,7 @@ ELK_DISCOVERY_INFO_NON_STANDARD_PORT = asdict(ELK_DISCOVERY_NON_STANDARD_PORT)
 MODULE = "homeassistant.components.elkm1"
 
 
-async def test_discovery_ignored_entry(hass):
+async def test_discovery_ignored_entry(hass: HomeAssistant) -> None:
     """Test we abort on ignored entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -52,7 +53,7 @@ async def test_discovery_ignored_entry(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_user_with_secure_elk_no_discovery(hass):
+async def test_form_user_with_secure_elk_no_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a secure elk."""
 
     with _patch_discovery(no_device=True):
@@ -98,7 +99,7 @@ async def test_form_user_with_secure_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_insecure_elk_skip_discovery(hass):
+async def test_form_user_with_insecure_elk_skip_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a insecure elk with skipping discovery."""
 
     with _patch_discovery(), _patch_elk():
@@ -150,7 +151,7 @@ async def test_form_user_with_insecure_elk_skip_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_insecure_elk_no_discovery(hass):
+async def test_form_user_with_insecure_elk_no_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a insecure elk."""
 
     with _patch_discovery(), _patch_elk():
@@ -202,7 +203,7 @@ async def test_form_user_with_insecure_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_insecure_elk_times_out(hass):
+async def test_form_user_with_insecure_elk_times_out(hass: HomeAssistant) -> None:
     """Test we can setup a insecure elk that times out."""
 
     with _patch_discovery(), _patch_elk():
@@ -247,7 +248,9 @@ async def test_form_user_with_insecure_elk_times_out(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_user_with_secure_elk_no_discovery_ip_already_configured(hass):
+async def test_form_user_with_secure_elk_no_discovery_ip_already_configured(
+    hass: HomeAssistant,
+) -> None:
     """Test we abort when we try to configure the same ip."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -285,7 +288,7 @@ async def test_form_user_with_secure_elk_no_discovery_ip_already_configured(hass
     assert result2["reason"] == "address_already_configured"
 
 
-async def test_form_user_with_secure_elk_with_discovery(hass):
+async def test_form_user_with_secure_elk_with_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a secure elk."""
 
     with _patch_discovery():
@@ -336,7 +339,9 @@ async def test_form_user_with_secure_elk_with_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_secure_elk_with_discovery_pick_manual(hass):
+async def test_form_user_with_secure_elk_with_discovery_pick_manual(
+    hass: HomeAssistant,
+) -> None:
     """Test we can setup a secure elk with discovery but user picks manual and directed discovery fails."""
 
     with _patch_discovery():
@@ -446,7 +451,7 @@ async def test_form_user_with_secure_elk_with_discovery_pick_manual_direct_disco
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_tls_elk_no_discovery(hass):
+async def test_form_user_with_tls_elk_no_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a secure elk."""
 
     with _patch_discovery(no_device=True):
@@ -492,7 +497,7 @@ async def test_form_user_with_tls_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_non_secure_elk_no_discovery(hass):
+async def test_form_user_with_non_secure_elk_no_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a non-secure elk."""
 
     with _patch_discovery(no_device=True):
@@ -536,7 +541,7 @@ async def test_form_user_with_non_secure_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_serial_elk_no_discovery(hass):
+async def test_form_user_with_serial_elk_no_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a serial elk."""
 
     with _patch_discovery(no_device=True):
@@ -580,7 +585,7 @@ async def test_form_user_with_serial_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with _patch_discovery(no_device=True):
         result = await hass.config_entries.flow.async_init(
@@ -611,7 +616,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_unknown_exception(hass):
+async def test_unknown_exception(hass: HomeAssistant) -> None:
     """Test we handle an unknown exception during connecting."""
     with _patch_discovery(no_device=True):
         result = await hass.config_entries.flow.async_init(
@@ -642,7 +647,7 @@ async def test_unknown_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -669,7 +674,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
 
-async def test_form_invalid_auth_no_password(hass):
+async def test_form_invalid_auth_no_password(hass: HomeAssistant) -> None:
     """Test we handle invalid auth error when no password is provided."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -696,7 +701,7 @@ async def test_form_invalid_auth_no_password(hass):
     assert result2["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
 
-async def test_form_import(hass):
+async def test_form_import(hass: HomeAssistant) -> None:
     """Test we get the form with import source."""
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
@@ -761,7 +766,7 @@ async def test_form_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import_device_discovered(hass):
+async def test_form_import_device_discovered(hass: HomeAssistant) -> None:
     """Test we can import with discovery."""
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
@@ -826,7 +831,7 @@ async def test_form_import_device_discovered(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import_non_secure_device_discovered(hass):
+async def test_form_import_non_secure_device_discovered(hass: HomeAssistant) -> None:
     """Test we can import non-secure with discovery."""
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
@@ -863,7 +868,9 @@ async def test_form_import_non_secure_device_discovered(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import_non_secure_non_stanadard_port_device_discovered(hass):
+async def test_form_import_non_secure_non_stanadard_port_device_discovered(
+    hass: HomeAssistant,
+) -> None:
     """Test we can import non-secure non standard port with discovery."""
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
@@ -900,7 +907,9 @@ async def test_form_import_non_secure_non_stanadard_port_device_discovered(hass)
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import_non_secure_device_discovered_invalid_auth(hass):
+async def test_form_import_non_secure_device_discovered_invalid_auth(
+    hass: HomeAssistant,
+) -> None:
     """Test we abort import with invalid auth."""
 
     mocked_elk = mock_elk(invalid_auth=True, sync_complete=False)
@@ -922,7 +931,7 @@ async def test_form_import_non_secure_device_discovered_invalid_auth(hass):
     assert result["reason"] == "invalid_auth"
 
 
-async def test_form_import_existing(hass):
+async def test_form_import_existing(hass: HomeAssistant) -> None:
     """Test we abort on existing import."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1025,7 +1034,7 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
     assert config_entry.unique_id == MOCK_MAC
 
 
-async def test_discovered_by_discovery_and_dhcp(hass):
+async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
     """Test we get the form with discovery and abort for dhcp source when we get both."""
 
     with _patch_discovery(), _patch_elk():
@@ -1063,7 +1072,7 @@ async def test_discovered_by_discovery_and_dhcp(hass):
     assert result3["reason"] == "already_in_progress"
 
 
-async def test_discovered_by_discovery(hass):
+async def test_discovered_by_discovery(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from discovery."""
 
     with _patch_discovery(), _patch_elk():
@@ -1108,7 +1117,7 @@ async def test_discovered_by_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovered_by_discovery_non_standard_port(hass):
+async def test_discovered_by_discovery_non_standard_port(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from discovery with a non-standard port."""
 
     with _patch_discovery(), _patch_elk():
@@ -1153,7 +1162,9 @@ async def test_discovered_by_discovery_non_standard_port(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovered_by_discovery_url_already_configured(hass):
+async def test_discovered_by_discovery_url_already_configured(
+    hass: HomeAssistant,
+) -> None:
     """Test we abort when we discover a device that is already setup."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1174,7 +1185,7 @@ async def test_discovered_by_discovery_url_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_discovered_by_dhcp_udp_responds(hass):
+async def test_discovered_by_dhcp_udp_responds(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from dhcp but with udp response."""
 
     with _patch_discovery(), _patch_elk():
@@ -1217,7 +1228,9 @@ async def test_discovered_by_dhcp_udp_responds(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(hass):
+async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(
+    hass: HomeAssistant,
+) -> None:
     """Test we can setup when discovered from dhcp but with udp response using the non-secure port."""
 
     with _patch_discovery(device=ELK_NON_SECURE_DISCOVERY), _patch_elk():
@@ -1261,7 +1274,9 @@ async def test_discovered_by_dhcp_udp_responds_with_nonsecure_port(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovered_by_dhcp_udp_responds_existing_config_entry(hass):
+async def test_discovered_by_dhcp_udp_responds_existing_config_entry(
+    hass: HomeAssistant,
+) -> None:
     """Test we can setup when discovered from dhcp but with udp response with an existing config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1307,7 +1322,7 @@ async def test_discovered_by_dhcp_udp_responds_existing_config_entry(hass):
     assert len(mock_setup_entry.mock_calls) == 2
 
 
-async def test_discovered_by_dhcp_no_udp_response(hass):
+async def test_discovered_by_dhcp_no_udp_response(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from dhcp but no udp response."""
 
     with _patch_discovery(no_device=True), _patch_elk():
@@ -1320,7 +1335,7 @@ async def test_discovered_by_dhcp_no_udp_response(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_multiple_instances_with_discovery(hass):
+async def test_multiple_instances_with_discovery(hass: HomeAssistant) -> None:
     """Test we can setup a secure elk."""
 
     elk_discovery_1 = ElkSystem("aa:bb:cc:dd:ee:ff", "127.0.0.1", 2601)
@@ -1456,7 +1471,7 @@ async def test_multiple_instances_with_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_multiple_instances_with_tls_v12(hass):
+async def test_multiple_instances_with_tls_v12(hass: HomeAssistant) -> None:
     """Test we can setup a secure elk with tls v1_2."""
 
     elk_discovery_1 = ElkSystem("aa:bb:cc:dd:ee:ff", "127.0.0.1", 2601)

--- a/tests/components/elkm1/test_logbook.py
+++ b/tests/components/elkm1/test_logbook.py
@@ -8,6 +8,7 @@ from homeassistant.components.elkm1.const import (
     EVENT_ELKM1_KEYPAD_KEY_PRESSED,
 )
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import _patch_discovery, _patch_elk
@@ -16,7 +17,7 @@ from tests.common import MockConfigEntry
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_elkm1_keypad_event(hass):
+async def test_humanify_elkm1_keypad_event(hass: HomeAssistant) -> None:
     """Test humanifying elkm1 keypad presses."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})

--- a/tests/components/elmax/test_config_flow.py
+++ b/tests/components/elmax/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.elmax.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.core import HomeAssistant
 
 from . import (
     MOCK_PANEL_ID,
@@ -27,7 +28,7 @@ from tests.common import MockConfigEntry
 CONF_POLLING = "polling"
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -36,7 +37,7 @@ async def test_show_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_standard_setup(hass):
+async def test_standard_setup(hass: HomeAssistant) -> None:
     """Test the standard setup case."""
     # Setup once.
     show_form_result = await hass.config_entries.flow.async_init(
@@ -64,7 +65,7 @@ async def test_standard_setup(hass):
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
-async def test_one_config_allowed(hass):
+async def test_one_config_allowed(hass: HomeAssistant) -> None:
     """Test that only one Elmax configuration is allowed for each panel."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -99,7 +100,7 @@ async def test_one_config_allowed(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_credentials(hass):
+async def test_invalid_credentials(hass: HomeAssistant) -> None:
     """Test that invalid credentials throws an error."""
     with patch(
         "elmax_api.http.Elmax.login",
@@ -120,7 +121,7 @@ async def test_invalid_credentials(hass):
         assert login_result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_connection_error(hass):
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test other than invalid credentials throws an error."""
     with patch(
         "elmax_api.http.Elmax.login",
@@ -141,7 +142,7 @@ async def test_connection_error(hass):
         assert login_result["errors"] == {"base": "network_error"}
 
 
-async def test_unhandled_error(hass):
+async def test_unhandled_error(hass: HomeAssistant) -> None:
     """Test unhandled exceptions."""
     with patch(
         "elmax_api.http.Elmax.get_panel_status",
@@ -169,7 +170,7 @@ async def test_unhandled_error(hass):
         assert result["errors"] == {"base": "unknown"}
 
 
-async def test_invalid_pin(hass):
+async def test_invalid_pin(hass: HomeAssistant) -> None:
     """Test error is thrown when a wrong pin is used to pair a panel."""
     # Simulate bad pin response.
     with patch(
@@ -198,7 +199,7 @@ async def test_invalid_pin(hass):
         assert result["errors"] == {"base": "invalid_pin"}
 
 
-async def test_no_online_panel(hass):
+async def test_no_online_panel(hass: HomeAssistant) -> None:
     """Test no-online panel is available."""
     # Simulate low-level api returns no panels.
     with patch(
@@ -220,7 +221,7 @@ async def test_no_online_panel(hass):
         assert login_result["errors"] == {"base": "no_panel_online"}
 
 
-async def test_show_reauth(hass):
+async def test_show_reauth(hass: HomeAssistant) -> None:
     """Test that the reauth form shows."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -236,7 +237,7 @@ async def test_show_reauth(hass):
     assert result["step_id"] == "reauth_confirm"
 
 
-async def test_reauth_flow(hass):
+async def test_reauth_flow(hass: HomeAssistant) -> None:
     """Test that the reauth flow works."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -278,7 +279,7 @@ async def test_reauth_flow(hass):
         assert result["reason"] == "reauth_successful"
 
 
-async def test_reauth_panel_disappeared(hass):
+async def test_reauth_panel_disappeared(hass: HomeAssistant) -> None:
     """Test that the case where panel is no longer associated with the user."""
     # Simulate a first setup
     MockConfigEntry(
@@ -321,7 +322,7 @@ async def test_reauth_panel_disappeared(hass):
         assert result["errors"] == {"base": "reauth_panel_disappeared"}
 
 
-async def test_reauth_invalid_pin(hass):
+async def test_reauth_invalid_pin(hass: HomeAssistant) -> None:
     """Test that the case where panel is no longer associated with the user."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -363,7 +364,7 @@ async def test_reauth_invalid_pin(hass):
         assert result["errors"] == {"base": "invalid_pin"}
 
 
-async def test_reauth_bad_login(hass):
+async def test_reauth_bad_login(hass: HomeAssistant) -> None:
     """Test bad login attempt at reauth time."""
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.emonitor.const import DOMAIN
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -18,7 +19,7 @@ def _mock_emonitor():
     )
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -50,7 +51,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -71,7 +72,7 @@ async def test_form_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -92,7 +93,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {CONF_HOST: "cannot_connect"}
 
 
-async def test_dhcp_can_confirm(hass):
+async def test_dhcp_can_confirm(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow can confirm right away."""
 
     with patch(
@@ -135,7 +136,7 @@ async def test_dhcp_can_confirm(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_dhcp_fails_to_connect(hass):
+async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow that fails to connect."""
 
     with patch(
@@ -157,7 +158,7 @@ async def test_dhcp_fails_to_connect(hass):
     assert result["step_id"] == "user"
 
 
-async def test_dhcp_already_exists(hass):
+async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow that fails to connect."""
 
     entry = MockConfigEntry(
@@ -186,7 +187,7 @@ async def test_dhcp_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_user_unique_id_already_exists(hass):
+async def test_user_unique_id_already_exists(hass: HomeAssistant) -> None:
     """Test creating an entry where the unique_id already exists."""
 
     entry = MockConfigEntry(

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -58,6 +58,7 @@ from tests.common import (
     async_mock_service,
     get_test_instance_port,
 )
+from tests.typing import ClientSessionGenerator
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()
@@ -331,7 +332,9 @@ async def test_light_without_brightness_supported(hass_hue, hue_client):
     assert light_without_brightness_json["type"] == "On/Off light"
 
 
-async def test_lights_all_dimmable(hass, hass_client_no_auth):
+async def test_lights_all_dimmable(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test CONF_LIGHTS_ALL_DIMMABLE."""
     # create a lamp without brightness support
     hass.states.async_set("light.no_brightness", "on", {})

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.emulated_hue.config import (
 )
 from homeassistant.components.emulated_hue.upnp import UPNPResponderProtocol
 from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
 
@@ -119,7 +120,7 @@ def test_config_alexa_entity_id_to_number() -> None:
     assert entity_id == "light.test"
 
 
-async def test_setup_works(hass):
+async def test_setup_works(hass: HomeAssistant) -> None:
     """Test setup works."""
     hass.config.components.add("network")
     with patch(

--- a/tests/components/emulated_kasa/test_init.py
+++ b/tests/components/emulated_kasa/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 ENTITY_SWITCH = "switch.ac"
@@ -141,7 +142,7 @@ def nested_value(ndict, *keys):
     return nested_value(ndict[key], *keys[1:])
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test that devices are reported correctly."""
     with patch(
         "sense_energy.SenseLink",
@@ -150,7 +151,7 @@ async def test_setup(hass):
         assert await async_setup_component(hass, DOMAIN, CONFIG) is True
 
 
-async def test_float(hass):
+async def test_float(hass: HomeAssistant) -> None:
     """Test a configuration using a simple float."""
     config = CONFIG_SWITCH[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(
@@ -193,7 +194,7 @@ async def test_float(hass):
     assert math.isclose(power, 0)
 
 
-async def test_switch_power(hass):
+async def test_switch_power(hass: HomeAssistant) -> None:
     """Test a configuration using a simple float."""
     config = CONFIG_SWITCH_NO_POWER[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(
@@ -226,7 +227,7 @@ async def test_switch_power(hass):
     assert math.isclose(power, 0)
 
 
-async def test_template(hass):
+async def test_template(hass: HomeAssistant) -> None:
     """Test a configuration using a complex template."""
     config = CONFIG_FAN[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(
@@ -285,7 +286,7 @@ async def test_template(hass):
     assert math.isclose(power, 0)
 
 
-async def test_sensor(hass):
+async def test_sensor(hass: HomeAssistant) -> None:
     """Test a configuration using a sensor in a template."""
     config = CONFIG_LIGHT[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(
@@ -342,7 +343,7 @@ async def test_sensor(hass):
     assert math.isclose(power, 0)
 
 
-async def test_sensor_state(hass):
+async def test_sensor_state(hass: HomeAssistant) -> None:
     """Test a configuration using a sensor in a template."""
     config = CONFIG_SENSOR[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(
@@ -389,7 +390,7 @@ async def test_sensor_state(hass):
     assert math.isclose(power, 0)
 
 
-async def test_multiple_devices(hass):
+async def test_multiple_devices(hass: HomeAssistant) -> None:
     """Test that devices are reported correctly."""
     config = CONFIG[DOMAIN][CONF_ENTITIES]
     assert await async_setup_component(

--- a/tests/components/emulated_roku/test_binding.py
+++ b/tests/components/emulated_roku/test_binding.py
@@ -13,9 +13,10 @@ from homeassistant.components.emulated_roku.binding import (
     ROKU_COMMAND_LAUNCH,
     EmulatedRoku,
 )
+from homeassistant.core import HomeAssistant
 
 
-async def test_events_fired_properly(hass):
+async def test_events_fired_properly(hass: HomeAssistant) -> None:
     """Test that events are fired correctly."""
     binding = EmulatedRoku(
         hass, "Test Emulated Roku", "1.2.3.4", 8060, None, None, None

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.components import emulated_roku
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -59,7 +60,7 @@ async def test_config_already_registered_not_configured(hass, mock_get_source_ip
     assert len(instantiate.mock_calls) == 0
 
 
-async def test_setup_entry_successful(hass):
+async def test_setup_entry_successful(hass: HomeAssistant) -> None:
     """Test setup entry is successful."""
     entry = Mock()
     entry.data = {
@@ -90,7 +91,7 @@ async def test_setup_entry_successful(hass):
     assert roku_instance.bind_multicast is False
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test being able to unload an entry."""
     entry = Mock()
     entry.data = {

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components.energy import async_get_manager, validate
 from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSON_DUMP
 from homeassistant.setup import async_setup_component
 
@@ -52,7 +53,7 @@ async def mock_energy_manager(recorder_mock, hass):
     return manager
 
 
-async def test_validation_empty_config(hass):
+async def test_validation_empty_config(hass: HomeAssistant) -> None:
     """Test validating an empty config."""
     assert (await validate.async_validate(hass)).as_dict() == {
         "energy_sources": [],

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components.energy import data, is_configured
 from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -13,6 +14,7 @@ from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
 )
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -41,7 +43,9 @@ def mock_energy_platform(hass):
     )
 
 
-async def test_get_preferences_no_data(hass, hass_ws_client) -> None:
+async def test_get_preferences_no_data(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we get error if no preferences set."""
     client = await hass_ws_client(hass)
 
@@ -203,7 +207,9 @@ async def test_save_preferences(
     assert msg["result"] == {**new_prefs, **new_prefs_2}
 
 
-async def test_handle_duplicate_from_stat(hass, hass_ws_client) -> None:
+async def test_handle_duplicate_from_stat(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we handle duplicate from stats."""
     client = await hass_ws_client(hass)
 
@@ -242,7 +248,9 @@ async def test_handle_duplicate_from_stat(hass, hass_ws_client) -> None:
     assert msg["error"]["code"] == "invalid_format"
 
 
-async def test_validate(hass, hass_ws_client) -> None:
+async def test_validate(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can validate the preferences."""
     client = await hass_ws_client(hass)
 
@@ -954,7 +962,9 @@ async def test_fossil_energy_consumption(recorder_mock, hass, hass_ws_client):
     }
 
 
-async def test_fossil_energy_consumption_checks(hass, hass_ws_client):
+async def test_fossil_energy_consumption_checks(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test fossil_energy_consumption parameter validation."""
     client = await hass_ws_client(hass)
     now = dt_util.utcnow()

--- a/tests/components/enocean/test_config_flow.py
+++ b/tests/components/enocean/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.enocean.config_flow import EnOceanFlowHandler
 from homeassistant.components.enocean.const import DOMAIN
 from homeassistant.const import CONF_DEVICE
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -12,7 +13,7 @@ DONGLE_VALIDATE_PATH_METHOD = "homeassistant.components.enocean.dongle.validate_
 DONGLE_DETECT_METHOD = "homeassistant.components.enocean.dongle.detect"
 
 
-async def test_user_flow_cannot_create_multiple_instances(hass):
+async def test_user_flow_cannot_create_multiple_instances(hass: HomeAssistant) -> None:
     """Test that the user flow aborts if an instance is already configured."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: "/already/configured/path"}
@@ -28,7 +29,7 @@ async def test_user_flow_cannot_create_multiple_instances(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_user_flow_with_detected_dongle(hass):
+async def test_user_flow_with_detected_dongle(hass: HomeAssistant) -> None:
     """Test the user flow with a detected ENOcean dongle."""
     FAKE_DONGLE_PATH = "/fake/dongle"
 
@@ -44,7 +45,7 @@ async def test_user_flow_with_detected_dongle(hass):
     assert EnOceanFlowHandler.MANUAL_PATH_VALUE in devices
 
 
-async def test_user_flow_with_no_detected_dongle(hass):
+async def test_user_flow_with_no_detected_dongle(hass: HomeAssistant) -> None:
     """Test the user flow with a detected ENOcean dongle."""
     with patch(DONGLE_DETECT_METHOD, Mock(return_value=[])):
         result = await hass.config_entries.flow.async_init(
@@ -55,7 +56,7 @@ async def test_user_flow_with_no_detected_dongle(hass):
     assert result["step_id"] == "manual"
 
 
-async def test_detection_flow_with_valid_path(hass):
+async def test_detection_flow_with_valid_path(hass: HomeAssistant) -> None:
     """Test the detection flow with a valid path selected."""
     USER_PROVIDED_PATH = "/user/provided/path"
 
@@ -68,7 +69,7 @@ async def test_detection_flow_with_valid_path(hass):
     assert result["data"][CONF_DEVICE] == USER_PROVIDED_PATH
 
 
-async def test_detection_flow_with_custom_path(hass):
+async def test_detection_flow_with_custom_path(hass: HomeAssistant) -> None:
     """Test the detection flow with custom path selected."""
     USER_PROVIDED_PATH = EnOceanFlowHandler.MANUAL_PATH_VALUE
     FAKE_DONGLE_PATH = "/fake/dongle"
@@ -86,7 +87,7 @@ async def test_detection_flow_with_custom_path(hass):
     assert result["step_id"] == "manual"
 
 
-async def test_detection_flow_with_invalid_path(hass):
+async def test_detection_flow_with_invalid_path(hass: HomeAssistant) -> None:
     """Test the detection flow with an invalid path selected."""
     USER_PROVIDED_PATH = "/invalid/path"
     FAKE_DONGLE_PATH = "/fake/dongle"
@@ -105,7 +106,7 @@ async def test_detection_flow_with_invalid_path(hass):
     assert CONF_DEVICE in result["errors"]
 
 
-async def test_manual_flow_with_valid_path(hass):
+async def test_manual_flow_with_valid_path(hass: HomeAssistant) -> None:
     """Test the manual flow with a valid path."""
     USER_PROVIDED_PATH = "/user/provided/path"
 
@@ -118,7 +119,7 @@ async def test_manual_flow_with_valid_path(hass):
     assert result["data"][CONF_DEVICE] == USER_PROVIDED_PATH
 
 
-async def test_manual_flow_with_invalid_path(hass):
+async def test_manual_flow_with_invalid_path(hass: HomeAssistant) -> None:
     """Test the manual flow with an invalid path."""
     USER_PROVIDED_PATH = "/user/provided/path"
 
@@ -135,7 +136,7 @@ async def test_manual_flow_with_invalid_path(hass):
     assert CONF_DEVICE in result["errors"]
 
 
-async def test_import_flow_with_valid_path(hass):
+async def test_import_flow_with_valid_path(hass: HomeAssistant) -> None:
     """Test the import flow with a valid path."""
     DATA_TO_IMPORT = {CONF_DEVICE: "/valid/path/to/import"}
 
@@ -150,7 +151,7 @@ async def test_import_flow_with_valid_path(hass):
     assert result["data"][CONF_DEVICE] == DATA_TO_IMPORT[CONF_DEVICE]
 
 
-async def test_import_flow_with_invalid_path(hass):
+async def test_import_flow_with_invalid_path(hass: HomeAssistant) -> None:
     """Test the import flow with an invalid path."""
     DATA_TO_IMPORT = {CONF_DEVICE: "/invalid/path/to/import"}
 

--- a/tests/components/environment_canada/test_config_flow.py
+++ b/tests/components/environment_canada/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.environment_canada.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -51,7 +52,7 @@ def mocked_ec(
     )
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test creating an entry."""
     with mocked_ec(), patch(
         "homeassistant.components.environment_canada.async_setup_entry",
@@ -69,7 +70,7 @@ async def test_create_entry(hass):
         assert result["title"] == FAKE_TITLE
 
 
-async def test_create_same_entry_twice(hass):
+async def test_create_same_entry_twice(hass: HomeAssistant) -> None:
     """Test duplicate entries."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -122,7 +123,7 @@ async def test_exception_handling(hass, error):
         assert result["errors"] == {"base": base_error}
 
 
-async def test_lat_lon_not_specified(hass):
+async def test_lat_lon_not_specified(hass: HomeAssistant) -> None:
     """Test that the import step works when coordinates are not specified."""
     with mocked_ec(), patch(
         "homeassistant.components.environment_canada.async_setup_entry",

--- a/tests/components/environment_canada/test_diagnostics.py
+++ b/tests/components/environment_canada/test_diagnostics.py
@@ -1,5 +1,4 @@
 """Test Environment Canada diagnostics."""
-
 from datetime import datetime, timezone
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +13,7 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 FIXTURE_USER_INPUT = {
     CONF_LATITUDE: 55.55,
@@ -71,7 +71,9 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     return config_entry
 
 
-async def test_entry_diagnostics(hass, hass_client):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test config entry diagnostics."""
 
     config_entry = await init_integration(hass)

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -6,9 +6,10 @@ from epson_projector.const import PWR_OFF_STATE
 from homeassistant import config_entries
 from homeassistant.components.epson.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     with patch("homeassistant.components.epson.Projector.get_power", return_value="01"):
@@ -40,7 +41,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -59,7 +60,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_powered_off(hass):
+async def test_form_powered_off(hass: HomeAssistant) -> None:
     """Test we handle powered off during initial configuration."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.components.esphome import (
 )
 from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import VALID_NOISE_PSK
@@ -760,7 +761,7 @@ async def test_discovery_dhcp_no_changes(hass, mock_client):
     assert entry.data[CONF_HOST] == "192.168.43.183"
 
 
-async def test_discovery_hassio(hass):
+async def test_discovery_hassio(hass: HomeAssistant) -> None:
     """Test dashboard discovery."""
     result = await hass.config_entries.flow.async_init(
         "esphome",

--- a/tests/components/eufylife_ble/test_config_flow.py
+++ b/tests/components/eufylife_ble/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the EufyLife config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.eufylife_ble.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_EUFYLIFE_SERVICE_INFO, T9146_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_EUFYLIFE_SERVICE_INFO, T9146_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "11:22:33:44:55:66"
 
 
-async def test_async_step_bluetooth_not_eufylife(hass):
+async def test_async_step_bluetooth_not_eufylife(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with an invalid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_eufylife(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.eufylife_ble.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "11:22:33:44:55:66"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.eufylife_ble.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/ezviz/test_config_flow.py
+++ b/tests/components/ezviz/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the EZVIZ config flow."""
-
 from unittest.mock import patch
 
 from pyezviz.exceptions import (
@@ -29,6 +28,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -102,7 +102,9 @@ async def test_user_custom_url(hass, ezviz_config_flow):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_step_discovery_abort_if_cloud_account_missing(hass):
+async def test_step_discovery_abort_if_cloud_account_missing(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery and confirm step, abort if cloud account was removed."""
 
     result = await hass.config_entries.flow.async_init(
@@ -159,7 +161,7 @@ async def test_async_step_integration_discovery(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test updating options."""
     with _patch_async_setup_entry() as mock_setup_entry:
         entry = await init_integration(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests (d-e):
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
