### PR TITLE
Add type hints to integration tests (j-m)

### DIFF
--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components import jewish_calendar
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -305,7 +306,9 @@ async def test_issur_melacha_sensor_update(
         )
 
 
-async def test_no_discovery_info(hass, caplog):
+async def test_no_discovery_info(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert BINARY_SENSOR_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import jewish_calendar
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -19,7 +20,7 @@ from . import (
 from tests.common import async_fire_time_changed
 
 
-async def test_jewish_calendar_min_config(hass):
+async def test_jewish_calendar_min_config(hass: HomeAssistant) -> None:
     """Test minimum jewish calendar configuration."""
     assert await async_setup_component(
         hass, jewish_calendar.DOMAIN, {"jewish_calendar": {}}
@@ -28,7 +29,7 @@ async def test_jewish_calendar_min_config(hass):
     assert hass.states.get("sensor.jewish_calendar_date") is not None
 
 
-async def test_jewish_calendar_hebrew(hass):
+async def test_jewish_calendar_hebrew(hass: HomeAssistant) -> None:
     """Test jewish calendar sensor with language set to hebrew."""
     assert await async_setup_component(
         hass, jewish_calendar.DOMAIN, {"jewish_calendar": {"language": "hebrew"}}
@@ -642,7 +643,9 @@ async def test_dafyomi_sensor(hass, test_time, result):
     assert hass.states.get("sensor.test_daf_yomi").state == result
 
 
-async def test_no_discovery_info(hass, caplog):
+async def test_no_discovery_info(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert SENSOR_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/juicenet/test_config_flow.py
+++ b/tests/components/juicenet/test_config_flow.py
@@ -7,6 +7,7 @@ from pyjuicenet import TokenError
 from homeassistant import config_entries
 from homeassistant.components.juicenet.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
 
 
 def _mock_juicenet_return_value(get_devices=None):
@@ -15,7 +16,7 @@ def _mock_juicenet_return_value(get_devices=None):
     return juicenet_mock
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -44,7 +45,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -62,7 +63,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -80,7 +81,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_catch_unknown_errors(hass):
+async def test_form_catch_unknown_errors(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -98,7 +99,7 @@ async def test_form_catch_unknown_errors(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test that import works as expected."""
 
     with patch(

--- a/tests/components/kegtron/test_config_flow.py
+++ b/tests/components/kegtron/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the Kegtron config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.kegtron.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -15,7 +15,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -34,7 +34,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "D0:CF:5E:5C:9B:75"
 
 
-async def test_async_step_bluetooth_not_kegtron(hass):
+async def test_async_step_bluetooth_not_kegtron(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not kegtron."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -45,7 +45,7 @@ async def test_async_step_bluetooth_not_kegtron(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -55,7 +55,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "D0:CF:5E:5C:9B:75"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.kegtron.config_flow.async_discovered_service_info",
@@ -106,7 +106,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -126,7 +128,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -143,7 +145,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -162,7 +164,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/kegtron/test_sensor.py
+++ b/tests/components/kegtron/test_sensor.py
@@ -1,8 +1,8 @@
 """Test the Kegtron sensors."""
-
 from homeassistant.components.kegtron.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import (
     KEGTRON_KT100_SERVICE_INFO,
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors_kt100(hass):
+async def test_sensors_kt100(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors for Kegtron KT-100."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -91,7 +91,7 @@ async def test_sensors_kt100(hass):
     await hass.async_block_till_done()
 
 
-async def test_sensors_kt200(hass):
+async def test_sensors_kt200(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors for Kegtron KT-200."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the MicroBot config flow."""
-
 from unittest.mock import ANY, AsyncMock, patch
 
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_ADDRESS
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -25,7 +25,7 @@ def patch_microbot_api():
     )
 
 
-async def test_bluetooth_discovery(hass):
+async def test_bluetooth_discovery(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -47,7 +47,7 @@ async def test_bluetooth_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_bluetooth_discovery_already_setup(hass):
+async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device when already setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -67,7 +67,7 @@ async def test_bluetooth_discovery_already_setup(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_user_setup(hass):
+async def test_user_setup(hass: HomeAssistant) -> None:
     """Test the user initiated form with valid mac."""
 
     with patch(
@@ -107,7 +107,7 @@ async def test_user_setup(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_already_configured(hass):
+async def test_user_setup_already_configured(hass: HomeAssistant) -> None:
     """Test the user initiated form with valid mac."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +128,7 @@ async def test_user_setup_already_configured(hass):
     assert result["reason"] == "no_unconfigured_devices"
 
 
-async def test_user_no_devices(hass):
+async def test_user_no_devices(hass: HomeAssistant) -> None:
     """Test the user initiated form with valid mac."""
     with patch_microbot_api(), patch(
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
@@ -141,7 +141,7 @@ async def test_user_no_devices(hass):
     assert result["reason"] == "no_unconfigured_devices"
 
 
-async def test_no_link(hass):
+async def test_no_link(hass: HomeAssistant) -> None:
     """Test the user initiated form with invalid response."""
 
     with patch_microbot_api(), patch(

--- a/tests/components/kira/test_init.py
+++ b/tests/components/kira/test_init.py
@@ -1,5 +1,4 @@
 """The tests for Kira."""
-
 import os
 import shutil
 import tempfile
@@ -8,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import homeassistant.components.kira as kira
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 TEST_CONFIG = {
@@ -45,13 +45,13 @@ def work_dir():
     shutil.rmtree(work_dir, ignore_errors=True)
 
 
-async def test_kira_empty_config(hass):
+async def test_kira_empty_config(hass: HomeAssistant) -> None:
     """Kira component should load a default sensor."""
     await async_setup_component(hass, kira.DOMAIN, {kira.DOMAIN: {}})
     assert len(hass.data[kira.DOMAIN]["sensor"]) == 1
 
 
-async def test_kira_setup(hass):
+async def test_kira_setup(hass: HomeAssistant) -> None:
     """Ensure platforms are loaded correctly."""
     await async_setup_component(hass, kira.DOMAIN, TEST_CONFIG)
     assert len(hass.data[kira.DOMAIN]["sensor"]) == 2

--- a/tests/components/kitchen_sink/test_config_flow.py
+++ b/tests/components/kitchen_sink/test_config_flow.py
@@ -3,9 +3,10 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.kitchen_sink import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test that we can import a config entry."""
     with patch("homeassistant.components.kitchen_sink.async_setup_entry"):
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -16,7 +17,7 @@ async def test_import(hass):
     assert entry.data == {}
 
 
-async def test_import_once(hass):
+async def test_import_once(hass: HomeAssistant) -> None:
     """Test that we don't create multiple config entries."""
     with patch(
         "homeassistant.components.kitchen_sink.async_setup_entry",

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -7,11 +7,13 @@ from aiohttp import ClientConnectorError, ClientResponseError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.kmtronic.const import CONF_REVERSE, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -47,7 +49,9 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_options(hass, aioclient_mock):
+async def test_form_options(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that the options form."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -84,7 +88,7 @@ async def test_form_options(hass, aioclient_mock):
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -107,7 +111,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -130,7 +134,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/kmtronic/test_init.py
+++ b/tests/components/kmtronic/test_init.py
@@ -3,11 +3,15 @@ import asyncio
 
 from homeassistant.components.kmtronic.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_unload_config_entry(hass, aioclient_mock):
+async def test_unload_config_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test entry unloading."""
 
     config_entry = MockConfigEntry(
@@ -35,7 +39,9 @@ async def test_unload_config_entry(hass, aioclient_mock):
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_config_entry_not_ready(hass, aioclient_mock):
+async def test_config_entry_not_ready(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests configuration entry not ready."""
 
     aioclient_mock.get(

--- a/tests/components/kmtronic/test_switch.py
+++ b/tests/components/kmtronic/test_switch.py
@@ -5,13 +5,17 @@ from http import HTTPStatus
 
 from homeassistant.components.kmtronic.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_relay_on_off(hass, aioclient_mock):
+async def test_relay_on_off(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests the relay turns on correctly."""
 
     aioclient_mock.get(
@@ -75,7 +79,7 @@ async def test_relay_on_off(hass, aioclient_mock):
     assert state.state == "on"
 
 
-async def test_update(hass, aioclient_mock):
+async def test_update(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Tests switch refreshes status periodically."""
     now = dt_util.utcnow()
     future = now + timedelta(minutes=10)
@@ -106,7 +110,9 @@ async def test_update(hass, aioclient_mock):
     assert state.state == "on"
 
 
-async def test_failed_update(hass, aioclient_mock):
+async def test_failed_update(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests coordinator update fails."""
     now = dt_util.utcnow()
     future = now + timedelta(minutes=10)
@@ -150,7 +156,9 @@ async def test_failed_update(hass, aioclient_mock):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_relay_on_off_reversed(hass, aioclient_mock):
+async def test_relay_on_off_reversed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests the relay turns on correctly when configured as reverse."""
 
     aioclient_mock.get(

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -100,7 +100,7 @@ class GatewayScannerMock:
             yield gateway
 
 
-async def test_user_single_instance(hass):
+async def test_user_single_instance(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.kodi.config_flow import (
     InvalidAuthError,
 )
 from homeassistant.components.kodi.const import DEFAULT_TIMEOUT, DOMAIN
+from homeassistant.core import HomeAssistant
 
 from .util import (
     TEST_CREDENTIALS,
@@ -401,7 +402,7 @@ async def test_form_exception_ws(hass, user_flow):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_discovery(hass):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test discovery flow works."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -442,7 +443,7 @@ async def test_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovery_cannot_connect_http(hass):
+async def test_discovery_cannot_connect_http(hass: HomeAssistant) -> None:
     """Test discovery aborts if cannot connect."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -461,7 +462,7 @@ async def test_discovery_cannot_connect_http(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_discovery_cannot_connect_ws(hass):
+async def test_discovery_cannot_connect_ws(hass: HomeAssistant) -> None:
     """Test discovery aborts if cannot connect to websocket."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -504,7 +505,7 @@ async def test_discovery_exception_http(hass, user_flow):
     assert result["reason"] == "unknown"
 
 
-async def test_discovery_invalid_auth(hass):
+async def test_discovery_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth during discovery."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -524,7 +525,7 @@ async def test_discovery_invalid_auth(hass):
     assert result["errors"] == {}
 
 
-async def test_discovery_duplicate_data(hass):
+async def test_discovery_duplicate_data(hass: HomeAssistant) -> None:
     """Test discovery aborts if same mDNS packet arrives."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -550,7 +551,7 @@ async def test_discovery_duplicate_data(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_discovery_updates_unique_id(hass):
+async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate discovery id aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -572,7 +573,7 @@ async def test_discovery_updates_unique_id(hass):
     assert entry.data["name"] == "hostname"
 
 
-async def test_discovery_without_unique_id(hass):
+async def test_discovery_without_unique_id(hass: HomeAssistant) -> None:
     """Test a discovery flow with no unique id aborts."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -584,7 +585,7 @@ async def test_discovery_without_unique_id(hass):
     assert result["reason"] == "no_uuid"
 
 
-async def test_form_import(hass):
+async def test_form_import(hass: HomeAssistant) -> None:
     """Test we get the form with import source."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -610,7 +611,7 @@ async def test_form_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import_invalid_auth(hass):
+async def test_form_import_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth on import."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -629,7 +630,7 @@ async def test_form_import_invalid_auth(hass):
     assert result["reason"] == "invalid_auth"
 
 
-async def test_form_import_cannot_connect(hass):
+async def test_form_import_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect on import."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -648,7 +649,7 @@ async def test_form_import_cannot_connect(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_form_import_exception(hass):
+async def test_form_import_exception(hass: HomeAssistant) -> None:
     """Test we handle unknown exception on import."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",

--- a/tests/components/kodi/test_init.py
+++ b/tests/components/kodi/test_init.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 
 from homeassistant.components.kodi.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     with patch(
         "homeassistant.components.kodi.media_player.async_setup_entry",

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components import konnected
 from homeassistant.components.konnected import config_flow
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -42,7 +43,7 @@ async def mock_panel_fixture():
         yield konn_client
 
 
-async def test_config_schema(hass):
+async def test_config_schema(hass: HomeAssistant) -> None:
     """Test that config schema is imported properly."""
     config = {
         konnected.DOMAIN: {
@@ -219,7 +220,7 @@ async def test_config_schema(hass):
     }
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that we do not discover anything or try to set up a Konnected panel."""
     assert await async_setup_component(hass, konnected.DOMAIN, {})
 
@@ -272,7 +273,7 @@ async def test_setup_defined_hosts_known_auth(hass, mock_panel):
     assert len(hass.config_entries.flow.async_progress()) == 0
 
 
-async def test_setup_defined_hosts_no_known_auth(hass):
+async def test_setup_defined_hosts_no_known_auth(hass: HomeAssistant) -> None:
     """Test we initiate config entry if config panel is not known."""
     assert (
         await async_setup_component(
@@ -292,7 +293,7 @@ async def test_setup_defined_hosts_no_known_auth(hass):
     assert len(hass.config_entries.flow.async_progress()) == 1
 
 
-async def test_setup_multiple(hass):
+async def test_setup_multiple(hass: HomeAssistant) -> None:
     """Test we initiate config entry for multiple panels."""
     assert (
         await async_setup_component(
@@ -356,7 +357,7 @@ async def test_setup_multiple(hass):
     )
 
 
-async def test_config_passed_to_config_entry(hass):
+async def test_config_passed_to_config_entry(hass: HomeAssistant) -> None:
     """Test that configured options for a host are loaded via config entry."""
     entry = MockConfigEntry(
         domain=konnected.DOMAIN,

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -6,11 +6,12 @@ from pykoplenti import AuthenticationException
 
 from homeassistant import config_entries
 from homeassistant.components.kostal_plenticore.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_formx(hass):
+async def test_formx(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -63,7 +64,7 @@ async def test_formx(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -97,7 +98,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"password": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -131,7 +132,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"host": "cannot_connect"}
 
 
-async def test_form_unexpected_error(hass):
+async def test_form_unexpected_error(hass: HomeAssistant) -> None:
     """Test we handle unexpected error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -165,7 +166,7 @@ async def test_form_unexpected_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_already_configured(hass):
+async def test_already_configured(hass: HomeAssistant) -> None:
     """Test we handle already configured error."""
     MockConfigEntry(
         domain="kostal_plenticore",

--- a/tests/components/kraken/test_config_flow.py
+++ b/tests/components/kraken/test_config_flow.py
@@ -3,13 +3,14 @@ from unittest.mock import patch
 
 from homeassistant.components.kraken.const import CONF_TRACKED_ASSET_PAIRS, DOMAIN
 from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
 
 from .const import TICKER_INFORMATION_RESPONSE, TRADEABLE_ASSET_PAIR_RESPONSE
 
 from tests.common import MockConfigEntry
 
 
-async def test_config_flow(hass):
+async def test_config_flow(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
     with patch(
         "homeassistant.components.kraken.async_setup_entry",
@@ -28,7 +29,7 @@ async def test_config_flow(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_already_configured(hass):
+async def test_already_configured(hass: HomeAssistant) -> None:
     """Test we cannot add a second config flow."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
@@ -39,7 +40,7 @@ async def test_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options for Kraken."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/kraken/test_init.py
+++ b/tests/components/kraken/test_init.py
@@ -2,15 +2,17 @@
 from unittest.mock import patch
 
 from pykrakenapi.pykrakenapi import CallRateLimitError, KrakenAPIError
+import pytest
 
 from homeassistant.components.kraken.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from .const import TICKER_INFORMATION_RESPONSE, TRADEABLE_ASSET_PAIR_RESPONSE
 
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload for Kraken."""
     with patch(
         "pykrakenapi.KrakenAPI.get_tradable_asset_pairs",
@@ -28,7 +30,9 @@ async def test_unload_entry(hass):
         assert DOMAIN not in hass.data
 
 
-async def test_unknown_error(hass, caplog):
+async def test_unknown_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test unload for Kraken."""
     with patch(
         "pykrakenapi.KrakenAPI.get_tradable_asset_pairs",
@@ -45,7 +49,9 @@ async def test_unknown_error(hass, caplog):
         assert "Unable to fetch data from Kraken.com:" in caplog.text
 
 
-async def test_callrate_limit(hass, caplog):
+async def test_callrate_limit(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test unload for Kraken."""
     with patch(
         "pykrakenapi.KrakenAPI.get_tradable_asset_pairs",

--- a/tests/components/kraken/test_sensor.py
+++ b/tests/components/kraken/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.kraken.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -24,7 +25,7 @@ from .const import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_sensor(hass):
+async def test_sensor(hass: HomeAssistant) -> None:
     """Test that sensor has a value."""
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.
@@ -229,7 +230,7 @@ async def test_sensor(hass):
         assert xbt_usd_opening_price_today.state == "0.0003513"
 
 
-async def test_sensors_available_after_restart(hass):
+async def test_sensors_available_after_restart(hass: HomeAssistant) -> None:
     """Test that all sensors are added again after a restart."""
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.
@@ -269,7 +270,7 @@ async def test_sensors_available_after_restart(hass):
         assert sensor.state == "0.0003494"
 
 
-async def test_sensors_added_after_config_update(hass):
+async def test_sensors_added_after_config_update(hass: HomeAssistant) -> None:
     """Test that sensors are added when another tracked asset pair is added."""
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.
@@ -315,7 +316,7 @@ async def test_sensors_added_after_config_update(hass):
         assert hass.states.get("sensor.ada_xbt_ask")
 
 
-async def test_missing_pair_marks_sensor_unavailable(hass):
+async def test_missing_pair_marks_sensor_unavailable(hass: HomeAssistant) -> None:
     """Test that a missing tradable asset pair marks the sensor unavailable."""
     utcnow = dt_util.utcnow()
     # Patching 'utcnow' to gain more control over the timed update.

--- a/tests/components/kulersky/test_config_flow.py
+++ b/tests/components/kulersky/test_config_flow.py
@@ -5,9 +5,10 @@ import pykulersky
 
 from homeassistant import config_entries
 from homeassistant.components.kulersky.config_flow import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_flow_success(hass):
+async def test_flow_success(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -39,7 +40,7 @@ async def test_flow_success(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_no_devices_found(hass):
+async def test_flow_no_devices_found(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -66,7 +67,7 @@ async def test_flow_no_devices_found(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_flow_exceptions_caught(hass):
+async def test_flow_exceptions_caught(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/launch_library/test_config_flow.py
+++ b/tests/components/launch_library/test_config_flow.py
@@ -4,11 +4,12 @@ from unittest.mock import patch
 from homeassistant import data_entry_flow
 from homeassistant.components.launch_library.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -30,7 +31,7 @@ async def test_create_entry(hass):
         assert result.get("result").data == {}
 
 
-async def test_integration_already_exists(hass):
+async def test_integration_already_exists(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
 
     MockConfigEntry(

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -31,7 +32,7 @@ IMPORT_DATA = {
 }
 
 
-async def test_step_import(hass):
+async def test_step_import(hass: HomeAssistant) -> None:
     """Test for import step."""
 
     with patch("pypck.connection.PchkConnectionManager.async_connect"), patch(
@@ -48,7 +49,7 @@ async def test_step_import(hass):
         assert result["data"] == IMPORT_DATA
 
 
-async def test_step_import_existing_host(hass):
+async def test_step_import_existing_host(hass: HomeAssistant) -> None:
     """Test for update of config_entry if imported host already exists."""
 
     # Create config entry and add it to hass

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -10,6 +10,7 @@ from pypck.connection import (
 from homeassistant import config_entries
 from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import MockPchkConnectionManager, setup_component
@@ -114,7 +115,7 @@ async def test_async_setup_entry_raises_timeout_error(hass, entry):
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
-async def test_async_setup_from_configuration_yaml(hass):
+async def test_async_setup_from_configuration_yaml(hass: HomeAssistant) -> None:
     """Test a successful setup using data from configuration.yaml."""
     with patch(
         "pypck.connection.PchkConnectionManager", MockPchkConnectionManager

--- a/tests/components/lg_soundbar/test_config_flow.py
+++ b/tests/components/lg_soundbar/test_config_flow.py
@@ -9,6 +9,7 @@ from unittest.mock import DEFAULT, patch
 from homeassistant import config_entries
 from homeassistant.components.lg_soundbar.const import DEFAULT_PORT, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -50,7 +51,7 @@ def setup_mock_temescal(
     tmock.side_effect = temescal_side_effect
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -88,7 +89,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_mac_info_response_empty(hass):
+async def test_form_mac_info_response_empty(hass: HomeAssistant) -> None:
     """Test we get the form, but response from the initial get_mac_info function call is empty."""
 
     result = await hass.config_entries.flow.async_init(
@@ -126,7 +127,9 @@ async def test_form_mac_info_response_empty(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_uuid_present_in_both_functions_uuid_q_empty(hass):
+async def test_form_uuid_present_in_both_functions_uuid_q_empty(
+    hass: HomeAssistant,
+) -> None:
     """Get the form, uuid present in both get_mac_info and get_product_info calls.
 
     Value from get_mac_info is not added to uuid_q before get_product_info is run.
@@ -169,7 +172,9 @@ async def test_form_uuid_present_in_both_functions_uuid_q_empty(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_uuid_present_in_both_functions_uuid_q_not_empty(hass):
+async def test_form_uuid_present_in_both_functions_uuid_q_not_empty(
+    hass: HomeAssistant,
+) -> None:
     """Get the form, uuid present in both get_mac_info and get_product_info calls.
 
     Value from get_mac_info is added to uuid_q before get_product_info is run.
@@ -215,7 +220,7 @@ async def test_form_uuid_present_in_both_functions_uuid_q_not_empty(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_uuid_missing_from_mac_info(hass):
+async def test_form_uuid_missing_from_mac_info(hass: HomeAssistant) -> None:
     """Test we get the form, but uuid is missing from the initial get_mac_info function call."""
 
     result = await hass.config_entries.flow.async_init(
@@ -254,7 +259,7 @@ async def test_form_uuid_missing_from_mac_info(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_uuid_not_provided_by_api(hass):
+async def test_form_uuid_not_provided_by_api(hass: HomeAssistant) -> None:
     """Test we get the form, but uuid is missing from the all API messages."""
 
     result = await hass.config_entries.flow.async_init(
@@ -295,7 +300,7 @@ async def test_form_uuid_not_provided_by_api(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_both_queues_empty(hass):
+async def test_form_both_queues_empty(hass: HomeAssistant) -> None:
     """Test we get the form, but none of the data we want is provided by the API."""
 
     result = await hass.config_entries.flow.async_init(
@@ -327,7 +332,7 @@ async def test_form_both_queues_empty(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_no_uuid_host_already_configured(hass):
+async def test_no_uuid_host_already_configured(hass: HomeAssistant) -> None:
     """Test we handle if the device has no UUID and the host has already been configured."""
 
     mock_entry = MockConfigEntry(
@@ -366,7 +371,7 @@ async def test_no_uuid_host_already_configured(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_form_socket_timeout(hass):
+async def test_form_socket_timeout(hass: HomeAssistant) -> None:
     """Test we handle socket.timeout error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -387,7 +392,7 @@ async def test_form_socket_timeout(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_os_error(hass):
+async def test_form_os_error(hass: HomeAssistant) -> None:
     """Test we handle OSError."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -408,7 +413,7 @@ async def test_form_os_error(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_already_configured(hass):
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test we handle already configured error."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/life360/test_config_flow.py
+++ b/tests/components/life360/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Life360 config flow."""
-
 from unittest.mock import patch
 
 from life360 import Life360Error, LoginError
@@ -16,6 +15,7 @@ from homeassistant.components.life360.const import (
     SHOW_DRIVING,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -287,7 +287,7 @@ async def test_reauth_config_flow_login_error(hass, life360_api, caplog):
 # ========== Option flow Tests =========================================================
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test an options flow."""
     config_entry = create_config_entry(hass)
 

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -326,7 +326,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
     }
 
 
-async def test_discovered_by_discovery_and_dhcp(hass):
+async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
     """Test we get the form with discovery and abort for dhcp source when we get both."""
 
     with _patch_discovery(), _patch_config_flow_try_connect():

--- a/tests/components/lifx/test_init.py
+++ b/tests/components/lifx/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.components import lifx
 from homeassistant.components.lifx import DOMAIN, discovery
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -26,7 +27,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_configuring_lifx_causes_discovery(hass):
+async def test_configuring_lifx_causes_discovery(hass: HomeAssistant) -> None:
     """Test that specifying empty config does discovery."""
     start_calls = 0
 
@@ -72,7 +73,7 @@ async def test_configuring_lifx_causes_discovery(hass):
         assert start_calls == 4
 
 
-async def test_config_entry_reload(hass):
+async def test_config_entry_reload(hass: HomeAssistant) -> None:
     """Test that a config entry can be reloaded."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
@@ -87,7 +88,7 @@ async def test_config_entry_reload(hass):
         assert already_migrated_config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_config_entry_retry(hass):
+async def test_config_entry_retry(hass: HomeAssistant) -> None:
     """Test that a config entry can be retried."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -101,7 +102,7 @@ async def test_config_entry_retry(hass):
         assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_get_version_fails(hass):
+async def test_get_version_fails(hass: HomeAssistant) -> None:
     """Test we handle get version failing."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -118,7 +119,7 @@ async def test_get_version_fails(hass):
         assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_dns_error_at_startup(hass):
+async def test_dns_error_at_startup(hass: HomeAssistant) -> None:
     """Test we handle get version failing."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -1114,7 +1114,7 @@ async def test_white_bulb(hass: HomeAssistant) -> None:
     bulb.set_color.reset_mock()
 
 
-async def test_config_zoned_light_strip_fails(hass):
+async def test_config_zoned_light_strip_fails(hass: HomeAssistant) -> None:
     """Test we handle failure to update zones."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL
@@ -1152,7 +1152,7 @@ async def test_config_zoned_light_strip_fails(hass):
         assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_white_light_fails(hass):
+async def test_white_light_fails(hass: HomeAssistant) -> None:
     """Test we handle failure to power on off."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=SERIAL

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.setup import async_setup_component
 import homeassistant.util.color as color_util
@@ -25,7 +26,7 @@ from tests.common import async_mock_service
 orig_Profiles = light.Profiles
 
 
-async def test_methods(hass):
+async def test_methods(hass: HomeAssistant) -> None:
     """Test if methods call the services as expected."""
     # Test is_on
     hass.states.async_set("light.test", STATE_ON)
@@ -1011,7 +1012,7 @@ async def test_light_brightness_pct_conversion(hass, enable_custom_integrations)
     assert data["brightness"] == 255
 
 
-async def test_profiles(hass):
+async def test_profiles(hass: HomeAssistant) -> None:
     """Test profiles loading."""
     profiles = orig_Profiles(hass)
     await profiles.async_initialize()
@@ -1028,7 +1029,7 @@ async def test_profiles(hass):
 
 
 @patch("os.path.isfile", MagicMock(side_effect=(True, False)))
-async def test_profile_load_optional_hs_color(hass):
+async def test_profile_load_optional_hs_color(hass: HomeAssistant) -> None:
     """Test profile loading with profiles containing no xy color."""
 
     csv_file = """the first line is skipped

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -2,12 +2,13 @@
 from homeassistant.components import light
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.intent import async_handle
 
 from tests.common import async_mock_service
 
 
-async def test_intent_set_color(hass):
+async def test_intent_set_color(hass: HomeAssistant) -> None:
     """Test the set color intent."""
     hass.states.async_set(
         "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS]}
@@ -32,7 +33,7 @@ async def test_intent_set_color(hass):
     assert call.data.get(light.ATTR_RGB_COLOR) == (0, 0, 255)
 
 
-async def test_intent_set_color_tests_feature(hass):
+async def test_intent_set_color_tests_feature(hass: HomeAssistant) -> None:
     """Test the set color intent."""
     hass.states.async_set("light.hello", "off")
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
@@ -51,7 +52,7 @@ async def test_intent_set_color_tests_feature(hass):
     assert len(calls) == 0
 
 
-async def test_intent_set_color_and_brightness(hass):
+async def test_intent_set_color_and_brightness(hass: HomeAssistant) -> None:
     """Test the set color intent."""
     hass.states.async_set(
         "light.hello_2", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS]}

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -3,7 +3,7 @@ import pytest
 
 from homeassistant.components import light
 from homeassistant.components.light.reproduce_state import DEPRECATION_WARNING
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
@@ -23,7 +23,9 @@ VALID_RGBWW_COLOR = {"rgbww_color": (255, 63, 111, 10, 20)}
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Light states."""
     hass.states.async_set("light.entity_off", "off", {})
     hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
@@ -222,7 +224,9 @@ async def test_filter_color_modes(hass, caplog, color_mode):
     assert len(turn_on_calls) == 1
 
 
-async def test_deprecation_warning(hass, caplog):
+async def test_deprecation_warning(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test deprecation warning."""
     hass.states.async_set("light.entity_off", "off", {})
     turn_on_calls = async_mock_service(hass, "light", "turn_on")

--- a/tests/components/litejet/test_config_flow.py
+++ b/tests/components/litejet/test_config_flow.py
@@ -6,11 +6,12 @@ from serial import SerialException
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.litejet.const import CONF_DEFAULT_TRANSITION, DOMAIN
 from homeassistant.const import CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_show_config_form(hass):
+async def test_show_config_form(hass: HomeAssistant) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -33,7 +34,7 @@ async def test_create_entry(hass, mock_litejet):
     assert result["data"] == test_data
 
 
-async def test_flow_entry_already_exists(hass):
+async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input when a config entry already exists."""
     first_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -51,7 +52,7 @@ async def test_flow_entry_already_exists(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_flow_open_failed(hass):
+async def test_flow_open_failed(hass: HomeAssistant) -> None:
     """Test user input when serial port open fails."""
     test_data = {CONF_PORT: "/dev/test"}
 
@@ -66,7 +67,7 @@ async def test_flow_open_failed(hass):
     assert result["errors"][CONF_PORT] == "open_failed"
 
 
-async def test_import_step(hass):
+async def test_import_step(hass: HomeAssistant) -> None:
     """Test initializing via import step."""
     test_data = {CONF_PORT: "/dev/imported"}
     result = await hass.config_entries.flow.async_init(
@@ -78,7 +79,7 @@ async def test_import_step(hass):
     assert result["data"] == test_data
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test updating options."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_PORT: "/dev/test"})
     entry.add_to_hass(hass)

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -2,12 +2,13 @@
 from homeassistant.components import litejet
 from homeassistant.components.litejet.const import DOMAIN
 from homeassistant.const import CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import async_init_integration
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that nothing happens."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
     assert DOMAIN not in hass.data

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_form(hass, mock_account):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_already_configured(hass):
+async def test_already_configured(hass: HomeAssistant) -> None:
     """Test we handle already configured."""
     MockConfigEntry(
         domain=litterrobot.DOMAIN,
@@ -59,7 +59,7 @@ async def test_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -77,7 +77,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -95,7 +95,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/livisi/test_config_flow.py
+++ b/tests/components/livisi/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Livisi Home Assistant config flow."""
-
 from unittest.mock import patch
 
 from aiolivisi import errors as livisi_errors
@@ -8,6 +7,7 @@ import pytest
 from homeassistant import data_entry_flow
 from homeassistant.components.livisi.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 
 from . import (
     VALID_CONFIG,
@@ -17,7 +17,7 @@ from . import (
 )
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test create LIVISI entity."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -2,13 +2,19 @@
 from http import HTTPStatus
 from unittest import mock
 
+import pytest
+
 from homeassistant.components.local_file.const import DOMAIN, SERVICE_UPDATE_FILE_PATH
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_loading_file(hass, hass_client):
+async def test_loading_file(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that it loads image from disk."""
     mock_registry(hass)
 
@@ -44,7 +50,9 @@ async def test_loading_file(hass, hass_client):
     assert body == "hello"
 
 
-async def test_file_not_readable(hass, caplog):
+async def test_file_not_readable(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a warning is shown setup when file is not readable."""
     mock_registry(hass)
 
@@ -69,7 +77,9 @@ async def test_file_not_readable(hass, caplog):
     assert "mock.file" in caplog.text
 
 
-async def test_camera_content_type(hass, hass_client):
+async def test_camera_content_type(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test local_file camera content_type."""
     cam_config_jpg = {
         "name": "test_jpg",
@@ -133,7 +143,7 @@ async def test_camera_content_type(hass, hass_client):
     assert body == image
 
 
-async def test_update_file_path(hass):
+async def test_update_file_path(hass: HomeAssistant) -> None:
     """Test update_file_path service."""
     # Setup platform
 

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.lock import DOMAIN, LockEntityFeature
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -145,7 +146,7 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass):
+async def test_action(hass: HomeAssistant) -> None:
     """Test for lock actions."""
     assert await async_setup_component(
         hass,

--- a/tests/components/lock/test_reproduce_state.py
+++ b/tests/components/lock/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Lock."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Lock states."""
     hass.states.async_set("lock.entity_locked", "locked", {})
     hass.states.async_set("lock.entity_unlocked", "unlocked", {})

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -1,15 +1,15 @@
 """The tests for the Logentries component."""
-
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 import homeassistant.components.logentries as logentries
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_setup_config_full(hass):
+async def test_setup_config_full(hass: HomeAssistant) -> None:
     """Test setup with all data."""
     config = {"logentries": {"token": "secret"}}
     hass.bus.listen = MagicMock()
@@ -18,7 +18,7 @@ async def test_setup_config_full(hass):
     assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
 
 
-async def test_setup_config_defaults(hass):
+async def test_setup_config_defaults(hass: HomeAssistant) -> None:
     """Test setup with defaults."""
     config = {"logentries": {"token": "token"}}
     hass.bus.listen = MagicMock()

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -3,8 +3,11 @@ from collections import defaultdict
 import logging
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components import logger
 from homeassistant.components.logger import LOGSEVERITY
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 HASS_NS = "unused.homeassistant"
@@ -17,7 +20,9 @@ INTEGRATION = "test_component"
 INTEGRATION_NS = f"homeassistant.components.{INTEGRATION}"
 
 
-async def test_log_filtering(hass, caplog):
+async def test_log_filtering(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test logging filters."""
 
     assert await async_setup_component(
@@ -85,7 +90,7 @@ async def test_log_filtering(hass, caplog):
     )
 
 
-async def test_setting_level(hass):
+async def test_setting_level(hass: HomeAssistant) -> None:
     """Test we set log levels."""
     mocks = defaultdict(Mock)
 
@@ -150,7 +155,7 @@ async def test_setting_level(hass):
     )
 
 
-async def test_can_set_level_from_yaml(hass):
+async def test_can_set_level_from_yaml(hass: HomeAssistant) -> None:
     """Test logger propagation."""
 
     assert await async_setup_component(

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.logi_circle.config_flow import (
     AuthorizationFailed,
     LogiCircleAuthCallbackView,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_coro
@@ -95,7 +96,7 @@ async def test_full_flow_implementation(hass, mock_logi_circle):
     assert result["title"] == "Logi Circle ({})".format("testId")
 
 
-async def test_we_reprompt_user_to_follow_link(hass):
+async def test_we_reprompt_user_to_follow_link(hass: HomeAssistant) -> None:
     """Test we prompt user to follow link if previously prompted."""
     flow = init_config_flow(hass)
 
@@ -103,7 +104,7 @@ async def test_we_reprompt_user_to_follow_link(hass):
     assert result["errors"]["base"] == "follow_link"
 
 
-async def test_abort_if_no_implementation_registered(hass):
+async def test_abort_if_no_implementation_registered(hass: HomeAssistant) -> None:
     """Test we abort if no implementation is registered."""
     flow = config_flow.LogiCircleFlowHandler()
     flow.hass = hass
@@ -113,7 +114,7 @@ async def test_abort_if_no_implementation_registered(hass):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_abort_if_already_setup(hass):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if Logi Circle is already setup."""
     flow = init_config_flow(hass)
     MockConfigEntry(domain=config_flow.DOMAIN).add_to_hass(hass)
@@ -160,7 +161,7 @@ async def test_abort_if_authorize_fails(hass, mock_logi_circle, side_effect, err
     assert result["errors"]["base"] == error
 
 
-async def test_not_pick_implementation_if_only_one(hass):
+async def test_not_pick_implementation_if_only_one(hass: HomeAssistant) -> None:
     """Test we bypass picking implementation if we have one flow_imp."""
     flow = init_config_flow(hass)
 
@@ -189,7 +190,7 @@ async def test_gen_auth_url(hass, mock_logi_circle):
     assert result == "http://authorize.url"
 
 
-async def test_callback_view_rejects_missing_code(hass):
+async def test_callback_view_rejects_missing_code(hass: HomeAssistant) -> None:
     """Test the auth callback view rejects requests with no code."""
     view = LogiCircleAuthCallbackView()
     resp = await view.get(MockRequest(hass, {}))

--- a/tests/components/lookin/test_config_flow.py
+++ b/tests/components/lookin/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_manual_setup_unknown_exception(hass: HomeAssistant):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_discovered_zeroconf(hass):
+async def test_discovered_zeroconf(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from zeroconf."""
 
     with _patch_get_info():
@@ -152,7 +152,7 @@ async def test_discovered_zeroconf(hass):
     assert entry.data[CONF_HOST] == "127.0.0.2"
 
 
-async def test_discovered_zeroconf_cannot_connect(hass):
+async def test_discovered_zeroconf_cannot_connect(hass: HomeAssistant) -> None:
     """Test we abort if we cannot connect when discovered from zeroconf."""
 
     with _patch_get_info(exception=NoUsableService):
@@ -167,7 +167,7 @@ async def test_discovered_zeroconf_cannot_connect(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_discovered_zeroconf_unknown_exception(hass):
+async def test_discovered_zeroconf_unknown_exception(hass: HomeAssistant) -> None:
     """Test we abort if we get an unknown exception when discovered from zeroconf."""
 
     with _patch_get_info(exception=Exception):

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.lovelace import cast as lovelace_cast
 from homeassistant.components.media_player import MediaClass
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -60,7 +61,7 @@ async def mock_yaml_dashboard(hass):
         yield
 
 
-async def test_root_object(hass):
+async def test_root_object(hass: HomeAssistant) -> None:
     """Test getting a root object."""
     assert (
         await lovelace_cast.async_get_media_browser_root_object(hass, "some-type") == []
@@ -80,7 +81,7 @@ async def test_root_object(hass):
     assert item.can_expand is True
 
 
-async def test_browse_media_error(hass):
+async def test_browse_media_error(hass: HomeAssistant) -> None:
     """Test browse media checks valid URL."""
     assert await async_setup_component(hass, "lovelace", {})
 

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -5,9 +5,11 @@ import pytest
 
 from homeassistant.components import frontend
 from homeassistant.components.lovelace import const, dashboard
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_capture_events
+from tests.typing import WebSocketGenerator
 
 
 async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
@@ -107,7 +109,9 @@ async def test_lovelace_from_storage_delete(hass, hass_ws_client, hass_storage):
     assert response["error"]["code"] == "config_not_found"
 
 
-async def test_lovelace_from_yaml(hass, hass_ws_client):
+async def test_lovelace_from_yaml(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we load lovelace config from yaml."""
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "yaml"}
@@ -263,7 +267,7 @@ async def test_dashboard_from_yaml(hass, hass_ws_client, url_path):
     assert len(events) == 1
 
 
-async def test_wrong_key_dashboard_from_yaml(hass):
+async def test_wrong_key_dashboard_from_yaml(hass: HomeAssistant) -> None:
     """Test we don't load lovelace dashboard without hyphen config from yaml."""
     with assert_setup_component(0):
         assert not await async_setup_component(
@@ -480,7 +484,9 @@ async def test_storage_dashboard_migrate(hass, hass_ws_client, hass_storage):
     )
 
 
-async def test_websocket_list_dashboards(hass, hass_ws_client):
+async def test_websocket_list_dashboards(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test listing dashboards both storage + YAML."""
     assert await async_setup_component(
         hass,

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -4,7 +4,10 @@ from unittest.mock import patch
 import uuid
 
 from homeassistant.components.lovelace import dashboard, resources
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import WebSocketGenerator
 
 RESOURCE_EXAMPLES = [
     {"type": "js", "url": "/local/bla.js"},
@@ -12,7 +15,9 @@ RESOURCE_EXAMPLES = [
 ]
 
 
-async def test_yaml_resources(hass, hass_ws_client):
+async def test_yaml_resources(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test defining resources in configuration.yaml."""
     assert await async_setup_component(
         hass, "lovelace", {"lovelace": {"mode": "yaml", "resources": RESOURCE_EXAMPLES}}
@@ -27,7 +32,9 @@ async def test_yaml_resources(hass, hass_ws_client):
     assert response["result"] == RESOURCE_EXAMPLES
 
 
-async def test_yaml_resources_backwards(hass, hass_ws_client):
+async def test_yaml_resources_backwards(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test defining resources in YAML ll config (legacy)."""
     with patch(
         "homeassistant.components.lovelace.dashboard.load_yaml",

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -2,12 +2,13 @@
 from unittest.mock import patch
 
 from homeassistant.components.lovelace import dashboard
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info
 
 
-async def test_system_health_info_autogen(hass):
+async def test_system_health_info_autogen(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "lovelace", {})
     assert await async_setup_component(hass, "system_health", {})
@@ -29,7 +30,7 @@ async def test_system_health_info_storage(hass, hass_storage):
     assert info == {"dashboards": 1, "mode": "storage", "resources": 0, "views": 0}
 
 
-async def test_system_health_info_yaml(hass):
+async def test_system_health_info_yaml(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
@@ -42,7 +43,7 @@ async def test_system_health_info_yaml(hass):
     assert info == {"dashboards": 1, "mode": "yaml", "resources": 0, "views": 1}
 
 
-async def test_system_health_info_yaml_not_found(hass):
+async def test_system_health_info_yaml_not_found(hass: HomeAssistant) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.components.lutron_caseta.const import (
     STEP_IMPORT_FAILED,
 )
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from . import ENTRY_MOCK_DATA, MockBridge
 
@@ -41,7 +42,7 @@ MOCK_ASYNC_PAIR_SUCCESS = {
 }
 
 
-async def test_bridge_import_flow(hass):
+async def test_bridge_import_flow(hass: HomeAssistant) -> None:
     """Test a bridge entry gets created and set up during the import flow."""
 
     entry_mock_data = {
@@ -76,7 +77,7 @@ async def test_bridge_import_flow(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_bridge_cannot_connect(hass):
+async def test_bridge_cannot_connect(hass: HomeAssistant) -> None:
     """Test checking for connection and cannot_connect error."""
 
     entry_mock_data = {
@@ -105,7 +106,7 @@ async def test_bridge_cannot_connect(hass):
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
-async def test_bridge_cannot_connect_unknown_error(hass):
+async def test_bridge_cannot_connect_unknown_error(hass: HomeAssistant) -> None:
     """Test checking for connection and encountering an unknown error."""
 
     with patch.object(Smartbridge, "create_tls") as create_tls:
@@ -128,7 +129,7 @@ async def test_bridge_cannot_connect_unknown_error(hass):
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
-async def test_bridge_invalid_ssl_error(hass):
+async def test_bridge_invalid_ssl_error(hass: HomeAssistant) -> None:
     """Test checking for connection and encountering invalid ssl certs."""
 
     with patch.object(Smartbridge, "create_tls", side_effect=ssl.SSLError):
@@ -148,7 +149,7 @@ async def test_bridge_invalid_ssl_error(hass):
     assert result["reason"] == CasetaConfigFlow.ABORT_REASON_CANNOT_CONNECT
 
 
-async def test_duplicate_bridge_import(hass):
+async def test_duplicate_bridge_import(hass: HomeAssistant) -> None:
     """Test that creating a bridge entry with a duplicate host errors."""
 
     mock_entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_MOCK_DATA)
@@ -170,7 +171,7 @@ async def test_duplicate_bridge_import(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_already_configured_with_ignored(hass):
+async def test_already_configured_with_ignored(hass: HomeAssistant) -> None:
     """Test ignored entries do not break checking for existing entries."""
 
     config_entry = MockConfigEntry(
@@ -417,7 +418,7 @@ async def test_zeroconf_host_already_configured(hass, tmpdir):
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_lutron_id_already_configured(hass):
+async def test_zeroconf_lutron_id_already_configured(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery when lutron id already configured."""
 
     config_entry = MockConfigEntry(
@@ -446,7 +447,7 @@ async def test_zeroconf_lutron_id_already_configured(hass):
     assert config_entry.data[CONF_HOST] == "1.1.1.1"
 
 
-async def test_zeroconf_not_lutron_device(hass):
+async def test_zeroconf_not_lutron_device(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery when it is not a lutron device."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/lutron_caseta/test_diagnostics.py
+++ b/tests/components/lutron_caseta/test_diagnostics.py
@@ -1,5 +1,4 @@
 """Test the Lutron Caseta diagnostics."""
-
 from unittest.mock import ANY, patch
 
 from homeassistant.components.lutron_caseta import DOMAIN
@@ -9,14 +8,18 @@ from homeassistant.components.lutron_caseta.const import (
     CONF_KEYFILE,
 )
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from . import MockBridge
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_diagnostics(hass, hass_client) -> None:
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test generating diagnostics for lutron_caseta."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/lutron_caseta/test_logbook.py
+++ b/tests/components/lutron_caseta/test_logbook.py
@@ -17,6 +17,7 @@ from homeassistant.components.lutron_caseta.const import (
 )
 from homeassistant.components.lutron_caseta.models import LutronCasetaData
 from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import MockBridge
@@ -25,7 +26,7 @@ from tests.common import MockConfigEntry
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_lutron_caseta_button_event(hass):
+async def test_humanify_lutron_caseta_button_event(hass: HomeAssistant) -> None:
     """Test humanifying lutron_caseta_button_events."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.lyric.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
@@ -30,7 +31,7 @@ async def mock_impl(hass):
     )
 
 
-async def test_abort_if_no_configuration(hass):
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     """Check flow abort when no configuration."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -35,7 +35,7 @@ from tests.components.alarm_control_panel import common
 CODE = "HELLO_CODE"
 
 
-async def test_setup_demo_platform(hass):
+async def test_setup_demo_platform(hass: HomeAssistant) -> None:
     """Test setup."""
     mock = MagicMock()
     add_entities = mock.MagicMock()
@@ -322,7 +322,7 @@ async def test_with_specific_pending(hass, service, expected_state):
     assert hass.states.get(entity_id).state == expected_state
 
 
-async def test_trigger_no_pending(hass):
+async def test_trigger_no_pending(hass: HomeAssistant) -> None:
     """Test triggering when no pending submitted method."""
     assert await async_setup_component(
         hass,
@@ -359,7 +359,7 @@ async def test_trigger_no_pending(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_delay(hass):
+async def test_trigger_with_delay(hass: HomeAssistant) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -404,7 +404,7 @@ async def test_trigger_with_delay(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_zero_trigger_time(hass):
+async def test_trigger_zero_trigger_time(hass: HomeAssistant) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
         hass,
@@ -430,7 +430,7 @@ async def test_trigger_zero_trigger_time(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_zero_trigger_time_with_pending(hass):
+async def test_trigger_zero_trigger_time_with_pending(hass: HomeAssistant) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
         hass,
@@ -456,7 +456,7 @@ async def test_trigger_zero_trigger_time_with_pending(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_pending(hass):
+async def test_trigger_with_pending(hass: HomeAssistant) -> None:
     """Test arm home method."""
     assert await async_setup_component(
         hass,
@@ -508,7 +508,7 @@ async def test_trigger_with_pending(hass):
     assert state.state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_unused_specific_delay(hass):
+async def test_trigger_with_unused_specific_delay(hass: HomeAssistant) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -554,7 +554,7 @@ async def test_trigger_with_unused_specific_delay(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_specific_delay(hass):
+async def test_trigger_with_specific_delay(hass: HomeAssistant) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -600,7 +600,7 @@ async def test_trigger_with_specific_delay(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_pending_and_delay(hass):
+async def test_trigger_with_pending_and_delay(hass: HomeAssistant) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -657,7 +657,7 @@ async def test_trigger_with_pending_and_delay(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_pending_and_specific_delay(hass):
+async def test_trigger_with_pending_and_specific_delay(hass: HomeAssistant) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -715,7 +715,7 @@ async def test_trigger_with_pending_and_specific_delay(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_specific_pending(hass):
+async def test_trigger_with_specific_pending(hass: HomeAssistant) -> None:
     """Test arm home method."""
     assert await async_setup_component(
         hass,
@@ -762,7 +762,7 @@ async def test_trigger_with_specific_pending(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_disarm_after_trigger(hass):
+async def test_trigger_with_disarm_after_trigger(hass: HomeAssistant) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -800,7 +800,7 @@ async def test_trigger_with_disarm_after_trigger(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_zero_specific_trigger_time(hass):
+async def test_trigger_with_zero_specific_trigger_time(hass: HomeAssistant) -> None:
     """Test trigger method."""
     assert await async_setup_component(
         hass,
@@ -827,7 +827,9 @@ async def test_trigger_with_zero_specific_trigger_time(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_unused_zero_specific_trigger_time(hass):
+async def test_trigger_with_unused_zero_specific_trigger_time(
+    hass: HomeAssistant,
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -866,7 +868,7 @@ async def test_trigger_with_unused_zero_specific_trigger_time(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_specific_trigger_time(hass):
+async def test_trigger_with_specific_trigger_time(hass: HomeAssistant) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -904,7 +906,7 @@ async def test_trigger_with_specific_trigger_time(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_no_disarm_after_trigger(hass):
+async def test_trigger_with_no_disarm_after_trigger(hass: HomeAssistant) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -947,7 +949,9 @@ async def test_trigger_with_no_disarm_after_trigger(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
 
-async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
+async def test_back_to_back_trigger_with_no_disarm_after_trigger(
+    hass: HomeAssistant,
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -1006,7 +1010,7 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
 
-async def test_disarm_while_pending_trigger(hass):
+async def test_disarm_while_pending_trigger(hass: HomeAssistant) -> None:
     """Test disarming while pending state."""
     assert await async_setup_component(
         hass,
@@ -1045,7 +1049,7 @@ async def test_disarm_while_pending_trigger(hass):
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_disarm_during_trigger_with_invalid_code(hass):
+async def test_disarm_during_trigger_with_invalid_code(hass: HomeAssistant) -> None:
     """Test disarming while code is invalid."""
     assert await async_setup_component(
         hass,
@@ -1091,7 +1095,7 @@ async def test_disarm_during_trigger_with_invalid_code(hass):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_disarm_with_template_code(hass):
+async def test_disarm_with_template_code(hass: HomeAssistant) -> None:
     """Attempt to disarm with a valid or invalid template-based code."""
     assert await async_setup_component(
         hass,
@@ -1128,7 +1132,7 @@ async def test_disarm_with_template_code(hass):
     assert state.state == STATE_ALARM_DISARMED
 
 
-async def test_arm_away_after_disabled_disarmed(hass):
+async def test_arm_away_after_disabled_disarmed(hass: HomeAssistant) -> None:
     """Test pending state with and without zero trigger time."""
     assert await async_setup_component(
         hass,
@@ -1407,7 +1411,7 @@ async def test_restore_state_triggered(hass, previous_state):
     assert state.state == previous_state
 
 
-async def test_restore_state_triggered_long_ago(hass):
+async def test_restore_state_triggered_long_ago(hass: HomeAssistant) -> None:
     """Ensure TRIGGERED state is resolved on startup."""
     time = dt_util.utcnow() - timedelta(seconds=125)
     entity_id = "alarm_control_panel.test"

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -11,6 +11,7 @@ from homeassistant.components.media_player import (
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -34,7 +35,7 @@ def cleanup_cache(hass):
         shutil.rmtree(default_tts)
 
 
-async def test_setup_component(hass):
+async def test_setup_component(hass: HomeAssistant) -> None:
     """Test setup component."""
     config = {tts.DOMAIN: {"platform": "marytts"}}
 
@@ -43,7 +44,7 @@ async def test_setup_component(hass):
         await hass.async_block_till_done()
 
 
-async def test_service_say(hass):
+async def test_service_say(hass: HomeAssistant) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -76,7 +77,7 @@ async def test_service_say(hass):
     assert url.endswith(".wav")
 
 
-async def test_service_say_with_effect(hass):
+async def test_service_say_with_effect(hass: HomeAssistant) -> None:
     """Test service call say with effects."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -109,7 +110,7 @@ async def test_service_say_with_effect(hass):
     assert url.endswith(".wav")
 
 
-async def test_service_say_http_error(hass):
+async def test_service_say_http_error(hass: HomeAssistant) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/mazda/test_binary_sensor.py
+++ b/tests/components/mazda/test_binary_sensor.py
@@ -1,13 +1,13 @@
 """The binary sensor tests for the Mazda Connected Services integration."""
-
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
 
-async def test_binary_sensors(hass):
+async def test_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of the binary sensors."""
     await init_integration(hass)
 
@@ -80,7 +80,7 @@ async def test_binary_sensors(hass):
     assert entry.unique_id == "JM000000000000000_hood"
 
 
-async def test_electric_vehicle_binary_sensors(hass):
+async def test_electric_vehicle_binary_sensors(hass: HomeAssistant) -> None:
     """Test sensors which are specific to electric vehicles."""
 
     await init_integration(hass, electric_vehicle=True)

--- a/tests/components/mazda/test_climate.py
+++ b/tests/components/mazda/test_climate.py
@@ -1,5 +1,4 @@
 """The climate tests for the Mazda Connected Services integration."""
-
 import json
 from unittest.mock import patch
 
@@ -39,6 +38,7 @@ from homeassistant.const import (
     CONF_REGION,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -47,7 +47,7 @@ from . import init_integration
 from tests.common import MockConfigEntry, load_fixture
 
 
-async def test_climate_setup(hass):
+async def test_climate_setup(hass: HomeAssistant) -> None:
     """Test the setup of the climate entity."""
     await init_integration(hass, electric_vehicle=True)
 
@@ -283,7 +283,7 @@ async def test_set_hvac_mode(hass, hvac_mode, api_method):
     getattr(client_mock, api_method).assert_called_once_with(12345)
 
 
-async def test_set_target_temperature(hass):
+async def test_set_target_temperature(hass: HomeAssistant) -> None:
     """Test setting the target temperature of the climate entity."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 

--- a/tests/components/mazda/test_config_flow.py
+++ b/tests/components/mazda/test_config_flow.py
@@ -31,7 +31,7 @@ FIXTURE_USER_INPUT_REAUTH_CHANGED_EMAIL = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test the entire flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -59,7 +59,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_account_already_exists(hass):
+async def test_account_already_exists(hass: HomeAssistant) -> None:
     """Test account already exists."""
     mock_config = MockConfigEntry(
         domain=DOMAIN,
@@ -139,7 +139,7 @@ async def test_form_account_locked(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "account_locked"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -158,7 +158,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/mazda/test_device_tracker.py
+++ b/tests/components/mazda/test_device_tracker.py
@@ -6,12 +6,13 @@ from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
 
-async def test_device_tracker(hass):
+async def test_device_tracker(hass: HomeAssistant) -> None:
     """Test creation of the device tracker."""
     await init_integration(hass)
 

--- a/tests/components/mazda/test_init.py
+++ b/tests/components/mazda/test_init.py
@@ -159,7 +159,7 @@ async def test_unload_config_entry(hass: HomeAssistant) -> None:
     assert entries[0].state is ConfigEntryState.NOT_LOADED
 
 
-async def test_init_electric_vehicle(hass):
+async def test_init_electric_vehicle(hass: HomeAssistant) -> None:
     """Test initialization of the integration with an electric vehicle."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 
@@ -172,7 +172,7 @@ async def test_init_electric_vehicle(hass):
     assert entries[0].state is ConfigEntryState.LOADED
 
 
-async def test_device_nickname(hass):
+async def test_device_nickname(hass: HomeAssistant) -> None:
     """Test creation of the device when vehicle has a nickname."""
     await init_integration(hass, use_nickname=True)
 
@@ -186,7 +186,7 @@ async def test_device_nickname(hass):
     assert reg_device.name == "My Mazda3"
 
 
-async def test_device_no_nickname(hass):
+async def test_device_no_nickname(hass: HomeAssistant) -> None:
     """Test creation of the device when vehicle has no nickname."""
     await init_integration(hass, use_nickname=False)
 
@@ -229,7 +229,7 @@ async def test_services(hass, service, service_data, expected_args):
     api_method.assert_called_once_with(*expected_args)
 
 
-async def test_service_invalid_device_id(hass):
+async def test_service_invalid_device_id(hass: HomeAssistant) -> None:
     """Test service call when the specified device ID is invalid."""
     await init_integration(hass)
 
@@ -250,7 +250,7 @@ async def test_service_invalid_device_id(hass):
     assert "Invalid device ID" in str(err.value)
 
 
-async def test_service_device_id_not_mazda_vehicle(hass):
+async def test_service_device_id_not_mazda_vehicle(hass: HomeAssistant) -> None:
     """Test service call when the specified device ID is not the device ID of a Mazda vehicle."""
     await init_integration(hass)
 
@@ -279,7 +279,7 @@ async def test_service_device_id_not_mazda_vehicle(hass):
     assert "Device ID is not a Mazda vehicle" in str(err.value)
 
 
-async def test_service_vehicle_id_not_found(hass):
+async def test_service_vehicle_id_not_found(hass: HomeAssistant) -> None:
     """Test service call when the vehicle ID is not found."""
     await init_integration(hass)
 
@@ -312,7 +312,7 @@ async def test_service_vehicle_id_not_found(hass):
     assert str(err.value) == "Vehicle ID not found"
 
 
-async def test_service_mazda_api_error(hass):
+async def test_service_mazda_api_error(hass: HomeAssistant) -> None:
     """Test the Mazda API raising an error when a service is called."""
     get_vehicles_fixture = json.loads(load_fixture("mazda/get_vehicles.json"))
     get_vehicle_status_fixture = json.loads(

--- a/tests/components/mazda/test_lock.py
+++ b/tests/components/mazda/test_lock.py
@@ -1,5 +1,4 @@
 """The lock tests for the Mazda Connected Services integration."""
-
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
@@ -7,12 +6,13 @@ from homeassistant.components.lock import (
     STATE_LOCKED,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
 
-async def test_lock_setup(hass):
+async def test_lock_setup(hass: HomeAssistant) -> None:
     """Test locking and unlocking the vehicle."""
     await init_integration(hass)
 
@@ -28,7 +28,7 @@ async def test_lock_setup(hass):
     assert state.state == STATE_LOCKED
 
 
-async def test_locking(hass):
+async def test_locking(hass: HomeAssistant) -> None:
     """Test locking the vehicle."""
     client_mock = await init_integration(hass)
 
@@ -43,7 +43,7 @@ async def test_locking(hass):
     client_mock.lock_doors.assert_called_once()
 
 
-async def test_unlocking(hass):
+async def test_unlocking(hass: HomeAssistant) -> None:
     """Test unlocking the vehicle."""
     client_mock = await init_integration(hass)
 

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -1,5 +1,4 @@
 """The sensor tests for the Mazda Connected Services integration."""
-
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -14,13 +13,14 @@ from homeassistant.const import (
     UnitOfLength,
     UnitOfPressure,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import init_integration
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test creation of the sensors."""
     await init_integration(hass)
 
@@ -131,7 +131,7 @@ async def test_sensors(hass):
     assert entry.unique_id == "JM000000000000000_rear_right_tire_pressure"
 
 
-async def test_sensors_us_customary_units(hass):
+async def test_sensors_us_customary_units(hass: HomeAssistant) -> None:
     """Test that the sensors work properly with US customary units."""
     hass.config.units = US_CUSTOMARY_SYSTEM
 
@@ -154,7 +154,7 @@ async def test_sensors_us_customary_units(hass):
     assert state.state == "1737"
 
 
-async def test_electric_vehicle_sensors(hass):
+async def test_electric_vehicle_sensors(hass: HomeAssistant) -> None:
     """Test sensors which are specific to electric vehicles."""
 
     await init_integration(hass, electric_vehicle=True)

--- a/tests/components/mazda/test_switch.py
+++ b/tests/components/mazda/test_switch.py
@@ -1,5 +1,4 @@
 """The switch tests for the Mazda Connected Services integration."""
-
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
@@ -7,12 +6,13 @@ from homeassistant.components.switch import (
     STATE_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
 
-async def test_switch_setup(hass):
+async def test_switch_setup(hass: HomeAssistant) -> None:
     """Test setup of the switch entity."""
     await init_integration(hass, electric_vehicle=True)
 
@@ -29,7 +29,7 @@ async def test_switch_setup(hass):
     assert state.state == STATE_ON
 
 
-async def test_start_charging(hass):
+async def test_start_charging(hass: HomeAssistant) -> None:
     """Test turning on the charging switch."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 
@@ -49,7 +49,7 @@ async def test_start_charging(hass):
     client_mock.get_ev_vehicle_status.assert_called_once()
 
 
-async def test_stop_charging(hass):
+async def test_stop_charging(hass: HomeAssistant) -> None:
     """Test turning off the charging switch."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 

--- a/tests/components/meater/test_config_flow.py
+++ b/tests/components/meater/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.meater import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -25,7 +26,7 @@ def mock_meater(mock_client):
         yield mock_
 
 
-async def test_duplicate_error(hass):
+async def test_duplicate_error(hass: HomeAssistant) -> None:
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "password123"}
 

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -14,10 +14,15 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
-async def test_get_image_http(hass, hass_client_no_auth):
+
+async def test_get_image_http(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test get image via http command."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -40,7 +45,9 @@ async def test_get_image_http(hass, hass_client_no_auth):
     assert content == b"image"
 
 
-async def test_get_image_http_remote(hass, hass_client_no_auth):
+async def test_get_image_http_remote(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test get image url via http command."""
     with patch(
         "homeassistant.components.media_player.MediaPlayerEntity."
@@ -126,7 +133,9 @@ async def test_get_async_get_browse_image(hass, hass_client_no_auth, hass_ws_cli
     assert content == b"image"
 
 
-async def test_media_browse(hass, hass_ws_client):
+async def test_media_browse(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test browsing media."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -201,7 +210,7 @@ async def test_media_browse(hass, hass_ws_client):
     assert msg["result"] == {"bla": "yo"}
 
 
-async def test_group_members_available_when_off(hass):
+async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
     """Test that group_members are still available when media_player is off."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -263,7 +272,7 @@ async def test_enqueue_rewrite(hass, input, expected):
     assert mock_play_media.mock_calls[0][2]["enqueue"] == expected
 
 
-async def test_enqueue_alert_exclusive(hass):
+async def test_enqueue_alert_exclusive(hass: HomeAssistant) -> None:
     """Test that alert and enqueue cannot be used together."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}

--- a/tests/components/media_player/test_reproduce_state.py
+++ b/tests/components/media_player/test_reproduce_state.py
@@ -1,5 +1,4 @@
 """The tests for reproduction of state."""
-
 import pytest
 
 from homeassistant.components.media_player import (
@@ -32,7 +31,7 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_PLAYING,
 )
-from homeassistant.core import Context, State
+from homeassistant.core import Context, HomeAssistant, State
 
 from tests.common import async_mock_service
 
@@ -72,7 +71,7 @@ async def test_state(hass, service, state, supported_feature):
     assert calls_1[0].data == {"entity_id": ENTITY_1}
 
 
-async def test_turn_on_with_mode(hass):
+async def test_turn_on_with_mode(hass: HomeAssistant) -> None:
     """Test that state with additional attributes call multiple services."""
     hass.states.async_set(
         ENTITY_1,
@@ -99,7 +98,7 @@ async def test_turn_on_with_mode(hass):
     assert calls_2[0].data == {"entity_id": ENTITY_1, ATTR_SOUND_MODE: "dummy"}
 
 
-async def test_multiple_same_state(hass):
+async def test_multiple_same_state(hass: HomeAssistant) -> None:
     """Test that multiple states with same state gets calls."""
     for entity in ENTITY_1, ENTITY_2:
         hass.states.async_set(
@@ -120,7 +119,7 @@ async def test_multiple_same_state(hass):
     assert any(call.data == {"entity_id": "media_player.test2"} for call in calls_1)
 
 
-async def test_multiple_different_state(hass):
+async def test_multiple_different_state(hass: HomeAssistant) -> None:
     """Test that multiple states with different state gets calls."""
     for entity in ENTITY_1, ENTITY_2:
         hass.states.async_set(
@@ -145,7 +144,7 @@ async def test_multiple_different_state(hass):
     assert calls_2[0].data == {"entity_id": "media_player.test2"}
 
 
-async def test_state_with_context(hass):
+async def test_state_with_context(hass: HomeAssistant) -> None:
     """Test that context is forwarded."""
     hass.states.async_set(
         ENTITY_1,
@@ -166,7 +165,7 @@ async def test_state_with_context(hass):
     assert calls[0].context == context
 
 
-async def test_attribute_no_state(hass):
+async def test_attribute_no_state(hass: HomeAssistant) -> None:
     """Test that no state service call is made with none state."""
     hass.states.async_set(
         ENTITY_1,
@@ -241,7 +240,7 @@ async def test_attribute(hass, service, attribute, supported_feature):
     assert calls_1[0].data == {"entity_id": ENTITY_1, attribute: value}
 
 
-async def test_play_media(hass):
+async def test_play_media(hass: HomeAssistant) -> None:
     """Test playing media."""
     hass.states.async_set(
         ENTITY_1,

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -7,7 +7,10 @@ import yarl
 from homeassistant.components import media_source
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import const, models
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import WebSocketGenerator
 
 
 async def test_is_media_source_id() -> None:
@@ -37,7 +40,7 @@ async def test_generate_media_source_id() -> None:
         )
 
 
-async def test_async_browse_media(hass):
+async def test_async_browse_media(hass: HomeAssistant) -> None:
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()
@@ -95,7 +98,7 @@ async def test_async_browse_media(hass):
     assert media.children[0].title == "Local Media"
 
 
-async def test_async_resolve_media(hass):
+async def test_async_resolve_media(hass: HomeAssistant) -> None:
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()
@@ -111,7 +114,9 @@ async def test_async_resolve_media(hass):
 
 
 @patch("homeassistant.helpers.frame._REPORTED_INTEGRATIONS", set())
-async def test_async_resolve_media_no_entity(hass, caplog):
+async def test_async_resolve_media_no_entity(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()
@@ -129,7 +134,7 @@ async def test_async_resolve_media_no_entity(hass, caplog):
     )
 
 
-async def test_async_unresolve_media(hass):
+async def test_async_unresolve_media(hass: HomeAssistant) -> None:
     """Test browse media."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()
@@ -149,7 +154,9 @@ async def test_async_unresolve_media(hass):
         )
 
 
-async def test_websocket_browse_media(hass, hass_ws_client):
+async def test_websocket_browse_media(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test browse media websocket."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/media_source/test_local_source.py
+++ b/tests/components/media_source/test_local_source.py
@@ -10,7 +10,10 @@ import pytest
 from homeassistant.components import media_source, websocket_api
 from homeassistant.components.media_source import const
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -27,7 +30,7 @@ async def temp_dir(hass):
         yield str(target_dir)
 
 
-async def test_async_browse_media(hass):
+async def test_async_browse_media(hass: HomeAssistant) -> None:
     """Test browse media."""
     local_media = hass.config.path("media")
     await async_process_ha_core_config(
@@ -83,7 +86,9 @@ async def test_async_browse_media(hass):
     assert media
 
 
-async def test_media_view(hass, hass_client):
+async def test_media_view(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test media view."""
     local_media = hass.config.path("media")
     await async_process_ha_core_config(

--- a/tests/components/melissa/test_climate.py
+++ b/tests/components/melissa/test_climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.melissa import DATA_MELISSA, climate as melissa
 from homeassistant.components.melissa.climate import MelissaClimate
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
 
 from tests.common import load_fixture
 
@@ -55,7 +56,7 @@ def melissa_mock():
     return api
 
 
-async def test_setup_platform(hass):
+async def test_setup_platform(hass: HomeAssistant) -> None:
     """Test setup_platform."""
     with patch(
         "homeassistant.components.melissa.climate.MelissaClimate"
@@ -75,7 +76,7 @@ async def test_setup_platform(hass):
         add_entities.assert_called_once_with(thermostats)
 
 
-async def test_get_name(hass):
+async def test_get_name(hass: HomeAssistant) -> None:
     """Test name property."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -84,7 +85,7 @@ async def test_get_name(hass):
         assert thermostat.name == "Melissa 12345678"
 
 
-async def test_current_fan_mode(hass):
+async def test_current_fan_mode(hass: HomeAssistant) -> None:
     """Test current_fan_mode property."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -97,7 +98,7 @@ async def test_current_fan_mode(hass):
         assert thermostat.fan_mode is None
 
 
-async def test_current_temperature(hass):
+async def test_current_temperature(hass: HomeAssistant) -> None:
     """Test current temperature."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -106,7 +107,7 @@ async def test_current_temperature(hass):
         assert thermostat.current_temperature == 27.4
 
 
-async def test_current_temperature_no_data(hass):
+async def test_current_temperature_no_data(hass: HomeAssistant) -> None:
     """Test current temperature without data."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -116,7 +117,7 @@ async def test_current_temperature_no_data(hass):
         assert thermostat.current_temperature is None
 
 
-async def test_target_temperature_step(hass):
+async def test_target_temperature_step(hass: HomeAssistant) -> None:
     """Test current target_temperature_step."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -125,7 +126,7 @@ async def test_target_temperature_step(hass):
         assert thermostat.target_temperature_step == 1
 
 
-async def test_current_operation(hass):
+async def test_current_operation(hass: HomeAssistant) -> None:
     """Test current operation."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -138,7 +139,7 @@ async def test_current_operation(hass):
         assert thermostat.hvac_action is None
 
 
-async def test_operation_list(hass):
+async def test_operation_list(hass: HomeAssistant) -> None:
     """Test the operation list."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -153,7 +154,7 @@ async def test_operation_list(hass):
         ] == thermostat.hvac_modes
 
 
-async def test_fan_modes(hass):
+async def test_fan_modes(hass: HomeAssistant) -> None:
     """Test the fan list."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -162,7 +163,7 @@ async def test_fan_modes(hass):
         assert ["auto", FAN_HIGH, FAN_MEDIUM, FAN_LOW] == thermostat.fan_modes
 
 
-async def test_target_temperature(hass):
+async def test_target_temperature(hass: HomeAssistant) -> None:
     """Test target temperature."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -175,7 +176,7 @@ async def test_target_temperature(hass):
         assert thermostat.target_temperature is None
 
 
-async def test_state(hass):
+async def test_state(hass: HomeAssistant) -> None:
     """Test state."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -188,7 +189,7 @@ async def test_state(hass):
         assert thermostat.state is None
 
 
-async def test_temperature_unit(hass):
+async def test_temperature_unit(hass: HomeAssistant) -> None:
     """Test temperature unit."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -197,7 +198,7 @@ async def test_temperature_unit(hass):
         assert thermostat.temperature_unit == UnitOfTemperature.CELSIUS
 
 
-async def test_min_temp(hass):
+async def test_min_temp(hass: HomeAssistant) -> None:
     """Test min temp."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -206,7 +207,7 @@ async def test_min_temp(hass):
         assert thermostat.min_temp == 16
 
 
-async def test_max_temp(hass):
+async def test_max_temp(hass: HomeAssistant) -> None:
     """Test max temp."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -215,7 +216,7 @@ async def test_max_temp(hass):
         assert thermostat.max_temp == 30
 
 
-async def test_supported_features(hass):
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test supported_features property."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -227,7 +228,7 @@ async def test_supported_features(hass):
         assert thermostat.supported_features == features
 
 
-async def test_set_temperature(hass):
+async def test_set_temperature(hass: HomeAssistant) -> None:
     """Test set_temperature."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -238,7 +239,7 @@ async def test_set_temperature(hass):
         assert thermostat.target_temperature == 25
 
 
-async def test_fan_mode(hass):
+async def test_fan_mode(hass: HomeAssistant) -> None:
     """Test set_fan_mode."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -251,7 +252,7 @@ async def test_fan_mode(hass):
         assert thermostat.fan_mode == FAN_HIGH
 
 
-async def test_set_operation_mode(hass):
+async def test_set_operation_mode(hass: HomeAssistant) -> None:
     """Test set_operation_mode."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -264,7 +265,7 @@ async def test_set_operation_mode(hass):
         assert thermostat.hvac_mode == HVACMode.COOL
 
 
-async def test_send(hass):
+async def test_send(hass: HomeAssistant) -> None:
     """Test send."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -283,7 +284,7 @@ async def test_send(hass):
         assert thermostat._cur_settings is None
 
 
-async def test_update(hass):
+async def test_update(hass: HomeAssistant) -> None:
     """Test update."""
     with patch(
         "homeassistant.components.melissa.climate._LOGGER.warning"
@@ -301,7 +302,7 @@ async def test_update(hass):
         )
 
 
-async def test_melissa_op_to_hass(hass):
+async def test_melissa_op_to_hass(hass: HomeAssistant) -> None:
     """Test for translate melissa operations to hass."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -314,7 +315,7 @@ async def test_melissa_op_to_hass(hass):
         assert thermostat.melissa_op_to_hass(5) is None
 
 
-async def test_melissa_fan_to_hass(hass):
+async def test_melissa_fan_to_hass(hass: HomeAssistant) -> None:
     """Test for translate melissa fan state to hass."""
     with patch("homeassistant.components.melissa"):
         api = melissa_mock()
@@ -327,7 +328,7 @@ async def test_melissa_fan_to_hass(hass):
         assert thermostat.melissa_fan_to_hass(4) is None
 
 
-async def test_hass_mode_to_melissa(hass):
+async def test_hass_mode_to_melissa(hass: HomeAssistant) -> None:
     """Test for hass operations to melssa."""
     with patch(
         "homeassistant.components.melissa.climate._LOGGER.warning"
@@ -345,7 +346,7 @@ async def test_hass_mode_to_melissa(hass):
         )
 
 
-async def test_hass_fan_to_melissa(hass):
+async def test_hass_fan_to_melissa(hass: HomeAssistant) -> None:
     """Test for translate melissa states to hass."""
     with patch(
         "homeassistant.components.melissa.climate._LOGGER.warning"

--- a/tests/components/melissa/test_init.py
+++ b/tests/components/melissa/test_init.py
@@ -2,11 +2,12 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components import melissa
+from homeassistant.core import HomeAssistant
 
 VALID_CONFIG = {"melissa": {"username": "********", "password": "********"}}
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setting up the Melissa component."""
     with patch("melissa.AsyncMelissa") as mocked_melissa, patch.object(
         melissa, "async_load_platform"

--- a/tests/components/melnor/test_config_flow.py
+++ b/tests/components/melnor/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the melnor config flow."""
-
 import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.melnor.const import DOMAIN
 from homeassistant.const import CONF_ADDRESS, CONF_MAC
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import (
@@ -17,7 +17,7 @@ from .conftest import (
 )
 
 
-async def test_user_step_no_devices(hass):
+async def test_user_step_no_devices(hass: HomeAssistant) -> None:
     """Test we handle no devices found."""
     with patch_async_setup_entry() as mock_setup_entry, patch_async_discovered_service_info(
         []
@@ -33,7 +33,7 @@ async def test_user_step_no_devices(hass):
         assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_user_step_discovered_devices(hass):
+async def test_user_step_discovered_devices(hass: HomeAssistant) -> None:
     """Test we properly handle device picking."""
 
     with patch_async_setup_entry() as mock_setup_entry, patch_async_discovered_service_info():
@@ -60,7 +60,7 @@ async def test_user_step_discovered_devices(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_step_with_existing_device(hass):
+async def test_user_step_with_existing_device(hass: HomeAssistant) -> None:
     """Test we properly handle device picking."""
 
     with patch_async_setup_entry() as mock_setup_entry, patch_async_discovered_service_info(
@@ -98,7 +98,7 @@ async def test_user_step_with_existing_device(hass):
         assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_bluetooth_discovered(hass):
+async def test_bluetooth_discovered(hass: HomeAssistant) -> None:
     """Test we short circuit to config entry creation."""
 
     with patch_async_setup_entry() as mock_setup_entry:
@@ -115,7 +115,7 @@ async def test_bluetooth_discovered(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_bluetooth_confirm(hass):
+async def test_bluetooth_confirm(hass: HomeAssistant) -> None:
     """Test we short circuit to config entry creation."""
 
     with patch_async_setup_entry() as mock_setup_entry:

--- a/tests/components/melnor/test_number.py
+++ b/tests/components/melnor/test_number.py
@@ -1,6 +1,7 @@
 """Test the Melnor sensors."""
-
 from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
 
 from .conftest import (
     mock_config_entry,
@@ -10,7 +11,7 @@ from .conftest import (
 )
 
 
-async def test_manual_watering_minutes(hass):
+async def test_manual_watering_minutes(hass: HomeAssistant) -> None:
     """Test the manual watering switch."""
 
     entry = mock_config_entry(hass)

--- a/tests/components/melnor/test_sensor.py
+++ b/tests/components/melnor/test_sensor.py
@@ -1,11 +1,11 @@
 """Test the Melnor sensors."""
-
 from __future__ import annotations
 
 from freezegun import freeze_time
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 import homeassistant.util.dt as dt_util
 
@@ -20,7 +20,7 @@ from .conftest import (
 from tests.common import async_fire_time_changed
 
 
-async def test_battery_sensor(hass):
+async def test_battery_sensor(hass: HomeAssistant) -> None:
     """Test the battery sensor."""
 
     entry = mock_config_entry(hass)
@@ -36,7 +36,7 @@ async def test_battery_sensor(hass):
         assert battery_sensor.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
 
-async def test_minutes_remaining_sensor(hass):
+async def test_minutes_remaining_sensor(hass: HomeAssistant) -> None:
     """Test the minutes remaining sensor."""
 
     now = dt_util.utcnow()
@@ -72,7 +72,7 @@ async def test_minutes_remaining_sensor(hass):
         assert minutes_remaining_sensor.state == end_time.isoformat(timespec="seconds")
 
 
-async def test_rssi_sensor(hass):
+async def test_rssi_sensor(hass: HomeAssistant) -> None:
     """Test the rssi sensor."""
 
     entry = mock_config_entry(hass)

--- a/tests/components/melnor/test_switch.py
+++ b/tests/components/melnor/test_switch.py
@@ -1,9 +1,9 @@
 """Test the Melnor sensors."""
-
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
 from .conftest import (
     mock_config_entry,
@@ -13,7 +13,7 @@ from .conftest import (
 )
 
 
-async def test_manual_watering_switch_metadata(hass):
+async def test_manual_watering_switch_metadata(hass: HomeAssistant) -> None:
     """Test the manual watering switch."""
 
     entry = mock_config_entry(hass)
@@ -27,7 +27,7 @@ async def test_manual_watering_switch_metadata(hass):
         assert switch.attributes["icon"] == "mdi:sprinkler"
 
 
-async def test_manual_watering_switch_on_off(hass):
+async def test_manual_watering_switch_on_off(hass: HomeAssistant) -> None:
     """Test the manual watering switch."""
 
     entry = mock_config_entry(hass)

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.met.const import DOMAIN, HOME_LOCATION_NAME
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -18,7 +19,7 @@ def met_setup_fixture():
         yield
 
 
-async def test_show_config_form(hass):
+async def test_show_config_form(hass: HomeAssistant) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -28,7 +29,7 @@ async def test_show_config_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_flow_with_home_location(hass):
+async def test_flow_with_home_location(hass: HomeAssistant) -> None:
     """Test config flow.
 
     Test the flow when a default location is configured.
@@ -52,7 +53,7 @@ async def test_flow_with_home_location(hass):
     assert default_data["elevation"] == 3
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     test_data = {
         "name": "home",
@@ -70,7 +71,7 @@ async def test_create_entry(hass):
     assert result["data"] == test_data
 
 
-async def test_flow_entry_already_exists(hass):
+async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists.
 
     Test when the form should show when user puts existing location
@@ -97,7 +98,7 @@ async def test_flow_entry_already_exists(hass):
     assert result["errors"]["name"] == "already_configured"
 
 
-async def test_onboarding_step(hass):
+async def test_onboarding_step(hass: HomeAssistant) -> None:
     """Test initializing via onboarding step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "onboarding"}, data={}

--- a/tests/components/met/test_init.py
+++ b/tests/components/met/test_init.py
@@ -1,4 +1,6 @@
 """Test the Met integration init."""
+import pytest
+
 from homeassistant.components.met.const import (
     DEFAULT_HOME_LATITUDE,
     DEFAULT_HOME_LONGITUDE,
@@ -6,11 +8,12 @@ from homeassistant.components.met.const import (
 )
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 
@@ -24,7 +27,9 @@ async def test_unload_entry(hass):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_fail_default_home_entry(hass, caplog):
+async def test_fail_default_home_entry(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test abort setup of default home location."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/met_eireann/test_config_flow.py
+++ b/tests/components/met_eireann/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.met_eireann.const import DOMAIN, HOME_LOCATION_NAME
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(name="met_eireann_setup", autouse=True)
@@ -17,7 +18,7 @@ def met_setup_fixture():
         yield
 
 
-async def test_show_config_form(hass):
+async def test_show_config_form(hass: HomeAssistant) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -27,7 +28,7 @@ async def test_show_config_form(hass):
     assert result["step_id"] == config_entries.SOURCE_USER
 
 
-async def test_flow_with_home_location(hass):
+async def test_flow_with_home_location(hass: HomeAssistant) -> None:
     """Test config flow.
 
     Test the flow when a default location is configured.
@@ -51,7 +52,7 @@ async def test_flow_with_home_location(hass):
     assert default_data["elevation"] == 3
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     test_data = {
         "name": "test",
@@ -69,7 +70,7 @@ async def test_create_entry(hass):
     assert result["data"] == test_data
 
 
-async def test_flow_entry_already_exists(hass):
+async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists.
 
     Test to ensure the config form does not allow duplicate entries.

--- a/tests/components/met_eireann/test_init.py
+++ b/tests/components/met_eireann/test_init.py
@@ -1,11 +1,12 @@
 """Test the Met Éireann integration init."""
 from homeassistant.components.met_eireann.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 

--- a/tests/components/meteoclimatic/test_config_flow.py
+++ b/tests/components/meteoclimatic/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import data_entry_flow
 from homeassistant.components.meteoclimatic.const import CONF_STATION_CODE, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 
 TEST_STATION_CODE = "ESCAT4300000043206B"
 TEST_STATION_NAME = "Reus (Tarragona)"
@@ -57,7 +58,7 @@ async def test_user(hass, client):
     assert result["data"][CONF_STATION_CODE] == TEST_STATION_CODE
 
 
-async def test_not_found(hass):
+async def test_not_found(hass: HomeAssistant) -> None:
     """Test when we have the station code is not found."""
     with patch(
         "homeassistant.components.meteoclimatic.config_flow.MeteoclimaticClient.weather_at_station",
@@ -73,7 +74,7 @@ async def test_not_found(hass):
         assert result["errors"]["base"] == "not_found"
 
 
-async def test_unknown_error(hass):
+async def test_unknown_error(hass: HomeAssistant) -> None:
     """Test when we have an unknown error fetching station data."""
     with patch(
         "homeassistant.components.meteoclimatic.config_flow.MeteoclimaticClient.weather_at_station",

--- a/tests/components/mfi/test_sensor.py
+++ b/tests/components/mfi/test_sensor.py
@@ -10,6 +10,7 @@ import homeassistant.components.mfi.sensor as mfi
 import homeassistant.components.sensor as sensor_component
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 PLATFORM = mfi
@@ -28,7 +29,7 @@ GOOD_CONFIG = {
 }
 
 
-async def test_setup_missing_config(hass):
+async def test_setup_missing_config(hass: HomeAssistant) -> None:
     """Test setup with missing configuration."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         config = {"sensor": {"platform": "mfi"}}
@@ -36,21 +37,21 @@ async def test_setup_missing_config(hass):
         assert not mock_client.called
 
 
-async def test_setup_failed_login(hass):
+async def test_setup_failed_login(hass: HomeAssistant) -> None:
     """Test setup with login failure."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         mock_client.side_effect = FailedToLogin
         assert not PLATFORM.setup_platform(hass, GOOD_CONFIG, None)
 
 
-async def test_setup_failed_connect(hass):
+async def test_setup_failed_connect(hass: HomeAssistant) -> None:
     """Test setup with connection failure."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         mock_client.side_effect = requests.exceptions.ConnectionError
         assert not PLATFORM.setup_platform(hass, GOOD_CONFIG, None)
 
 
-async def test_setup_minimum(hass):
+async def test_setup_minimum(hass: HomeAssistant) -> None:
     """Test setup with minimum configuration."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         config = deepcopy(GOOD_CONFIG)
@@ -63,7 +64,7 @@ async def test_setup_minimum(hass):
         )
 
 
-async def test_setup_with_port(hass):
+async def test_setup_with_port(hass: HomeAssistant) -> None:
     """Test setup with port."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         assert await async_setup_component(hass, COMPONENT.DOMAIN, GOOD_CONFIG)
@@ -74,7 +75,7 @@ async def test_setup_with_port(hass):
         )
 
 
-async def test_setup_with_tls_disabled(hass):
+async def test_setup_with_tls_disabled(hass: HomeAssistant) -> None:
     """Test setup without TLS."""
     with mock.patch("homeassistant.components.mfi.sensor.MFiClient") as mock_client:
         config = deepcopy(GOOD_CONFIG)
@@ -89,7 +90,7 @@ async def test_setup_with_tls_disabled(hass):
         )
 
 
-async def test_setup_adds_proper_devices(hass):
+async def test_setup_adds_proper_devices(hass: HomeAssistant) -> None:
     """Test if setup adds devices."""
     with mock.patch(
         "homeassistant.components.mfi.sensor.MFiClient"

--- a/tests/components/mfi/test_switch.py
+++ b/tests/components/mfi/test_switch.py
@@ -5,6 +5,7 @@ import pytest
 
 import homeassistant.components.mfi.switch as mfi
 import homeassistant.components.switch as switch_component
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 PLATFORM = mfi
@@ -23,7 +24,7 @@ GOOD_CONFIG = {
 }
 
 
-async def test_setup_adds_proper_devices(hass):
+async def test_setup_adds_proper_devices(hass: HomeAssistant) -> None:
     """Test if setup adds devices."""
     with mock.patch(
         "homeassistant.components.mfi.switch.MFiClient"

--- a/tests/components/microsoft_face/test_init.py
+++ b/tests/components/microsoft_face/test_init.py
@@ -18,9 +18,11 @@ from homeassistant.components.microsoft_face import (
     SERVICE_TRAIN_GROUP,
 )
 from homeassistant.const import ATTR_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 def create_group(hass, name):
@@ -120,7 +122,9 @@ async def test_setup_component_test_service(hass, mock_update):
     assert hass.services.has_service(mf.DOMAIN, "face_person")
 
 
-async def test_setup_component_test_entities(hass, aioclient_mock):
+async def test_setup_component_test_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component."""
     aioclient_mock.get(
         ENDPOINT_URL.format("persongroups"),
@@ -184,7 +188,9 @@ async def test_service_groups(hass, mock_update, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 2
 
 
-async def test_service_person(hass, aioclient_mock):
+async def test_service_person(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test person services."""
     aioclient_mock.get(
         ENDPOINT_URL.format("persongroups"),
@@ -252,7 +258,9 @@ async def test_service_train(hass, mock_update, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_face(hass, aioclient_mock):
+async def test_service_face(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test person face services."""
     aioclient_mock.get(
         ENDPOINT_URL.format("persongroups"),

--- a/tests/components/mill/test_config_flow.py
+++ b/tests/components/mill/test_config_flow.py
@@ -4,12 +4,13 @@ from unittest.mock import patch
 from homeassistant import config_entries
 from homeassistant.components.mill.const import CLOUD, CONNECTION_TYPE, DOMAIN, LOCAL
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
 
-async def test_show_config_form(hass):
+async def test_show_config_form(hass: HomeAssistant) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -19,7 +20,7 @@ async def test_show_config_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -54,7 +55,7 @@ async def test_create_entry(hass):
     }
 
 
-async def test_flow_entry_already_exists(hass):
+async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
 
     test_data = {
@@ -94,7 +95,7 @@ async def test_flow_entry_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_connection_error(hass):
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test connection error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -123,7 +124,7 @@ async def test_connection_error(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_local_create_entry(hass):
+async def test_local_create_entry(hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -163,7 +164,7 @@ async def test_local_create_entry(hass):
     assert result["data"] == test_data
 
 
-async def test_local_flow_entry_already_exists(hass):
+async def test_local_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
 
     test_data = {
@@ -213,7 +214,7 @@ async def test_local_flow_entry_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_local_connection_error(hass):
+async def test_local_connection_error(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/mill/test_init.py
+++ b/tests/components/mill/test_init.py
@@ -1,15 +1,15 @@
 """Tests for Mill init."""
-
 from unittest.mock import patch
 
 from homeassistant.components import mill
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_coro
 
 
-async def test_setup_with_cloud_config(hass):
+async def test_setup_with_cloud_config(hass: HomeAssistant) -> None:
     """Test setup of cloud config."""
     entry = MockConfigEntry(
         domain=mill.DOMAIN,
@@ -28,7 +28,7 @@ async def test_setup_with_cloud_config(hass):
     assert len(mock_connect.mock_calls) == 1
 
 
-async def test_setup_with_cloud_config_fails(hass):
+async def test_setup_with_cloud_config_fails(hass: HomeAssistant) -> None:
     """Test setup of cloud config."""
     entry = MockConfigEntry(
         domain=mill.DOMAIN,
@@ -44,7 +44,7 @@ async def test_setup_with_cloud_config_fails(hass):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_with_old_cloud_config(hass):
+async def test_setup_with_old_cloud_config(hass: HomeAssistant) -> None:
     """Test setup of old cloud config."""
     entry = MockConfigEntry(
         domain=mill.DOMAIN,
@@ -62,7 +62,7 @@ async def test_setup_with_old_cloud_config(hass):
     assert len(mock_connect.mock_calls) == 1
 
 
-async def test_setup_with_local_config(hass):
+async def test_setup_with_local_config(hass: HomeAssistant) -> None:
     """Test setup of local config."""
     entry = MockConfigEntry(
         domain=mill.DOMAIN,
@@ -96,7 +96,7 @@ async def test_setup_with_local_config(hass):
     assert len(mock_connect.mock_calls) == 1
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test removing mill client."""
     entry = MockConfigEntry(
         domain=mill.DOMAIN,

--- a/tests/components/moat/test_config_flow.py
+++ b/tests/components/moat/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the Moat config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.moat.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import MOAT_S2_SERVICE_INFO, NOT_MOAT_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import MOAT_S2_SERVICE_INFO, NOT_MOAT_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -30,7 +30,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_moat(hass):
+async def test_async_step_bluetooth_not_moat(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not moat."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -41,7 +41,7 @@ async def test_async_step_bluetooth_not_moat(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -51,7 +51,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.moat.config_flow.async_discovered_service_info",
@@ -74,7 +74,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.moat.config_flow.async_discovered_service_info",
@@ -102,7 +102,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -122,7 +124,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -139,7 +141,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -158,7 +160,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/moat/test_sensor.py
+++ b/tests/components/moat/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the Moat sensors."""
-
-
 from homeassistant.components.moat.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import MOAT_S2_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -8,11 +8,13 @@ import pytest
 
 from homeassistant.components.mobile_app.const import CONF_SECRET, DOMAIN
 from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import REGISTER, REGISTER_CLEARTEXT, RENDER_TEMPLATE
 
 from tests.common import mock_coro
+from tests.typing import ClientSessionGenerator
 
 
 async def test_registration(hass, hass_client, hass_admin_user):
@@ -58,7 +60,9 @@ async def test_registration(hass, hass_client, hass_admin_user):
     )
 
 
-async def test_registration_encryption(hass, hass_client):
+async def test_registration_encryption(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that registrations happen."""
     try:
         from nacl.encoding import Base64Encoder
@@ -101,7 +105,9 @@ async def test_registration_encryption(hass, hass_client):
     assert json.loads(decrypted_data) == {"one": "Hello world"}
 
 
-async def test_registration_encryption_legacy(hass, hass_client):
+async def test_registration_encryption_legacy(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test that registrations happen."""
     try:
         from nacl.encoding import Base64Encoder

--- a/tests/components/mobile_app/test_logbook.py
+++ b/tests/components/mobile_app/test_logbook.py
@@ -1,17 +1,17 @@
 """The tests for mobile_app logbook."""
-
 from homeassistant.components.mobile_app.logbook import (
     DOMAIN,
     IOS_EVENT_ZONE_ENTERED,
     IOS_EVENT_ZONE_EXITED,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_ios_events(hass):
+async def test_humanify_ios_events(hass: HomeAssistant) -> None:
     """Test humanifying ios events."""
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})

--- a/tests/components/mochad/test_light.py
+++ b/tests/components/mochad/test_light.py
@@ -1,11 +1,11 @@
 """The tests for the mochad light platform."""
-
 import unittest.mock as mock
 
 import pytest
 
 from homeassistant.components import light
 from homeassistant.components.mochad import light as mochad
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -24,7 +24,7 @@ def light_mock(hass, brightness):
     return mochad.MochadLight(hass, controller_mock, dev_dict)
 
 
-async def test_setup_adds_proper_devices(hass):
+async def test_setup_adds_proper_devices(hass: HomeAssistant) -> None:
     """Test if setup adds devices."""
     good_config = {
         "mochad": {},

--- a/tests/components/mochad/test_switch.py
+++ b/tests/components/mochad/test_switch.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import switch
 from homeassistant.components.mochad import switch as mochad
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -25,7 +26,7 @@ def switch_mock(hass):
     return mochad.MochadSwitch(hass, controller_mock, dev_dict)
 
 
-async def test_setup_adds_proper_devices(hass):
+async def test_setup_adds_proper_devices(hass: HomeAssistant) -> None:
     """Test if setup adds devices."""
     good_config = {
         "mochad": {},

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -388,7 +388,9 @@ async def test_slave_binary_sensor(hass, expected, slaves, mock_do_cycle):
         assert entry.unique_id == unique_id
 
 
-async def test_no_discovery_info_binary_sensor(hass, caplog):
+async def test_no_discovery_info_binary_sensor(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert SENSOR_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
     CONF_SLAVE,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
@@ -538,7 +538,9 @@ async def test_wrong_unpack_climate(hass, mock_do_cycle):
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
 
 
-async def test_no_discovery_info_climate(hass, caplog):
+async def test_no_discovery_info_climate(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert CLIMATE_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -1,5 +1,4 @@
 """The tests for the Modbus cover component."""
-
 from pymodbus.exceptions import ModbusException
 import pytest
 
@@ -29,7 +28,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
@@ -311,7 +310,9 @@ async def test_service_cover_move(hass, mock_modbus, mock_ha):
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
 
 
-async def test_no_discovery_info_cover(hass, caplog):
+async def test_no_discovery_info_cover(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert COVER_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
@@ -312,7 +312,9 @@ async def test_service_fan_update(hass, mock_modbus, mock_ha):
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
-async def test_no_discovery_info_fan(hass, caplog):
+async def test_no_discovery_info_fan(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert FAN_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -90,6 +90,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -626,7 +627,9 @@ async def test_pb_read(
     assert state == do_expect
 
 
-async def test_pymodbus_constructor_fail(hass, caplog):
+async def test_pymodbus_constructor_fail(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Run test for failing pymodbus constructor."""
     config = {
         DOMAIN: [

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
@@ -312,7 +312,9 @@ async def test_service_light_update(hass, mock_modbus, mock_ha):
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
-async def test_no_discovery_info_light(hass, caplog):
+async def test_no_discovery_info_light(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert LIGHT_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -40,7 +40,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -954,7 +954,9 @@ async def test_service_sensor_update(hass, mock_modbus, mock_ha):
     assert hass.states.get(ENTITY_ID).state == "32"
 
 
-async def test_no_discovery_info_sensor(hass, caplog):
+async def test_no_discovery_info_sensor(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert SENSOR_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -398,7 +398,9 @@ async def test_delay_switch(hass, mock_modbus):
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
-async def test_no_discovery_info_switch(hass, caplog):
+async def test_no_discovery_info_switch(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert SWITCH_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/modern_forms/test_init.py
+++ b/tests/components/modern_forms/test_init.py
@@ -37,7 +37,9 @@ async def test_unload_config_entry(
     assert not hass.data.get(DOMAIN)
 
 
-async def test_fan_only_device(hass, aioclient_mock):
+async def test_fan_only_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we set unique ID if not set yet."""
     await init_integration(
         hass, aioclient_mock, mock_type=modern_forms_no_light_call_mock

--- a/tests/components/mold_indicator/test_sensor.py
+++ b/tests/components/mold_indicator/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -29,7 +30,7 @@ def init_sensors_fixture(hass):
     )
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test the mold indicator sensor setup."""
     assert await async_setup_component(
         hass,
@@ -50,7 +51,7 @@ async def test_setup(hass):
     assert moldind.attributes.get("unit_of_measurement") == PERCENTAGE
 
 
-async def test_invalidcalib(hass):
+async def test_invalidcalib(hass: HomeAssistant) -> None:
     """Test invalid sensor values."""
     hass.states.async_set(
         "test.indoortemp", "10", {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS}
@@ -85,7 +86,7 @@ async def test_invalidcalib(hass):
     assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
 
-async def test_invalidhum(hass):
+async def test_invalidhum(hass: HomeAssistant) -> None:
     """Test invalid sensor values."""
     hass.states.async_set(
         "test.indoortemp", "10", {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS}
@@ -143,7 +144,7 @@ async def test_invalidhum(hass):
     assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
 
-async def test_calculation(hass):
+async def test_calculation(hass: HomeAssistant) -> None:
     """Test the mold indicator internal calculations."""
     assert await async_setup_component(
         hass,
@@ -182,7 +183,7 @@ async def test_calculation(hass):
     assert state == "68"
 
 
-async def test_unknown_sensor(hass):
+async def test_unknown_sensor(hass: HomeAssistant) -> None:
     """Test the sensor_changed function."""
     assert await async_setup_component(
         hass,
@@ -260,7 +261,7 @@ async def test_unknown_sensor(hass):
     assert esttemp == 27.5
 
 
-async def test_sensor_changed(hass):
+async def test_sensor_changed(hass: HomeAssistant) -> None:
     """Test the sensor_changed function."""
     assert await async_setup_component(
         hass,

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.monoprice.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -23,7 +24,7 @@ CONFIG = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -53,7 +54,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -71,7 +72,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_generic_exception(hass):
+async def test_generic_exception(hass: HomeAssistant) -> None:
     """Test we handle cannot generic exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -89,7 +90,7 @@ async def test_generic_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     conf = {CONF_PORT: "/test/port", CONF_SOURCES: {"4": "four"}}
 

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -89,7 +90,7 @@ class MockMonoprice:
         self.zones[zone.zone] = AttrDict(zone)
 
 
-async def test_cannot_connect(hass):
+async def test_cannot_connect(hass: HomeAssistant) -> None:
     """Test connection error."""
 
     with patch(
@@ -155,7 +156,7 @@ async def _call_monoprice_service(hass, name, data):
     await hass.services.async_call(DOMAIN, name, service_data=data, blocking=True)
 
 
-async def test_service_calls_with_entity_id(hass):
+async def test_service_calls_with_entity_id(hass: HomeAssistant) -> None:
     """Test snapshot save/restore service calls."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -199,7 +200,7 @@ async def test_service_calls_with_entity_id(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "one"
 
 
-async def test_service_calls_with_all_entities(hass):
+async def test_service_calls_with_all_entities(hass: HomeAssistant) -> None:
     """Test snapshot save/restore service calls."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -232,7 +233,7 @@ async def test_service_calls_with_all_entities(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "one"
 
 
-async def test_service_calls_without_relevant_entities(hass):
+async def test_service_calls_without_relevant_entities(hass: HomeAssistant) -> None:
     """Test snapshot save/restore service calls."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -265,7 +266,7 @@ async def test_service_calls_without_relevant_entities(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "three"
 
 
-async def test_restore_without_snapshort(hass):
+async def test_restore_without_snapshort(hass: HomeAssistant) -> None:
     """Test restore when snapshot wasn't called."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -276,7 +277,7 @@ async def test_restore_without_snapshort(hass):
         assert not method_call.called
 
 
-async def test_update(hass):
+async def test_update(hass: HomeAssistant) -> None:
     """Test updating values from monoprice."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -301,7 +302,7 @@ async def test_update(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "three"
 
 
-async def test_failed_update(hass):
+async def test_failed_update(hass: HomeAssistant) -> None:
     """Test updating failure from monoprice."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -327,7 +328,7 @@ async def test_failed_update(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "one"
 
 
-async def test_empty_update(hass):
+async def test_empty_update(hass: HomeAssistant) -> None:
     """Test updating with no state from monoprice."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -353,7 +354,7 @@ async def test_empty_update(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "one"
 
 
-async def test_supported_features(hass):
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test supported features property."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -369,7 +370,7 @@ async def test_supported_features(hass):
     )
 
 
-async def test_source_list(hass):
+async def test_source_list(hass: HomeAssistant) -> None:
     """Test source list property."""
     await _setup_monoprice(hass, MockMonoprice())
 
@@ -378,7 +379,7 @@ async def test_source_list(hass):
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["one", "three"]
 
 
-async def test_source_list_with_options(hass):
+async def test_source_list_with_options(hass: HomeAssistant) -> None:
     """Test source list property."""
     await _setup_monoprice_with_options(hass, MockMonoprice())
 
@@ -387,7 +388,7 @@ async def test_source_list_with_options(hass):
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["two", "four"]
 
 
-async def test_select_source(hass):
+async def test_select_source(hass: HomeAssistant) -> None:
     """Test source selection methods."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -408,7 +409,7 @@ async def test_select_source(hass):
     assert monoprice.zones[11].source == 3
 
 
-async def test_unknown_source(hass):
+async def test_unknown_source(hass: HomeAssistant) -> None:
     """Test behavior when device has unknown source."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -423,7 +424,7 @@ async def test_unknown_source(hass):
     assert state.attributes.get(ATTR_INPUT_SOURCE) is None
 
 
-async def test_turn_on_off(hass):
+async def test_turn_on_off(hass: HomeAssistant) -> None:
     """Test turning on the zone."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -435,7 +436,7 @@ async def test_turn_on_off(hass):
     assert monoprice.zones[11].power
 
 
-async def test_mute_volume(hass):
+async def test_mute_volume(hass: HomeAssistant) -> None:
     """Test mute functionality."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -454,7 +455,7 @@ async def test_mute_volume(hass):
     assert monoprice.zones[11].mute
 
 
-async def test_volume_up_down(hass):
+async def test_volume_up_down(hass: HomeAssistant) -> None:
     """Test increasing volume by one."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -488,7 +489,7 @@ async def test_volume_up_down(hass):
     assert monoprice.zones[11].volume == 37
 
 
-async def test_first_run_with_available_zones(hass):
+async def test_first_run_with_available_zones(hass: HomeAssistant) -> None:
     """Test first run with all zones available."""
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
@@ -499,7 +500,7 @@ async def test_first_run_with_available_zones(hass):
     assert not entry.disabled
 
 
-async def test_first_run_with_failing_zones(hass):
+async def test_first_run_with_failing_zones(hass: HomeAssistant) -> None:
     """Test first run with failed zones."""
     monoprice = MockMonoprice()
 
@@ -516,7 +517,7 @@ async def test_first_run_with_failing_zones(hass):
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_not_first_run_with_failing_zone(hass):
+async def test_not_first_run_with_failing_zone(hass: HomeAssistant) -> None:
     """Test first run with failed zones."""
     monoprice = MockMonoprice()
 

--- a/tests/components/mopeka/test_config_flow.py
+++ b/tests/components/mopeka/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the Mopeka config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.mopeka.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_MOPEKA_SERVICE_INFO, PRO_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_MOPEKA_SERVICE_INFO, PRO_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -30,7 +30,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_mopeka(hass):
+async def test_async_step_bluetooth_not_mopeka(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not mopeka."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -41,7 +41,7 @@ async def test_async_step_bluetooth_not_mopeka(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -51,7 +51,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.mopeka.config_flow.async_discovered_service_info",
@@ -74,7 +74,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.mopeka.config_flow.async_discovered_service_info",
@@ -102,7 +102,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -122,7 +124,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -139,7 +141,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -158,7 +160,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/mopeka/test_sensor.py
+++ b/tests/components/mopeka/test_sensor.py
@@ -1,6 +1,4 @@
 """Test the Mopeka sensors."""
-
-
 from homeassistant.components.mopeka.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import (
@@ -10,6 +8,7 @@ from homeassistant.const import (
     UnitOfLength,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 
 from . import PRO_GOOD_SIGNAL_SERVICE_INFO, PRO_SERVICE_INFO
 
@@ -17,7 +16,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors_bad_signal(hass):
+async def test_sensors_bad_signal(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors when there is bad signal."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -51,7 +50,7 @@ async def test_sensors_bad_signal(hass):
     await hass.async_block_till_done()
 
 
-async def test_sensors_good_signal(hass):
+async def test_sensors_good_signal(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors when there is good signal."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components import dhcp
 from homeassistant.components.motion_blinds import const
 from homeassistant.components.motion_blinds.config_flow import DEFAULT_GATEWAY_NAME
 from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -103,7 +104,7 @@ def motion_blinds_connect_fixture(mock_get_source_ip):
         yield
 
 
-async def test_config_flow_manual_host_success(hass):
+async def test_config_flow_manual_host_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -136,7 +137,7 @@ async def test_config_flow_manual_host_success(hass):
     }
 
 
-async def test_config_flow_discovery_1_success(hass):
+async def test_config_flow_discovery_1_success(hass: HomeAssistant) -> None:
     """Successful flow with 1 gateway discovered."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -173,7 +174,7 @@ async def test_config_flow_discovery_1_success(hass):
     }
 
 
-async def test_config_flow_discovery_2_success(hass):
+async def test_config_flow_discovery_2_success(hass: HomeAssistant) -> None:
     """Successful flow with 2 gateway discovered."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -227,7 +228,7 @@ async def test_config_flow_discovery_2_success(hass):
     }
 
 
-async def test_config_flow_connection_error(hass):
+async def test_config_flow_connection_error(hass: HomeAssistant) -> None:
     """Failed flow manually initialized by the user with connection timeout."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -259,7 +260,7 @@ async def test_config_flow_connection_error(hass):
     assert result["reason"] == "connection_error"
 
 
-async def test_config_flow_discovery_fail(hass):
+async def test_config_flow_discovery_fail(hass: HomeAssistant) -> None:
     """Failed flow with no gateways discovered."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -283,7 +284,7 @@ async def test_config_flow_discovery_fail(hass):
     assert result["errors"] == {"base": "discovery_error"}
 
 
-async def test_config_flow_invalid_interface(hass):
+async def test_config_flow_invalid_interface(hass: HomeAssistant) -> None:
     """Failed flow manually initialized by the user with invalid interface."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -320,7 +321,7 @@ async def test_config_flow_invalid_interface(hass):
     }
 
 
-async def test_dhcp_flow(hass):
+async def test_dhcp_flow(hass: HomeAssistant) -> None:
     """Successful flow from DHCP discovery."""
     dhcp_data = dhcp.DhcpServiceInfo(
         ip=TEST_HOST,
@@ -354,7 +355,7 @@ async def test_dhcp_flow(hass):
     }
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -386,7 +387,7 @@ async def test_options_flow(hass):
     }
 
 
-async def test_change_connection_settings(hass):
+async def test_change_connection_settings(hass: HomeAssistant) -> None:
     """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,

--- a/tests/components/motion_blinds/test_gateway.py
+++ b/tests/components/motion_blinds/test_gateway.py
@@ -4,11 +4,12 @@ from unittest.mock import Mock
 from motionblinds import DEVICE_TYPES_WIFI, BlindType
 
 from homeassistant.components.motion_blinds.gateway import device_name
+from homeassistant.core import HomeAssistant
 
 TEST_BLIND_MAC = "abcdefghujkl0001"
 
 
-async def test_device_name(hass):
+async def test_device_name(hass: HomeAssistant) -> None:
     """test_device_name."""
     blind = Mock()
     blind.blind_type = BlindType.RollerBlind.name


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests:
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
