### PR TITLE
Add type hints to integration tests (h-i)

### DIFF
--- a/tests/components/habitica/test_config_flow.py
+++ b/tests/components/habitica/test_config_flow.py
@@ -5,11 +5,12 @@ from aiohttp import ClientResponseError
 
 from homeassistant import config_entries
 from homeassistant.components.habitica.const import DEFAULT_URL, DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -47,7 +48,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_credentials(hass):
+async def test_form_invalid_credentials(hass: HomeAssistant) -> None:
     """Test we handle invalid credentials error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -73,7 +74,7 @@ async def test_form_invalid_credentials(hass):
     assert result2["errors"] == {"base": "invalid_credentials"}
 
 
-async def test_form_unexpected_exception(hass):
+async def test_form_unexpected_exception(hass: HomeAssistant) -> None:
     """Test we handle unexpected exception error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -99,7 +100,7 @@ async def test_form_unexpected_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_manual_flow_config_exist(hass):
+async def test_manual_flow_config_exist(hass: HomeAssistant) -> None:
     """Test config flow discovers only already configured config."""
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.components import ssdp
 from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -20,7 +21,7 @@ def _get_mock_harmonyapi(connect=None, close=None):
     return harmonyapi_mock
 
 
-async def test_user_form(hass):
+async def test_user_form(hass: HomeAssistant) -> None:
     """Test we get the user form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -49,7 +50,7 @@ async def test_user_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_ssdp(hass):
+async def test_form_ssdp(hass: HomeAssistant) -> None:
     """Test we get the form with ssdp source."""
 
     with patch(
@@ -101,7 +102,7 @@ async def test_form_ssdp(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_ssdp_fails_to_get_remote_id(hass):
+async def test_form_ssdp_fails_to_get_remote_id(hass: HomeAssistant) -> None:
     """Test we abort if we cannot get the remote id."""
 
     with patch(
@@ -124,7 +125,9 @@ async def test_form_ssdp_fails_to_get_remote_id(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(hass):
+async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(
+    hass: HomeAssistant,
+) -> None:
     """Test we abort without connecting if the host is already known."""
 
     config_entry = MockConfigEntry(
@@ -160,7 +163,7 @@ async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(hass):
     assert result["type"] == "abort"
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/harmony/test_subscriber.py
+++ b/tests/components/harmony/test_subscriber.py
@@ -1,5 +1,4 @@
 """Test the HarmonySubscriberMixin class."""
-
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
@@ -7,6 +6,7 @@ from homeassistant.components.harmony.subscriber import (
     HarmonyCallback,
     HarmonySubscriberMixin,
 )
+from homeassistant.core import HomeAssistant
 
 _NO_PARAM_CALLBACKS = {
     "connected": "_connected",
@@ -26,14 +26,14 @@ _ALL_CALLBACK_NAMES = list(_NO_PARAM_CALLBACKS.keys()) + list(
 _ACTIVITY_TUPLE = ("not", "used")
 
 
-async def test_no_callbacks(hass):
+async def test_no_callbacks(hass: HomeAssistant) -> None:
     """Ensure we handle no subscriptions."""
     subscriber = HarmonySubscriberMixin(hass)
     _call_all_callbacks(subscriber)
     await hass.async_block_till_done()
 
 
-async def test_empty_callbacks(hass):
+async def test_empty_callbacks(hass: HomeAssistant) -> None:
     """Ensure we handle a missing callback in a subscription."""
     subscriber = HarmonySubscriberMixin(hass)
 
@@ -43,7 +43,7 @@ async def test_empty_callbacks(hass):
     await hass.async_block_till_done()
 
 
-async def test_async_callbacks(hass):
+async def test_async_callbacks(hass: HomeAssistant) -> None:
     """Ensure we handle async callbacks."""
     subscriber = HarmonySubscriberMixin(hass)
 
@@ -61,7 +61,7 @@ async def test_async_callbacks(hass):
         callback_mock.assert_awaited_once_with(_ACTIVITY_TUPLE)
 
 
-async def test_long_async_callbacks(hass):
+async def test_long_async_callbacks(hass: HomeAssistant) -> None:
     """Ensure we handle async callbacks that may have sleeps."""
     subscriber = HarmonySubscriberMixin(hass)
 
@@ -87,7 +87,7 @@ async def test_long_async_callbacks(hass):
     await notifier_event_one.wait()
 
 
-async def test_callbacks(hass):
+async def test_callbacks(hass: HomeAssistant) -> None:
     """Ensure we handle non-async callbacks."""
     subscriber = HarmonySubscriberMixin(hass)
 
@@ -105,7 +105,7 @@ async def test_callbacks(hass):
         callback_mock.assert_called_once_with(_ACTIVITY_TUPLE)
 
 
-async def test_subscribe_unsubscribe(hass):
+async def test_subscribe_unsubscribe(hass: HomeAssistant) -> None:
     """Ensure we handle subscriptions and unsubscriptions correctly."""
     subscriber = HarmonySubscriberMixin(hass)
 

--- a/tests/components/hassio/test_config_flow.py
+++ b/tests/components/hassio/test_config_flow.py
@@ -2,9 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.hassio import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_config_flow(hass):
+async def test_config_flow(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     with patch(
@@ -25,7 +26,7 @@ async def test_config_flow(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_multiple_entries(hass):
+async def test_multiple_entries(hass: HomeAssistant) -> None:
     """Test creating multiple hassio entries."""
     await test_config_flow(hass)
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/hassio/test_system_health.py
+++ b/tests/components/hassio/test_system_health.py
@@ -5,14 +5,18 @@ from unittest.mock import patch
 
 from aiohttp import ClientError
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_init import MOCK_ENVIRON
 
 from tests.common import get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_hassio_system_health(hass, aioclient_mock):
+async def test_hassio_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test hassio system health."""
     aioclient_mock.get("http://127.0.0.1/info", json={"result": "ok", "data": {}})
     aioclient_mock.get("http://127.0.0.1/host/info", json={"result": "ok", "data": {}})
@@ -69,7 +73,9 @@ async def test_hassio_system_health(hass, aioclient_mock):
     }
 
 
-async def test_hassio_system_health_with_issues(hass, aioclient_mock):
+async def test_hassio_system_health_with_issues(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test hassio system health."""
     aioclient_mock.get("http://127.0.0.1/info", json={"result": "ok", "data": {}})
     aioclient_mock.get("http://127.0.0.1/host/info", json={"result": "ok", "data": {}})

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -1,5 +1,4 @@
 """The tests for the hassio update entities."""
-
 import os
 from unittest.mock import patch
 
@@ -7,10 +6,12 @@ import pytest
 
 from homeassistant.components.hassio import DOMAIN
 from homeassistant.components.hassio.handler import HassioAPIError
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
@@ -192,7 +193,9 @@ async def test_update_entities(
     assert state.attributes["auto_update"] is auto_update
 
 
-async def test_update_addon(hass, aioclient_mock):
+async def test_update_addon(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating addon update entity."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -219,7 +222,9 @@ async def test_update_addon(hass, aioclient_mock):
     )
 
 
-async def test_update_os(hass, aioclient_mock):
+async def test_update_os(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating OS update entity."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -246,7 +251,9 @@ async def test_update_os(hass, aioclient_mock):
     )
 
 
-async def test_update_core(hass, aioclient_mock):
+async def test_update_core(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating core update entity."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -273,7 +280,9 @@ async def test_update_core(hass, aioclient_mock):
     )
 
 
-async def test_update_supervisor(hass, aioclient_mock):
+async def test_update_supervisor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating supervisor update entity."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -300,7 +309,9 @@ async def test_update_supervisor(hass, aioclient_mock):
     )
 
 
-async def test_update_addon_with_error(hass, aioclient_mock):
+async def test_update_addon_with_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating addon update entity with error."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -327,7 +338,9 @@ async def test_update_addon_with_error(hass, aioclient_mock):
         )
 
 
-async def test_update_os_with_error(hass, aioclient_mock):
+async def test_update_os_with_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating OS update entity with error."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -354,7 +367,9 @@ async def test_update_os_with_error(hass, aioclient_mock):
         )
 
 
-async def test_update_supervisor_with_error(hass, aioclient_mock):
+async def test_update_supervisor_with_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating supervisor update entity with error."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -381,7 +396,9 @@ async def test_update_supervisor_with_error(hass, aioclient_mock):
         )
 
 
-async def test_update_core_with_error(hass, aioclient_mock):
+async def test_update_core_with_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test updating core update entity with error."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -503,7 +520,7 @@ async def test_not_release_notes(hass, aioclient_mock, hass_ws_client):
     assert result["result"] is None
 
 
-async def test_no_os_entity(hass):
+async def test_no_os_entity(hass: HomeAssistant) -> None:
     """Test handling where there is no os entity."""
     with patch.dict(os.environ, MOCK_ENVIRON), patch(
         "homeassistant.components.hassio.HassIO.get_info",
@@ -525,7 +542,9 @@ async def test_no_os_entity(hass):
     assert not hass.states.get("update.home_assistant_operating_system_update")
 
 
-async def test_setting_up_core_update_when_addon_fails(hass, caplog):
+async def test_setting_up_core_update_when_addon_fails(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setting up core update when single addon fails."""
     with patch.dict(os.environ, MOCK_ENVIRON), patch(
         "homeassistant.components.hassio.HassIO.get_addon_stats",

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.heos.config_flow import HeosFlowHandler
 from homeassistant.components.heos.const import DATA_DISCOVERED_HOSTS, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 
 async def test_flow_aborts_already_setup(hass, config_entry):
@@ -22,7 +23,7 @@ async def test_flow_aborts_already_setup(hass, config_entry):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_no_host_shows_form(hass):
+async def test_no_host_shows_form(hass: HomeAssistant) -> None:
     """Test form is shown when host not provided."""
     flow = HeosFlowHandler()
     flow.hass = hass

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -471,7 +471,7 @@ async def test_route_not_found(hass: HomeAssistant, caplog):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Test sensor restore state."""
     # Home assistant is not running yet
     hass.state = CoreState.not_running

--- a/tests/components/hisense_aehw4a1/test_init.py
+++ b/tests/components/hisense_aehw4a1/test_init.py
@@ -5,10 +5,11 @@ from pyaehw4a1 import exceptions
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import hisense_aehw4a1
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_creating_entry_sets_up_climate_discovery(hass):
+async def test_creating_entry_sets_up_climate_discovery(hass: HomeAssistant) -> None:
     """Test setting up Hisense AEH-W4A1 loads the climate component."""
     with patch(
         "homeassistant.components.hisense_aehw4a1.config_flow.AehW4a1.discovery",
@@ -32,7 +33,7 @@ async def test_creating_entry_sets_up_climate_discovery(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_configuring_hisense_w4a1_create_entry(hass):
+async def test_configuring_hisense_w4a1_create_entry(hass: HomeAssistant) -> None:
     """Test that specifying config will create an entry."""
     with patch(
         "homeassistant.components.hisense_aehw4a1.config_flow.AehW4a1.check",
@@ -51,7 +52,9 @@ async def test_configuring_hisense_w4a1_create_entry(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_configuring_hisense_w4a1_not_creates_entry_for_device_not_found(hass):
+async def test_configuring_hisense_w4a1_not_creates_entry_for_device_not_found(
+    hass: HomeAssistant,
+) -> None:
     """Test that specifying config will not create an entry."""
     with patch(
         "homeassistant.components.hisense_aehw4a1.config_flow.AehW4a1.check",
@@ -70,7 +73,9 @@ async def test_configuring_hisense_w4a1_not_creates_entry_for_device_not_found(h
     assert len(mock_setup.mock_calls) == 0
 
 
-async def test_configuring_hisense_w4a1_not_creates_entry_for_empty_import(hass):
+async def test_configuring_hisense_w4a1_not_creates_entry_for_empty_import(
+    hass: HomeAssistant,
+) -> None:
     """Test that specifying config will not create an entry."""
     with patch(
         "homeassistant.components.hisense_aehw4a1.async_setup_entry",

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -6,6 +6,7 @@ from apyhiveapi.helper import hive_exceptions
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.hive.const import CONF_CODE, CONF_DEVICE_NAME, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -22,7 +23,7 @@ MFA_RESEND_CODE = "0000"
 MFA_INVALID_CODE = "HIVE"
 
 
-async def test_import_flow(hass):
+async def test_import_flow(hass: HomeAssistant) -> None:
     """Check import flow."""
 
     with patch(
@@ -64,7 +65,7 @@ async def test_import_flow(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_flow(hass):
+async def test_user_flow(hass: HomeAssistant) -> None:
     """Test the user flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -113,7 +114,7 @@ async def test_user_flow(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_user_flow_2fa(hass):
+async def test_user_flow_2fa(hass: HomeAssistant) -> None:
     """Test user flow with 2FA."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -209,7 +210,7 @@ async def test_user_flow_2fa(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_reauth_flow(hass):
+async def test_reauth_flow(hass: HomeAssistant) -> None:
     """Test the reauth flow."""
 
     mock_config = MockConfigEntry(
@@ -268,7 +269,7 @@ async def test_reauth_flow(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_reauth_2fa_flow(hass):
+async def test_reauth_2fa_flow(hass: HomeAssistant) -> None:
     """Test the reauth flow."""
 
     mock_config = MockConfigEntry(
@@ -344,7 +345,7 @@ async def test_reauth_2fa_flow(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_option_flow(hass):
+async def test_option_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
 
     entry = MockConfigEntry(
@@ -381,7 +382,7 @@ async def test_option_flow(hass):
     assert result["data"][CONF_SCAN_INTERVAL] == UPDATED_SCAN_INTERVAL
 
 
-async def test_user_flow_2fa_send_new_code(hass):
+async def test_user_flow_2fa_send_new_code(hass: HomeAssistant) -> None:
     """Resend a 2FA code if it didn't arrive."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -488,7 +489,7 @@ async def test_user_flow_2fa_send_new_code(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_abort_if_existing_entry(hass):
+async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     """Check flow abort when an entry already exist."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -511,7 +512,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_user_flow_invalid_username(hass):
+async def test_user_flow_invalid_username(hass: HomeAssistant) -> None:
     """Test user flow with invalid username."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -534,7 +535,7 @@ async def test_user_flow_invalid_username(hass):
     assert result2["errors"] == {"base": "invalid_username"}
 
 
-async def test_user_flow_invalid_password(hass):
+async def test_user_flow_invalid_password(hass: HomeAssistant) -> None:
     """Test user flow with invalid password."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -557,7 +558,7 @@ async def test_user_flow_invalid_password(hass):
     assert result2["errors"] == {"base": "invalid_password"}
 
 
-async def test_user_flow_no_internet_connection(hass):
+async def test_user_flow_no_internet_connection(hass: HomeAssistant) -> None:
     """Test user flow with no internet connection."""
 
     result = await hass.config_entries.flow.async_init(
@@ -581,7 +582,7 @@ async def test_user_flow_no_internet_connection(hass):
     assert result2["errors"] == {"base": "no_internet_available"}
 
 
-async def test_user_flow_2fa_no_internet_connection(hass):
+async def test_user_flow_2fa_no_internet_connection(hass: HomeAssistant) -> None:
     """Test user flow with no internet connection."""
 
     result = await hass.config_entries.flow.async_init(
@@ -620,7 +621,7 @@ async def test_user_flow_2fa_no_internet_connection(hass):
     assert result3["errors"] == {"base": "no_internet_available"}
 
 
-async def test_user_flow_2fa_invalid_code(hass):
+async def test_user_flow_2fa_invalid_code(hass: HomeAssistant) -> None:
     """Test user flow with 2FA."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -657,7 +658,7 @@ async def test_user_flow_2fa_invalid_code(hass):
     assert result3["errors"] == {"base": "invalid_code"}
 
 
-async def test_user_flow_unknown_error(hass):
+async def test_user_flow_unknown_error(hass: HomeAssistant) -> None:
     """Test user flow when unknown error occurs."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -680,7 +681,7 @@ async def test_user_flow_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_user_flow_2fa_unknown_error(hass):
+async def test_user_flow_2fa_unknown_error(hass: HomeAssistant) -> None:
     """Test 2fa flow when unknown error occurs."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/hlk_sw16/test_config_flow.py
+++ b/tests/components/hlk_sw16/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.hlk_sw16.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
 class MockSW16Client:
@@ -47,7 +48,7 @@ async def create_mock_hlk_sw16_connection(fail):
     return client
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -108,7 +109,7 @@ async def test_form(hass):
     assert result4["reason"] == "already_configured"
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -149,7 +150,7 @@ async def test_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_data(hass):
+async def test_form_invalid_data(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -175,7 +176,7 @@ async def test_form_invalid_data(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -1,5 +1,4 @@
 """The tests for Core components."""
-
 import asyncio
 import unittest
 from unittest.mock import Mock, patch
@@ -31,6 +30,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import entity
 from homeassistant.setup import async_setup_component
@@ -236,7 +236,9 @@ class TestComponentsCore(unittest.TestCase):
         assert not mock_stop.called
 
 
-async def test_turn_on_skips_domains_without_service(hass, caplog):
+async def test_turn_on_skips_domains_without_service(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if turn_on is blocking domain with no service."""
     await async_setup_component(hass, "homeassistant", {})
     async_mock_service(hass, "light", SERVICE_TURN_ON)
@@ -275,7 +277,7 @@ async def test_turn_on_skips_domains_without_service(hass, caplog):
     )
 
 
-async def test_entity_update(hass):
+async def test_entity_update(hass: HomeAssistant) -> None:
     """Test being able to call entity update."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -294,7 +296,7 @@ async def test_entity_update(hass):
     assert mock_update.mock_calls[0][1][1] == "light.kitchen"
 
 
-async def test_setting_location(hass):
+async def test_setting_location(hass: HomeAssistant) -> None:
     """Test setting the location."""
     await async_setup_component(hass, "homeassistant", {})
     events = async_capture_events(hass, EVENT_CORE_CONFIG_UPDATE)
@@ -358,7 +360,9 @@ async def test_turn_on_off_toggle_schema(hass, hass_read_only_user):
                 )
 
 
-async def test_not_allowing_recursion(hass, caplog):
+async def test_not_allowing_recursion(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we do not allow recursion."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -375,7 +379,7 @@ async def test_not_allowing_recursion(hass, caplog):
         ), service
 
 
-async def test_reload_config_entry_by_entity_id(hass):
+async def test_reload_config_entry_by_entity_id(hass: HomeAssistant) -> None:
     """Test being able to reload a config entry by entity_id."""
     await async_setup_component(hass, "homeassistant", {})
     entity_reg = mock_registry(hass)
@@ -415,7 +419,7 @@ async def test_reload_config_entry_by_entity_id(hass):
         )
 
 
-async def test_reload_config_entry_by_entry_id(hass):
+async def test_reload_config_entry_by_entry_id(hass: HomeAssistant) -> None:
     """Test being able to reload a config entry by config entry id."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -473,7 +477,9 @@ async def test_raises_when_db_upgrade_in_progress(hass, service, caplog):
     assert mock_async_migration_in_progress.called
 
 
-async def test_raises_when_config_is_invalid(hass, caplog):
+async def test_raises_when_config_is_invalid(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test an exception is raised when the configuration is invalid."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -510,7 +516,7 @@ async def test_raises_when_config_is_invalid(hass, caplog):
     assert mock_async_check_ha_config_file.called
 
 
-async def test_restart_homeassistant(hass):
+async def test_restart_homeassistant(hass: HomeAssistant) -> None:
     """Test we can restart when there is no configuration error."""
     await async_setup_component(hass, "homeassistant", {})
     with patch(
@@ -528,7 +534,7 @@ async def test_restart_homeassistant(hass):
         assert mock_restart.called
 
 
-async def test_stop_homeassistant(hass):
+async def test_stop_homeassistant(hass: HomeAssistant) -> None:
     """Test we can stop when there is a configuration error."""
     await async_setup_component(hass, "homeassistant", {})
     with patch(
@@ -546,7 +552,7 @@ async def test_stop_homeassistant(hass):
         assert mock_restart.called
 
 
-async def test_save_persistent_states(hass):
+async def test_save_persistent_states(hass: HomeAssistant) -> None:
     """Test we can call save_persistent_states."""
     await async_setup_component(hass, "homeassistant", {})
     with patch(

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -7,12 +7,13 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import scene as ha_scene
 from homeassistant.components.homeassistant.scene import EVENT_SCENE_RELOADED
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, async_mock_service
 
 
-async def test_reload_config_service(hass):
+async def test_reload_config_service(hass: HomeAssistant) -> None:
     """Test the reload config service."""
     assert await async_setup_component(hass, "scene", {})
 
@@ -42,7 +43,7 @@ async def test_reload_config_service(hass):
     assert hass.states.get("scene.bye") is not None
 
 
-async def test_apply_service(hass):
+async def test_apply_service(hass: HomeAssistant) -> None:
     """Test the apply service."""
     assert await async_setup_component(hass, "scene", {})
     assert await async_setup_component(hass, "light", {"light": {"platform": "demo"}})
@@ -84,7 +85,9 @@ async def test_apply_service(hass):
     assert turn_on_calls[0].data.get("brightness") == 50
 
 
-async def test_create_service(hass, caplog):
+async def test_create_service(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the create service."""
     assert await async_setup_component(
         hass,
@@ -161,7 +164,9 @@ async def test_create_service(hass, caplog):
     assert scene.attributes.get("entity_id") == ["light.kitchen"]
 
 
-async def test_snapshot_service(hass, caplog):
+async def test_snapshot_service(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the snapshot option."""
     assert await async_setup_component(hass, "scene", {"scene": {}})
     await hass.async_block_till_done()
@@ -219,7 +224,7 @@ async def test_snapshot_service(hass, caplog):
     assert "light.bed_light" in scene.attributes.get("entity_id")
 
 
-async def test_ensure_no_intersection(hass):
+async def test_ensure_no_intersection(hass: HomeAssistant) -> None:
     """Test that entities and snapshot_entities do not overlap."""
     assert await async_setup_component(hass, "scene", {"scene": {}})
     await hass.async_block_till_done()
@@ -240,7 +245,7 @@ async def test_ensure_no_intersection(hass):
     assert hass.states.get("scene.hallo") is None
 
 
-async def test_scenes_with_entity(hass):
+async def test_scenes_with_entity(hass: HomeAssistant) -> None:
     """Test finding scenes with a specific entity."""
     assert await async_setup_component(
         hass,
@@ -264,7 +269,7 @@ async def test_scenes_with_entity(hass):
     ]
 
 
-async def test_entities_in_scene(hass):
+async def test_entities_in_scene(hass: HomeAssistant) -> None:
     """Test finding entities in a scene."""
     assert await async_setup_component(
         hass,
@@ -290,7 +295,7 @@ async def test_entities_in_scene(hass):
         assert ha_scene.entities_in_scene(hass, scene_id) == entities
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test passing config in YAML."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -47,7 +47,7 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     STATE_ON,
 )
-from homeassistant.core import HomeAssistantError, State
+from homeassistant.core import HomeAssistant, HomeAssistantError, State
 from homeassistant.helpers import device_registry, entity_registry as er, instance_id
 from homeassistant.helpers.entityfilter import (
     CONF_EXCLUDE_DOMAINS,
@@ -744,7 +744,7 @@ async def test_homekit_start_with_a_device(
     await homekit.async_stop()
 
 
-async def test_homekit_stop(hass):
+async def test_homekit_stop(hass: HomeAssistant) -> None:
     """Test HomeKit stop method."""
     entry = await async_init_integration(hass)
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -50,7 +50,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .util import async_init_integration
 
@@ -257,7 +257,7 @@ async def test_async_show_setup_msg(hass, hk_driver, mock_get_source_ip):
     assert pincode.decode() in mock_create.mock_calls[0][1][1]
 
 
-async def test_async_dismiss_setup_msg(hass):
+async def test_async_dismiss_setup_msg(hass: HomeAssistant) -> None:
     """Test dismiss setup message."""
     with patch(
         "homeassistant.components.persistent_notification.async_dismiss",
@@ -270,7 +270,7 @@ async def test_async_dismiss_setup_msg(hass):
     assert mock_dismiss.mock_calls[0][1][1] == "entry_id"
 
 
-async def test_port_is_available(hass):
+async def test_port_is_available(hass: HomeAssistant) -> None:
     """Test we can get an available port and it is actually available."""
     with patch(
         "homeassistant.components.homekit.util.socket.socket",
@@ -303,7 +303,7 @@ async def test_port_is_available(hass):
         assert not async_port_is_available(next_port)
 
 
-async def test_port_is_available_skips_existing_entries(hass):
+async def test_port_is_available_skips_existing_entries(hass: HomeAssistant) -> None:
     """Test we can get an available port and it is actually available."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -380,7 +380,7 @@ async def test_accessory_friendly_name() -> None:
     assert accessory_friendly_name("hass title", accessory) == "Hass title 123"
 
 
-async def test_lock_state_needs_accessory_mode(hass):
+async def test_lock_state_needs_accessory_mode(hass: HomeAssistant) -> None:
     """Test that locks are setup as accessories."""
     hass.states.async_set("lock.mine", "locked")
     assert state_needs_accessory_mode(hass.states.get("lock.mine")) is True

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import Helper, get_next_aid, setup_test_component
@@ -37,7 +38,7 @@ def create_switch_with_ecobee_clear_hold_button(accessory):
     return service
 
 
-async def test_press_button(hass):
+async def test_press_button(hass: HomeAssistant) -> None:
     """Test a switch service that has a button characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_setup_button)
 
@@ -64,7 +65,7 @@ async def test_press_button(hass):
     )
 
 
-async def test_ecobee_clear_hold_press_button(hass):
+async def test_ecobee_clear_hold_press_button(hass: HomeAssistant) -> None:
     """Test ecobee clear hold button characteristic is correctly handled."""
     helper = await setup_test_component(
         hass, create_switch_with_ecobee_clear_hold_button

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -1,5 +1,4 @@
 """Tests for homekit_controller init."""
-
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -26,6 +25,7 @@ from .common import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 ALIVE_DEVICE_NAME = "testdevice"
 ALIVE_DEVICE_ENTITY_ID = "light.testdevice"
@@ -75,7 +75,9 @@ def create_alive_service(accessory):
     return service
 
 
-async def test_device_remove_devices(hass, hass_ws_client):
+async def test_device_remove_devices(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can only remove a device that no longer exists."""
     assert await async_setup_component(hass, "config", {})
     helper: Helper = await setup_test_component(hass, create_alive_service)

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -4,6 +4,7 @@ from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.homekit_controller.const import ENTITY_MAP
 from homeassistant.components.homekit_controller.storage import EntityMapStorage
+from homeassistant.core import HomeAssistant
 
 from .common import setup_platform, setup_test_component
 
@@ -42,7 +43,7 @@ async def test_storage_is_removed(hass, hass_storage):
     assert hass_storage[ENTITY_MAP]["data"]["pairings"] == {}
 
 
-async def test_storage_is_removed_idempotent(hass):
+async def test_storage_is_removed_idempotent(hass: HomeAssistant) -> None:
     """Test entity map storage removal is idempotent."""
     await setup_platform(hass)
 

--- a/tests/components/homematic/test_notify.py
+++ b/tests/components/homematic/test_notify.py
@@ -1,12 +1,12 @@
 """The tests for the Homematic notification platform."""
-
 import homeassistant.components.notify as notify_comp
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
 
 
-async def test_setup_full(hass):
+async def test_setup_full(hass: HomeAssistant) -> None:
     """Test valid configuration."""
     await async_setup_component(
         hass,
@@ -32,7 +32,7 @@ async def test_setup_full(hass):
     assert handle_config[notify_comp.DOMAIN]
 
 
-async def test_setup_without_optional(hass):
+async def test_setup_without_optional(hass: HomeAssistant) -> None:
     """Test valid configuration without optional."""
     await async_setup_component(
         hass,
@@ -57,7 +57,7 @@ async def test_setup_without_optional(hass):
     assert handle_config[notify_comp.DOMAIN]
 
 
-async def test_bad_config(hass):
+async def test_bad_config(hass: HomeAssistant) -> None:
     """Test invalid configuration."""
     config = {notify_comp.DOMAIN: {"name": "test", "platform": "homematic"}}
     with assert_setup_component(0) as handle_config:

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import get_and_check_entity_basics
@@ -36,7 +37,7 @@ async def _async_manipulate_security_zones(
     await hass.async_block_till_done()
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -23,12 +23,13 @@ from homeassistant.components.homematicip_cloud.generic_entity import (
     ATTR_SABOTAGE,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -22,12 +22,13 @@ from homeassistant.components.homematicip_cloud.climate import (
     ATTR_PRESET_END_TIME,
     PERMANENT_END_TIME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import HAPID, async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, CLIMATE_DOMAIN, {CLIMATE_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.homematicip_cloud.const import (
     HMIPC_NAME,
     HMIPC_PIN,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -66,7 +67,7 @@ async def test_flow_works(hass, simple_mock_home):
     assert result["result"].unique_id == "ABC123"
 
 
-async def test_flow_init_connection_error(hass):
+async def test_flow_init_connection_error(hass: HomeAssistant) -> None:
     """Test config flow with accesspoint connection error."""
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
@@ -82,7 +83,7 @@ async def test_flow_init_connection_error(hass):
     assert result["step_id"] == "init"
 
 
-async def test_flow_link_connection_error(hass):
+async def test_flow_link_connection_error(hass: HomeAssistant) -> None:
     """Test config flow client registration connection error."""
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
@@ -104,7 +105,7 @@ async def test_flow_link_connection_error(hass):
     assert result["reason"] == "connection_aborted"
 
 
-async def test_flow_link_press_button(hass):
+async def test_flow_link_press_button(hass: HomeAssistant) -> None:
     """Test config flow ask for pressing the blue button."""
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
@@ -124,7 +125,7 @@ async def test_flow_link_press_button(hass):
     assert result["errors"] == {"base": "press_the_button"}
 
 
-async def test_init_flow_show_form(hass):
+async def test_init_flow_show_form(hass: HomeAssistant) -> None:
     """Test config flow shows up with a form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -134,7 +135,7 @@ async def test_init_flow_show_form(hass):
     assert result["step_id"] == "init"
 
 
-async def test_init_already_configured(hass):
+async def test_init_already_configured(hass: HomeAssistant) -> None:
     """Test accesspoint is already configured."""
     MockConfigEntry(domain=HMIPC_DOMAIN, unique_id="ABC123").add_to_hass(hass)
     with patch(
@@ -177,7 +178,7 @@ async def test_import_config(hass, simple_mock_home):
     assert result["result"].unique_id == "ABC123"
 
 
-async def test_import_existing_config(hass):
+async def test_import_existing_config(hass: HomeAssistant) -> None:
     """Test abort of an existing accesspoint from config."""
     MockConfigEntry(domain=HMIPC_DOMAIN, unique_id="ABC123").add_to_hass(hass)
     with patch(

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -8,12 +8,13 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, COVER_DOMAIN, {COVER_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -1,5 +1,4 @@
 """Test HomematicIP Cloud accesspoint."""
-
 from unittest.mock import Mock, patch
 
 from homematicip.aio.auth import AsyncAuth
@@ -19,6 +18,7 @@ from homeassistant.components.homematicip_cloud.hap import (
     HomematicipHAP,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .helper import HAPID, HAPPIN
@@ -26,7 +26,7 @@ from .helper import HAPID, HAPPIN
 from tests.common import MockConfigEntry
 
 
-async def test_auth_setup(hass):
+async def test_auth_setup(hass: HomeAssistant) -> None:
     """Test auth setup for client registration."""
     config = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
     hmip_auth = HomematicipAuth(hass, config)
@@ -34,7 +34,7 @@ async def test_auth_setup(hass):
         assert await hmip_auth.async_setup()
 
 
-async def test_auth_setup_connection_error(hass):
+async def test_auth_setup_connection_error(hass: HomeAssistant) -> None:
     """Test auth setup connection error behaviour."""
     config = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
     hmip_auth = HomematicipAuth(hass, config)
@@ -42,7 +42,7 @@ async def test_auth_setup_connection_error(hass):
         assert not await hmip_auth.async_setup()
 
 
-async def test_auth_auth_check_and_register(hass):
+async def test_auth_auth_check_and_register(hass: HomeAssistant) -> None:
     """Test auth client registration."""
     config = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
 
@@ -59,7 +59,7 @@ async def test_auth_auth_check_and_register(hass):
         assert await hmip_auth.async_register() == "ABC"
 
 
-async def test_auth_auth_check_and_register_with_exception(hass):
+async def test_auth_auth_check_and_register_with_exception(hass: HomeAssistant) -> None:
     """Test auth client registration."""
     config = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
     hmip_auth = HomematicipAuth(hass, config)
@@ -73,7 +73,7 @@ async def test_auth_auth_check_and_register_with_exception(hass):
         assert await hmip_auth.async_register() is False
 
 
-async def test_hap_setup_works(hass):
+async def test_hap_setup_works(hass: HomeAssistant) -> None:
     """Test a successful setup of a accesspoint."""
     # This test should not be accessing the integration internals
     entry = MockConfigEntry(

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,5 +1,4 @@
 """Test HomematicIP Cloud setup process."""
-
 from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.base.base_connection import HmipConnectionError
@@ -15,6 +14,7 @@ from homeassistant.components.homematicip_cloud.const import (
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -130,7 +130,7 @@ async def test_load_entry_fails_due_to_generic_exception(hass, hmip_config_entry
     assert hmip_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test being able to unload an entry."""
     mock_config = {HMIPC_AUTHTOKEN: "123", HMIPC_HAPID: "ABC123", HMIPC_NAME: "name"}
     MockConfigEntry(domain=HMIPC_DOMAIN, data=mock_config).add_to_hass(hass)
@@ -173,7 +173,7 @@ async def test_hmip_dump_hap_config_services(hass, mock_hap_with_service):
         assert write_mock.mock_calls
 
 
-async def test_setup_services_and_unload_services(hass):
+async def test_setup_services_and_unload_services(hass: HomeAssistant) -> None:
     """Test setup services and unload services."""
     mock_config = {HMIPC_AUTHTOKEN: "123", HMIPC_HAPID: "ABC123", HMIPC_NAME: "name"}
     MockConfigEntry(domain=HMIPC_DOMAIN, data=mock_config).add_to_hass(hass)
@@ -202,7 +202,7 @@ async def test_setup_services_and_unload_services(hass):
     assert not hass.services.async_services().get(HMIPC_DOMAIN)
 
 
-async def test_setup_two_haps_unload_one_by_one(hass):
+async def test_setup_two_haps_unload_one_by_one(hass: HomeAssistant) -> None:
     """Test setup two access points and unload one by one and check services."""
 
     # Setup AP1

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -12,12 +12,13 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -32,12 +32,13 @@ from homeassistant.const import (
     UnitOfSpeed,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -5,12 +5,13 @@ from homeassistant.components.homematicip_cloud.generic_entity import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homematicip_cloud/test_weather.py
+++ b/tests/components/homematicip_cloud/test_weather.py
@@ -8,12 +8,13 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .helper import async_manipulate_test_data, get_and_check_entity_basics
 
 
-async def test_manually_configured_platform(hass):
+async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     """Test that we do not set up an access point."""
     assert await async_setup_component(
         hass, WEATHER_DOMAIN, {WEATHER_DOMAIN: {"platform": HMIPC_DOMAIN}}

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .generator import get_mock_device
@@ -15,7 +16,9 @@ from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_manual_flow_works(hass, aioclient_mock):
+async def test_manual_flow_works(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow accepts user configuration."""
 
     device = get_mock_device()
@@ -49,7 +52,9 @@ async def test_manual_flow_works(hass, aioclient_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovery_flow_works(hass, aioclient_mock):
+async def test_discovery_flow_works(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test discovery setup flow works."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -218,7 +223,9 @@ async def test_discovery_flow_during_onboarding_disabled_api(
     assert len(mock_onboarding.mock_calls) == 1
 
 
-async def test_discovery_disabled_api(hass, aioclient_mock):
+async def test_discovery_disabled_api(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test discovery detecting disabled api."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -266,7 +273,9 @@ async def test_discovery_disabled_api(hass, aioclient_mock):
     assert result["errors"] == {"base": "api_not_enabled"}
 
 
-async def test_discovery_missing_data_in_service_info(hass, aioclient_mock):
+async def test_discovery_missing_data_in_service_info(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test discovery detecting missing discovery info."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -295,7 +304,9 @@ async def test_discovery_missing_data_in_service_info(hass, aioclient_mock):
     assert result["reason"] == "invalid_discovery_parameters"
 
 
-async def test_discovery_invalid_api(hass, aioclient_mock):
+async def test_discovery_invalid_api(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test discovery detecting invalid_api."""
 
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -324,7 +335,9 @@ async def test_discovery_invalid_api(hass, aioclient_mock):
     assert result["reason"] == "unsupported_api_version"
 
 
-async def test_check_disabled_api(hass, aioclient_mock):
+async def test_check_disabled_api(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test check detecting disabled api."""
 
     def mock_initialize():
@@ -352,7 +365,9 @@ async def test_check_disabled_api(hass, aioclient_mock):
     assert result["errors"] == {"base": "api_not_enabled"}
 
 
-async def test_check_error_handling_api(hass, aioclient_mock):
+async def test_check_error_handling_api(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test check detecting error with api."""
 
     def mock_initialize():
@@ -380,7 +395,9 @@ async def test_check_error_handling_api(hass, aioclient_mock):
     assert result["reason"] == "unknown_error"
 
 
-async def test_check_detects_invalid_api(hass, aioclient_mock):
+async def test_check_detects_invalid_api(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test check detecting device endpoint failed fetching data."""
 
     def mock_initialize():
@@ -408,7 +425,9 @@ async def test_check_detects_invalid_api(hass, aioclient_mock):
     assert result["reason"] == "unsupported_api_version"
 
 
-async def test_check_requesterror(hass, aioclient_mock):
+async def test_check_requesterror(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test check detecting device endpoint failed fetching data due to a requesterror."""
 
     def mock_initialize():
@@ -436,7 +455,9 @@ async def test_check_requesterror(hass, aioclient_mock):
     assert result["errors"] == {"base": "network_error"}
 
 
-async def test_reauth_flow(hass, aioclient_mock):
+async def test_reauth_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test reauth flow while API is enabled."""
 
     mock_entry = MockConfigEntry(
@@ -470,7 +491,9 @@ async def test_reauth_flow(hass, aioclient_mock):
         assert result["reason"] == "reauth_successful"
 
 
-async def test_reauth_error(hass, aioclient_mock):
+async def test_reauth_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test reauth flow while API is still disabled."""
 
     def mock_initialize():

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock, mock_open, patch
 from aiohttp.hdrs import AUTHORIZATION
 
 import homeassistant.components.html5.notify as html5
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 CONFIG_FILE = "file.conf"
 
@@ -239,7 +242,9 @@ class TestHtml5Notify:
         assert mock_wp.mock_calls[3][2]["headers"]["priority"] == "normal"
 
 
-async def test_registering_new_device_view(hass, hass_client):
+async def test_registering_new_device_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML view works."""
     client = await mock_client(hass, hass_client)
 
@@ -251,7 +256,9 @@ async def test_registering_new_device_view(hass, hass_client):
     assert mock_save.mock_calls[0][1][1] == {"unnamed device": SUBSCRIPTION_1}
 
 
-async def test_registering_new_device_view_with_name(hass, hass_client):
+async def test_registering_new_device_view_with_name(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML view works with name attribute."""
     client = await mock_client(hass, hass_client)
 
@@ -266,7 +273,9 @@ async def test_registering_new_device_view_with_name(hass, hass_client):
     assert mock_save.mock_calls[0][1][1] == {"test device": SUBSCRIPTION_1}
 
 
-async def test_registering_new_device_expiration_view(hass, hass_client):
+async def test_registering_new_device_expiration_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML view works."""
     client = await mock_client(hass, hass_client)
 
@@ -277,7 +286,9 @@ async def test_registering_new_device_expiration_view(hass, hass_client):
     assert mock_save.mock_calls[0][1][1] == {"unnamed device": SUBSCRIPTION_4}
 
 
-async def test_registering_new_device_fails_view(hass, hass_client):
+async def test_registering_new_device_fails_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test subs. are not altered when registering a new device fails."""
     registrations = {}
     client = await mock_client(hass, hass_client, registrations)
@@ -292,7 +303,9 @@ async def test_registering_new_device_fails_view(hass, hass_client):
     assert registrations == {}
 
 
-async def test_registering_existing_device_view(hass, hass_client):
+async def test_registering_existing_device_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test subscription is updated when registering existing device."""
     registrations = {}
     client = await mock_client(hass, hass_client, registrations)
@@ -306,7 +319,9 @@ async def test_registering_existing_device_view(hass, hass_client):
     assert registrations == {"unnamed device": SUBSCRIPTION_4}
 
 
-async def test_registering_existing_device_view_with_name(hass, hass_client):
+async def test_registering_existing_device_view_with_name(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test subscription is updated when reg'ing existing device with name."""
     registrations = {}
     client = await mock_client(hass, hass_client, registrations)
@@ -323,7 +338,9 @@ async def test_registering_existing_device_view_with_name(hass, hass_client):
     assert registrations == {"test device": SUBSCRIPTION_4}
 
 
-async def test_registering_existing_device_fails_view(hass, hass_client):
+async def test_registering_existing_device_fails_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test sub. is not updated when registering existing device fails."""
     registrations = {}
     client = await mock_client(hass, hass_client, registrations)
@@ -337,7 +354,9 @@ async def test_registering_existing_device_fails_view(hass, hass_client):
     assert registrations == {"unnamed device": SUBSCRIPTION_1}
 
 
-async def test_registering_new_device_validation(hass, hass_client):
+async def test_registering_new_device_validation(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test various errors when registering a new device."""
     client = await mock_client(hass, hass_client)
 
@@ -358,7 +377,9 @@ async def test_registering_new_device_validation(hass, hass_client):
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_unregistering_device_view(hass, hass_client):
+async def test_unregistering_device_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML unregister view works."""
     registrations = {"some device": SUBSCRIPTION_1, "other device": SUBSCRIPTION_2}
     client = await mock_client(hass, hass_client, registrations)
@@ -374,7 +395,9 @@ async def test_unregistering_device_view(hass, hass_client):
     assert registrations == {"other device": SUBSCRIPTION_2}
 
 
-async def test_unregister_device_view_handle_unknown_subscription(hass, hass_client):
+async def test_unregister_device_view_handle_unknown_subscription(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML unregister view handles unknown subscriptions."""
     registrations = {}
     client = await mock_client(hass, hass_client, registrations)
@@ -390,7 +413,9 @@ async def test_unregister_device_view_handle_unknown_subscription(hass, hass_cli
     assert len(mock_save.mock_calls) == 0
 
 
-async def test_unregistering_device_view_handles_save_error(hass, hass_client):
+async def test_unregistering_device_view_handles_save_error(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the HTML unregister view handles save errors."""
     registrations = {"some device": SUBSCRIPTION_1, "other device": SUBSCRIPTION_2}
     client = await mock_client(hass, hass_client, registrations)
@@ -411,7 +436,9 @@ async def test_unregistering_device_view_handles_save_error(hass, hass_client):
     }
 
 
-async def test_callback_view_no_jwt(hass, hass_client):
+async def test_callback_view_no_jwt(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the notification callback view works without JWT."""
     client = await mock_client(hass, hass_client)
     resp = await client.post(
@@ -424,7 +451,9 @@ async def test_callback_view_no_jwt(hass, hass_client):
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_callback_view_with_jwt(hass, hass_client):
+async def test_callback_view_with_jwt(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the notification callback view works with JWT."""
     registrations = {"device": SUBSCRIPTION_1}
     client = await mock_client(hass, hass_client, registrations)
@@ -460,7 +489,9 @@ async def test_callback_view_with_jwt(hass, hass_client):
     assert body == {"event": "push", "status": "ok"}
 
 
-async def test_send_fcm_without_targets(hass, hass_client):
+async def test_send_fcm_without_targets(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the notification is send with FCM without targets."""
     registrations = {"device": SUBSCRIPTION_5}
     await mock_client(hass, hass_client, registrations)
@@ -479,7 +510,9 @@ async def test_send_fcm_without_targets(hass, hass_client):
     assert mock_wp.mock_calls[2][1][0] == SUBSCRIPTION_5["subscription"]
 
 
-async def test_send_fcm_expired(hass, hass_client):
+async def test_send_fcm_expired(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the FCM target is removed when expired."""
     registrations = {"device": SUBSCRIPTION_5}
     await mock_client(hass, hass_client, registrations)
@@ -499,7 +532,9 @@ async def test_send_fcm_expired(hass, hass_client):
     assert "device" not in registrations
 
 
-async def test_send_fcm_expired_save_fails(hass, hass_client):
+async def test_send_fcm_expired_save_fails(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that the FCM target remains after expiry if save_json fails."""
     registrations = {"device": SUBSCRIPTION_5}
     await mock_client(hass, hass_client, registrations)

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -29,7 +29,7 @@ from homeassistant.components.http.request_context import (
     current_request,
     setup_request_context,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from . import HTTP_HEADER_HA_AUTH, mock_real_ip
@@ -98,7 +98,7 @@ def trusted_networks_auth(hass):
     return prv
 
 
-async def test_auth_middleware_loaded_by_default(hass):
+async def test_auth_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.async_setup_auth") as mock_setup:
         await async_setup_component(hass, "http", {"http": {}})
@@ -546,7 +546,7 @@ async def test_async_user_not_allowed_do_auth(hass, app):
         )
 
 
-async def test_create_user_once(hass):
+async def test_create_user_once(hass: HomeAssistant) -> None:
     """Test that we reuse the user."""
     cur_users = len(await hass.auth.async_get_users())
     app = web.Application()

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -19,10 +19,13 @@ from homeassistant.components.http.ban import (
     setup_bans,
 )
 from homeassistant.components.http.view import request_handler_factory
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from . import mock_real_ip
+
+from tests.typing import ClientSessionGenerator
 
 SUPERVISOR_IP = "1.2.3.4"
 BANNED_IPS = ["200.201.202.203", "100.64.0.2"]
@@ -49,7 +52,9 @@ def gethostbyaddr_mock():
         yield
 
 
-async def test_access_from_banned_ip(hass, aiohttp_client):
+async def test_access_from_banned_ip(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test accessing to server from banned IP. Both trusted and not."""
     app = web.Application()
     app["hass"] = hass
@@ -105,7 +110,9 @@ async def test_access_from_banned_ip_with_partially_broken_yaml_file(
     assert "Failed to load IP ban" in caplog.text
 
 
-async def test_no_ip_bans_file(hass, aiohttp_client):
+async def test_no_ip_bans_file(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test no ip bans file."""
     app = web.Application()
     app["hass"] = hass
@@ -123,7 +130,9 @@ async def test_no_ip_bans_file(hass, aiohttp_client):
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_failure_loading_ip_bans_file(hass, aiohttp_client):
+async def test_failure_loading_ip_bans_file(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test failure loading ip bans file."""
     app = web.Application()
     app["hass"] = hass
@@ -224,7 +233,7 @@ async def test_access_from_supervisor_ip(
         assert len(manager.ip_bans_lookup) == bans
 
 
-async def test_ban_middleware_not_loaded_by_config(hass):
+async def test_ban_middleware_not_loaded_by_config(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_bans") as mock_setup:
         await async_setup_component(
@@ -234,7 +243,7 @@ async def test_ban_middleware_not_loaded_by_config(hass):
     assert len(mock_setup.mock_calls) == 0
 
 
-async def test_ban_middleware_loaded_by_default(hass):
+async def test_ban_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_bans") as mock_setup:
         await async_setup_component(hass, "http", {"http": {}})
@@ -297,7 +306,9 @@ async def test_ip_bans_file_creation(hass, aiohttp_client, caplog):
         )
 
 
-async def test_failed_login_attempts_counter(hass, aiohttp_client):
+async def test_failed_login_attempts_counter(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Testing if failed login attempts counter increased."""
     app = web.Application()
     app["hass"] = hass

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -16,14 +16,17 @@ import pytest
 
 from homeassistant.components.http.cors import setup_cors
 from homeassistant.components.http.view import HomeAssistantView
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import HTTP_HEADER_HA_AUTH
 
+from tests.typing import ClientSessionGenerator
+
 TRUSTED_ORIGIN = "https://home-assistant.io"
 
 
-async def test_cors_middleware_loaded_by_default(hass):
+async def test_cors_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
         await async_setup_component(hass, "http", {"http": {}})
@@ -31,7 +34,7 @@ async def test_cors_middleware_loaded_by_default(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_cors_middleware_loaded_from_config(hass):
+async def test_cors_middleware_loaded_from_config(hass: HomeAssistant) -> None:
     """Test accessing to server from banned IP when feature is off."""
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
         await async_setup_component(
@@ -101,7 +104,7 @@ async def test_cors_preflight_allowed(client):
     assert req.headers[ACCESS_CONTROL_ALLOW_HEADERS] == "X-REQUESTED-WITH"
 
 
-async def test_cors_middleware_with_cors_allowed_view(hass):
+async def test_cors_middleware_with_cors_allowed_view(hass: HomeAssistant) -> None:
     """Test that we can configure cors and have a cors_allowed view."""
 
     class MyView(HomeAssistantView):
@@ -131,7 +134,9 @@ async def test_cors_middleware_with_cors_allowed_view(hass):
     await hass.http.app.startup()
 
 
-async def test_cors_works_with_frontend(hass, hass_client):
+async def test_cors_works_with_frontend(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test CORS works with the frontend."""
     assert await async_setup_component(
         hass,
@@ -143,7 +148,9 @@ async def test_cors_works_with_frontend(hass, hass_client):
     assert resp.status == HTTPStatus.OK
 
 
-async def test_cors_on_static_files(hass, hass_client):
+async def test_cors_on_static_files(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that we enable CORS for static files."""
     assert await async_setup_component(
         hass, "frontend", {"http": {"cors_allowed_origins": ["http://www.example.com"]}}

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 import homeassistant.components.http as http
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -103,7 +104,7 @@ async def test_not_log_password(hass, hass_client_no_auth, caplog, legacy_auth):
     assert "some-pass" not in logs
 
 
-async def test_proxy_config(hass):
+async def test_proxy_config(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (
         await async_setup_component(
@@ -120,7 +121,7 @@ async def test_proxy_config(hass):
     )
 
 
-async def test_proxy_config_only_use_xff(hass):
+async def test_proxy_config_only_use_xff(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (
         await async_setup_component(
@@ -130,7 +131,7 @@ async def test_proxy_config_only_use_xff(hass):
     )
 
 
-async def test_proxy_config_only_trust_proxies(hass):
+async def test_proxy_config_only_trust_proxies(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (
         await async_setup_component(
@@ -412,7 +413,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
     assert len(mock_builder.mock_calls) == 1
 
 
-async def test_cors_defaults(hass):
+async def test_cors_defaults(hass: HomeAssistant) -> None:
     """Test the CORS default settings."""
     with patch("homeassistant.components.http.setup_cors") as mock_setup:
         assert await async_setup_component(hass, "http", {})

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Huawei LTE config flow."""
-
 from unittest.mock import patch
 
 from huawei_lte_api.enums.client import ResponseCodeEnum
@@ -19,6 +18,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -36,7 +36,7 @@ FIXTURE_USER_INPUT_OPTIONS = {
 }
 
 
-async def test_show_set_form(hass):
+async def test_show_set_form(hass: HomeAssistant) -> None:
     """Test that the setup form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
@@ -366,7 +366,7 @@ async def test_reauth(
         assert entry.data[k] == v
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options produce expected data."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -13,6 +13,7 @@ from homeassistant.components.hue.const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 
@@ -55,7 +56,7 @@ async def test_bridge_setup_v2(hass, mock_api_v2):
     assert forward_entries == {"light", "binary_sensor", "sensor", "switch", "scene"}
 
 
-async def test_bridge_setup_invalid_api_key(hass):
+async def test_bridge_setup_invalid_api_key(hass: HomeAssistant) -> None:
     """Test we start config flow if username is no longer whitelisted."""
     entry = Mock()
     entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
@@ -71,7 +72,7 @@ async def test_bridge_setup_invalid_api_key(hass):
     assert mock_init.mock_calls[0][2]["data"] == {"host": "1.2.3.4"}
 
 
-async def test_bridge_setup_timeout(hass):
+async def test_bridge_setup_timeout(hass: HomeAssistant) -> None:
     """Test we retry to connect if we cannot connect."""
     entry = Mock()
     entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -11,9 +11,11 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.hue import config_flow, const
 from homeassistant.components.hue.errors import CannotConnect
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture(name="hue_setup", autouse=True)
@@ -46,7 +48,7 @@ def create_mock_api_discovery(aioclient_mock, bridges):
         )
 
 
-async def test_flow_works(hass):
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test config flow ."""
     disc_bridge = get_discovered_bridge(supports_v2=True)
 
@@ -89,7 +91,7 @@ async def test_flow_works(hass):
     }
 
 
-async def test_manual_flow_works(hass):
+async def test_manual_flow_works(hass: HomeAssistant) -> None:
     """Test config flow discovers only already configured bridges."""
     disc_bridge = get_discovered_bridge(bridge_id="id-1234", host="2.2.2.2")
 
@@ -141,7 +143,7 @@ async def test_manual_flow_works(hass):
     assert entry.unique_id == "id-1234"
 
 
-async def test_manual_flow_bridge_exist(hass):
+async def test_manual_flow_bridge_exist(hass: HomeAssistant) -> None:
     """Test config flow aborts on already configured bridges."""
     MockConfigEntry(
         domain="hue", unique_id="id-1234", data={"host": "2.2.2.2"}
@@ -166,7 +168,9 @@ async def test_manual_flow_bridge_exist(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_manual_flow_no_discovered_bridges(hass, aioclient_mock):
+async def test_manual_flow_no_discovered_bridges(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow discovers no bridges."""
     create_mock_api_discovery(aioclient_mock, [])
 
@@ -177,7 +181,9 @@ async def test_manual_flow_no_discovered_bridges(hass, aioclient_mock):
     assert result["step_id"] == "manual"
 
 
-async def test_flow_all_discovered_bridges_exist(hass, aioclient_mock):
+async def test_flow_all_discovered_bridges_exist(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow discovers only already configured bridges."""
     mock_host = "1.2.3.4"
     mock_id = "bla"
@@ -195,7 +201,9 @@ async def test_flow_all_discovered_bridges_exist(hass, aioclient_mock):
     assert result["step_id"] == "manual"
 
 
-async def test_flow_bridges_discovered(hass, aioclient_mock):
+async def test_flow_bridges_discovered(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow discovers two bridges."""
     # Add ignored config entry. Should still show up as option.
     MockConfigEntry(
@@ -220,7 +228,9 @@ async def test_flow_bridges_discovered(hass, aioclient_mock):
     result["data_schema"]({"id": "manual"})
 
 
-async def test_flow_two_bridges_discovered_one_new(hass, aioclient_mock):
+async def test_flow_two_bridges_discovered_one_new(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow discovers two bridges."""
     create_mock_api_discovery(aioclient_mock, [("1.2.3.4", "bla"), ("5.6.7.8", "beer")])
     MockConfigEntry(
@@ -239,7 +249,7 @@ async def test_flow_two_bridges_discovered_one_new(hass, aioclient_mock):
         assert not result["data_schema"]({"id": "bla"})
 
 
-async def test_flow_timeout_discovery(hass):
+async def test_flow_timeout_discovery(hass: HomeAssistant) -> None:
     """Test config flow ."""
     with patch(
         "homeassistant.components.hue.config_flow.discover_nupnp",
@@ -253,7 +263,7 @@ async def test_flow_timeout_discovery(hass):
     assert result["reason"] == "discover_timeout"
 
 
-async def test_flow_link_unknown_error(hass):
+async def test_flow_link_unknown_error(hass: HomeAssistant) -> None:
     """Test if a unknown error happened during the linking processes."""
     disc_bridge = get_discovered_bridge()
     with patch(
@@ -278,7 +288,7 @@ async def test_flow_link_unknown_error(hass):
     assert result["errors"] == {"base": "linking"}
 
 
-async def test_flow_link_button_not_pressed(hass):
+async def test_flow_link_button_not_pressed(hass: HomeAssistant) -> None:
     """Test config flow ."""
     disc_bridge = get_discovered_bridge()
     with patch(
@@ -303,7 +313,7 @@ async def test_flow_link_button_not_pressed(hass):
     assert result["errors"] == {"base": "register_failed"}
 
 
-async def test_flow_link_cannot_connect(hass):
+async def test_flow_link_cannot_connect(hass: HomeAssistant) -> None:
     """Test config flow ."""
     disc_bridge = get_discovered_bridge()
     with patch(
@@ -327,7 +337,9 @@ async def test_flow_link_cannot_connect(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_import_with_no_config(hass, aioclient_mock):
+async def test_import_with_no_config(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test importing a host without an existing config file."""
     create_mock_api_discovery(aioclient_mock, [("0.0.0.0", "1234")])
     result = await hass.config_entries.flow.async_init(
@@ -394,7 +406,9 @@ async def test_creating_entry_removes_entries_for_same_host_or_bridge(
     assert new_entry.unique_id == "id-1234"
 
 
-async def test_bridge_homekit(hass, aioclient_mock):
+async def test_bridge_homekit(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a bridge being discovered via HomeKit."""
     create_mock_api_discovery(aioclient_mock, [("0.0.0.0", "bla")])
 
@@ -423,7 +437,7 @@ async def test_bridge_homekit(hass, aioclient_mock):
     assert flow["context"]["unique_id"] == config_entries.DEFAULT_DISCOVERY_UNIQUE_ID
 
 
-async def test_bridge_import_already_configured(hass):
+async def test_bridge_import_already_configured(hass: HomeAssistant) -> None:
     """Test if a import flow aborts if host is already configured."""
     MockConfigEntry(
         domain="hue", unique_id="aabbccddeeff", data={"host": "0.0.0.0"}
@@ -439,7 +453,9 @@ async def test_bridge_import_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_bridge_homekit_already_configured(hass, aioclient_mock):
+async def test_bridge_homekit_already_configured(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test if a HomeKit discovered bridge has already been configured."""
     create_mock_api_discovery(aioclient_mock, [("0.0.0.0", "aabbccddeeff")])
     MockConfigEntry(
@@ -464,7 +480,7 @@ async def test_bridge_homekit_already_configured(hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow_v1(hass):
+async def test_options_flow_v1(hass: HomeAssistant) -> None:
     """Test options config flow for a V1 bridge."""
     entry = MockConfigEntry(
         domain="hue",
@@ -510,7 +526,7 @@ def _get_schema_default(schema, key_name):
     raise KeyError(f"{key_name} not found in schema")
 
 
-async def test_options_flow_v2(hass):
+async def test_options_flow_v2(hass: HomeAssistant) -> None:
     """Test options config flow for a V2 bridge."""
     entry = MockConfigEntry(
         domain="hue",
@@ -543,7 +559,9 @@ async def test_options_flow_v2(hass):
     }
 
 
-async def test_bridge_zeroconf(hass, aioclient_mock):
+async def test_bridge_zeroconf(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a bridge being discovered."""
     create_mock_api_discovery(aioclient_mock, [("192.168.1.217", "ecb5fafffeabcabc")])
     result = await hass.config_entries.flow.async_init(
@@ -568,7 +586,9 @@ async def test_bridge_zeroconf(hass, aioclient_mock):
     assert result["step_id"] == "link"
 
 
-async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
+async def test_bridge_zeroconf_already_exists(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test a bridge being discovered by zeroconf already exists."""
     create_mock_api_discovery(
         aioclient_mock, [("0.0.0.0", "ecb5faabcabc"), ("192.168.1.217", "ecb5faabcabc")]
@@ -603,7 +623,7 @@ async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
     assert entry.data["host"] == "192.168.1.217"
 
 
-async def test_bridge_zeroconf_ipv6(hass):
+async def test_bridge_zeroconf_ipv6(hass: HomeAssistant) -> None:
     """Test a bridge being discovered by zeroconf and ipv6 address."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import hue
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -32,7 +33,7 @@ def mock_bridge_setup():
         yield mock_bridge.return_value
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that we do not discover anything or try to set up a bridge."""
     assert await async_setup_component(hass, hue.DOMAIN, {}) is True
 
@@ -125,7 +126,7 @@ async def test_fixing_unique_id_other_correct(hass, mock_bridge_setup):
     assert hass.config_entries.async_entries() == [correct_entry]
 
 
-async def test_security_vuln_check(hass):
+async def test_security_vuln_check(hass: HomeAssistant) -> None:
     """Test that we report security vulnerabilities."""
     entry = MockConfigEntry(
         domain=hue.DOMAIN, data={"host": "0.0.0.0", "api_version": 1}

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -2,12 +2,13 @@
 from unittest.mock import patch
 
 from homeassistant.components import hue
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
 
-async def test_migrate_api_key(hass):
+async def test_migrate_api_key(hass: HomeAssistant) -> None:
     """Test if username gets migrated to api_key."""
     config_entry = MockConfigEntry(
         domain=hue.DOMAIN,
@@ -22,7 +23,7 @@ async def test_migrate_api_key(hass):
     }
 
 
-async def test_auto_switchover(hass):
+async def test_auto_switchover(hass: HomeAssistant) -> None:
     """Test if config entry from v1 automatically switches to v2."""
     config_entry = MockConfigEntry(
         domain=hue.DOMAIN,

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -9,11 +9,12 @@ from energyflip import (
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.huisbaasje.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -55,7 +56,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -77,7 +78,7 @@ async def test_form_invalid_auth(hass):
     assert form_result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_authenticate_cannot_connect(hass):
+async def test_form_authenticate_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error in authenticate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -99,7 +100,7 @@ async def test_form_authenticate_cannot_connect(hass):
     assert form_result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_authenticate_unknown_error(hass):
+async def test_form_authenticate_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle an unknown error in authenticate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -121,7 +122,7 @@ async def test_form_authenticate_unknown_error(hass):
     assert form_result["errors"] == {"base": "unknown"}
 
 
-async def test_form_customer_overview_cannot_connect(hass):
+async def test_form_customer_overview_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error in customer_overview."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -143,7 +144,7 @@ async def test_form_customer_overview_cannot_connect(hass):
     assert form_result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_customer_overview_authentication_error(hass):
+async def test_form_customer_overview_authentication_error(hass: HomeAssistant) -> None:
     """Test we handle an unknown error in customer_overview."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -165,7 +166,7 @@ async def test_form_customer_overview_authentication_error(hass):
     assert form_result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_customer_overview_unknown_error(hass):
+async def test_form_customer_overview_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle an unknown error in customer_overview."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -187,7 +188,7 @@ async def test_form_customer_overview_unknown_error(hass):
     assert form_result["errors"] == {"base": "unknown"}
 
 
-async def test_form_entry_exists(hass):
+async def test_form_entry_exists(hass: HomeAssistant) -> None:
     """Test we handle an already existing entry."""
     MockConfigEntry(
         unique_id="test-id",

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -6,6 +6,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_action
 from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -147,7 +148,7 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass):
+async def test_action(hass: HomeAssistant) -> None:
     """Test for actions."""
     hass.states.async_set(
         "humidifier.entity",

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -8,6 +8,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_trigger
 from homeassistant.const import ATTR_MODE, ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -357,7 +358,7 @@ async def test_invalid_config(hass, calls):
     assert len(calls) == 0
 
 
-async def test_get_trigger_capabilities_on(hass):
+async def test_get_trigger_capabilities_on(hass: HomeAssistant) -> None:
     """Test we get the expected capabilities from a humidifier trigger."""
     capabilities = await device_trigger.async_get_trigger_capabilities(
         hass,
@@ -377,7 +378,7 @@ async def test_get_trigger_capabilities_on(hass):
     ) == [{"name": "for", "optional": True, "type": "positive_time_period_dict"}]
 
 
-async def test_get_trigger_capabilities_off(hass):
+async def test_get_trigger_capabilities_off(hass: HomeAssistant) -> None:
     """Test we get the expected capabilities from a humidifier trigger."""
     capabilities = await device_trigger.async_get_trigger_capabilities(
         hass,
@@ -397,7 +398,7 @@ async def test_get_trigger_capabilities_off(hass):
     ) == [{"name": "for", "optional": True, "type": "positive_time_period_dict"}]
 
 
-async def test_get_trigger_capabilities_humidity(hass):
+async def test_get_trigger_capabilities_humidity(hass: HomeAssistant) -> None:
     """Test we get the expected capabilities from a humidifier trigger."""
     capabilities = await device_trigger.async_get_trigger_capabilities(
         hass,

--- a/tests/components/humidifier/test_init.py
+++ b/tests/components/humidifier/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock
 
 from homeassistant.components.humidifier import HumidifierEntity
+from homeassistant.core import HomeAssistant
 
 
 class MockHumidifierEntity(HumidifierEntity):
@@ -13,7 +14,7 @@ class MockHumidifierEntity(HumidifierEntity):
         return 0
 
 
-async def test_sync_turn_on(hass):
+async def test_sync_turn_on(hass: HomeAssistant) -> None:
     """Test if async turn_on calls sync turn_on."""
     humidifier = MockHumidifierEntity()
     humidifier.hass = hass
@@ -24,7 +25,7 @@ async def test_sync_turn_on(hass):
     assert humidifier.turn_on.called
 
 
-async def test_sync_turn_off(hass):
+async def test_sync_turn_off(hass: HomeAssistant) -> None:
     """Test if async turn_off calls sync turn_off."""
     humidifier = MockHumidifierEntity()
     humidifier.hass = hass

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -17,12 +17,13 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.intent import IntentHandleError, async_handle
 
 from tests.common import async_mock_service
 
 
-async def test_intent_set_humidity(hass):
+async def test_intent_set_humidity(hass: HomeAssistant) -> None:
     """Test the set humidity intent."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier", STATE_ON, {ATTR_HUMIDITY: 40}
@@ -50,7 +51,7 @@ async def test_intent_set_humidity(hass):
     assert call.data.get(ATTR_HUMIDITY) == 50
 
 
-async def test_intent_set_humidity_and_turn_on(hass):
+async def test_intent_set_humidity_and_turn_on(hass: HomeAssistant) -> None:
     """Test the set humidity intent for turned off humidifier."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier", STATE_OFF, {ATTR_HUMIDITY: 40}
@@ -85,7 +86,7 @@ async def test_intent_set_humidity_and_turn_on(hass):
     assert call.data.get(ATTR_HUMIDITY) == 50
 
 
-async def test_intent_set_mode(hass):
+async def test_intent_set_mode(hass: HomeAssistant) -> None:
     """Test the set mode intent."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier",
@@ -123,7 +124,7 @@ async def test_intent_set_mode(hass):
     assert call.data.get(ATTR_MODE) == "away"
 
 
-async def test_intent_set_mode_and_turn_on(hass):
+async def test_intent_set_mode_and_turn_on(hass: HomeAssistant) -> None:
     """Test the set mode intent."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier",
@@ -165,7 +166,7 @@ async def test_intent_set_mode_and_turn_on(hass):
     assert call.data.get(ATTR_MODE) == "away"
 
 
-async def test_intent_set_mode_tests_feature(hass):
+async def test_intent_set_mode_tests_feature(hass: HomeAssistant) -> None:
     """Test the set mode intent where modes are not supported."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier", STATE_ON, {ATTR_HUMIDITY: 40}
@@ -187,7 +188,7 @@ async def test_intent_set_mode_tests_feature(hass):
     assert len(mode_calls) == 0
 
 
-async def test_intent_set_unknown_mode(hass):
+async def test_intent_set_unknown_mode(hass: HomeAssistant) -> None:
     """Test the set mode intent for unsupported mode."""
     hass.states.async_set(
         "humidifier.bedroom_humidifier",

--- a/tests/components/humidifier/test_reproduce_state.py
+++ b/tests/components/humidifier/test_reproduce_state.py
@@ -1,5 +1,4 @@
 """The tests for reproduction of state."""
-
 import pytest
 
 from homeassistant.components.humidifier.const import (
@@ -19,7 +18,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, State
+from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
@@ -28,7 +27,9 @@ ENTITY_1 = "humidifier.test1"
 ENTITY_2 = "humidifier.test2"
 
 
-async def test_reproducing_on_off_states(hass, caplog):
+async def test_reproducing_on_off_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing humidifier states."""
     hass.states.async_set(ENTITY_1, "off", {ATTR_MODE: MODE_NORMAL, ATTR_HUMIDITY: 45})
     hass.states.async_set(ENTITY_2, "on", {ATTR_MODE: MODE_NORMAL, ATTR_HUMIDITY: 45})
@@ -85,7 +86,7 @@ async def test_reproducing_on_off_states(hass, caplog):
     assert len(humidity_calls) == 0
 
 
-async def test_multiple_attrs(hass):
+async def test_multiple_attrs(hass: HomeAssistant) -> None:
     """Test turn on with multiple attributes."""
     hass.states.async_set(ENTITY_1, STATE_OFF, {})
 
@@ -109,7 +110,7 @@ async def test_multiple_attrs(hass):
     assert humidity_calls[0].data == {"entity_id": ENTITY_1, "humidity": 45}
 
 
-async def test_turn_off_multiple_attrs(hass):
+async def test_turn_off_multiple_attrs(hass: HomeAssistant) -> None:
     """Test set mode and humidity for off state."""
     hass.states.async_set(ENTITY_1, STATE_ON, {})
 
@@ -131,7 +132,7 @@ async def test_turn_off_multiple_attrs(hass):
     assert len(humidity_calls) == 0
 
 
-async def test_multiple_modes(hass):
+async def test_multiple_modes(hass: HomeAssistant) -> None:
     """Test that multiple states gets calls."""
     hass.states.async_set(ENTITY_1, STATE_OFF, {})
     hass.states.async_set(ENTITY_2, STATE_OFF, {})
@@ -171,7 +172,7 @@ async def test_multiple_modes(hass):
     )
 
 
-async def test_state_with_none(hass):
+async def test_state_with_none(hass: HomeAssistant) -> None:
     """Test that none is not a humidifier state."""
     hass.states.async_set(ENTITY_1, STATE_OFF, {})
 
@@ -190,7 +191,7 @@ async def test_state_with_none(hass):
     assert len(humidity_calls) == 0
 
 
-async def test_state_with_context(hass):
+async def test_state_with_context(hass: HomeAssistant) -> None:
     """Test that context is forwarded."""
     hass.states.async_set(ENTITY_1, STATE_OFF, {})
 

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -85,7 +86,7 @@ def _get_mock_powerview_fwversion(fwversion=None, get_resources=None):
     return mock_powerview_fwversion
 
 
-async def test_user_form(hass):
+async def test_user_form(hass: HomeAssistant) -> None:
     """Test we get the user form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -128,7 +129,7 @@ async def test_user_form(hass):
     assert result4["type"] == "abort"
 
 
-async def test_user_form_legacy(hass):
+async def test_user_form_legacy(hass: HomeAssistant) -> None:
     """Test we get the user form with a legacy device."""
 
     result = await hass.config_entries.flow.async_init(
@@ -254,7 +255,7 @@ async def test_form_homekit_and_dhcp(hass, source, discovery_info):
     assert result3["type"] == "abort"
 
 
-async def test_discovered_by_homekit_and_dhcp(hass):
+async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
     """Test we get the form with homekit and abort for dhcp source when we get both."""
 
     mock_powerview_userdata = _get_mock_powerview_userdata()
@@ -285,7 +286,7 @@ async def test_discovered_by_homekit_and_dhcp(hass):
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -307,7 +308,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_no_data(hass):
+async def test_form_no_data(hass: HomeAssistant) -> None:
     """Test we handle no data being returned from the hub."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -327,7 +328,7 @@ async def test_form_no_data(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_unknown_exception(hass):
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test we handle unknown exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.hvv_departures.const import (
 )
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_OFFSET, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -26,7 +27,7 @@ FIXTURE_OPTIONS = json.loads(load_fixture("hvv_departures/options.json"))
 FIXTURE_DEPARTURE_LIST = json.loads(load_fixture("hvv_departures/departure_list.json"))
 
 
-async def test_user_flow(hass):
+async def test_user_flow(hass: HomeAssistant) -> None:
     """Test that config flow works."""
 
     with patch(
@@ -89,7 +90,7 @@ async def test_user_flow(hass):
         }
 
 
-async def test_user_flow_no_results(hass):
+async def test_user_flow_no_results(hass: HomeAssistant) -> None:
     """Test that config flow works when there are no results."""
 
     with patch(
@@ -126,7 +127,7 @@ async def test_user_flow_no_results(hass):
         assert result_station["errors"]["base"] == "no_results"
 
 
-async def test_user_flow_invalid_auth(hass):
+async def test_user_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test that config flow handles invalid auth."""
 
     with patch(
@@ -152,7 +153,7 @@ async def test_user_flow_invalid_auth(hass):
         assert result_user["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_flow_cannot_connect(hass):
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test that config flow handles connection errors."""
 
     with patch(
@@ -174,7 +175,7 @@ async def test_user_flow_cannot_connect(hass):
         assert result_user["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_flow_station(hass):
+async def test_user_flow_station(hass: HomeAssistant) -> None:
     """Test that config flow handles empty data on step station."""
 
     with patch(
@@ -207,7 +208,7 @@ async def test_user_flow_station(hass):
         assert result_station["step_id"] == "station"
 
 
-async def test_user_flow_station_select(hass):
+async def test_user_flow_station_select(hass: HomeAssistant) -> None:
     """Test that config flow handles empty data on step station_select."""
 
     with patch(
@@ -242,7 +243,7 @@ async def test_user_flow_station_select(hass):
         assert result_station_select["step_id"] == "station_select"
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 
     config_entry = MockConfigEntry(
@@ -291,7 +292,7 @@ async def test_options_flow(hass):
         }
 
 
-async def test_options_flow_invalid_auth(hass):
+async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 
     config_entry = MockConfigEntry(
@@ -330,7 +331,7 @@ async def test_options_flow_invalid_auth(hass):
         assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_options_flow_cannot_connect(hass):
+async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/ialarm/test_config_flow.py
+++ b/tests/components/ialarm/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.ialarm.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -12,7 +13,7 @@ TEST_DATA = {CONF_HOST: "1.1.1.1", CONF_PORT: 18034}
 TEST_MAC = "00:00:54:12:34:56"
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +43,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -60,7 +61,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_exception(hass):
+async def test_form_exception(hass: HomeAssistant) -> None:
     """Test we handle unknown exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -78,7 +79,7 @@ async def test_form_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_exists(hass):
+async def test_form_already_exists(hass: HomeAssistant) -> None:
     """Test that a flow with an existing host aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -7,6 +7,7 @@ from iaqualink.exception import (
 )
 
 from homeassistant.components.iaqualink import config_flow
+from homeassistant.core import HomeAssistant
 
 
 async def test_already_configured(hass, config_entry, config_data):
@@ -22,7 +23,7 @@ async def test_already_configured(hass, config_entry, config_data):
     assert result["type"] == "abort"
 
 
-async def test_without_config(hass):
+async def test_without_config(hass: HomeAssistant) -> None:
     """Test config flow with no configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass

--- a/tests/components/iaqualink/test_utils.py
+++ b/tests/components/iaqualink/test_utils.py
@@ -1,15 +1,15 @@
 """Tests for iAqualink integration utility functions."""
-
 from iaqualink.exception import AqualinkServiceException
 import pytest
 
 from homeassistant.components.iaqualink.utils import await_or_reraise
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import async_raises, async_returns
 
 
-async def test_await_or_reraise(hass):
+async def test_await_or_reraise(hass: HomeAssistant) -> None:
     """Test await_or_reraise for all values of awaitable."""
     async_noop = async_returns(None)
     await await_or_reraise(async_noop())

--- a/tests/components/ibeacon/test_coordinator.py
+++ b/tests/components/ibeacon/test_coordinator.py
@@ -1,6 +1,4 @@
 """Test the ibeacon sensors."""
-
-
 from datetime import timedelta
 import time
 
@@ -9,6 +7,7 @@ import pytest
 
 from homeassistant.components.ibeacon.const import ATTR_SOURCE, DOMAIN, UPDATE_INTERVAL
 from homeassistant.const import STATE_HOME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 from homeassistant.util import dt as dt_util
 
@@ -35,7 +34,7 @@ def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
 
 
-async def test_many_groups_same_address_ignored(hass):
+async def test_many_groups_same_address_ignored(hass: HomeAssistant) -> None:
     """Test the different uuid, major, minor from many addresses removes all associated entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -70,7 +69,7 @@ async def test_many_groups_same_address_ignored(hass):
     assert hass.states.get("sensor.bluecharm_177999_8105_estimated_distance") is None
 
 
-async def test_ignore_not_ibeacons(hass):
+async def test_ignore_not_ibeacons(hass: HomeAssistant) -> None:
     """Test we ignore non-ibeacon data."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -91,7 +90,7 @@ async def test_ignore_not_ibeacons(hass):
     assert len(hass.states.async_entity_ids()) == before_entity_count
 
 
-async def test_ignore_no_name_but_create_if_set_later(hass):
+async def test_ignore_no_name_but_create_if_set_later(hass: HomeAssistant) -> None:
     """Test we ignore devices with no name but create it if it set set later."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -125,7 +124,7 @@ async def test_ignore_no_name_but_create_if_set_later(hass):
     assert len(hass.states.async_entity_ids()) > before_entity_count
 
 
-async def test_ignore_default_name(hass):
+async def test_ignore_default_name(hass: HomeAssistant) -> None:
     """Test we ignore devices with default name."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -147,7 +146,7 @@ async def test_ignore_default_name(hass):
     assert len(hass.states.async_entity_ids()) == before_entity_count
 
 
-async def test_rotating_major_minor_and_mac_with_name(hass):
+async def test_rotating_major_minor_and_mac_with_name(hass: HomeAssistant) -> None:
     """Test the different uuid, major, minor from many addresses removes all associated entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -182,7 +181,7 @@ async def test_rotating_major_minor_and_mac_with_name(hass):
     assert len(hass.states.async_entity_ids("device_tracker")) == before_entity_count
 
 
-async def test_rotating_major_minor_and_mac_no_name(hass):
+async def test_rotating_major_minor_and_mac_no_name(hass: HomeAssistant) -> None:
     """Test no-name devices with different uuid, major, minor from many addresses removes all associated entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -217,7 +216,9 @@ async def test_rotating_major_minor_and_mac_no_name(hass):
     assert len(hass.states.async_entity_ids("device_tracker")) == before_entity_count
 
 
-async def test_ignore_transient_devices_unless_we_see_them_a_few_times(hass):
+async def test_ignore_transient_devices_unless_we_see_them_a_few_times(
+    hass: HomeAssistant,
+) -> None:
     """Test we ignore transient devices unless we see them a few times."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -263,7 +264,7 @@ async def test_ignore_transient_devices_unless_we_see_them_a_few_times(hass):
     assert hass.states.get("device_tracker.s6da7c9389bd5452cc_cccc").state == STATE_HOME
 
 
-async def test_changing_source_attribute(hass):
+async def test_changing_source_attribute(hass: HomeAssistant) -> None:
     """Test update of the source attribute."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ibeacon/test_device_tracker.py
+++ b/tests/components/ibeacon/test_device_tracker.py
@@ -1,6 +1,4 @@
 """Test the ibeacon device trackers."""
-
-
 from datetime import timedelta
 import time
 from unittest.mock import patch
@@ -24,6 +22,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import (
@@ -46,7 +45,7 @@ def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
 
 
-async def test_device_tracker_fixed_address(hass):
+async def test_device_tracker_fixed_address(hass: HomeAssistant) -> None:
     """Test creating and updating device_tracker."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -79,7 +78,7 @@ async def test_device_tracker_fixed_address(hass):
     await hass.async_block_till_done()
 
 
-async def test_device_tracker_random_address(hass):
+async def test_device_tracker_random_address(hass: HomeAssistant) -> None:
     """Test creating and updating device_tracker."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -142,7 +141,9 @@ async def test_device_tracker_random_address(hass):
     assert tracker_attributes[ATTR_FRIENDLY_NAME] == "RandomAddress_1234"
 
 
-async def test_device_tracker_random_address_infrequent_changes(hass):
+async def test_device_tracker_random_address_infrequent_changes(
+    hass: HomeAssistant,
+) -> None:
     """Test creating and updating device_tracker with a random mac that only changes once per day."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -1,8 +1,8 @@
 """Test the ibeacon init."""
-
 import pytest
 
 from homeassistant.components.ibeacon.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -10,6 +10,7 @@ from . import BLUECHARM_BEACON_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +32,9 @@ async def remove_device(ws_client, device_id, config_entry_id):
     return response["success"]
 
 
-async def test_device_remove_devices(hass, hass_ws_client):
+async def test_device_remove_devices(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can only remove a device that no longer exists."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ibeacon/test_sensor.py
+++ b/tests/components/ibeacon/test_sensor.py
@@ -1,6 +1,4 @@
 """Test the ibeacon sensors."""
-
-
 from datetime import timedelta
 
 import pytest
@@ -13,6 +11,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import (
@@ -38,7 +37,7 @@ def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
 
 
-async def test_sensors_updates_fixed_mac_address(hass):
+async def test_sensors_updates_fixed_mac_address(hass: HomeAssistant) -> None:
     """Test creating and updating sensors with a fixed mac address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -117,7 +116,7 @@ async def test_sensors_updates_fixed_mac_address(hass):
     await hass.async_block_till_done()
 
 
-async def test_sensor_with_no_local_name(hass):
+async def test_sensor_with_no_local_name(hass: HomeAssistant) -> None:
     """Test creating and updating sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -140,7 +139,7 @@ async def test_sensor_with_no_local_name(hass):
     assert await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_sensor_sees_last_service_info(hass):
+async def test_sensor_sees_last_service_info(hass: HomeAssistant) -> None:
     """Test sensors are created from recent history."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -159,7 +158,7 @@ async def test_sensor_sees_last_service_info(hass):
     await hass.async_block_till_done()
 
 
-async def test_can_unload_and_reload(hass):
+async def test_can_unload_and_reload(hass: HomeAssistant) -> None:
     """Test sensors get recreated on unload/setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -187,7 +186,7 @@ async def test_can_unload_and_reload(hass):
     )
 
 
-async def test_multiple_uuids_same_beacon(hass):
+async def test_multiple_uuids_same_beacon(hass: HomeAssistant) -> None:
     """Test a beacon that broadcasts multiple uuids."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ifttt/test_init.py
+++ b/tests/components/ifttt/test_init.py
@@ -2,10 +2,14 @@
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ifttt
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+
+from tests.typing import ClientSessionGenerator
 
 
-async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
+async def test_config_flow_registers_webhook(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test setting up IFTTT and sending webhook."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/ign_sismologia/test_geo_location.py
+++ b/tests/components/ign_sismologia/test_geo_location.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     UnitOfLength,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -70,7 +71,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -196,7 +197,7 @@ async def test_setup(hass):
             assert len(all_states) == 0
 
 
-async def test_setup_with_custom_location(hass):
+async def test_setup_with_custom_location(hass: HomeAssistant) -> None:
     """Test the setup with a custom location."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 20.5, (38.1, -3.1))

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -6,12 +6,14 @@ import pytest
 import homeassistant.components.http as http
 import homeassistant.components.image_processing as ip
 from homeassistant.const import ATTR_ENTITY_PICTURE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from . import common
 
 from tests.common import assert_setup_component, async_capture_events
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -50,7 +52,7 @@ async def setup_image_processing_face(hass):
     return async_capture_events(hass, "image_processing.detect_face")
 
 
-async def test_setup_component(hass):
+async def test_setup_component(hass: HomeAssistant) -> None:
     """Set up demo platform on image_process component."""
     config = {ip.DOMAIN: {"platform": "demo"}}
 
@@ -58,7 +60,7 @@ async def test_setup_component(hass):
         assert await async_setup_component(hass, ip.DOMAIN, config)
 
 
-async def test_setup_component_with_service(hass):
+async def test_setup_component_with_service(hass: HomeAssistant) -> None:
     """Set up demo platform on image_process component test service."""
     config = {ip.DOMAIN: {"platform": "demo"}}
 
@@ -109,7 +111,9 @@ async def test_get_image_without_exists_camera(
     assert state.state == "0"
 
 
-async def test_face_event_call(hass, aioclient_mock):
+async def test_face_event_call(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up and scan a picture and test faces from event."""
     face_events = await setup_image_processing_face(hass)
     aioclient_mock.get(get_url(hass), content=b"image")

--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -6,6 +6,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 from homeassistant.components.imap_email_content import sensor as imap_email_content
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.template import Template
 
@@ -28,7 +29,7 @@ class FakeEMailReader:
         return self._messages.popleft()
 
 
-async def test_allowed_sender(hass):
+async def test_allowed_sender(hass: HomeAssistant) -> None:
     """Test emails from allowed sender."""
     test_message = email.message.Message()
     test_message["From"] = "sender@test.com"
@@ -57,7 +58,7 @@ async def test_allowed_sender(hass):
     )
 
 
-async def test_multi_part_with_text(hass):
+async def test_multi_part_with_text(hass: HomeAssistant) -> None:
     """Test multi part emails."""
     msg = MIMEMultipart("alternative")
     msg["Subject"] = "Link"
@@ -87,7 +88,7 @@ async def test_multi_part_with_text(hass):
     assert sensor.extra_state_attributes["body"] == "Test Message"
 
 
-async def test_multi_part_only_html(hass):
+async def test_multi_part_only_html(hass: HomeAssistant) -> None:
     """Test multi part emails with only HTML."""
     msg = MIMEMultipart("alternative")
     msg["Subject"] = "Link"
@@ -117,7 +118,7 @@ async def test_multi_part_only_html(hass):
     )
 
 
-async def test_multi_part_only_other_text(hass):
+async def test_multi_part_only_other_text(hass: HomeAssistant) -> None:
     """Test multi part emails with only other text."""
     msg = MIMEMultipart("alternative")
     msg["Subject"] = "Link"
@@ -144,7 +145,7 @@ async def test_multi_part_only_other_text(hass):
     assert sensor.extra_state_attributes["body"] == "Test Message"
 
 
-async def test_multiple_emails(hass):
+async def test_multiple_emails(hass: HomeAssistant) -> None:
     """Test multiple emails."""
     states = []
 
@@ -186,7 +187,7 @@ async def test_multiple_emails(hass):
     assert sensor.extra_state_attributes["body"] == "Test Message 2"
 
 
-async def test_sender_not_allowed(hass):
+async def test_sender_not_allowed(hass: HomeAssistant) -> None:
     """Test not whitelisted emails."""
     test_message = email.message.Message()
     test_message["From"] = "sender@test.com"
@@ -208,7 +209,7 @@ async def test_sender_not_allowed(hass):
     assert sensor.state is None
 
 
-async def test_template(hass):
+async def test_template(hass: HomeAssistant) -> None:
     """Test value template."""
     test_message = email.message.Message()
     test_message["From"] = "sender@test.com"

--- a/tests/components/inkbird/test_config_flow.py
+++ b/tests/components/inkbird/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the INKBIRD config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.inkbird.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import IBBQ_SERVICE_INFO, NOT_INKBIRD_SERVICE_INFO, SPS_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import IBBQ_SERVICE_INFO, NOT_INKBIRD_SERVICE_INFO, SPS_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -30,7 +30,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
 
 
-async def test_async_step_bluetooth_not_inkbird(hass):
+async def test_async_step_bluetooth_not_inkbird(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not inkbird."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -41,7 +41,7 @@ async def test_async_step_bluetooth_not_inkbird(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -51,7 +51,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.inkbird.config_flow.async_discovered_service_info",
@@ -74,7 +74,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "61DE521B-F0BF-9F44-64D4-75BBE1738105"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.inkbird.config_flow.async_discovered_service_info",
@@ -102,7 +102,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -122,7 +124,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -139,7 +141,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -158,7 +160,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the INKBIRD config flow."""
-
-
 from homeassistant.components.inkbird.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import SPS_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the input_boolean component."""
-
 import logging
 from unittest.mock import patch
 
@@ -19,7 +18,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -52,7 +51,7 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [None, 1, {}, {"name with space": None}]
 
@@ -60,7 +59,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_methods(hass):
+async def test_methods(hass: HomeAssistant) -> None:
     """Test is_on, turn_on, turn_off methods."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test_1": None}})
     entity_id = "input_boolean.test_1"
@@ -86,7 +85,7 @@ async def test_methods(hass):
     assert is_on(hass, entity_id)
 
 
-async def test_config_options(hass):
+async def test_config_options(hass: HomeAssistant) -> None:
     """Test configuration options."""
     count_start = len(hass.states.async_entity_ids())
 
@@ -122,7 +121,7 @@ async def test_config_options(hass):
     assert state_2.attributes.get(ATTR_ICON) == "mdi:work"
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -147,7 +146,7 @@ async def test_restore_state(hass):
     assert state.state == "off"
 
 
-async def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_boolean.b1", "on"), State("input_boolean.b2", "off"))

--- a/tests/components/input_boolean/test_reproduce_state.py
+++ b/tests/components/input_boolean/test_reproduce_state.py
@@ -1,10 +1,10 @@
 """Test reproduce state for input boolean."""
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
 
-async def test_reproducing_states(hass):
+async def test_reproducing_states(hass: HomeAssistant) -> None:
     """Test reproducing input_boolean states."""
     assert await async_setup_component(
         hass,

--- a/tests/components/input_button/test_init.py
+++ b/tests/components/input_button/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.setup import async_setup_component
@@ -44,7 +44,7 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [None, 1, {}, {"name with space": None}]
 
@@ -52,7 +52,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_config_options(hass):
+async def test_config_options(hass: HomeAssistant) -> None:
     """Test configuration options."""
     count_start = len(hass.states.async_entity_ids())
 
@@ -88,7 +88,7 @@ async def test_config_options(hass):
     assert state_2.attributes.get(ATTR_ICON) == "mdi:work"
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the Input slider component."""
-
 import datetime
 from unittest.mock import patch
 
@@ -26,7 +25,7 @@ from homeassistant.components.input_datetime import (
     SERVICE_RELOAD,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_NAME
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -121,7 +120,7 @@ def test_invalid_configs(config):
         CONFIG_SCHEMA({DOMAIN: config})
 
 
-async def test_set_datetime(hass):
+async def test_set_datetime(hass: HomeAssistant) -> None:
     """Test set_datetime method using date & time."""
     await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_datetime": {"has_time": True, "has_date": True}}}
@@ -149,7 +148,7 @@ async def test_set_datetime(hass):
     assert state.attributes["timestamp"] == dt_obj.timestamp()
 
 
-async def test_set_datetime_2(hass):
+async def test_set_datetime_2(hass: HomeAssistant) -> None:
     """Test set_datetime method using datetime."""
     await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_datetime": {"has_time": True, "has_date": True}}}
@@ -177,7 +176,7 @@ async def test_set_datetime_2(hass):
     assert state.attributes["timestamp"] == dt_obj.timestamp()
 
 
-async def test_set_datetime_3(hass):
+async def test_set_datetime_3(hass: HomeAssistant) -> None:
     """Test set_datetime method using timestamp."""
     await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_datetime": {"has_time": True, "has_date": True}}}
@@ -205,7 +204,7 @@ async def test_set_datetime_3(hass):
     assert state.attributes["timestamp"] == dt_obj.timestamp()
 
 
-async def test_set_datetime_time(hass):
+async def test_set_datetime_time(hass: HomeAssistant) -> None:
     """Test set_datetime method with only time."""
     await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_time": {"has_time": True, "has_date": False}}}
@@ -225,7 +224,7 @@ async def test_set_datetime_time(hass):
     assert state.attributes["timestamp"] == (19 * 3600) + (46 * 60) + 30
 
 
-async def test_set_invalid(hass):
+async def test_set_invalid(hass: HomeAssistant) -> None:
     """Test set_datetime method with only time."""
     initial = "2017-01-01"
     await async_setup_component(
@@ -255,7 +254,7 @@ async def test_set_invalid(hass):
     assert state.state == initial
 
 
-async def test_set_invalid_2(hass):
+async def test_set_invalid_2(hass: HomeAssistant) -> None:
     """Test set_datetime method with date and datetime."""
     initial = "2017-01-01"
     await async_setup_component(
@@ -285,7 +284,7 @@ async def test_set_invalid_2(hass):
     assert state.state == initial
 
 
-async def test_set_datetime_date(hass):
+async def test_set_datetime_date(hass: HomeAssistant) -> None:
     """Test set_datetime method with only date."""
     await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_date": {"has_time": False, "has_date": True}}}
@@ -307,7 +306,7 @@ async def test_set_datetime_date(hass):
     assert state.attributes["timestamp"] == date_dt_obj.timestamp()
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -365,7 +364,7 @@ async def test_restore_state(hass):
     assert state_was_date.state == default.strftime(FMT_TIME)
 
 
-async def test_default_value(hass):
+async def test_default_value(hass: HomeAssistant) -> None:
     """Test default value if none has been set via initial or restore state."""
     await async_setup_component(
         hass,
@@ -657,7 +656,7 @@ async def test_setup_no_config(hass, hass_admin_user):
     assert count_start == len(hass.states.async_entity_ids())
 
 
-async def test_timestamp(hass):
+async def test_timestamp(hass: HomeAssistant) -> None:
     """Test timestamp."""
     hass.config.set_time_zone("America/Los_Angeles")
 

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Input datetime."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Input datetime states."""
     hass.states.async_set(
         "input_datetime.entity_datetime",

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Input number component."""
-
 from unittest.mock import patch
 
 import pytest
@@ -19,7 +18,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_NAME,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -96,7 +95,7 @@ async def decrement(hass, entity_id):
     )
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [
         None,
@@ -108,7 +107,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_set_value(hass, caplog):
+async def test_set_value(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test set_value method."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_1": {"initial": 50, "min": 0, "max": 100}}}
@@ -139,7 +138,7 @@ async def test_set_value(hass, caplog):
     assert float(state.state) == 70
 
 
-async def test_increment(hass):
+async def test_increment(hass: HomeAssistant) -> None:
     """Test increment method."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_2": {"initial": 50, "min": 0, "max": 51}}}
@@ -162,7 +161,7 @@ async def test_increment(hass):
     assert float(state.state) == 51
 
 
-async def test_rounding(hass):
+async def test_rounding(hass: HomeAssistant) -> None:
     """Test increment introducing floating point error is rounded."""
     assert await async_setup_component(
         hass,
@@ -182,7 +181,7 @@ async def test_rounding(hass):
     assert float(state.state) == 3.6
 
 
-async def test_decrement(hass):
+async def test_decrement(hass: HomeAssistant) -> None:
     """Test decrement method."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test_3": {"initial": 50, "min": 49, "max": 100}}}
@@ -205,7 +204,7 @@ async def test_decrement(hass):
     assert float(state.state) == 49
 
 
-async def test_mode(hass):
+async def test_mode(hass: HomeAssistant) -> None:
     """Test mode settings."""
     assert await async_setup_component(
         hass,
@@ -232,7 +231,7 @@ async def test_mode(hass):
     assert state.attributes["mode"] == "slider"
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_number.b1", "70"), State("input_number.b2", "200"))
@@ -255,7 +254,7 @@ async def test_restore_state(hass):
     assert float(state.state) == 10
 
 
-async def test_restore_invalid_state(hass):
+async def test_restore_invalid_state(hass: HomeAssistant) -> None:
     """Ensure an invalid restore state is handled."""
     mock_restore_cache(
         hass, (State("input_number.b1", "="), State("input_number.b2", "200"))
@@ -278,7 +277,7 @@ async def test_restore_invalid_state(hass):
     assert float(state.state) == 10
 
 
-async def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State("input_number.b1", "70"), State("input_number.b2", "200"))
@@ -306,7 +305,7 @@ async def test_initial_state_overrules_restore_state(hass):
     assert float(state.state) == 60
 
 
-async def test_no_initial_state_and_no_restore_state(hass):
+async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> None:
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting
 

--- a/tests/components/input_number/test_reproduce_state.py
+++ b/tests/components/input_number/test_reproduce_state.py
@@ -1,5 +1,7 @@
 """Test reproduce state for Input number."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
@@ -7,7 +9,9 @@ VALID_NUMBER1 = "19.0"
 VALID_NUMBER2 = "99.9"
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Input number states."""
 
     assert await async_setup_component(

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Input select component."""
-
 from unittest.mock import patch
 
 import pytest
@@ -26,7 +25,7 @@ from homeassistant.const import (
     ATTR_NAME,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Context, State
+from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -68,7 +67,7 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [
         None,
@@ -81,7 +80,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_select_option(hass):
+async def test_select_option(hass: HomeAssistant) -> None:
     """Test select_option methods."""
     assert await async_setup_component(
         hass,
@@ -112,7 +111,7 @@ async def test_select_option(hass):
     assert state.state == "another option"
 
 
-async def test_select_next(hass):
+async def test_select_next(hass: HomeAssistant) -> None:
     """Test select_next methods."""
     assert await async_setup_component(
         hass,
@@ -150,7 +149,7 @@ async def test_select_next(hass):
     assert state.state == "first option"
 
 
-async def test_select_previous(hass):
+async def test_select_previous(hass: HomeAssistant) -> None:
     """Test select_previous methods."""
     assert await async_setup_component(
         hass,
@@ -188,7 +187,7 @@ async def test_select_previous(hass):
     assert state.state == "last option"
 
 
-async def test_select_first_last(hass):
+async def test_select_first_last(hass: HomeAssistant) -> None:
     """Test select_first and _last methods."""
     assert await async_setup_component(
         hass,
@@ -228,7 +227,7 @@ async def test_select_first_last(hass):
     assert state.state == "last option"
 
 
-async def test_config_options(hass):
+async def test_config_options(hass: HomeAssistant) -> None:
     """Test configuration options."""
     count_start = len(hass.states.async_entity_ids())
 
@@ -268,7 +267,7 @@ async def test_config_options(hass):
     assert state_2.attributes.get(ATTR_ICON) == "mdi:work"
 
 
-async def test_set_options_service(hass):
+async def test_set_options_service(hass: HomeAssistant) -> None:
     """Test set_options service."""
     assert await async_setup_component(
         hass,
@@ -324,7 +323,7 @@ async def test_set_options_service(hass):
     assert state.state == "test2"
 
 
-async def test_set_options_service_duplicate(hass):
+async def test_set_options_service_duplicate(hass: HomeAssistant) -> None:
     """Test set_options service with duplicates."""
     assert await async_setup_component(
         hass,
@@ -364,7 +363,7 @@ async def test_set_options_service_duplicate(hass):
     ]
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -387,7 +386,7 @@ async def test_restore_state(hass):
     assert state.state == "first option"
 
 
-async def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -1,5 +1,7 @@
 """Test reproduce state for Input select."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
@@ -15,7 +17,9 @@ VALID_OPTION_SET2 = [VALID_OPTION4, VALID_OPTION5, VALID_OPTION6]
 ENTITY = "input_select.test_select"
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Input select states."""
 
     # Setup entity

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Input text component."""
-
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +22,7 @@ from homeassistant.const import (
     ATTR_NAME,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -79,7 +78,7 @@ async def async_set_value(hass, entity_id, value):
     )
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [
         None,
@@ -91,7 +90,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_set_value(hass):
+async def test_set_value(hass: HomeAssistant) -> None:
     """Test set_value method."""
     assert await async_setup_component(
         hass,
@@ -121,7 +120,7 @@ async def test_set_value(hass):
     assert hass.states.get(entity_id_2).state == ""
 
 
-async def test_mode(hass):
+async def test_mode(hass: HomeAssistant) -> None:
     """Test mode settings."""
     assert await async_setup_component(
         hass,
@@ -158,7 +157,7 @@ async def test_mode(hass):
     assert state.attributes["mode"] == "password"
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -180,7 +179,7 @@ async def test_restore_state(hass):
     assert str(state.state) == "unknown"
 
 
-async def test_initial_state_overrules_restore_state(hass):
+async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,
@@ -209,7 +208,7 @@ async def test_initial_state_overrules_restore_state(hass):
     assert str(state.state) == "test"
 
 
-async def test_no_initial_state_and_no_restore_state(hass):
+async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> None:
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting
 
@@ -243,7 +242,7 @@ async def test_input_text_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_config_none(hass):
+async def test_config_none(hass: HomeAssistant) -> None:
     """Set up input_text without any config."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": None}})
 

--- a/tests/components/input_text/test_reproduce_state.py
+++ b/tests/components/input_text/test_reproduce_state.py
@@ -1,5 +1,7 @@
 """Test reproduce state for Input text."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
@@ -9,7 +11,9 @@ INVALID_TEXT1 = "This text is too long!"
 INVALID_TEXT2 = "Short"
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Input text states."""
 
     # Setup entity for testing

--- a/tests/components/insteon/test_api_device.py
+++ b/tests/components/insteon/test_api_device.py
@@ -17,12 +17,14 @@ from homeassistant.components.insteon.api.device import (
     async_device_name,
 )
 from homeassistant.components.insteon.const import DOMAIN, MULTIPLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .const import MOCK_USER_INPUT_PLM
 from .mock_devices import MockDevices
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def _async_setup(hass, hass_ws_client):
@@ -50,7 +52,9 @@ async def _async_setup(hass, hass_ws_client):
     return ws_client, devices, ha_device, dev_reg
 
 
-async def test_get_device_api(hass, hass_ws_client):
+async def test_get_device_api(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting an Insteon device."""
 
     ws_client, devices, ha_device, _ = await _async_setup(hass, hass_ws_client)
@@ -65,7 +69,9 @@ async def test_get_device_api(hass, hass_ws_client):
         assert result["address"] == "11.11.11"
 
 
-async def test_no_ha_device(hass, hass_ws_client):
+async def test_no_ha_device(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test response when no HA device exists."""
 
     ws_client, devices, _, _ = await _async_setup(hass, hass_ws_client)
@@ -79,7 +85,9 @@ async def test_no_ha_device(hass, hass_ws_client):
         assert msg["error"]["message"] == HA_DEVICE_NOT_FOUND
 
 
-async def test_no_insteon_device(hass, hass_ws_client):
+async def test_no_insteon_device(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test response when no Insteon device exists."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -125,7 +133,9 @@ async def test_no_insteon_device(hass, hass_ws_client):
         assert msg["error"]["message"] == INSTEON_DEVICE_NOT_FOUND
 
 
-async def test_get_ha_device_name(hass, hass_ws_client):
+async def test_get_ha_device_name(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting the HA device name from an Insteon address."""
 
     _, devices, _, device_reg = await _async_setup(hass, hass_ws_client)
@@ -144,7 +154,9 @@ async def test_get_ha_device_name(hass, hass_ws_client):
         assert name == ""
 
 
-async def test_add_device_api(hass, hass_ws_client):
+async def test_add_device_api(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test adding an Insteon device."""
 
     ws_client, devices, _, _ = await _async_setup(hass, hass_ws_client)
@@ -172,7 +184,9 @@ async def test_add_device_api(hass, hass_ws_client):
         assert msg["event"]["type"] == "linking_stopped"
 
 
-async def test_cancel_add_device(hass, hass_ws_client):
+async def test_cancel_add_device(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test cancelling adding of a new device."""
 
     ws_client, devices, _, _ = await _async_setup(hass, hass_ws_client)

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -627,7 +627,7 @@ async def test_options_override_bad_data(hass: HomeAssistant):
     assert result["errors"] == {"base": "input_error"}
 
 
-async def test_discovery_via_usb(hass):
+async def test_discovery_via_usb(hass: HomeAssistant) -> None:
     """Test usb flow."""
     discovery_info = usb.UsbServiceInfo(
         device="/dev/ttyINSTEON",
@@ -656,7 +656,7 @@ async def test_discovery_via_usb(hass):
     assert result2["data"] == {"device": "/dev/ttyINSTEON"}
 
 
-async def test_discovery_via_usb_already_setup(hass):
+async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
     """Test usb flow -- already setup."""
 
     MockConfigEntry(

--- a/tests/components/insteon/test_lock.py
+++ b/tests/components/insteon/test_lock.py
@@ -1,5 +1,4 @@
 """Tests for the Insteon lock."""
-
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +18,7 @@ from homeassistant.const import (  # ATTR_ENTITY_ID,;
     STATE_UNLOCKED,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .const import MOCK_USER_INPUT_PLM
@@ -57,7 +57,7 @@ async def mock_connection(*args, **kwargs):
     return True
 
 
-async def test_lock_lock(hass):
+async def test_lock_lock(hass: HomeAssistant) -> None:
     """Test locking an Insteon lock device."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
@@ -82,7 +82,7 @@ async def test_lock_lock(hass):
         await hass.async_block_till_done()
 
 
-async def test_lock_unlock(hass):
+async def test_lock_unlock(hass: HomeAssistant) -> None:
     """Test locking an Insteon lock device."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -140,7 +140,7 @@ async def test_restore_state_failed(hass: HomeAssistant) -> None:
     assert "device_class" not in state.attributes
 
 
-async def test_trapezoidal(hass):
+async def test_trapezoidal(hass: HomeAssistant) -> None:
     """Test integration sensor state."""
     config = {
         "sensor": {
@@ -177,7 +177,7 @@ async def test_trapezoidal(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
 
 
-async def test_left(hass):
+async def test_left(hass: HomeAssistant) -> None:
     """Test integration sensor state with left reimann method."""
     config = {
         "sensor": {
@@ -217,7 +217,7 @@ async def test_left(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
 
 
-async def test_right(hass):
+async def test_right(hass: HomeAssistant) -> None:
     """Test integration sensor state with left reimann method."""
     config = {
         "sensor": {
@@ -257,7 +257,7 @@ async def test_right(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
 
 
-async def test_prefix(hass):
+async def test_prefix(hass: HomeAssistant) -> None:
     """Test integration sensor state using a power source."""
     config = {
         "sensor": {
@@ -293,7 +293,7 @@ async def test_prefix(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
 
 
-async def test_suffix(hass):
+async def test_suffix(hass: HomeAssistant) -> None:
     """Test integration sensor state using a network counter source."""
     config = {
         "sensor": {
@@ -332,7 +332,7 @@ async def test_suffix(hass):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfInformation.KILOBYTES
 
 
-async def test_suffix_2(hass):
+async def test_suffix_2(hass: HomeAssistant) -> None:
     """Test integration sensor state."""
     config = {
         "sensor": {
@@ -368,7 +368,7 @@ async def test_suffix_2(hass):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "m³"
 
 
-async def test_units(hass):
+async def test_units(hass: HomeAssistant) -> None:
     """Test integration sensor units using a power source."""
     config = {
         "sensor": {
@@ -409,7 +409,7 @@ async def test_units(hass):
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.WATT_HOUR
 
 
-async def test_device_class(hass):
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test integration sensor units using a power source."""
     config = {
         "sensor": {
@@ -458,7 +458,7 @@ async def test_device_class(hass):
     assert state.attributes.get("device_class") == SensorDeviceClass.ENERGY
 
 
-async def test_calc_errors(hass):
+async def test_calc_errors(hass: HomeAssistant) -> None:
     """Test integration sensor units using a power source."""
     config = {
         "sensor": {

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -3,6 +3,7 @@ import pytest
 
 from homeassistant.components.cover import SERVICE_OPEN_COVER
 from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
 
@@ -58,7 +59,7 @@ async def test_http_handle_intent(hass, hass_client, hass_admin_user):
     }
 
 
-async def test_cover_intents_loading(hass):
+async def test_cover_intents_loading(hass: HomeAssistant) -> None:
     """Test Cover Intents Loading."""
     assert await async_setup_component(hass, "intent", {})
 
@@ -86,7 +87,7 @@ async def test_cover_intents_loading(hass):
     assert call.data == {"entity_id": "cover.garage_door"}
 
 
-async def test_turn_on_intent(hass):
+async def test_turn_on_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOn intent."""
     result = await async_setup_component(hass, "homeassistant", {})
     result = await async_setup_component(hass, "intent", {})
@@ -108,7 +109,7 @@ async def test_turn_on_intent(hass):
     assert call.data == {"entity_id": ["light.test_light"]}
 
 
-async def test_turn_off_intent(hass):
+async def test_turn_off_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOff intent."""
     result = await async_setup_component(hass, "homeassistant", {})
     result = await async_setup_component(hass, "intent", {})
@@ -129,7 +130,7 @@ async def test_turn_off_intent(hass):
     assert call.data == {"entity_id": ["light.test_light"]}
 
 
-async def test_toggle_intent(hass):
+async def test_toggle_intent(hass: HomeAssistant) -> None:
     """Test HassToggle intent."""
     result = await async_setup_component(hass, "homeassistant", {})
     result = await async_setup_component(hass, "intent", {})
@@ -150,7 +151,7 @@ async def test_toggle_intent(hass):
     assert call.data == {"entity_id": ["light.test_light"]}
 
 
-async def test_turn_on_multiple_intent(hass):
+async def test_turn_on_multiple_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOn intent with multiple similar entities.
 
     This tests that matching finds the proper entity among similar names.

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -1,11 +1,12 @@
 """Test intent_script component."""
 from homeassistant.bootstrap import async_setup_component
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
 from tests.common import async_mock_service
 
 
-async def test_intent_script(hass):
+async def test_intent_script(hass: HomeAssistant) -> None:
     """Test intent scripts work."""
     calls = async_mock_service(hass, "test", "service")
 
@@ -44,7 +45,7 @@ async def test_intent_script(hass):
     assert response.card["simple"]["content"] == "Content for Paulus"
 
 
-async def test_intent_script_wait_response(hass):
+async def test_intent_script_wait_response(hass: HomeAssistant) -> None:
     """Test intent scripts work."""
     calls = async_mock_service(hass, "test", "service")
 
@@ -89,7 +90,7 @@ async def test_intent_script_wait_response(hass):
     assert response.card["simple"]["content"] == "Content for Paulus"
 
 
-async def test_intent_script_falsy_reprompt(hass):
+async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
     """Test intent scripts work."""
     calls = async_mock_service(hass, "test", "service")
 

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import ios
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_coro
@@ -23,7 +24,7 @@ def mock_dependencies(hass):
     mock_component(hass, "device_tracker")
 
 
-async def test_creating_entry_sets_up_sensor(hass):
+async def test_creating_entry_sets_up_sensor(hass: HomeAssistant) -> None:
     """Test setting up iOS loads the sensor component."""
     with patch(
         "homeassistant.components.ios.sensor.async_setup_entry",
@@ -35,7 +36,7 @@ async def test_creating_entry_sets_up_sensor(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_configuring_ios_creates_entry(hass):
+async def test_configuring_ios_creates_entry(hass: HomeAssistant) -> None:
     """Test that specifying config will create an entry."""
     with patch(
         "homeassistant.components.ios.async_setup_entry", return_value=mock_coro(True)
@@ -46,7 +47,7 @@ async def test_configuring_ios_creates_entry(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_not_configuring_ios_not_creates_entry(hass):
+async def test_not_configuring_ios_not_creates_entry(hass: HomeAssistant) -> None:
     """Test that no config will not create an entry."""
     with patch(
         "homeassistant.components.ios.async_setup_entry", return_value=mock_coro(True)

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -1,9 +1,9 @@
 """Tests for IPMA config flow."""
-
 from unittest.mock import Mock, patch
 
 from homeassistant.components.ipma import DOMAIN, config_flow
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -36,7 +36,7 @@ async def test_show_config_form_default_values() -> None:
     assert result["step_id"] == "user"
 
 
-async def test_flow_with_home_location(hass):
+async def test_flow_with_home_location(hass: HomeAssistant) -> None:
     """Test config flow .
 
     Tests the flow when a default location is configured
@@ -122,7 +122,7 @@ async def test_flow_entry_config_entry_already_exists() -> None:
         assert len(flow._errors) == 1
 
 
-async def test_config_entry_migration(hass):
+async def test_config_entry_migration(hass: HomeAssistant) -> None:
     """Tests config entry without mode in unique_id can be migrated."""
     ipma_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ipma/test_init.py
+++ b/tests/components/ipma/test_init.py
@@ -1,5 +1,4 @@
 """Test the IPMA integration."""
-
 from unittest.mock import patch
 
 from pyipma import IPMAException
@@ -7,13 +6,14 @@ from pyipma import IPMAException
 from homeassistant.components.ipma import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
+from homeassistant.core import HomeAssistant
 
 from .test_weather import MockLocation
 
 from tests.common import MockConfigEntry
 
 
-async def test_async_setup_raises_entry_not_ready(hass):
+async def test_async_setup_raises_entry_not_ready(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
 
     with patch(
@@ -32,7 +32,7 @@ async def test_async_setup_raises_entry_not_ready(hass):
         assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_config_entry(hass):
+async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test entry unloading."""
 
     with patch(

--- a/tests/components/ipma/test_system_health.py
+++ b/tests/components/ipma/test_system_health.py
@@ -2,12 +2,16 @@
 import asyncio
 
 from homeassistant.components.ipma.system_health import IPMA_API_URL
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_ipma_system_health(hass, aioclient_mock):
+async def test_ipma_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test ipma system health."""
     aioclient_mock.get(IPMA_API_URL, json={"result": "ok", "data": {}})
 

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -20,6 +20,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 
 from . import MockLocation
 
@@ -52,7 +53,7 @@ class MockBadLocation(MockLocation):
         return []
 
 
-async def test_setup_config_flow(hass):
+async def test_setup_config_flow(hass: HomeAssistant) -> None:
     """Test for successfully setting up the IPMA platform."""
     with patch(
         "pyipma.location.Location.get",
@@ -75,7 +76,7 @@ async def test_setup_config_flow(hass):
     assert state.attributes.get("friendly_name") == "HomeTown"
 
 
-async def test_daily_forecast(hass):
+async def test_daily_forecast(hass: HomeAssistant) -> None:
     """Test for successfully getting daily forecast."""
     with patch(
         "pyipma.location.Location.get",
@@ -100,7 +101,7 @@ async def test_daily_forecast(hass):
 
 
 @freeze_time("2020-01-14 23:00:00")
-async def test_hourly_forecast(hass):
+async def test_hourly_forecast(hass: HomeAssistant) -> None:
     """Test for successfully getting daily forecast."""
     with patch(
         "pyipma.location.Location.get",
@@ -122,7 +123,7 @@ async def test_hourly_forecast(hass):
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == "S"
 
 
-async def test_failed_get_observation_forecast(hass):
+async def test_failed_get_observation_forecast(hass: HomeAssistant) -> None:
     """Test for successfully setting up the IPMA platform."""
     with patch(
         "pyipma.location.Location.get",

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -2,6 +2,7 @@
 from homeassistant import data_entry_flow
 from homeassistant.components.iqvia import CONF_ZIP_CODE, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 
 
 async def test_duplicate_error(hass, config, config_entry):
@@ -13,7 +14,7 @@ async def test_duplicate_error(hass, config, config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_zip_code(hass):
+async def test_invalid_zip_code(hass: HomeAssistant) -> None:
     """Test that an invalid ZIP code key throws an error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={CONF_ZIP_CODE: "bad"}
@@ -22,7 +23,7 @@ async def test_invalid_zip_code(hass):
     assert result["errors"] == {CONF_ZIP_CODE: "invalid_zip_code"}
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/islamic_prayer_times/test_config_flow.py
+++ b/tests/components/islamic_prayer_times/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import islamic_prayer_times
 from homeassistant.components.islamic_prayer_times import config_flow  # noqa: F401
 from homeassistant.components.islamic_prayer_times.const import CONF_CALC_METHOD, DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -21,7 +22,7 @@ def mock_setup():
         yield
 
 
-async def test_flow_works(hass):
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         islamic_prayer_times.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -36,7 +37,7 @@ async def test_flow_works(hass):
     assert result["title"] == "Islamic Prayer Times"
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test updating options."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -59,7 +60,7 @@ async def test_options(hass):
     assert result["data"][CONF_CALC_METHOD] == "makkah"
 
 
-async def test_integration_already_configured(hass):
+async def test_integration_already_configured(hass: HomeAssistant) -> None:
     """Test integration is already configured."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/islamic_prayer_times/test_init.py
+++ b/tests/components/islamic_prayer_times/test_init.py
@@ -1,5 +1,4 @@
 """Tests for Islamic Prayer Times init."""
-
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -9,6 +8,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import islamic_prayer_times
+from homeassistant.core import HomeAssistant
 
 from . import (
     NEW_PRAYER_TIMES,
@@ -27,7 +27,7 @@ def set_utc(hass):
     hass.config.set_time_zone("UTC")
 
 
-async def test_successful_config_entry(hass):
+async def test_successful_config_entry(hass: HomeAssistant) -> None:
     """Test that Islamic Prayer Times is configured successfully."""
 
     entry = MockConfigEntry(
@@ -49,7 +49,7 @@ async def test_successful_config_entry(hass):
         }
 
 
-async def test_setup_failed(hass):
+async def test_setup_failed(hass: HomeAssistant) -> None:
     """Test Islamic Prayer Times failed due to an error."""
 
     entry = MockConfigEntry(
@@ -68,7 +68,7 @@ async def test_setup_failed(hass):
         assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test removing Islamic Prayer Times."""
     entry = MockConfigEntry(
         domain=islamic_prayer_times.DOMAIN,
@@ -88,7 +88,7 @@ async def test_unload_entry(hass):
         assert islamic_prayer_times.DOMAIN not in hass.data
 
 
-async def test_islamic_prayer_times_timestamp_format(hass):
+async def test_islamic_prayer_times_timestamp_format(hass: HomeAssistant) -> None:
     """Test Islamic prayer times timestamp format."""
     entry = MockConfigEntry(domain=islamic_prayer_times.DOMAIN, data={})
     entry.add_to_hass(hass)
@@ -106,7 +106,7 @@ async def test_islamic_prayer_times_timestamp_format(hass):
         )
 
 
-async def test_update(hass):
+async def test_update(hass: HomeAssistant) -> None:
     """Test sensors are updated with new prayer times."""
     entry = MockConfigEntry(domain=islamic_prayer_times.DOMAIN, data={})
     entry.add_to_hass(hass)

--- a/tests/components/islamic_prayer_times/test_sensor.py
+++ b/tests/components/islamic_prayer_times/test_sensor.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import islamic_prayer_times
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from . import NOW, PRAYER_TIMES, PRAYER_TIMES_TIMESTAMPS
@@ -18,7 +19,7 @@ def set_utc(hass):
     hass.config.set_time_zone("UTC")
 
 
-async def test_islamic_prayer_times_sensors(hass):
+async def test_islamic_prayer_times_sensors(hass: HomeAssistant) -> None:
     """Test minimum Islamic prayer times configuration."""
     entry = MockConfigEntry(domain=islamic_prayer_times.DOMAIN, data={})
     entry.add_to_hass(hass)

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -721,7 +721,7 @@ async def test_form_dhcp_existing_ignored_entry(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_reauth(hass):
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test we can reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/isy994/test_system_health.py
+++ b/tests/components/isy994/test_system_health.py
@@ -6,18 +6,22 @@ from aiohttp import ClientError
 
 from homeassistant.components.isy994.const import DOMAIN, ISY_URL_POSTFIX
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_config_flow import MOCK_HOSTNAME, MOCK_UUID
 
 from tests.common import MockConfigEntry, get_system_health_info
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_ENTRY_ID = "cad4af20b811990e757588519917d6af"
 MOCK_CONNECTED = "connected"
 MOCK_HEARTBEAT = "2021-05-01T00:00:00.000000"
 
 
-async def test_system_health(hass, aioclient_mock):
+async def test_system_health(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test system health."""
     aioclient_mock.get(f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}", text="")
 
@@ -54,7 +58,9 @@ async def test_system_health(hass, aioclient_mock):
     assert info["websocket_status"] == MOCK_CONNECTED
 
 
-async def test_system_health_failed_connect(hass, aioclient_mock):
+async def test_system_health_failed_connect(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test system health."""
     aioclient_mock.get(f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}", exc=ClientError)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests:
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
