### PR TITLE
Add type hints to integration tests (q-s)

### DIFF
--- a/tests/components/qingping/test_binary_sensor.py
+++ b/tests/components/qingping/test_binary_sensor.py
@@ -1,8 +1,7 @@
 """Test the Qingping binary sensors."""
-
-
 from homeassistant.components.qingping.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 
 from . import LIGHT_AND_SIGNAL_SERVICE_INFO
 
@@ -10,7 +9,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_binary_sensors(hass):
+async def test_binary_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the binary sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/qingping/test_config_flow.py
+++ b/tests/components/qingping/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the Qingping config flow."""
-
 import asyncio
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.qingping.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -16,7 +16,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -37,7 +37,9 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_enough_info_at_start(hass):
+async def test_async_step_bluetooth_not_enough_info_at_start(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with only a partial adv at the start."""
     with patch(
         "homeassistant.components.qingping.config_flow.async_process_advertisements",
@@ -62,7 +64,7 @@ async def test_async_step_bluetooth_not_enough_info_at_start(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_qingping(hass):
+async def test_async_step_bluetooth_not_qingping(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not qingping."""
     with patch(
         "homeassistant.components.qingping.config_flow.async_process_advertisements",
@@ -77,7 +79,7 @@ async def test_async_step_bluetooth_not_qingping(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -87,7 +89,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.qingping.config_flow.async_discovered_service_info",
@@ -112,7 +114,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.qingping.config_flow.async_discovered_service_info",
@@ -142,7 +144,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -162,7 +166,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -179,7 +183,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -198,7 +202,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/qingping/test_sensor.py
+++ b/tests/components/qingping/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the Qingping sensors."""
-
-
 from homeassistant.components.qingping.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import LIGHT_AND_SIGNAL_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     UnitOfLength,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -69,7 +70,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -188,7 +189,7 @@ async def test_setup(hass):
             assert len(all_states) == 0
 
 
-async def test_setup_with_custom_location(hass):
+async def test_setup_with_custom_location(hass: HomeAssistant) -> None:
     """Test the setup with a custom location."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -8,9 +8,14 @@ from yarl import URL
 
 from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.test_util.aiohttp import AiohttpClientMockResponse, MockLongPollSideEffect
+from tests.test_util.aiohttp import (
+    AiohttpClientMocker,
+    AiohttpClientMockResponse,
+    MockLongPollSideEffect,
+)
 
 
 @pytest.fixture
@@ -278,7 +283,9 @@ async def test_button(hass, aioclient_mock, qs_devices):
     listen_mock.stop()
 
 
-async def test_failed_update_devices(hass, aioclient_mock):
+async def test_failed_update_devices(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that code behaves correctly when unable to get the devices."""
 
     config = {"qwikswitch": {}}

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.rachio.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -22,7 +23,7 @@ def _mock_rachio_return_value(get=None, info=None):
     return rachio_mock
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -62,7 +63,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -84,7 +85,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -106,7 +107,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_homekit(hass):
+async def test_form_homekit(hass: HomeAssistant) -> None:
     """Test that we abort from homekit if rachio is already setup."""
 
     result = await hass.config_entries.flow.async_init(
@@ -151,7 +152,7 @@ async def test_form_homekit(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_homekit_ignored(hass):
+async def test_form_homekit_ignored(hass: HomeAssistant) -> None:
     """Test that we abort from homekit if rachio is ignored."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/radiotherm/test_config_flow.py
+++ b/tests/components/radiotherm/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
 from homeassistant.components.radiotherm.const import DOMAIN
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -23,7 +24,7 @@ def _mock_radiotherm():
     return tstat
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -55,7 +56,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -76,7 +77,7 @@ async def test_form_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -97,7 +98,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {CONF_HOST: "cannot_connect"}
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test we get can import from yaml."""
     with patch(
         "homeassistant.components.radiotherm.data.radiotherm.get_thermostat",
@@ -118,7 +119,7 @@ async def test_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_import_cannot_connect(hass):
+async def test_import_cannot_connect(hass: HomeAssistant) -> None:
     """Test we abort if we cannot connect on import from yaml."""
     with patch(
         "homeassistant.components.radiotherm.data.radiotherm.get_thermostat",
@@ -134,7 +135,7 @@ async def test_import_cannot_connect(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_dhcp_can_confirm(hass):
+async def test_dhcp_can_confirm(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow can confirm right away."""
 
     with patch(
@@ -178,7 +179,7 @@ async def test_dhcp_can_confirm(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_dhcp_fails_to_connect(hass):
+async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow that fails to connect."""
 
     with patch(
@@ -200,7 +201,7 @@ async def test_dhcp_fails_to_connect(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_dhcp_already_exists(hass):
+async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow that fails to connect."""
 
     entry = MockConfigEntry(
@@ -229,7 +230,7 @@ async def test_dhcp_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_user_unique_id_already_exists(hass):
+async def test_user_unique_id_already_exists(hass: HomeAssistant) -> None:
     """Test creating an entry where the unique_id already exists."""
 
     entry = MockConfigEntry(

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.rainmachine import (
     DOMAIN,
 )
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
@@ -113,7 +114,7 @@ async def test_options_flow(hass, config, config_entry):
         }
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/random/test_binary_sensor.py
+++ b/tests/components/random/test_binary_sensor.py
@@ -1,10 +1,11 @@
 """The test for the Random binary sensor platform."""
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_random_binary_sensor_on(hass):
+async def test_random_binary_sensor_on(hass: HomeAssistant) -> None:
     """Test the Random binary sensor."""
     config = {"binary_sensor": {"platform": "random", "name": "test"}}
 
@@ -24,7 +25,7 @@ async def test_random_binary_sensor_on(hass):
     assert state.state == "on"
 
 
-async def test_random_binary_sensor_off(hass):
+async def test_random_binary_sensor_off(hass: HomeAssistant) -> None:
     """Test the Random binary sensor."""
     config = {"binary_sensor": {"platform": "random", "name": "test"}}
 

--- a/tests/components/random/test_sensor.py
+++ b/tests/components/random/test_sensor.py
@@ -1,8 +1,9 @@
 """The test for the random number sensor platform."""
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_random_sensor(hass):
+async def test_random_sensor(hass: HomeAssistant) -> None:
     """Test the Random number sensor."""
     config = {
         "sensor": {

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -780,7 +780,7 @@ def test_recorder_setup_failure_without_event_listener(hass: HomeAssistant) -> N
     hass.stop()
 
 
-async def test_defaults_set(hass):
+async def test_defaults_set(hass: HomeAssistant) -> None:
     """Test the config defaults are set."""
     recorder_config = None
 
@@ -1637,7 +1637,9 @@ async def test_database_lock_without_instance(recorder_mock, hass):
             assert instance.unlock_database()
 
 
-async def test_in_memory_database(hass, caplog):
+async def test_in_memory_database(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test connecting to an in-memory recorder is not allowed."""
     assert not await async_setup_component(
         hass, recorder.DOMAIN, {recorder.DOMAIN: {recorder.CONF_DB_URL: "sqlite://"}}

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -46,7 +46,7 @@ def _get_native_states(hass, entity_id):
         ]
 
 
-async def test_schema_update_calls(hass):
+async def test_schema_update_calls(hass: HomeAssistant) -> None:
     """Test that schema migrations occur in correct order."""
     assert recorder.util.async_migration_in_progress(hass) is False
 
@@ -75,7 +75,7 @@ async def test_schema_update_calls(hass):
     )
 
 
-async def test_migration_in_progress(hass):
+async def test_migration_in_progress(hass: HomeAssistant) -> None:
     """Test that we can check for migration in progress."""
     assert recorder.util.async_migration_in_progress(hass) is False
 
@@ -95,7 +95,7 @@ async def test_migration_in_progress(hass):
     assert recorder.get_instance(hass).schema_version == SCHEMA_VERSION
 
 
-async def test_database_migration_failed(hass):
+async def test_database_migration_failed(hass: HomeAssistant) -> None:
     """Test we notify if the migration fails."""
     assert recorder.util.async_migration_in_progress(hass) is False
 
@@ -126,7 +126,7 @@ async def test_database_migration_failed(hass):
     assert len(mock_dismiss.mock_calls) == 1
 
 
-async def test_database_migration_encounters_corruption(hass):
+async def test_database_migration_encounters_corruption(hass: HomeAssistant) -> None:
     """Test we move away the database if its corrupt."""
 
     assert recorder.util.async_migration_in_progress(hass) is False
@@ -157,7 +157,9 @@ async def test_database_migration_encounters_corruption(hass):
     assert move_away.called
 
 
-async def test_database_migration_encounters_corruption_not_sqlite(hass):
+async def test_database_migration_encounters_corruption_not_sqlite(
+    hass: HomeAssistant,
+) -> None:
     """Test we fail on database error when we cannot recover."""
     assert recorder.util.async_migration_in_progress(hass) is False
 
@@ -191,7 +193,7 @@ async def test_database_migration_encounters_corruption_not_sqlite(hass):
     assert len(mock_dismiss.mock_calls) == 1
 
 
-async def test_events_during_migration_are_queued(hass):
+async def test_events_during_migration_are_queued(hass: HomeAssistant) -> None:
     """Test that events during migration are queued."""
 
     assert recorder.util.async_migration_in_progress(hass) is False
@@ -225,7 +227,7 @@ async def test_events_during_migration_are_queued(hass):
     assert len(db_states) == 2
 
 
-async def test_events_during_migration_queue_exhausted(hass):
+async def test_events_during_migration_queue_exhausted(hass: HomeAssistant) -> None:
     """Test that events during migration takes so long the queue is exhausted."""
 
     assert recorder.util.async_migration_in_progress(hass) is False

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -926,7 +926,7 @@ def test_execute_stmt_lambda_element(hass_recorder):
 
 
 @freeze_time(datetime(2022, 10, 21, 7, 25, tzinfo=timezone.utc))
-async def test_resolve_period(hass):
+async def test_resolve_period(hass: HomeAssistant) -> None:
     """Test statistic_during_period."""
 
     now = dt_util.utcnow()

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -19,6 +19,7 @@ from homeassistant.components.recorder.statistics import (
 )
 from homeassistant.components.recorder.websocket_api import UNIT_SCHEMA
 from homeassistant.components.sensor import UNIT_CONVERTERS
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import recorder as recorder_helper
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -33,6 +34,7 @@ from .common import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 DISTANCE_SENSOR_FT_ATTRIBUTES = {
     "device_class": "distance",
@@ -2051,7 +2053,9 @@ async def test_recorder_info(recorder_mock, hass, hass_ws_client):
     }
 
 
-async def test_recorder_info_no_recorder(hass, hass_ws_client):
+async def test_recorder_info_no_recorder(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting recorder status when recorder is not present."""
     client = await hass_ws_client()
 
@@ -2061,7 +2065,9 @@ async def test_recorder_info_no_recorder(hass, hass_ws_client):
     assert response["error"]["code"] == "unknown_command"
 
 
-async def test_recorder_info_bad_recorder_config(hass, hass_ws_client):
+async def test_recorder_info_bad_recorder_config(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting recorder status when recorder is not started."""
     config = {recorder.CONF_DB_URL: "sqlite://no_file", recorder.CONF_DB_RETRY_WAIT: 0}
 
@@ -2085,7 +2091,9 @@ async def test_recorder_info_bad_recorder_config(hass, hass_ws_client):
     assert response["result"]["thread_running"] is False
 
 
-async def test_recorder_info_migration_queue_exhausted(hass, hass_ws_client):
+async def test_recorder_info_migration_queue_exhausted(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting recorder status when recorder queue is exhausted."""
     assert recorder.util.async_migration_in_progress(hass) is False
 

--- a/tests/components/reddit/test_sensor.py
+++ b/tests/components/reddit/test_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 VALID_CONFIG = {
@@ -149,7 +150,7 @@ class MockSubreddit:
 
 
 @patch("praw.Reddit", new=MockPraw)
-async def test_setup_with_valid_config(hass):
+async def test_setup_with_valid_config(hass: HomeAssistant) -> None:
     """Test the platform setup with Reddit configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG)
     await hass.async_block_till_done()
@@ -176,7 +177,7 @@ async def test_setup_with_valid_config(hass):
 
 
 @patch("praw.Reddit", new=MockPraw)
-async def test_setup_with_invalid_config(hass):
+async def test_setup_with_invalid_config(hass: HomeAssistant) -> None:
     """Test the platform setup with invalid Reddit configuration."""
     assert await async_setup_component(hass, "sensor", INVALID_SORT_BY_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Remote component, adapted from Light Test."""
-
 import homeassistant.components.remote as remote
 from homeassistant.components.remote import (
     ATTR_ALTERNATIVE,
@@ -19,6 +18,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_service
 
@@ -29,7 +29,7 @@ SERVICE_DELETE_COMMAND = "delete_command"
 ENTITY_ID = "entity_id_val"
 
 
-async def test_is_on(hass):
+async def test_is_on(hass: HomeAssistant) -> None:
     """Test is_on."""
     hass.states.async_set("remote.test", STATE_ON)
     assert remote.is_on(hass, "remote.test")
@@ -38,7 +38,7 @@ async def test_is_on(hass):
     assert not remote.is_on(hass, "remote.test")
 
 
-async def test_turn_on(hass):
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test turn_on."""
     turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
     await hass.services.async_call(DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID})
@@ -51,7 +51,7 @@ async def test_turn_on(hass):
     assert call.domain == DOMAIN
 
 
-async def test_turn_off(hass):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test turn_off."""
     turn_off_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_OFF)
 
@@ -69,7 +69,7 @@ async def test_turn_off(hass):
     assert call.data[ATTR_ENTITY_ID] == ENTITY_ID
 
 
-async def test_send_command(hass):
+async def test_send_command(hass: HomeAssistant) -> None:
     """Test send_command."""
     send_command_calls = async_mock_service(hass, DOMAIN, SERVICE_SEND_COMMAND)
 
@@ -93,7 +93,7 @@ async def test_send_command(hass):
     assert call.data[ATTR_ENTITY_ID] == ENTITY_ID
 
 
-async def test_learn_command(hass):
+async def test_learn_command(hass: HomeAssistant) -> None:
     """Test learn_command."""
     learn_command_calls = async_mock_service(hass, DOMAIN, SERVICE_LEARN_COMMAND)
 
@@ -117,7 +117,7 @@ async def test_learn_command(hass):
     assert call.data[ATTR_ENTITY_ID] == ENTITY_ID
 
 
-async def test_delete_command(hass):
+async def test_delete_command(hass: HomeAssistant) -> None:
     """Test delete_command."""
     delete_command_calls = async_mock_service(
         hass, remote.DOMAIN, SERVICE_DELETE_COMMAND

--- a/tests/components/remote/test_reproduce_state.py
+++ b/tests/components/remote/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Remote."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Remote states."""
     hass.states.async_set("remote.entity_off", "off", {})
     hass.states.async_set("remote.entity_on", "on", {})

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components import dhcp
 from homeassistant.components.reolink import const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 
 from tests.common import MockConfigEntry
@@ -58,7 +59,7 @@ def reolink_connect_fixture(mock_get_source_ip):
         yield
 
 
-async def test_config_flow_manual_success(hass):
+async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -91,7 +92,7 @@ async def test_config_flow_manual_success(hass):
     }
 
 
-async def test_config_flow_errors(hass):
+async def test_config_flow_errors(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user after some errors."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -201,7 +202,7 @@ async def test_config_flow_errors(hass):
     }
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -239,7 +240,7 @@ async def test_options_flow(hass):
     }
 
 
-async def test_change_connection_settings(hass):
+async def test_change_connection_settings(hass: HomeAssistant) -> None:
     """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -282,7 +283,7 @@ async def test_change_connection_settings(hass):
     assert config_entry.data[CONF_PASSWORD] == TEST_PASSWORD2
 
 
-async def test_reauth(hass):
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test a reauth flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -342,7 +343,7 @@ async def test_reauth(hass):
     assert config_entry.data[CONF_PASSWORD] == TEST_PASSWORD2
 
 
-async def test_dhcp_flow(hass):
+async def test_dhcp_flow(hass: HomeAssistant) -> None:
     """Successful flow from DHCP discovery."""
     dhcp_data = dhcp.DhcpServiceInfo(
         ip=TEST_HOST,
@@ -380,7 +381,7 @@ async def test_dhcp_flow(hass):
     }
 
 
-async def test_dhcp_abort_flow(hass):
+async def test_dhcp_abort_flow(hass: HomeAssistant) -> None:
     """Test dhcp discovery aborts if already configured."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -7,6 +7,7 @@ import serial.tools.list_ports
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.rfxtrx import DOMAIN, config_flow
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
@@ -288,7 +289,7 @@ async def test_setup_serial_manual_fail(com_mock, hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_options_global(hass):
+async def test_options_global(hass: HomeAssistant) -> None:
     """Test if we can set global options."""
 
     entry = MockConfigEntry(
@@ -323,7 +324,7 @@ async def test_options_global(hass):
     assert not set(entry.data["protocols"]) ^ set(SOME_PROTOCOLS)
 
 
-async def test_no_protocols(hass):
+async def test_no_protocols(hass: HomeAssistant) -> None:
     """Test we set protocols to None if none are selected."""
 
     entry = MockConfigEntry(
@@ -358,7 +359,7 @@ async def test_no_protocols(hass):
     assert entry.data["protocols"] is None
 
 
-async def test_options_add_device(hass):
+async def test_options_add_device(hass: HomeAssistant) -> None:
     """Test we can add a device."""
 
     entry = MockConfigEntry(
@@ -419,7 +420,7 @@ async def test_options_add_device(hass):
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
 
-async def test_options_add_duplicate_device(hass):
+async def test_options_add_duplicate_device(hass: HomeAssistant) -> None:
     """Test we can add a device."""
 
     entry = MockConfigEntry(
@@ -455,7 +456,7 @@ async def test_options_add_duplicate_device(hass):
     assert result["errors"]["event_code"] == "already_configured_device"
 
 
-async def test_options_replace_sensor_device(hass):
+async def test_options_replace_sensor_device(hass: HomeAssistant) -> None:
     """Test we can replace a sensor device."""
 
     entry = MockConfigEntry(
@@ -612,7 +613,7 @@ async def test_options_replace_sensor_device(hass):
     assert not state
 
 
-async def test_options_replace_control_device(hass):
+async def test_options_replace_control_device(hass: HomeAssistant) -> None:
     """Test we can replace a control device."""
 
     entry = MockConfigEntry(
@@ -715,7 +716,7 @@ async def test_options_replace_control_device(hass):
     assert not state
 
 
-async def test_options_add_and_configure_device(hass):
+async def test_options_add_and_configure_device(hass: HomeAssistant) -> None:
     """Test we can add a device."""
 
     entry = MockConfigEntry(
@@ -824,7 +825,7 @@ async def test_options_add_and_configure_device(hass):
     assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]
 
 
-async def test_options_configure_rfy_cover_device(hass):
+async def test_options_configure_rfy_cover_device(hass: HomeAssistant) -> None:
     """Test we can configure the venetion blind mode of an Rfy cover."""
 
     entry = MockConfigEntry(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -7,13 +7,14 @@ import RFXtrx as rfxtrxmod
 
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from .conftest import create_rfx_test_cfg, setup_rfx_test_cfg
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 SOME_PROTOCOLS = ["ac", "arc"]
 
@@ -90,7 +91,9 @@ async def test_send(hass, rfxtrx):
     ]
 
 
-async def test_ws_device_remove(hass, hass_ws_client):
+async def test_ws_device_remove(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test removing a device through device registry."""
     assert await async_setup_component(hass, "config", {})
 
@@ -127,7 +130,7 @@ async def test_ws_device_remove(hass, hass_ws_client):
     assert mock_entry.data["devices"] == {}
 
 
-async def test_connect(hass):
+async def test_connect(hass: HomeAssistant) -> None:
     """Test that we attempt to connect to the device."""
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake")
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -141,7 +144,7 @@ async def test_connect(hass):
     connect.assert_called_once_with("/dev/ttyUSBfake", ANY, modes=ANY)
 
 
-async def test_connect_with_protocols(hass):
+async def test_connect_with_protocols(hass: HomeAssistant) -> None:
     """Test that we attempt to set protocols."""
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -4,9 +4,10 @@ from unittest.mock import Mock, patch
 from homeassistant import config_entries
 from homeassistant.components.ring import DOMAIN
 from homeassistant.components.ring.config_flow import InvalidAuth
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +43,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.risco.config_flow import (
 )
 from homeassistant.components.risco.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
@@ -50,7 +51,7 @@ TEST_OPTIONS = {
 }
 
 
-async def test_cloud_form(hass):
+async def test_cloud_form(hass: HomeAssistant) -> None:
     """Test we get the cloud form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -117,7 +118,7 @@ async def test_cloud_error(hass, login_with_error, error):
     assert result3["errors"] == {"base": error}
 
 
-async def test_form_cloud_already_exists(hass):
+async def test_form_cloud_already_exists(hass: HomeAssistant) -> None:
     """Test that a flow with an existing username aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -212,7 +213,7 @@ async def test_form_reauth_with_new_username(hass, cloud_config_entry):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_local_form(hass):
+async def test_local_form(hass: HomeAssistant) -> None:
     """Test we get the local form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -276,7 +277,7 @@ async def test_local_error(hass, connect_with_error, error):
     assert result3["errors"] == {"base": error}
 
 
-async def test_form_local_already_exists(hass):
+async def test_form_local_already_exists(hass: HomeAssistant) -> None:
     """Test that a flow with an existing host aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -311,7 +312,7 @@ async def test_form_local_already_exists(hass):
     assert result3["reason"] == "already_configured"
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -355,7 +356,7 @@ async def test_options_flow(hass):
     }
 
 
-async def test_ha_to_risco_schema(hass):
+async def test_ha_to_risco_schema(hass: HomeAssistant) -> None:
     """Test that the schema for the ha-to-risco mapping step is generated properly."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/rituals_perfume_genie/test_config_flow.py
+++ b/tests/components/rituals_perfume_genie/test_config_flow.py
@@ -8,6 +8,7 @@ from pyrituals import AuthenticationException
 from homeassistant import config_entries
 from homeassistant.components.rituals_perfume_genie.const import ACCOUNT_HASH, DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 
 TEST_EMAIL = "rituals@example.com"
 VALID_PASSWORD = "passw0rd"
@@ -22,7 +23,7 @@ def _mock_account(*_):
     return account
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -52,7 +53,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -74,7 +75,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_auth_exception(hass):
+async def test_form_auth_exception(hass: HomeAssistant) -> None:
     """Test we handle auth exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -96,7 +97,7 @@ async def test_form_auth_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -2,6 +2,7 @@
 import datetime
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 VALID_CONFIG_MINIMAL = {
@@ -156,7 +157,7 @@ def get_no_departures_mock():
     }
 
 
-async def test_rmvtransport_min_config(hass):
+async def test_rmvtransport_min_config(hass: HomeAssistant) -> None:
     """Test minimal rmvtransport configuration."""
     with patch(
         "RMVtransport.RMVtransport.get_departures",
@@ -177,7 +178,7 @@ async def test_rmvtransport_min_config(hass):
     assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
 
 
-async def test_rmvtransport_name_config(hass):
+async def test_rmvtransport_name_config(hass: HomeAssistant) -> None:
     """Test custom name configuration."""
     with patch(
         "RMVtransport.RMVtransport.get_departures",
@@ -190,7 +191,7 @@ async def test_rmvtransport_name_config(hass):
     assert state.attributes["friendly_name"] == "My Station"
 
 
-async def test_rmvtransport_misc_config(hass):
+async def test_rmvtransport_misc_config(hass: HomeAssistant) -> None:
     """Test misc configuration."""
     with patch(
         "RMVtransport.RMVtransport.get_departures",
@@ -204,7 +205,7 @@ async def test_rmvtransport_misc_config(hass):
     assert state.attributes["line"] == 21
 
 
-async def test_rmvtransport_dest_config(hass):
+async def test_rmvtransport_dest_config(hass: HomeAssistant) -> None:
     """Test destination configuration."""
     with patch(
         "RMVtransport.RMVtransport.get_departures",
@@ -223,7 +224,7 @@ async def test_rmvtransport_dest_config(hass):
     assert state.attributes["departure_time"] == datetime.datetime(2018, 8, 6, 14, 25)
 
 
-async def test_rmvtransport_no_departures(hass):
+async def test_rmvtransport_no_departures(hass: HomeAssistant) -> None:
     """Test for no departures."""
     with patch(
         "RMVtransport.RMVtransport.get_departures",

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components import dhcp
 from homeassistant.components.roomba import config_flow
 from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -112,7 +113,7 @@ def _mocked_connection_refused_on_getpassword(*_):
     return roomba_password
 
 
-async def test_form_user_discovery_and_password_fetch(hass):
+async def test_form_user_discovery_and_password_fetch(hass: HomeAssistant) -> None:
     """Test we can discovery and fetch the password."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -170,7 +171,7 @@ async def test_form_user_discovery_and_password_fetch(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_discovery_skips_known(hass):
+async def test_form_user_discovery_skips_known(hass: HomeAssistant) -> None:
     """Test discovery proceeds to manual if all discovered are already known."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
@@ -189,7 +190,9 @@ async def test_form_user_discovery_skips_known(hass):
     assert result["step_id"] == "manual"
 
 
-async def test_form_user_no_devices_found_discovery_aborts_already_configured(hass):
+async def test_form_user_no_devices_found_discovery_aborts_already_configured(
+    hass: HomeAssistant,
+) -> None:
     """Test if we manually configure an existing host we abort."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
@@ -217,7 +220,9 @@ async def test_form_user_no_devices_found_discovery_aborts_already_configured(ha
     assert result2["reason"] == "already_configured"
 
 
-async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
+async def test_form_user_discovery_manual_and_auto_password_fetch(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery skipped and we can auto fetch the password."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -287,7 +292,9 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_discover_fails_aborts_already_configured(hass):
+async def test_form_user_discover_fails_aborts_already_configured(
+    hass: HomeAssistant,
+) -> None:
     """Test if we manually configure an existing host we abort after failed discovery."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
@@ -355,7 +362,9 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
     assert result3["reason"] == "cannot_connect"
 
 
-async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass):
+async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery finds no devices and we can auto fetch the password."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -416,7 +425,9 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(hass):
+async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery finds no devices and password fetch fails."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -547,7 +558,9 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_user_discovery_and_password_fetch_gets_connection_refused(hass):
+async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
+    hass: HomeAssistant,
+) -> None:
     """Test we can discovery and fetch the password manually."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -801,7 +814,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_dhcp_discovery_with_ignored(hass):
+async def test_dhcp_discovery_with_ignored(hass: HomeAssistant) -> None:
     """Test ignored entries do not break checking for existing entries."""
 
     config_entry = MockConfigEntry(
@@ -826,7 +839,7 @@ async def test_dhcp_discovery_with_ignored(hass):
     assert result["type"] == "form"
 
 
-async def test_dhcp_discovery_already_configured_host(hass):
+async def test_dhcp_discovery_already_configured_host(hass: HomeAssistant) -> None:
     """Test we abort if the host is already configured."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: MOCK_IP})
@@ -850,7 +863,7 @@ async def test_dhcp_discovery_already_configured_host(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_dhcp_discovery_already_configured_blid(hass):
+async def test_dhcp_discovery_already_configured_blid(hass: HomeAssistant) -> None:
     """Test we abort if the blid is already configured."""
 
     config_entry = MockConfigEntry(
@@ -876,7 +889,7 @@ async def test_dhcp_discovery_already_configured_blid(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_dhcp_discovery_not_irobot(hass):
+async def test_dhcp_discovery_not_irobot(hass: HomeAssistant) -> None:
     """Test we abort if the discovered device is not an irobot device."""
 
     config_entry = MockConfigEntry(
@@ -902,7 +915,7 @@ async def test_dhcp_discovery_not_irobot(hass):
     assert result["reason"] == "not_irobot_device"
 
 
-async def test_dhcp_discovery_partial_hostname(hass):
+async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
     """Test we abort flows when we have a partial hostname."""
 
     with patch(

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.roon.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -68,7 +69,7 @@ class RoonDiscoveryFailedMock(RoonDiscoveryMock):
         return []
 
 
-async def test_successful_discovery_and_auth(hass):
+async def test_successful_discovery_and_auth(hass: HomeAssistant) -> None:
     """Test when discovery and auth both work ok."""
 
     with patch(
@@ -106,7 +107,7 @@ async def test_successful_discovery_and_auth(hass):
     }
 
 
-async def test_unsuccessful_discovery_user_form_and_auth(hass):
+async def test_unsuccessful_discovery_user_form_and_auth(hass: HomeAssistant) -> None:
     """Test unsuccessful discover, user adding the host via the form and then successful auth."""
 
     with patch(
@@ -147,7 +148,7 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
     }
 
 
-async def test_duplicate_config(hass):
+async def test_duplicate_config(hass: HomeAssistant) -> None:
     """Test user adding the host via the form for host that is already configured."""
 
     CONFIG = {"host": "1.1.1.1"}
@@ -185,7 +186,7 @@ async def test_duplicate_config(hass):
         assert result2["reason"] == "already_configured"
 
 
-async def test_successful_discovery_no_auth(hass):
+async def test_successful_discovery_no_auth(hass: HomeAssistant) -> None:
     """Test successful discover, but failed auth."""
 
     with patch(
@@ -222,7 +223,7 @@ async def test_successful_discovery_no_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_unexpected_exception(hass):
+async def test_unexpected_exception(hass: HomeAssistant) -> None:
     """Test successful discover, and unexpected exception during auth."""
 
     with patch(

--- a/tests/components/rpi_power/test_binary_sensor.py
+++ b/tests/components/rpi_power/test_binary_sensor.py
@@ -3,12 +3,15 @@ from datetime import timedelta
 import logging
 from unittest.mock import MagicMock
 
+import pytest
+
 from homeassistant.components.rpi_power.binary_sensor import (
     DESCRIPTION_NORMALIZED,
     DESCRIPTION_UNDER_VOLTAGE,
 )
 from homeassistant.components.rpi_power.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -30,7 +33,7 @@ async def _async_setup_component(hass, detected):
     return mocked_under_voltage
 
 
-async def test_new(hass, caplog):
+async def test_new(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test new entry."""
     await _async_setup_component(hass, False)
     state = hass.states.get(ENTITY_ID)
@@ -38,7 +41,9 @@ async def test_new(hass, caplog):
     assert not any(x.levelno == logging.WARNING for x in caplog.records)
 
 
-async def test_new_detected(hass, caplog):
+async def test_new_detected(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test new entry with under voltage detected."""
     mocked_under_voltage = await _async_setup_component(hass, True)
     state = hass.states.get(ENTITY_ID)

--- a/tests/components/rtsp_to_webrtc/test_config_flow.py
+++ b/tests/components/rtsp_to_webrtc/test_config_flow.py
@@ -111,7 +111,7 @@ async def test_server_failure(hass: HomeAssistant) -> None:
         assert result.get("errors") == {"base": "server_failure"}
 
 
-async def test_hassio_discovery(hass):
+async def test_hassio_discovery(hass: HomeAssistant) -> None:
     """Test supervisor add-on discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/ruckus_unleashed/test_config_flow.py
+++ b/tests/components/ruckus_unleashed/test_config_flow.py
@@ -6,6 +6,7 @@ from pyruckus.exceptions import AuthenticationError
 
 from homeassistant import config_entries
 from homeassistant.components.ruckus_unleashed.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.util import utcnow
 
 from . import CONFIG, DEFAULT_SYSTEM_INFO, DEFAULT_TITLE
@@ -13,7 +14,7 @@ from . import CONFIG, DEFAULT_SYSTEM_INFO, DEFAULT_TITLE
 from tests.common import async_fire_time_changed
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -46,7 +47,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -65,7 +66,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -84,7 +85,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -103,7 +104,7 @@ async def test_form_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect_unknown_serial(hass):
+async def test_form_cannot_connect_unknown_serial(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error on invalid serial number."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -130,7 +131,7 @@ async def test_form_cannot_connect_unknown_serial(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_duplicate_error(hass):
+async def test_form_duplicate_error(hass: HomeAssistant) -> None:
     """Test we handle duplicate error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.components.ruckus_unleashed import API_MAC, DOMAIN
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import utcnow
@@ -22,7 +23,7 @@ from . import (
 from tests.common import async_fire_time_changed
 
 
-async def test_client_connected(hass):
+async def test_client_connected(hass: HomeAssistant) -> None:
     """Test client connected."""
     await init_integration(hass)
 
@@ -41,7 +42,7 @@ async def test_client_connected(hass):
     assert test_client.state == STATE_HOME
 
 
-async def test_client_disconnected(hass):
+async def test_client_disconnected(hass: HomeAssistant) -> None:
     """Test client disconnected."""
     await init_integration(hass)
 
@@ -58,7 +59,7 @@ async def test_client_disconnected(hass):
         assert test_client.state == STATE_NOT_HOME
 
 
-async def test_clients_update_failed(hass):
+async def test_clients_update_failed(hass: HomeAssistant) -> None:
     """Test failed update."""
     await init_integration(hass)
 
@@ -75,7 +76,7 @@ async def test_clients_update_failed(hass):
         assert test_client.state == STATE_UNAVAILABLE
 
 
-async def test_restoring_clients(hass):
+async def test_restoring_clients(hass: HomeAssistant) -> None:
     """Test restoring existing device_tracker entities if not detected on startup."""
     entry = mock_config_entry()
     entry.add_to_hass(hass)

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.ruckus_unleashed import (
     MANUFACTURER,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
@@ -27,7 +28,7 @@ from . import (
 )
 
 
-async def test_setup_entry_login_error(hass):
+async def test_setup_entry_login_error(hass: HomeAssistant) -> None:
     """Test entry setup failed due to login error."""
     entry = mock_config_entry()
     with patch(
@@ -41,7 +42,7 @@ async def test_setup_entry_login_error(hass):
     assert result is False
 
 
-async def test_setup_entry_connection_error(hass):
+async def test_setup_entry_connection_error(hass: HomeAssistant) -> None:
     """Test entry setup failed due to connection error."""
     entry = mock_config_entry()
     with patch(
@@ -55,7 +56,7 @@ async def test_setup_entry_connection_error(hass):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_router_device_setup(hass):
+async def test_router_device_setup(hass: HomeAssistant) -> None:
     """Test a router device is created."""
     await init_integration(hass)
 
@@ -75,7 +76,7 @@ async def test_router_device_setup(hass):
     assert device.via_device_id is None
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 
@@ -89,7 +90,7 @@ async def test_unload_entry(hass):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_config_not_ready_during_setup(hass):
+async def test_config_not_ready_during_setup(hass: HomeAssistant) -> None:
     """Test we throw a ConfigNotReady if Coordinator update fails."""
     entry = mock_config_entry()
     with patch(

--- a/tests/components/ruuvitag_ble/test_config_flow.py
+++ b/tests/components/ruuvitag_ble/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Ruuvitag config flow."""
-
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.ruuvitag_ble.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .fixtures import CONFIGURED_NAME, NOT_RUUVITAG_SERVICE_INFO, RUUVITAG_SERVICE_INFO
@@ -18,7 +18,7 @@ def mock_bluetooth(enable_bluetooth):
     """Mock bluetooth for all tests in this module."""
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -38,7 +38,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == RUUVITAG_SERVICE_INFO.address
 
 
-async def test_async_step_bluetooth_not_ruuvitag(hass):
+async def test_async_step_bluetooth_not_ruuvitag(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not ruuvitag."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -49,7 +49,7 @@ async def test_async_step_bluetooth_not_ruuvitag(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -59,7 +59,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
@@ -83,7 +83,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == RUUVITAG_SERVICE_INFO.address
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
@@ -113,7 +113,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -133,7 +135,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -150,7 +152,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -169,7 +171,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -32,7 +32,7 @@ VALID_CONFIG_OLD = {
 }
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -63,7 +63,7 @@ async def test_create_entry(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_auth_error(hass):
+async def test_auth_error(hass: HomeAssistant) -> None:
     """Test that the user step fails."""
     with patch(
         "homeassistant.components.sabnzbd.sab.SabnzbdApi.check_available",

--- a/tests/components/safe_mode/test_init.py
+++ b/tests/components/safe_mode/test_init.py
@@ -1,8 +1,9 @@
 """Tests for safe mode integration."""
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_works(hass):
+async def test_works(hass: HomeAssistant) -> None:
     """Test safe mode works."""
     assert await async_setup_component(hass, "safe_mode", {})
     await hass.async_block_till_done()

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.yaml import loader as yaml_loader
@@ -216,7 +216,7 @@ async def activate(hass, entity_id=ENTITY_MATCH_ALL):
     await hass.services.async_call(scene.DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
-async def test_services_registered(hass):
+async def test_services_registered(hass: HomeAssistant) -> None:
     """Test we register services with empty config."""
     assert await async_setup_component(hass, "scene", {})
     assert hass.services.has_service("scene", "reload")

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -22,11 +22,12 @@ from homeassistant.components.screenlogic.const import (
     MIN_SCAN_INTERVAL,
 )
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_flow_discovery(hass):
+async def test_flow_discovery(hass: HomeAssistant) -> None:
     """Test the flow works with basic discovery."""
 
     with patch(
@@ -67,7 +68,7 @@ async def test_flow_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_discover_none(hass):
+async def test_flow_discover_none(hass: HomeAssistant) -> None:
     """Test when nothing is discovered."""
 
     with patch(
@@ -83,7 +84,7 @@ async def test_flow_discover_none(hass):
     assert result["step_id"] == "gateway_entry"
 
 
-async def test_flow_discover_error(hass):
+async def test_flow_discover_error(hass: HomeAssistant) -> None:
     """Test when discovery errors."""
 
     with patch(
@@ -123,7 +124,7 @@ async def test_flow_discover_error(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_dhcp(hass):
+async def test_dhcp(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -164,7 +165,7 @@ async def test_dhcp(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_manual_entry(hass):
+async def test_form_manual_entry(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     with patch(
@@ -219,7 +220,7 @@ async def test_form_manual_entry(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
         "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
@@ -245,7 +246,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {CONF_IP_ADDRESS: "cannot_connect"}
 
 
-async def test_option_flow(hass):
+async def test_option_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
@@ -270,7 +271,7 @@ async def test_option_flow(hass):
     assert result["data"] == {CONF_SCAN_INTERVAL: 15}
 
 
-async def test_option_flow_defaults(hass):
+async def test_option_flow_defaults(hass: HomeAssistant) -> None:
     """Test config flow options."""
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
@@ -296,7 +297,7 @@ async def test_option_flow_defaults(hass):
     }
 
 
-async def test_option_flow_input_floor(hass):
+async def test_option_flow_input_floor(hass: HomeAssistant) -> None:
     """Test config flow options."""
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Script component."""
-
 import asyncio
 from datetime import timedelta
 from unittest.mock import Mock, patch
@@ -43,6 +42,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed, async_mock_service, mock_restore_cache
 from tests.components.logbook.common import MockRow, mock_humanify
+from tests.typing import WebSocketGenerator
 
 ENTITY_ID = "script.test"
 
@@ -53,7 +53,7 @@ def calls(hass):
     return async_mock_service(hass, "test", "script")
 
 
-async def test_passing_variables(hass):
+async def test_passing_variables(hass: HomeAssistant) -> None:
     """Test different ways of passing in variables."""
     mock_restore_cache(hass, ())
     calls = []
@@ -410,7 +410,7 @@ async def test_reload_unchanged_script(hass, calls, script_config):
         assert len(calls) == 2
 
 
-async def test_service_descriptions(hass):
+async def test_service_descriptions(hass: HomeAssistant) -> None:
     """Test that service descriptions are loaded and reloaded correctly."""
     # Test 1: has "description" but no "fields"
     assert await async_setup_component(
@@ -485,7 +485,7 @@ async def test_service_descriptions(hass):
     assert descriptions[DOMAIN]["turn_on"]["name"] == "Turn on"
 
 
-async def test_shared_context(hass):
+async def test_shared_context(hass: HomeAssistant) -> None:
     """Test that the shared context is passed down the chain."""
     event = "test_event"
     context = Context()
@@ -524,7 +524,9 @@ async def test_shared_context(hass):
     assert state.context == context
 
 
-async def test_logging_script_error(hass, caplog):
+async def test_logging_script_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test logging script error."""
     assert await async_setup_component(
         hass,
@@ -539,7 +541,7 @@ async def test_logging_script_error(hass, caplog):
     assert "Error executing script" in caplog.text
 
 
-async def test_turning_no_scripts_off(hass):
+async def test_turning_no_scripts_off(hass: HomeAssistant) -> None:
     """Test it is possible to turn two scripts off."""
     assert await async_setup_component(hass, "script", {})
 
@@ -549,7 +551,7 @@ async def test_turning_no_scripts_off(hass):
     )
 
 
-async def test_async_get_descriptions_script(hass):
+async def test_async_get_descriptions_script(hass: HomeAssistant) -> None:
     """Test async_set_service_schema for the script integration."""
     script_config = {
         DOMAIN: {
@@ -583,7 +585,7 @@ async def test_async_get_descriptions_script(hass):
     )
 
 
-async def test_extraction_functions(hass):
+async def test_extraction_functions(hass: HomeAssistant) -> None:
     """Test extraction functions."""
     assert await async_setup_component(
         hass,
@@ -656,7 +658,7 @@ async def test_extraction_functions(hass):
     }
 
 
-async def test_config_basic(hass):
+async def test_config_basic(hass: HomeAssistant) -> None:
     """Test passing info in config."""
     assert await async_setup_component(
         hass,
@@ -682,7 +684,7 @@ async def test_config_basic(hass):
     assert entry.unique_id == "test_script"
 
 
-async def test_config_multiple_domains(hass):
+async def test_config_multiple_domains(hass: HomeAssistant) -> None:
     """Test splitting configuration over multiple domains."""
     assert await async_setup_component(
         hass,
@@ -712,7 +714,7 @@ async def test_config_multiple_domains(hass):
     assert test_script.name == "Secondary domain"
 
 
-async def test_logbook_humanify_script_started_event(hass):
+async def test_logbook_humanify_script_started_event(hass: HomeAssistant) -> None:
     """Test humanifying script started event."""
     hass.config.components.add("recorder")
     await async_setup_component(hass, DOMAIN, {})
@@ -829,7 +831,9 @@ async def test_concurrent_script(hass, concurrently):
     assert not script.is_on(hass, "script.script2")
 
 
-async def test_script_variables(hass, caplog):
+async def test_script_variables(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test defining scripts."""
     assert await async_setup_component(
         hass,
@@ -926,7 +930,9 @@ async def test_script_variables(hass, caplog):
     assert mock_calls[3].data["value"] == 1
 
 
-async def test_script_this_var_always(hass, caplog):
+async def test_script_this_var_always(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test script always has reference to this, even with no variabls are configured."""
 
     assert await async_setup_component(
@@ -1216,7 +1222,9 @@ async def test_setup_with_duplicate_scripts(
     assert len(hass.states.async_entity_ids("script")) == 1
 
 
-async def test_websocket_config(hass, hass_ws_client):
+async def test_websocket_config(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test config command."""
     config = {
         "alias": "hello",
@@ -1361,7 +1369,9 @@ async def test_blueprint_script_bad_config(
     assert details in caplog.text
 
 
-async def test_blueprint_script_fails_substitution(hass, caplog):
+async def test_blueprint_script_fails_substitution(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test blueprint script with bad inputs."""
     with patch(
         "homeassistant.components.blueprint.models.BlueprintInputs.async_substitute",

--- a/tests/components/sense/test_config_flow.py
+++ b/tests/components/sense/test_config_flow.py
@@ -12,6 +12,7 @@ from sense_energy import (
 from homeassistant import config_entries
 from homeassistant.components.sense.const import DOMAIN
 from homeassistant.const import CONF_CODE
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -68,7 +69,7 @@ async def test_form(hass, mock_sense):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -194,7 +195,7 @@ async def test_form_mfa_required_exception(hass, mock_sense):
     assert result3["errors"] == {"base": "unknown"}
 
 
-async def test_form_timeout(hass):
+async def test_form_timeout(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -213,7 +214,7 @@ async def test_form_timeout(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -232,7 +233,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_exception(hass):
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/sensirion_ble/test_config_flow.py
+++ b/tests/components/sensirion_ble/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Sensirion config flow."""
-
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.sensirion_ble.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .fixtures import (
@@ -22,7 +22,7 @@ def mock_bluetooth(enable_bluetooth):
     """Mock bluetooth for all tests in this module."""
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -42,7 +42,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
 
 
-async def test_async_step_bluetooth_not_sensirion(hass):
+async def test_async_step_bluetooth_not_sensirion(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not sensirion."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_bluetooth_not_sensirion(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -63,7 +63,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
@@ -87,7 +87,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == SENSIRION_SERVICE_INFO.address
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.sensirion_ble.config_flow.async_discovered_service_info",
@@ -117,7 +117,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -137,7 +139,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -154,7 +156,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -173,7 +175,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/sensorpro/test_config_flow.py
+++ b/tests/components/sensorpro/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the SensorPro config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.sensorpro.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_SENSORPRO_SERVICE_INFO, SENSORPRO_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_SENSORPRO_SERVICE_INFO, SENSORPRO_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_sensorpro(hass):
+async def test_async_step_bluetooth_not_sensorpro(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not sensorpro."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_sensorpro(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.sensorpro.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.sensorpro.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/sensorpro/test_sensor.py
+++ b/tests/components/sensorpro/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the SensorPro sensors."""
-
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.sensorpro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import SENSORPRO_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/sensorpush/test_config_flow.py
+++ b/tests/components/sensorpush/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the SensorPush config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.sensorpush.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import HTPWX_SERVICE_INFO, HTW_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import HTPWX_SERVICE_INFO, HTW_SERVICE_INFO, NOT_SENSOR_PUSH_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
 
 
-async def test_async_step_bluetooth_not_sensorpush(hass):
+async def test_async_step_bluetooth_not_sensorpush(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not sensorpush."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_sensorpush(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.sensorpush.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "61DE521B-F0BF-9F44-64D4-75BBE1738105"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.sensorpush.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/sensorpush/test_sensor.py
+++ b/tests/components/sensorpush/test_sensor.py
@@ -1,8 +1,8 @@
 """Test the SensorPush sensors."""
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.sensorpush.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import HTPWX_SERVICE_INFO
 
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.seventeentrack.sensor import (
     CONF_SHOW_DELIVERED,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
 
@@ -148,28 +149,28 @@ async def _goto_future(hass, future=None):
         await hass.async_block_till_done()
 
 
-async def test_full_valid_config(hass):
+async def test_full_valid_config(hass: HomeAssistant) -> None:
     """Ensure everything starts correctly."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_FULL)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
 
 
-async def test_valid_config(hass):
+async def test_valid_config(hass: HomeAssistant) -> None:
     """Ensure everything starts correctly."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids()) == len(ProfileMock.summary_data.keys())
 
 
-async def test_invalid_config(hass):
+async def test_invalid_config(hass: HomeAssistant) -> None:
     """Ensure nothing is created when config is wrong."""
     assert await async_setup_component(hass, "sensor", INVALID_CONFIG)
 
     assert not hass.states.async_entity_ids("sensor")
 
 
-async def test_add_package(hass):
+async def test_add_package(hass: HomeAssistant) -> None:
     """Ensure package is added correctly when user add a new package."""
     package = Package(
         tracking_number="456",
@@ -205,7 +206,7 @@ async def test_add_package(hass):
     assert len(hass.states.async_entity_ids()) == 2
 
 
-async def test_remove_package(hass):
+async def test_remove_package(hass: HomeAssistant) -> None:
     """Ensure entity is not there anymore if package is not there."""
     package1 = Package(
         tracking_number="456",
@@ -245,7 +246,7 @@ async def test_remove_package(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
 
-async def test_friendly_name_changed(hass):
+async def test_friendly_name_changed(hass: HomeAssistant) -> None:
     """Test friendly name change."""
     package = Package(
         tracking_number="456",
@@ -286,7 +287,7 @@ async def test_friendly_name_changed(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
 
-async def test_delivered_not_shown(hass):
+async def test_delivered_not_shown(hass: HomeAssistant) -> None:
     """Ensure delivered packages are not shown."""
     package = Package(
         tracking_number="456",
@@ -311,7 +312,7 @@ async def test_delivered_not_shown(hass):
         persistent_notification_mock.create.assert_called()
 
 
-async def test_delivered_shown(hass):
+async def test_delivered_shown(hass: HomeAssistant) -> None:
     """Ensure delivered packages are show when user choose to show them."""
     package = Package(
         tracking_number="456",
@@ -336,7 +337,7 @@ async def test_delivered_shown(hass):
         persistent_notification_mock.create.assert_not_called()
 
 
-async def test_becomes_delivered_not_shown_notification(hass):
+async def test_becomes_delivered_not_shown_notification(hass: HomeAssistant) -> None:
     """Ensure notification is triggered when package becomes delivered."""
     package = Package(
         tracking_number="456",
@@ -377,7 +378,7 @@ async def test_becomes_delivered_not_shown_notification(hass):
         assert not hass.states.async_entity_ids()
 
 
-async def test_summary_correctly_updated(hass):
+async def test_summary_correctly_updated(hass: HomeAssistant) -> None:
     """Ensure summary entities are not duplicated."""
     package = Package(
         tracking_number="456",
@@ -426,7 +427,7 @@ async def test_summary_correctly_updated(hass):
     )
 
 
-async def test_utc_timestamp(hass):
+async def test_utc_timestamp(hass: HomeAssistant) -> None:
     """Ensure package timestamp is converted correctly from HA-defined time zone to UTC."""
     package = Package(
         tracking_number="456",

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -14,7 +14,7 @@ from .const import CONFIG, TEST_PASSWORD, TEST_USERNAME, UNIQUE_ID
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -200,7 +200,7 @@ async def test_device_properties(
     assert getattr(device, device_property) == target_value
 
 
-async def test_locate(hass):
+async def test_locate(hass: HomeAssistant) -> None:
     """Test that the locate command works."""
     with patch.object(SharkIqVacuum, "async_find_device") as mock_locate:
         data = {ATTR_ENTITY_ID: VAC_ENTITY_ID}

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant.components import shell_command
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -27,7 +28,7 @@ def mock_process_creator(error: bool = False):
     return mock_process
 
 
-async def test_executing_service(hass):
+async def test_executing_service(hass: HomeAssistant) -> None:
     """Test if able to call a configured service."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "called.txt")
@@ -43,7 +44,7 @@ async def test_executing_service(hass):
         assert os.path.isfile(path)
 
 
-async def test_config_not_dict(hass):
+async def test_config_not_dict(hass: HomeAssistant) -> None:
     """Test that setup fails if config is not a dict."""
     assert not await async_setup_component(
         hass,
@@ -52,7 +53,7 @@ async def test_config_not_dict(hass):
     )
 
 
-async def test_config_not_valid_service_names(hass):
+async def test_config_not_valid_service_names(hass: HomeAssistant) -> None:
     """Test that setup fails if config contains invalid service names."""
     assert not await async_setup_component(
         hass,
@@ -160,7 +161,9 @@ async def test_stderr_captured(mock_output, hass):
 
 
 @pytest.mark.skip(reason="disabled to check if it fixes flaky CI")
-async def test_do_no_run_forever(hass, caplog):
+async def test_do_no_run_forever(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test subprocesses terminate after the timeout."""
 
     with patch.object(shell_command, "COMMAND_TIMEOUT", 0.001):

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.components.shelly.const import (
     BLEScannerMode,
 )
 from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import init_integration
@@ -275,7 +276,7 @@ async def test_form_errors_test_connection(hass, exc, base_error):
     assert result2["errors"] == {"base": base_error}
 
 
-async def test_form_already_configured(hass):
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
@@ -340,7 +341,7 @@ async def test_user_setup_ignored_device(hass, mock_block_device):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_firmware_unsupported(hass):
+async def test_form_firmware_unsupported(hass: HomeAssistant) -> None:
     """Test we abort if device firmware is unsupported."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -540,7 +541,7 @@ async def test_zeroconf_sleeping_device(hass, mock_block_device, monkeypatch):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_sleeping_device_error(hass):
+async def test_zeroconf_sleeping_device_error(hass: HomeAssistant) -> None:
     """Test sleeping device configuration via zeroconf with error."""
     with patch(
         "homeassistant.components.shelly.config_flow.get_info",
@@ -563,7 +564,7 @@ async def test_zeroconf_sleeping_device_error(hass):
         assert result["reason"] == "cannot_connect"
 
 
-async def test_zeroconf_already_configured(hass):
+async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
@@ -587,7 +588,7 @@ async def test_zeroconf_already_configured(hass):
     assert entry.data["host"] == "1.1.1.1"
 
 
-async def test_zeroconf_ignored(hass):
+async def test_zeroconf_ignored(hass: HomeAssistant) -> None:
     """Test zeroconf when the device was previously ignored."""
 
     entry = MockConfigEntry(
@@ -611,7 +612,7 @@ async def test_zeroconf_ignored(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_with_wifi_ap_ip(hass):
+async def test_zeroconf_with_wifi_ap_ip(hass: HomeAssistant) -> None:
     """Test we ignore the Wi-FI AP IP."""
 
     entry = MockConfigEntry(
@@ -635,7 +636,7 @@ async def test_zeroconf_with_wifi_ap_ip(hass):
     assert entry.data["host"] == "2.2.2.2"
 
 
-async def test_zeroconf_firmware_unsupported(hass):
+async def test_zeroconf_firmware_unsupported(hass: HomeAssistant) -> None:
     """Test we abort if device firmware is unsupported."""
     with patch(
         "homeassistant.components.shelly.config_flow.get_info",
@@ -651,7 +652,7 @@ async def test_zeroconf_firmware_unsupported(hass):
         assert result["reason"] == "unsupported_firmware"
 
 
-async def test_zeroconf_cannot_connect(hass):
+async def test_zeroconf_cannot_connect(hass: HomeAssistant) -> None:
     """Test we get the form."""
     with patch(
         "homeassistant.components.shelly.config_flow.get_info",

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.components.shelly.const import (
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.setup import async_setup_component
 
@@ -49,7 +50,9 @@ async def test_shared_device_mac(
     assert "will resume when device is online" in caplog.text
 
 
-async def test_setup_entry_not_shelly(hass, caplog):
+async def test_setup_entry_not_shelly(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test not Shelly entry."""
     entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     entry.add_to_hass(hass)

--- a/tests/components/shopping_list/test_config_flow.py
+++ b/tests/components/shopping_list/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test config flow."""
-
 from homeassistant import data_entry_flow
 from homeassistant.components.shopping_list.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test entry will be imported."""
 
     result = await hass.config_entries.flow.async_init(
@@ -14,7 +14,7 @@ async def test_import(hass):
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
-async def test_user(hass):
+async def test_user(hass: HomeAssistant) -> None:
     """Test we can start a config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -25,7 +25,7 @@ async def test_user(hass):
     assert result["step_id"] == "user"
 
 
-async def test_user_confirm(hass):
+async def test_user_confirm(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.sia.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PORT, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -186,7 +187,7 @@ async def test_create_additional_account(hass, entry_with_additional_account_con
     assert entry_with_additional_account_config["options"] == ADDITIONAL_OUT["options"]
 
 
-async def test_abort_form(hass):
+async def test_abort_form(hass: HomeAssistant) -> None:
     """Test aborting a config that already exists."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -304,7 +305,7 @@ async def test_unknown_account(hass, flow_at_user_step):
         assert result_err["data_schema"] == ACCOUNT_SCHEMA
 
 
-async def test_options_basic(hass):
+async def test_options_basic(hass: HomeAssistant) -> None:
     """Test options flow for single account."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -329,7 +330,7 @@ async def test_options_basic(hass):
     }
 
 
-async def test_options_additional(hass):
+async def test_options_additional(hass: HomeAssistant) -> None:
     """Test options flow for single account."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/sigfox/test_sensor.py
+++ b/tests/components/sigfox/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sigfox.sensor import (
     CONF_API_LOGIN,
     CONF_API_PASSWORD,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 TEST_API_LOGIN = "foo"
@@ -31,7 +32,7 @@ VALID_MESSAGE = """
 """
 
 
-async def test_invalid_credentials(hass):
+async def test_invalid_credentials(hass: HomeAssistant) -> None:
     """Test for invalid credentials."""
     with requests_mock.Mocker() as mock_req:
         url = re.compile(API_URL + "devicetypes")
@@ -41,7 +42,7 @@ async def test_invalid_credentials(hass):
     assert len(hass.states.async_entity_ids()) == 0
 
 
-async def test_valid_credentials(hass):
+async def test_valid_credentials(hass: HomeAssistant) -> None:
     """Test for valid credentials."""
     with requests_mock.Mocker() as mock_req:
         url1 = re.compile(API_URL + "devicetypes")

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -12,7 +12,7 @@ import simplehound.core as hound
 import homeassistant.components.image_processing as ip
 import homeassistant.components.sighthound.image_processing as sh
 from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 TEST_DIR = os.path.dirname(__file__)
@@ -82,7 +82,9 @@ def mock_now():
         yield now_dt
 
 
-async def test_bad_api_key(hass, caplog):
+async def test_bad_api_key(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Catch bad api key."""
     with mock.patch(
         "simplehound.core.cloud.detect", side_effect=hound.SimplehoundException

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.components.simplisafe.config_flow import CONF_AUTH_CODE
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 VALID_AUTH_CODE = "code12345123451234512345123451234512345123451"
@@ -32,7 +33,7 @@ async def test_duplicate_error(config_entry, hass, setup_simplisafe):
         assert result["reason"] == "already_configured"
 
 
-async def test_invalid_auth_code_length(hass):
+async def test_invalid_auth_code_length(hass: HomeAssistant) -> None:
     """Test that an invalid auth code length show the correct error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -47,7 +48,7 @@ async def test_invalid_auth_code_length(hass):
     assert result["errors"] == {CONF_AUTH_CODE: "invalid_auth_code_length"}
 
 
-async def test_invalid_credentials(hass):
+async def test_invalid_credentials(hass: HomeAssistant) -> None:
     """Test that invalid credentials show the correct error."""
     with patch(
         "homeassistant.components.simplisafe.config_flow.API.async_from_auth",

--- a/tests/components/simulated/test_sensor.py
+++ b/tests/components/simulated/test_sensor.py
@@ -17,10 +17,11 @@ from homeassistant.components.simulated.sensor import (
     DEFAULT_SEED,
 )
 from homeassistant.const import CONF_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_simulated_sensor_default_config(hass):
+async def test_simulated_sensor_default_config(hass: HomeAssistant) -> None:
     """Test default config."""
     config = {"sensor": {"platform": "simulated"}}
     assert await async_setup_component(hass, "sensor", config)

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.components.siren import (
     process_turn_on_params,
 )
 from homeassistant.components.siren.const import SirenEntityFeature
+from homeassistant.core import HomeAssistant
 
 
 class MockSirenEntity(SirenEntity):
@@ -32,7 +33,7 @@ class MockSirenEntity(SirenEntity):
             )
 
 
-async def test_sync_turn_on(hass):
+async def test_sync_turn_on(hass: HomeAssistant) -> None:
     """Test if async turn_on calls sync turn_on."""
     siren = MockSirenEntity()
     siren.hass = hass
@@ -43,7 +44,7 @@ async def test_sync_turn_on(hass):
     assert siren.turn_on.called
 
 
-async def test_sync_turn_off(hass):
+async def test_sync_turn_off(hass: HomeAssistant) -> None:
     """Test if async turn_off calls sync turn_off."""
     siren = MockSirenEntity()
     siren.hass = hass
@@ -54,7 +55,7 @@ async def test_sync_turn_off(hass):
     assert siren.turn_off.called
 
 
-async def test_no_available_tones(hass):
+async def test_no_available_tones(hass: HomeAssistant) -> None:
     """Test ValueError when siren advertises tones but has no available_tones."""
     siren = MockSirenEntity(SirenEntityFeature.TONES)
     siren.hass = hass
@@ -62,7 +63,7 @@ async def test_no_available_tones(hass):
         process_turn_on_params(siren, {"tone": "test"})
 
 
-async def test_available_tones_list(hass):
+async def test_available_tones_list(hass: HomeAssistant) -> None:
     """Test that valid tones from tone list will get passed in."""
     siren = MockSirenEntity(
         SirenEntityFeature.TONES, available_tones_as_attr=["a", "b"]
@@ -71,7 +72,7 @@ async def test_available_tones_list(hass):
     assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": "a"}
 
 
-async def test_available_tones(hass):
+async def test_available_tones(hass: HomeAssistant) -> None:
     """Test different available tones scenarios."""
     siren = MockSirenEntity(
         SirenEntityFeature.TONES, available_tones_in_desc=["a", "b"]
@@ -81,7 +82,7 @@ async def test_available_tones(hass):
     assert siren.available_tones is None
 
 
-async def test_available_tones_dict(hass):
+async def test_available_tones_dict(hass: HomeAssistant) -> None:
     """Test that valid tones from available_tones dict will get passed in."""
     siren = MockSirenEntity(SirenEntityFeature.TONES, {1: "a", 2: "b"})
     siren.hass = hass
@@ -89,7 +90,7 @@ async def test_available_tones_dict(hass):
     assert process_turn_on_params(siren, {"tone": 1}) == {"tone": 1}
 
 
-async def test_missing_tones_list(hass):
+async def test_missing_tones_list(hass: HomeAssistant) -> None:
     """Test ValueError when setting a tone that is missing from available_tones list."""
     siren = MockSirenEntity(SirenEntityFeature.TONES, ["a", "b"])
     siren.hass = hass
@@ -97,7 +98,7 @@ async def test_missing_tones_list(hass):
         process_turn_on_params(siren, {"tone": "test"})
 
 
-async def test_missing_tones_dict(hass):
+async def test_missing_tones_dict(hass: HomeAssistant) -> None:
     """Test ValueError when setting a tone that is missing from available_tones dict."""
     siren = MockSirenEntity(SirenEntityFeature.TONES, {1: "a", 2: "b"})
     siren.hass = hass

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -95,7 +95,7 @@ async def test_success(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reauth_password(hass):
+async def test_reauth_password(hass: HomeAssistant) -> None:
     """Test reauth form."""
 
     # set up initially

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -9,12 +9,13 @@ from pysma.exceptions import (
 
 from homeassistant.components.sma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import MOCK_DEVICE, MOCK_USER_INPUT, _patch_async_setup_entry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -39,7 +40,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -58,7 +59,7 @@ async def test_form_cannot_connect(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -77,7 +78,7 @@ async def test_form_invalid_auth(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_cannot_retrieve_device_info(hass):
+async def test_form_cannot_retrieve_device_info(hass: HomeAssistant) -> None:
     """Test we handle cannot retrieve device info error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -96,7 +97,7 @@ async def test_form_cannot_retrieve_device_info(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_unexpected_exception(hass):
+async def test_form_unexpected_exception(hass: HomeAssistant) -> None:
     """Test we handle unexpected exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.smappee.const import (
 )
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
@@ -21,7 +22,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-async def test_show_user_form(hass):
+async def test_show_user_form(hass: HomeAssistant) -> None:
     """Test that the user set up form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +33,7 @@ async def test_show_user_form(hass):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
-async def test_show_user_host_form(hass):
+async def test_show_user_host_form(hass: HomeAssistant) -> None:
     """Test that the host form is served after choosing the local option."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -49,7 +50,7 @@ async def test_show_user_host_form(hass):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
-async def test_show_zeroconf_connection_error_form(hass):
+async def test_show_zeroconf_connection_error_form(hass: HomeAssistant) -> None:
     """Test that the zeroconf confirmation form is served."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value=None):
         result = await hass.config_entries.flow.async_init(
@@ -79,7 +80,9 @@ async def test_show_zeroconf_connection_error_form(hass):
         assert len(hass.config_entries.async_entries(DOMAIN)) == 0
 
 
-async def test_show_zeroconf_connection_error_form_next_generation(hass):
+async def test_show_zeroconf_connection_error_form_next_generation(
+    hass: HomeAssistant,
+) -> None:
     """Test that the zeroconf confirmation form is served."""
     with patch("pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=False):
         result = await hass.config_entries.flow.async_init(
@@ -109,7 +112,7 @@ async def test_show_zeroconf_connection_error_form_next_generation(hass):
         assert len(hass.config_entries.async_entries(DOMAIN)) == 0
 
 
-async def test_connection_error(hass):
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test we show user form on Smappee connection error."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value=None), patch(
         "pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=None
@@ -134,7 +137,7 @@ async def test_connection_error(hass):
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_user_local_connection_error(hass):
+async def test_user_local_connection_error(hass: HomeAssistant) -> None:
     """Test we show user form on Smappee connection error in local next generation option."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value=None), patch(
         "pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=True
@@ -163,7 +166,7 @@ async def test_user_local_connection_error(hass):
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_zeroconf_wrong_mdns(hass):
+async def test_zeroconf_wrong_mdns(hass: HomeAssistant) -> None:
     """Test we abort if unsupported mDNS name is discovered."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -183,7 +186,7 @@ async def test_zeroconf_wrong_mdns(hass):
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_full_user_wrong_mdns(hass):
+async def test_full_user_wrong_mdns(hass: HomeAssistant) -> None:
     """Test we abort user flow if unsupported mDNS name got resolved."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
@@ -214,7 +217,7 @@ async def test_full_user_wrong_mdns(hass):
         assert result["reason"] == "invalid_mdns"
 
 
-async def test_user_device_exists_abort(hass):
+async def test_user_device_exists_abort(hass: HomeAssistant) -> None:
     """Test we abort user flow if Smappee device already configured."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
@@ -255,7 +258,7 @@ async def test_user_device_exists_abort(hass):
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_zeroconf_device_exists_abort(hass):
+async def test_zeroconf_device_exists_abort(hass: HomeAssistant) -> None:
     """Test we abort zeroconf flow if Smappee device already configured."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
@@ -294,7 +297,7 @@ async def test_zeroconf_device_exists_abort(hass):
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_cloud_device_exists_abort(hass):
+async def test_cloud_device_exists_abort(hass: HomeAssistant) -> None:
     """Test we abort cloud flow if Smappee Cloud device already configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -315,7 +318,7 @@ async def test_cloud_device_exists_abort(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_zeroconf_abort_if_cloud_device_exists(hass):
+async def test_zeroconf_abort_if_cloud_device_exists(hass: HomeAssistant) -> None:
     """Test we abort zeroconf flow if Smappee Cloud device already configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -344,7 +347,9 @@ async def test_zeroconf_abort_if_cloud_device_exists(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_zeroconf_confirm_abort_if_cloud_device_exists(hass):
+async def test_zeroconf_confirm_abort_if_cloud_device_exists(
+    hass: HomeAssistant,
+) -> None:
     """Test we abort zeroconf confirm flow if Smappee Cloud device already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -376,7 +381,7 @@ async def test_zeroconf_confirm_abort_if_cloud_device_exists(hass):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-async def test_abort_cloud_flow_if_local_device_exists(hass):
+async def test_abort_cloud_flow_if_local_device_exists(hass: HomeAssistant) -> None:
     """Test we abort the cloud flow if a Smappee local device already configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -453,7 +458,7 @@ async def test_full_user_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_full_zeroconf_flow(hass):
+async def test_full_zeroconf_flow(hass: HomeAssistant) -> None:
     """Test the full zeroconf flow."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
@@ -495,7 +500,7 @@ async def test_full_zeroconf_flow(hass):
         assert entry.unique_id == "1006000212"
 
 
-async def test_full_user_local_flow(hass):
+async def test_full_user_local_flow(hass: HomeAssistant) -> None:
     """Test the full zeroconf flow."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",
@@ -534,7 +539,7 @@ async def test_full_user_local_flow(hass):
         assert entry.unique_id == "1006000212"
 
 
-async def test_full_zeroconf_flow_next_generation(hass):
+async def test_full_zeroconf_flow_next_generation(hass: HomeAssistant) -> None:
     """Test the full zeroconf flow."""
     with patch(
         "pysmappee.mqtt.SmappeeLocalMqtt.start_attempt", return_value=True

--- a/tests/components/smappee/test_init.py
+++ b/tests/components/smappee/test_init.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 
 from homeassistant.components.smappee.const import DOMAIN
 from homeassistant.config_entries import SOURCE_ZEROCONF
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_unload_config_entry(hass):
+async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test unload config entry flow."""
     with patch("pysmappee.api.SmappeeLocalApi.logon", return_value={}), patch(
         "pysmappee.api.SmappeeLocalApi.load_advanced_config",

--- a/tests/components/smart_meter_texas/test_config_flow.py
+++ b/tests/components/smart_meter_texas/test_config_flow.py
@@ -12,13 +12,14 @@ from smart_meter_texas.exceptions import (
 from homeassistant import config_entries
 from homeassistant.components.smart_meter_texas.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 TEST_LOGIN = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +43,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -82,7 +83,7 @@ async def test_form_cannot_connect(hass, side_effect):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_exception(hass):
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test base exception is handled."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -101,7 +102,7 @@ async def test_form_unknown_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_duplicate_account(hass):
+async def test_form_duplicate_account(hass: HomeAssistant) -> None:
     """Test that a duplicate account cannot be configured."""
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -8,12 +8,13 @@ from homeassistant.components.homeassistant import (
 from homeassistant.components.smart_meter_texas.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_ID, setup_integration
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that no config is successful."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
     await hass.async_block_till_done()

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -17,11 +17,12 @@ from homeassistant.components.smartthings.const import (
 )
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_import_shows_user_step(hass):
+async def test_import_shows_user_step(hass: HomeAssistant) -> None:
     """Test import source shows the user form."""
     # Webhook confirmation shown
     result = await hass.config_entries.flow.async_init(
@@ -421,7 +422,7 @@ async def test_entry_created_with_cloudhook(
         )
 
 
-async def test_invalid_webhook_aborts(hass):
+async def test_invalid_webhook_aborts(hass: HomeAssistant) -> None:
     """Test flow aborts if webhook is invalid."""
     # Webhook confirmation shown
     await async_process_ha_core_config(
@@ -439,7 +440,7 @@ async def test_invalid_webhook_aborts(hass):
     assert "component_url" in result["description_placeholders"]
 
 
-async def test_invalid_token_shows_error(hass):
+async def test_invalid_token_shows_error(hass: HomeAssistant) -> None:
     """Test an error is shown for invalid token formats."""
     token = "123456789"
 

--- a/tests/components/smartthings/test_smartapp.py
+++ b/tests/components/smartthings/test_smartapp.py
@@ -10,6 +10,7 @@ from homeassistant.components.smartthings.const import (
     DATA_MANAGER,
     DOMAIN,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -73,7 +74,7 @@ async def test_smartapp_uninstall(hass, config_entry):
         assert remove.call_count == 1
 
 
-async def test_smartapp_webhook(hass):
+async def test_smartapp_webhook(hass: HomeAssistant) -> None:
     """Test the smartapp webhook calls the manager."""
     manager = Mock()
     manager.handle_request = AsyncMock(return_value={})

--- a/tests/components/smarttub/test_config_flow.py
+++ b/tests/components/smarttub/test_config_flow.py
@@ -6,11 +6,12 @@ from smarttub import LoginFailed
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.smarttub.const import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -9,6 +9,7 @@ import homeassistant.components.notify as notify
 from homeassistant.components.smtp import DOMAIN
 from homeassistant.components.smtp.notify import MailNotificationService
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_fixture_path
@@ -22,7 +23,7 @@ class MockSMTP(MailNotificationService):
         return msg.as_string(), recipients
 
 
-async def test_reload_notify(hass):
+async def test_reload_notify(hass: HomeAssistant) -> None:
     """Verify we can reload the notify service."""
 
     with patch(

--- a/tests/components/snips/test_init.py
+++ b/tests/components/snips/test_init.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.bootstrap import async_setup_component
 import homeassistant.components.snips as snips
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.intent import ServiceIntentHandler, async_register
 
 from tests.common import async_fire_mqtt_message, async_mock_intent, async_mock_service
@@ -28,7 +29,9 @@ async def test_snips_config(hass, mqtt_mock):
     assert result
 
 
-async def test_snips_no_mqtt(hass, caplog):
+async def test_snips_no_mqtt(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test Snips Config."""
     result = await async_setup_component(
         hass,
@@ -419,7 +422,7 @@ async def test_intent_special_slots(hass, mqtt_mock):
     assert calls[0].data["site_id"] == "default"
 
 
-async def test_snips_say(hass):
+async def test_snips_say(hass: HomeAssistant) -> None:
     """Test snips say with invalid config."""
     calls = async_mock_service(hass, "snips", "say", snips.SERVICE_SCHEMA_SAY)
     data = {"text": "Hello"}
@@ -432,7 +435,7 @@ async def test_snips_say(hass):
     assert calls[0].data["text"] == "Hello"
 
 
-async def test_snips_say_action(hass):
+async def test_snips_say_action(hass: HomeAssistant) -> None:
     """Test snips say_action with invalid config."""
     calls = async_mock_service(
         hass, "snips", "say_action", snips.SERVICE_SCHEMA_SAY_ACTION
@@ -449,7 +452,7 @@ async def test_snips_say_action(hass):
     assert calls[0].data["intent_filter"] == ["myIntent"]
 
 
-async def test_snips_say_invalid_config(hass):
+async def test_snips_say_invalid_config(hass: HomeAssistant) -> None:
     """Test snips say with invalid config."""
     calls = async_mock_service(hass, "snips", "say", snips.SERVICE_SCHEMA_SAY)
 
@@ -461,7 +464,7 @@ async def test_snips_say_invalid_config(hass):
     assert len(calls) == 0
 
 
-async def test_snips_say_action_invalid(hass):
+async def test_snips_say_action_invalid(hass: HomeAssistant) -> None:
     """Test snips say_action with invalid config."""
     calls = async_mock_service(
         hass, "snips", "say_action", snips.SERVICE_SCHEMA_SAY_ACTION
@@ -476,7 +479,7 @@ async def test_snips_say_action_invalid(hass):
     assert len(calls) == 0
 
 
-async def test_snips_feedback_on(hass):
+async def test_snips_feedback_on(hass: HomeAssistant) -> None:
     """Test snips say with invalid config."""
     calls = async_mock_service(
         hass, "snips", "feedback_on", snips.SERVICE_SCHEMA_FEEDBACK
@@ -492,7 +495,7 @@ async def test_snips_feedback_on(hass):
     assert calls[0].data["site_id"] == "remote"
 
 
-async def test_snips_feedback_off(hass):
+async def test_snips_feedback_off(hass: HomeAssistant) -> None:
     """Test snips say with invalid config."""
     calls = async_mock_service(
         hass, "snips", "feedback_off", snips.SERVICE_SCHEMA_FEEDBACK
@@ -508,7 +511,7 @@ async def test_snips_feedback_off(hass):
     assert calls[0].data["site_id"] == "remote"
 
 
-async def test_snips_feedback_config(hass):
+async def test_snips_feedback_config(hass: HomeAssistant) -> None:
     """Test snips say with invalid config."""
     calls = async_mock_service(
         hass, "snips", "feedback_on", snips.SERVICE_SCHEMA_FEEDBACK

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.solarlog import config_flow
 from homeassistant.components.solarlog.const import DEFAULT_HOST, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -14,7 +15,7 @@ NAME = "Solarlog test 1 2 3"
 HOST = "http://1.1.1.1"
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -8,6 +8,7 @@ from solax.inverters import X1MiniV34
 from homeassistant import config_entries
 from homeassistant.components.solax.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 
 def __mock_real_time_api_success():
@@ -20,7 +21,7 @@ def __mock_get_data():
     )
 
 
-async def test_form_success(hass):
+async def test_form_success(hass: HomeAssistant) -> None:
     """Test successful form."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -51,7 +52,7 @@ async def test_form_success(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_connect_error(hass):
+async def test_form_connect_error(hass: HomeAssistant) -> None:
     """Test cannot connect form."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -72,7 +73,7 @@ async def test_form_connect_error(hass):
     assert entry_result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test unknown error form."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -6,6 +6,7 @@ from requests import RequestException
 
 from homeassistant import data_entry_flow
 from homeassistant.components.soma import DOMAIN, config_flow
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -13,7 +14,7 @@ MOCK_HOST = "123.45.67.89"
 MOCK_PORT = 3000
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test user form showing."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -21,7 +22,7 @@ async def test_form(hass):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
-async def test_import_abort(hass):
+async def test_import_abort(hass: HomeAssistant) -> None:
     """Test configuration from YAML aborting with existing entity."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -31,7 +32,7 @@ async def test_import_abort(hass):
     assert result["reason"] == "already_setup"
 
 
-async def test_import_create(hass):
+async def test_import_create(hass: HomeAssistant) -> None:
     """Test configuration from YAML."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -40,7 +41,7 @@ async def test_import_create(hass):
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
-async def test_error_status(hass):
+async def test_error_status(hass: HomeAssistant) -> None:
     """Test Connect successfully returning error status."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -50,7 +51,7 @@ async def test_error_status(hass):
     assert result["reason"] == "result_error"
 
 
-async def test_key_error(hass):
+async def test_key_error(hass: HomeAssistant) -> None:
     """Test Connect returning empty string."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -60,7 +61,7 @@ async def test_key_error(hass):
     assert result["reason"] == "connection_error"
 
 
-async def test_exception(hass):
+async def test_exception(hass: HomeAssistant) -> None:
     """Test if RequestException fires when no connection can be made."""
     flow = config_flow.SomaFlowHandler()
     flow.hass = hass
@@ -70,7 +71,7 @@ async def test_exception(hass):
     assert result["reason"] == "connection_error"
 
 
-async def test_full_flow(hass):
+async def test_full_flow(hass: HomeAssistant) -> None:
     """Check classic use case."""
     hass.data[DOMAIN] = {}
     flow = config_flow.SomaFlowHandler()

--- a/tests/components/somfy_mylink/test_config_flow.py
+++ b/tests/components/somfy_mylink/test_config_flow.py
@@ -12,11 +12,12 @@ from homeassistant.components.somfy_mylink.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_form_user(hass):
+async def test_form_user(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -52,7 +53,7 @@ async def test_form_user(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_already_configured(hass):
+async def test_form_user_already_configured(hass: HomeAssistant) -> None:
     """Test we abort if already configured."""
 
     config_entry = MockConfigEntry(
@@ -87,7 +88,7 @@ async def test_form_user_already_configured(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -114,7 +115,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -137,7 +138,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle broad exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -160,7 +161,7 @@ async def test_form_unknown_error(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_options_not_loaded(hass):
+async def test_options_not_loaded(hass: HomeAssistant) -> None:
     """Test options will not display until loaded."""
 
     config_entry = MockConfigEntry(
@@ -233,7 +234,7 @@ async def test_options_with_targets(hass, reversed):
         await hass.async_block_till_done()
 
 
-async def test_form_user_already_configured_from_dhcp(hass):
+async def test_form_user_already_configured_from_dhcp(hass: HomeAssistant) -> None:
     """Test we abort if already configured from dhcp."""
 
     config_entry = MockConfigEntry(
@@ -265,7 +266,7 @@ async def test_form_user_already_configured_from_dhcp(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_already_configured_with_ignored(hass):
+async def test_already_configured_with_ignored(hass: HomeAssistant) -> None:
     """Test ignored entries do not break checking for existing entries."""
 
     config_entry = MockConfigEntry(
@@ -285,7 +286,7 @@ async def test_already_configured_with_ignored(hass):
     assert result["type"] == "form"
 
 
-async def test_dhcp_discovery(hass):
+async def test_dhcp_discovery(hass: HomeAssistant) -> None:
     """Test we can process the discovery from dhcp."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/songpal/test_config_flow.py
+++ b/tests/components/songpal/test_config_flow.py
@@ -7,6 +7,7 @@ from homeassistant.components import ssdp
 from homeassistant.components.songpal.const import CONF_ENDPOINT, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -55,7 +56,7 @@ def _patch_setup():
     )
 
 
-async def test_flow_ssdp(hass):
+async def test_flow_ssdp(hass: HomeAssistant) -> None:
     """Test working ssdp flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -80,7 +81,7 @@ async def test_flow_ssdp(hass):
         assert result["data"] == CONF_DATA
 
 
-async def test_flow_user(hass):
+async def test_flow_user(hass: HomeAssistant) -> None:
     """Test working user initialized flow."""
     mocked_device = _create_mocked_device()
 
@@ -109,7 +110,7 @@ async def test_flow_user(hass):
     mocked_device.get_interface_information.assert_called_once()
 
 
-async def test_flow_import(hass):
+async def test_flow_import(hass: HomeAssistant) -> None:
     """Test working import flow."""
     mocked_device = _create_mocked_device()
 
@@ -125,7 +126,7 @@ async def test_flow_import(hass):
     mocked_device.get_interface_information.assert_not_called()
 
 
-async def test_flow_import_without_name(hass):
+async def test_flow_import_without_name(hass: HomeAssistant) -> None:
     """Test import flow without optional name."""
     mocked_device = _create_mocked_device()
 
@@ -149,7 +150,7 @@ def _create_mock_config_entry(hass):
     ).add_to_hass(hass)
 
 
-async def test_ssdp_bravia(hass):
+async def test_ssdp_bravia(hass: HomeAssistant) -> None:
     """Test discovering a bravia TV."""
     ssdp_data = dataclasses.replace(SSDP_DATA)
     ssdp_data.upnp = copy.deepcopy(ssdp_data.upnp)
@@ -165,7 +166,7 @@ async def test_ssdp_bravia(hass):
     assert result["reason"] == "not_songpal_device"
 
 
-async def test_sddp_exist(hass):
+async def test_sddp_exist(hass: HomeAssistant) -> None:
     """Test discovering existed device."""
     _create_mock_config_entry(hass)
     result = await hass.config_entries.flow.async_init(
@@ -177,7 +178,7 @@ async def test_sddp_exist(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_user_exist(hass):
+async def test_user_exist(hass: HomeAssistant) -> None:
     """Test user adding existed device."""
     mocked_device = _create_mocked_device()
     _create_mock_config_entry(hass)
@@ -193,7 +194,7 @@ async def test_user_exist(hass):
     mocked_device.get_interface_information.assert_called_once()
 
 
-async def test_import_exist(hass):
+async def test_import_exist(hass: HomeAssistant) -> None:
     """Test importing existed device."""
     mocked_device = _create_mocked_device()
     _create_mock_config_entry(hass)
@@ -209,7 +210,7 @@ async def test_import_exist(hass):
     mocked_device.get_interface_information.assert_not_called()
 
 
-async def test_user_invalid(hass):
+async def test_user_invalid(hass: HomeAssistant) -> None:
     """Test using adding invalid config."""
     mocked_device = _create_mocked_device(True)
     _create_mock_config_entry(hass)
@@ -226,7 +227,7 @@ async def test_user_invalid(hass):
     mocked_device.get_interface_information.assert_not_called()
 
 
-async def test_import_invalid(hass):
+async def test_import_invalid(hass: HomeAssistant) -> None:
     """Test importing invalid config."""
     mocked_device = _create_mocked_device(True)
     _create_mock_config_entry(hass)

--- a/tests/components/songpal/test_init.py
+++ b/tests/components/songpal/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components import songpal
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -26,7 +27,7 @@ def _patch_media_setup():
     )
 
 
-async def test_setup_empty(hass):
+async def test_setup_empty(hass: HomeAssistant) -> None:
     """Test setup without any configuration."""
     with _patch_media_setup() as setup:
         assert await async_setup_component(hass, songpal.DOMAIN, {}) is True
@@ -34,7 +35,7 @@ async def test_setup_empty(hass):
     setup.assert_not_called()
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setup the platform."""
     mocked_device = _create_mocked_device()
 
@@ -50,7 +51,7 @@ async def test_setup(hass):
     setup.assert_called_once()
 
 
-async def test_unload(hass):
+async def test_unload(hass: HomeAssistant) -> None:
     """Test unload entity."""
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
     entry.add_to_hass(hass)

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from songpal import (
     ConnectChange,
     ContentChange,
@@ -15,6 +16,7 @@ from homeassistant.components import media_player, songpal
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.songpal.const import SET_SOUND_SETTING
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -51,7 +53,7 @@ def _get_attributes(hass):
     return state.as_dict()["attributes"]
 
 
-async def test_setup_platform(hass):
+async def test_setup_platform(hass: HomeAssistant) -> None:
     """Test the legacy setup platform."""
     mocked_device = _create_mocked_device(throw_exception=True)
     with _patch_media_player_device(mocked_device):
@@ -76,7 +78,9 @@ async def test_setup_platform(hass):
     assert len(all_states) == 0
 
 
-async def test_setup_failed(hass, caplog):
+async def test_setup_failed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test failed to set up the entity."""
     mocked_device = _create_mocked_device(throw_exception=True)
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -103,7 +107,7 @@ async def test_setup_failed(hass, caplog):
     assert not any(x.levelno == logging.ERROR for x in caplog.records)
 
 
-async def test_state(hass):
+async def test_state(hass: HomeAssistant) -> None:
     """Test state of the entity."""
     mocked_device = _create_mocked_device()
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -136,7 +140,7 @@ async def test_state(hass):
     assert entity.unique_id == MAC
 
 
-async def test_state_wireless(hass):
+async def test_state_wireless(hass: HomeAssistant) -> None:
     """Test state of the entity with only Wireless MAC."""
     mocked_device = _create_mocked_device(wired_mac=None, wireless_mac=WIRELESS_MAC)
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -171,7 +175,7 @@ async def test_state_wireless(hass):
     assert entity.unique_id == WIRELESS_MAC
 
 
-async def test_state_both(hass):
+async def test_state_both(hass: HomeAssistant) -> None:
     """Test state of the entity with both Wired and Wireless MAC."""
     mocked_device = _create_mocked_device(wired_mac=MAC, wireless_mac=WIRELESS_MAC)
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -208,7 +212,7 @@ async def test_state_both(hass):
     assert entity.unique_id == MAC
 
 
-async def test_services(hass):
+async def test_services(hass: HomeAssistant) -> None:
     """Test services."""
     mocked_device = _create_mocked_device()
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -295,7 +299,7 @@ async def test_services(hass):
     mocked_device3.set_sound_settings.assert_called_once_with("name", "value")
 
 
-async def test_websocket_events(hass):
+async def test_websocket_events(hass: HomeAssistant) -> None:
     """Test websocket events."""
     mocked_device = _create_mocked_device()
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
@@ -333,7 +337,9 @@ async def test_websocket_events(hass):
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
 
-async def test_disconnected(hass, caplog):
+async def test_disconnected(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test disconnected behavior."""
     mocked_device = _create_mocked_device()
     entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, PropertyMock, patch
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.spc import DATA_API
 from homeassistant.const import STATE_ALARM_ARMED_AWAY, STATE_ALARM_DISARMED
+from homeassistant.core import HomeAssistant
 
 from tests.common import mock_coro
 
@@ -30,7 +31,7 @@ async def test_invalid_device_config(hass, monkeypatch):
         assert await async_setup_component(hass, "spc", config) is False
 
 
-async def test_update_alarm_device(hass):
+async def test_update_alarm_device(hass: HomeAssistant) -> None:
     """Test that alarm panel state changes on incoming websocket data."""
     import pyspcwebgw
     from pyspcwebgw.const import AreaMode

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -43,7 +43,7 @@ async def component_setup(hass: HomeAssistant) -> None:
     assert result
 
 
-async def test_abort_if_no_configuration(hass):
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     """Check flow aborts when no configuration is present."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -60,7 +60,7 @@ async def test_abort_if_no_configuration(hass):
     assert result["reason"] == "missing_credentials"
 
 
-async def test_zeroconf_abort_if_existing_entry(hass):
+async def test_zeroconf_abort_if_existing_entry(hass: HomeAssistant) -> None:
     """Check zeroconf flow aborts when an entry already exist."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
@@ -304,7 +304,7 @@ async def test_reauth_account_mismatch(
     assert result["reason"] == "reauth_account_mismatch"
 
 
-async def test_abort_if_no_reauth_entry(hass):
+async def test_abort_if_no_reauth_entry(hass: HomeAssistant) -> None:
     """Check flow aborts when no entry is known when entring reauth confirmation."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "reauth_confirm"}

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Logitech Squeezebox config flow."""
-
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -9,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.squeezebox.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
@@ -35,7 +35,7 @@ async def patch_async_query_unauthorized(self, *args):
     return False
 
 
-async def test_user_form(hass):
+async def test_user_form(hass: HomeAssistant) -> None:
     """Test user-initiated flow, including discovery and the edit step."""
     with patch(
         "pysqueezebox.Server.async_query",
@@ -74,7 +74,7 @@ async def test_user_form(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_timeout(hass):
+async def test_user_form_timeout(hass: HomeAssistant) -> None:
     """Test we handle server search timeout."""
     with patch(
         "homeassistant.components.squeezebox.config_flow.async_discover",
@@ -98,7 +98,7 @@ async def test_user_form_timeout(hass):
                 assert key.description == {"suggested_value": HOST2}
 
 
-async def test_user_form_duplicate(hass):
+async def test_user_form_duplicate(hass: HomeAssistant) -> None:
     """Test duplicate discovered servers are skipped."""
     with patch(
         "homeassistant.components.squeezebox.config_flow.async_discover",
@@ -116,7 +116,7 @@ async def test_user_form_duplicate(hass):
         assert result["errors"] == {"base": "no_server_found"}
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "edit"}
@@ -141,7 +141,7 @@ async def test_form_invalid_auth(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "edit"}
@@ -165,7 +165,7 @@ async def test_form_cannot_connect(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_discovery(hass):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test handling of discovered server."""
     with patch(
         "pysqueezebox.Server.async_query",
@@ -180,7 +180,7 @@ async def test_discovery(hass):
         assert result["step_id"] == "edit"
 
 
-async def test_discovery_no_uuid(hass):
+async def test_discovery_no_uuid(hass: HomeAssistant) -> None:
     """Test handling of discovered server with unavailable uuid."""
     with patch("pysqueezebox.Server.async_query", new=patch_async_query_unauthorized):
         result = await hass.config_entries.flow.async_init(
@@ -192,7 +192,7 @@ async def test_discovery_no_uuid(hass):
         assert result["step_id"] == "edit"
 
 
-async def test_dhcp_discovery(hass):
+async def test_dhcp_discovery(hass: HomeAssistant) -> None:
     """Test we can process discovery from dhcp."""
     with patch(
         "pysqueezebox.Server.async_query",
@@ -213,7 +213,7 @@ async def test_dhcp_discovery(hass):
         assert result["step_id"] == "edit"
 
 
-async def test_dhcp_discovery_no_server_found(hass):
+async def test_dhcp_discovery_no_server_found(hass: HomeAssistant) -> None:
     """Test we can handle dhcp discovery when no server is found."""
     with patch(
         "homeassistant.components.squeezebox.config_flow.async_discover",
@@ -232,7 +232,7 @@ async def test_dhcp_discovery_no_server_found(hass):
         assert result["step_id"] == "user"
 
 
-async def test_dhcp_discovery_existing_player(hass):
+async def test_dhcp_discovery_existing_player(hass: HomeAssistant) -> None:
     """Test that we properly ignore known players during dhcp discover."""
     with patch(
         "homeassistant.helpers.entity_registry.EntityRegistry.async_get_entity_id",

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.srp_energy.const import CONF_IS_TOU, SRP_ENERGY_DOMAIN
+from homeassistant.core import HomeAssistant
 
 from . import ENTRY_CONFIG, init_integration
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test user config."""
     # First get the form
     result = await hass.config_entries.flow.async_init(
@@ -36,7 +37,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test user config with invalid auth."""
     result = await hass.config_entries.flow.async_init(
         SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -54,7 +55,7 @@ async def test_form_invalid_auth(hass):
         assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_form_value_error(hass):
+async def test_form_value_error(hass: HomeAssistant) -> None:
     """Test user config that throws a value error."""
     result = await hass.config_entries.flow.async_init(
         SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -72,7 +73,7 @@ async def test_form_value_error(hass):
         assert result["errors"]["base"] == "invalid_account"
 
 
-async def test_form_unknown_exception(hass):
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test user config that throws an unknown exception."""
     result = await hass.config_entries.flow.async_init(
         SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -90,7 +91,7 @@ async def test_form_unknown_exception(hass):
         assert result["errors"]["base"] == "unknown"
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test handling of configuration imported."""
     with patch(
         "homeassistant.components.srp_energy.config_flow.SrpEnergyClient"
@@ -109,7 +110,7 @@ async def test_config(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_integration_already_configured(hass):
+async def test_integration_already_configured(hass: HomeAssistant) -> None:
     """Test integration is already configured."""
     await init_integration(hass)
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/srp_energy/test_init.py
+++ b/tests/components/srp_energy/test_init.py
@@ -1,18 +1,19 @@
 """Tests for Srp Energy component Init."""
 from homeassistant import config_entries
 from homeassistant.components import srp_energy
+from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
 
-async def test_setup_entry(hass):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup entry fails if deCONZ is not available."""
     config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
     assert hass.data[srp_energy.SRP_ENERGY_DOMAIN]
 
 
-async def test_unload_entry(hass):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test being able to unload an entry."""
     config_entry = await init_integration(hass)
     assert hass.data[srp_energy.SRP_ENERGY_DOMAIN]
@@ -21,7 +22,7 @@ async def test_unload_entry(hass):
     assert not hass.data[srp_energy.SRP_ENERGY_DOMAIN]
 
 
-async def test_async_setup_entry_with_exception(hass):
+async def test_async_setup_entry_with_exception(hass: HomeAssistant) -> None:
     """Test exception when SrpClient can't load."""
     await init_integration(hass, side_effect=Exception())
     assert srp_energy.SRP_ENERGY_DOMAIN not in hass.data

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -12,9 +12,10 @@ from homeassistant.components.srp_energy.const import (
 )
 from homeassistant.components.srp_energy.sensor import SrpEntity, async_setup_entry
 from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
 
 
-async def test_async_setup_entry(hass):
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test the sensor."""
     fake_async_add_entities = MagicMock()
     fake_srp_energy_client = MagicMock()
@@ -33,7 +34,7 @@ async def test_async_setup_entry(hass):
     await async_setup_entry(hass, fake_config, fake_async_add_entities)
 
 
-async def test_async_setup_entry_timeout_error(hass):
+async def test_async_setup_entry_timeout_error(hass: HomeAssistant) -> None:
     """Test fetching usage data. Failed the first time because was too get response."""
     fake_async_add_entities = MagicMock()
     fake_srp_energy_client = MagicMock()
@@ -56,7 +57,7 @@ async def test_async_setup_entry_timeout_error(hass):
     ].coordinator.last_update_success
 
 
-async def test_async_setup_entry_connect_error(hass):
+async def test_async_setup_entry_connect_error(hass: HomeAssistant) -> None:
     """Test fetching usage data. Failed the first time because was too get response."""
     fake_async_add_entities = MagicMock()
     fake_srp_energy_client = MagicMock()
@@ -79,7 +80,7 @@ async def test_async_setup_entry_connect_error(hass):
     ].coordinator.last_update_success
 
 
-async def test_srp_entity(hass):
+async def test_srp_entity(hass: HomeAssistant) -> None:
     """Test the SrpEntity."""
     fake_coordinator = MagicMock(data=1.99999999999)
     srp_entity = SrpEntity(fake_coordinator)
@@ -104,7 +105,7 @@ async def test_srp_entity(hass):
     assert not fake_coordinator.async_add_listener.data.called
 
 
-async def test_srp_entity_no_data(hass):
+async def test_srp_entity_no_data(hass: HomeAssistant) -> None:
     """Test the SrpEntity."""
     fake_coordinator = MagicMock(data=False)
     srp_entity = SrpEntity(fake_coordinator)
@@ -112,7 +113,7 @@ async def test_srp_entity_no_data(hass):
     assert srp_entity.extra_state_attributes is None
 
 
-async def test_srp_entity_no_coord_data(hass):
+async def test_srp_entity_no_coord_data(hass: HomeAssistant) -> None:
     """Test the SrpEntity."""
     fake_coordinator = MagicMock(data=False)
     srp_entity = SrpEntity(fake_coordinator)
@@ -121,7 +122,7 @@ async def test_srp_entity_no_coord_data(hass):
     assert srp_entity.usage is None
 
 
-async def test_srp_entity_async_update(hass):
+async def test_srp_entity_async_update(hass: HomeAssistant) -> None:
     """Test the SrpEntity."""
 
     async def async_magic():

--- a/tests/components/starline/test_config_flow.py
+++ b/tests/components/starline/test_config_flow.py
@@ -3,6 +3,7 @@ import requests_mock
 
 from homeassistant import config_entries
 from homeassistant.components.starline import config_flow
+from homeassistant.core import HomeAssistant
 
 TEST_APP_ID = "666"
 TEST_APP_SECRET = "appsecret"
@@ -15,7 +16,7 @@ TEST_APP_USERNAME = "sluser"
 TEST_APP_PASSWORD = "slpassword"
 
 
-async def test_flow_works(hass):
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test that config flow works."""
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -69,7 +70,7 @@ async def test_flow_works(hass):
         assert result["title"] == f"Application {TEST_APP_ID}"
 
 
-async def test_step_auth_app_code_falls(hass):
+async def test_step_auth_app_code_falls(hass: HomeAssistant) -> None:
     """Test config flow works when app auth code fails."""
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -88,7 +89,7 @@ async def test_step_auth_app_code_falls(hass):
         assert result["errors"] == {"base": "error_auth_app"}
 
 
-async def test_step_auth_app_token_falls(hass):
+async def test_step_auth_app_token_falls(hass: HomeAssistant) -> None:
     """Test config flow works when app auth token fails."""
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -111,7 +112,7 @@ async def test_step_auth_app_token_falls(hass):
         assert result["errors"] == {"base": "error_auth_app"}
 
 
-async def test_step_auth_user_falls(hass):
+async def test_step_auth_user_falls(hass: HomeAssistant) -> None:
     """Test config flow works when user fails."""
     with requests_mock.Mocker() as mock:
         mock.post("https://id.starline.ru/apiV3/user/login/", text='{"state": 0}')

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -4,10 +4,15 @@ from http import HTTPStatus
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.startca.sensor import StartcaData
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfInformation
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_capped_setup(hass, aioclient_mock):
+
+async def test_capped_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the default setup."""
     config = {
         "platform": "startca",
@@ -103,7 +108,9 @@ async def test_capped_setup(hass, aioclient_mock):
     assert state.state == "95.05"
 
 
-async def test_unlimited_setup(hass, aioclient_mock):
+async def test_unlimited_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the default setup."""
     config = {
         "platform": "startca",
@@ -199,7 +206,9 @@ async def test_unlimited_setup(hass, aioclient_mock):
     assert state.state == "inf"
 
 
-async def test_bad_return_code(hass, aioclient_mock):
+async def test_bad_return_code(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test handling a return code that isn't HTTP OK."""
     aioclient_mock.get(
         "https://www.start.ca/support/usage/api?key=NOTAKEY",
@@ -212,7 +221,9 @@ async def test_bad_return_code(hass, aioclient_mock):
     assert result is False
 
 
-async def test_bad_json_decode(hass, aioclient_mock):
+async def test_bad_json_decode(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test decoding invalid json result."""
     aioclient_mock.get(
         "https://www.start.ca/support/usage/api?key=NOTAKEY", text="this is not xml"

--- a/tests/components/statsd/test_init.py
+++ b/tests/components/statsd/test_init.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 import homeassistant.components.statsd as statsd
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -28,7 +29,7 @@ def test_invalid_config() -> None:
         statsd.CONFIG_SCHEMA(config)
 
 
-async def test_statsd_setup_full(hass):
+async def test_statsd_setup_full(hass: HomeAssistant) -> None:
     """Test setup with all data."""
     config = {"statsd": {"host": "host", "port": 123, "rate": 1, "prefix": "foo"}}
     hass.bus.listen = MagicMock()
@@ -42,7 +43,7 @@ async def test_statsd_setup_full(hass):
     assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
 
 
-async def test_statsd_setup_defaults(hass):
+async def test_statsd_setup_defaults(hass: HomeAssistant) -> None:
     """Test setup with defaults."""
     config = {"statsd": {"host": "host"}}
 

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -1,14 +1,17 @@
 """Test stream init."""
-
 import logging
 
 import av
+import pytest
 
 from homeassistant.components.stream import __name__ as stream_name
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_log_levels(hass, caplog):
+async def test_log_levels(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that the worker logs the url without username and password."""
 
     logging.getLogger(stream_name).setLevel(logging.INFO)

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.homeassistant import (
 from homeassistant.components.subaru.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .api_responses import (
@@ -28,7 +29,7 @@ from .conftest import (
 )
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test DOMAIN is empty if there is no config."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -8,13 +8,14 @@ import pytest
 import homeassistant.components.sun as sun
 from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_setting_rising(hass):
+async def test_setting_rising(hass: HomeAssistant) -> None:
     """Test retrieving sun setting and rising."""
     utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)
     with freeze_time(utc_now):
@@ -106,7 +107,9 @@ async def test_setting_rising(hass):
     )
 
 
-async def test_state_change(hass, caplog):
+async def test_state_change(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if the state changes at next setting/rising."""
     now = datetime(2016, 6, 1, 8, 0, 0, tzinfo=dt_util.UTC)
     with freeze_time(now):
@@ -155,7 +158,7 @@ async def test_state_change(hass, caplog):
     assert hass.states.get(sun.ENTITY_ID).state == sun.STATE_BELOW_HORIZON
 
 
-async def test_norway_in_june(hass):
+async def test_norway_in_june(hass: HomeAssistant) -> None:
     """Test location in Norway where the sun doesn't set in summer."""
     hass.config.latitude = 69.6
     hass.config.longitude = 18.8
@@ -179,7 +182,7 @@ async def test_norway_in_june(hass):
 
 
 @pytest.mark.skip
-async def test_state_change_count(hass):
+async def test_state_change_count(hass: HomeAssistant) -> None:
     """Count the number of state change events in a location."""
     # Skipped because it's a bit slow. Has been validated with
     # multiple lattitudes and dates

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -145,7 +145,7 @@ async def test_flow_entry_already_exists(
     assert result["reason"] == "already_configured"
 
 
-async def test_reauthentication(hass):
+async def test_reauthentication(hass: HomeAssistant) -> None:
     """Test surepetcare reauthentication."""
     old_entry = MockConfigEntry(
         domain="surepetcare",
@@ -182,7 +182,7 @@ async def test_reauthentication(hass):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_reauthentication_failure(hass):
+async def test_reauthentication_failure(hass: HomeAssistant) -> None:
     """Test surepetcare reauthentication failure."""
     old_entry = MockConfigEntry(
         domain="surepetcare",
@@ -220,7 +220,7 @@ async def test_reauthentication_failure(hass):
     assert result2["errors"]["base"] == "invalid_auth"
 
 
-async def test_reauthentication_cannot_connect(hass):
+async def test_reauthentication_cannot_connect(hass: HomeAssistant) -> None:
     """Test surepetcare reauthentication failure."""
     old_entry = MockConfigEntry(
         domain="surepetcare",
@@ -258,7 +258,7 @@ async def test_reauthentication_cannot_connect(hass):
     assert result2["errors"]["base"] == "cannot_connect"
 
 
-async def test_reauthentication_unknown_failure(hass):
+async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:
     """Test surepetcare reauthentication failure."""
     old_entry = MockConfigEntry(
         domain="surepetcare",

--- a/tests/components/switch/test_light.py
+++ b/tests/components/switch/test_light.py
@@ -4,6 +4,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import common as switch_common
@@ -11,7 +12,7 @@ from . import common as switch_common
 from tests.components.light import common
 
 
-async def test_default_state(hass):
+async def test_default_state(hass: HomeAssistant) -> None:
     """Test light switch default state."""
     await async_setup_component(
         hass,
@@ -39,7 +40,7 @@ async def test_default_state(hass):
     assert state.attributes.get(ATTR_COLOR_MODE) is None
 
 
-async def test_light_service_calls(hass):
+async def test_light_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to light."""
     await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
     await async_setup_component(
@@ -72,7 +73,7 @@ async def test_light_service_calls(hass):
     assert hass.states.get("light.light_switch").state == "off"
 
 
-async def test_switch_service_calls(hass):
+async def test_switch_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to switch."""
     await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
     await async_setup_component(

--- a/tests/components/switch/test_reproduce_state.py
+++ b/tests/components/switch/test_reproduce_state.py
@@ -1,11 +1,15 @@
 """Test reproduce state for Switch."""
-from homeassistant.core import State
+import pytest
+
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Switch states."""
     hass.states.async_set("switch.entity_off", "off", {})
     hass.states.async_set("switch.entity_on", "on", {})

--- a/tests/components/switchbee/test_config_flow.py
+++ b/tests/components/switchbee/test_config_flow.py
@@ -14,7 +14,7 @@ from . import MOCK_FAILED_TO_LOGIN_MSG, MOCK_INVALID_TOKEN_MGS
 from tests.common import MockConfigEntry, load_fixture
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     coordinator_data = json.loads(load_fixture("switchbee.json", "switchbee"))
@@ -101,7 +101,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass):
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle an unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -124,7 +124,7 @@ async def test_form_unknown_error(hass):
     assert form_result["errors"] == {"base": "unknown"}
 
 
-async def test_form_entry_exists(hass):
+async def test_form_entry_exists(hass: HomeAssistant) -> None:
     """Test we handle an already existing entry."""
 
     coordinator_data = json.loads(load_fixture("switchbee.json", "switchbee"))

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the switchbot config flow."""
-
 from unittest.mock import patch
 
 from switchbot import SwitchbotAccountConnectionError, SwitchbotAuthenticationError
@@ -17,6 +16,7 @@ from homeassistant.const import (
     CONF_SENSOR_TYPE,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -38,7 +38,7 @@ from tests.common import MockConfigEntry
 DOMAIN = "switchbot"
 
 
-async def test_bluetooth_discovery(hass):
+async def test_bluetooth_discovery(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -65,7 +65,7 @@ async def test_bluetooth_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_bluetooth_discovery_requires_password(hass):
+async def test_bluetooth_discovery_requires_password(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device that needs a password."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -93,7 +93,7 @@ async def test_bluetooth_discovery_requires_password(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_bluetooth_discovery_lock_key(hass):
+async def test_bluetooth_discovery_lock_key(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a lock."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -153,7 +153,7 @@ async def test_bluetooth_discovery_lock_key(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_bluetooth_discovery_already_setup(hass):
+async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device when already setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -175,7 +175,7 @@ async def test_bluetooth_discovery_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_not_switchbot(hass):
+async def test_async_step_bluetooth_not_switchbot(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not switchbot."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -186,7 +186,7 @@ async def test_async_step_bluetooth_not_switchbot(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_bluetooth_not_connectable(hass):
+async def test_async_step_bluetooth_not_connectable(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth and its not connectable switchbot."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -197,7 +197,7 @@ async def test_async_step_bluetooth_not_connectable(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_user_setup_wohand(hass):
+async def test_user_setup_wohand(hass: HomeAssistant) -> None:
     """Test the user initiated form with password and valid mac."""
 
     with patch(
@@ -228,7 +228,7 @@ async def test_user_setup_wohand(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wohand_already_configured(hass):
+async def test_user_setup_wohand_already_configured(hass: HomeAssistant) -> None:
     """Test the user initiated form with password and valid mac."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -252,7 +252,7 @@ async def test_user_setup_wohand_already_configured(hass):
     assert result["reason"] == "no_unconfigured_devices"
 
 
-async def test_user_setup_wocurtain(hass):
+async def test_user_setup_wocurtain(hass: HomeAssistant) -> None:
     """Test the user initiated form with password and valid mac."""
 
     with patch(
@@ -283,7 +283,7 @@ async def test_user_setup_wocurtain(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wocurtain_or_bot(hass):
+async def test_user_setup_wocurtain_or_bot(hass: HomeAssistant) -> None:
     """Test the user initiated form with valid address."""
 
     with patch(
@@ -319,7 +319,7 @@ async def test_user_setup_wocurtain_or_bot(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wocurtain_or_bot_with_password(hass):
+async def test_user_setup_wocurtain_or_bot_with_password(hass: HomeAssistant) -> None:
     """Test the user initiated form and valid address and a bot with a password."""
 
     with patch(
@@ -363,7 +363,7 @@ async def test_user_setup_wocurtain_or_bot_with_password(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_single_bot_with_password(hass):
+async def test_user_setup_single_bot_with_password(hass: HomeAssistant) -> None:
     """Test the user initiated form for a bot with a password."""
 
     with patch(
@@ -395,7 +395,7 @@ async def test_user_setup_single_bot_with_password(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wolock_key(hass):
+async def test_user_setup_wolock_key(hass: HomeAssistant) -> None:
     """Test the user initiated form for a lock."""
 
     with patch(
@@ -458,7 +458,7 @@ async def test_user_setup_wolock_key(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wolock_auth(hass):
+async def test_user_setup_wolock_auth(hass: HomeAssistant) -> None:
     """Test the user initiated form for a lock."""
 
     with patch(
@@ -527,7 +527,7 @@ async def test_user_setup_wolock_auth(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wolock_auth_switchbot_api_down(hass):
+async def test_user_setup_wolock_auth_switchbot_api_down(hass: HomeAssistant) -> None:
     """Test the user initiated form for a lock when the switchbot api is down."""
 
     with patch(
@@ -564,7 +564,7 @@ async def test_user_setup_wolock_auth_switchbot_api_down(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_user_setup_wolock_or_bot(hass):
+async def test_user_setup_wolock_or_bot(hass: HomeAssistant) -> None:
     """Test the user initiated form for a lock."""
 
     with patch(
@@ -622,7 +622,7 @@ async def test_user_setup_wolock_or_bot(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_setup_wosensor(hass):
+async def test_user_setup_wosensor(hass: HomeAssistant) -> None:
     """Test the user initiated form with password and valid mac."""
     with patch(
         "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
@@ -652,7 +652,7 @@ async def test_user_setup_wosensor(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_no_devices(hass):
+async def test_user_no_devices(hass: HomeAssistant) -> None:
     """Test the user initiated form with password and valid mac."""
     with patch(
         "homeassistant.components.switchbot.config_flow.async_discovered_service_info",
@@ -665,7 +665,9 @@ async def test_user_no_devices(hass):
     assert result["reason"] == "no_unconfigured_devices"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -703,7 +705,7 @@ async def test_async_step_user_takes_precedence_over_discovery(hass):
     assert not hass.config_entries.flow.async_progress(DOMAIN)
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test updating options."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.switcher_kis.const import DATA_DISCOVERY, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
@@ -12,7 +13,7 @@ from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
 from tests.common import MockConfigEntry
 
 
-async def test_import(hass):
+async def test_import(hass: HomeAssistant) -> None:
     """Test import step."""
     with patch(
         "homeassistant.components.switcher_kis.async_setup_entry", return_value=True

--- a/tests/components/syncthing/test_config_flow.py
+++ b/tests/components/syncthing/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for syncthing config flow."""
-
 from unittest.mock import patch
 
 from aiosyncthing.exceptions import UnauthorizedError
@@ -7,6 +6,7 @@ from aiosyncthing.exceptions import UnauthorizedError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.syncthing.const import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -23,7 +23,7 @@ MOCK_ENTRY = {
 }
 
 
-async def test_show_setup_form(hass):
+async def test_show_setup_form(hass: HomeAssistant) -> None:
     """Test that the setup form is served."""
 
     result = await hass.config_entries.flow.async_init(
@@ -34,7 +34,7 @@ async def test_show_setup_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_flow_successful(hass):
+async def test_flow_successful(hass: HomeAssistant) -> None:
     """Test with required fields only."""
     with patch(
         "aiosyncthing.system.System.status", return_value={"myID": "server-id"}
@@ -61,7 +61,7 @@ async def test_flow_successful(hass):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_already_configured(hass):
+async def test_flow_already_configured(hass: HomeAssistant) -> None:
     """Test name is already configured."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY, unique_id="server-id")
@@ -78,7 +78,7 @@ async def test_flow_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_flow_invalid_auth(hass):
+async def test_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test invalid auth."""
 
     with patch("aiosyncthing.system.System.status", side_effect=UnauthorizedError):
@@ -92,7 +92,7 @@ async def test_flow_invalid_auth(hass):
         assert result["errors"]["token"] == "invalid_auth"
 
 
-async def test_flow_cannot_connect(hass):
+async def test_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test cannot connect."""
 
     with patch("aiosyncthing.system.System.status", side_effect=Exception):

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for syncthru config flow."""
-
 import re
 from unittest.mock import patch
 
@@ -10,8 +9,10 @@ from homeassistant.components import ssdp
 from homeassistant.components.syncthru.config_flow import SyncThru
 from homeassistant.components.syncthru.const import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_URL
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, mock_coro
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 FIXTURE_USER_INPUT = {
     CONF_URL: "http://192.168.1.2/",
@@ -37,7 +38,7 @@ def mock_connection(aioclient_mock):
     )
 
 
-async def test_show_setup_form(hass):
+async def test_show_setup_form(hass: HomeAssistant) -> None:
     """Test that the setup form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
@@ -47,7 +48,9 @@ async def test_show_setup_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_already_configured_by_url(hass, aioclient_mock):
+async def test_already_configured_by_url(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we match and update already configured devices by URL."""
 
     udn = "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
@@ -71,7 +74,7 @@ async def test_already_configured_by_url(hass, aioclient_mock):
     assert result["result"].unique_id == udn
 
 
-async def test_syncthru_not_supported(hass):
+async def test_syncthru_not_supported(hass: HomeAssistant) -> None:
     """Test we show user form on unsupported device."""
     with patch.object(SyncThru, "update", side_effect=SyncThruAPINotSupported):
         result = await hass.config_entries.flow.async_init(
@@ -85,7 +88,7 @@ async def test_syncthru_not_supported(hass):
     assert result["errors"] == {CONF_URL: "syncthru_not_supported"}
 
 
-async def test_unknown_state(hass):
+async def test_unknown_state(hass: HomeAssistant) -> None:
     """Test we show user form on unsupported device."""
     with patch.object(SyncThru, "update", return_value=mock_coro()), patch.object(
         SyncThru, "is_unknown_state", return_value=True
@@ -101,7 +104,9 @@ async def test_unknown_state(hass):
     assert result["errors"] == {CONF_URL: "unknown_state"}
 
 
-async def test_success(hass, aioclient_mock):
+async def test_success(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test successful flow provides entry creation data."""
 
     mock_connection(aioclient_mock)
@@ -121,7 +126,7 @@ async def test_success(hass, aioclient_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_ssdp(hass, aioclient_mock):
+async def test_ssdp(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test SSDP discovery initiates config properly."""
 
     mock_connection(aioclient_mock)

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -5,9 +5,11 @@ from unittest.mock import AsyncMock, Mock, patch
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info, mock_platform
+from tests.typing import WebSocketGenerator
 
 
 async def gather_system_health_info(hass, hass_ws_client):
@@ -44,7 +46,9 @@ async def gather_system_health_info(hass, hass_ws_client):
     return data
 
 
-async def test_info_endpoint_return_info(hass, hass_ws_client):
+async def test_info_endpoint_return_info(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the info endpoint works."""
     assert await async_setup_component(hass, "homeassistant", {})
 
@@ -61,7 +65,9 @@ async def test_info_endpoint_return_info(hass, hass_ws_client):
     assert data == {"info": {"hello": True}}
 
 
-async def test_info_endpoint_register_callback(hass, hass_ws_client):
+async def test_info_endpoint_register_callback(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the info endpoint allows registering callbacks."""
 
     async def mock_info(hass):
@@ -79,7 +85,9 @@ async def test_info_endpoint_register_callback(hass, hass_ws_client):
     assert await get_system_health_info(hass, "lovelace") == {"storage": "YAML"}
 
 
-async def test_info_endpoint_register_callback_timeout(hass, hass_ws_client):
+async def test_info_endpoint_register_callback_timeout(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the info endpoint timing out."""
 
     async def mock_info(hass):
@@ -94,7 +102,9 @@ async def test_info_endpoint_register_callback_timeout(hass, hass_ws_client):
     assert data == {"info": {"error": {"type": "failed", "error": "timeout"}}}
 
 
-async def test_info_endpoint_register_callback_exc(hass, hass_ws_client):
+async def test_info_endpoint_register_callback_exc(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the info endpoint requires auth."""
 
     async def mock_info(hass):

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -9,9 +9,10 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import system_log
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
 from tests.common import async_capture_events
+from tests.typing import WebSocketGenerator
 
 _LOGGER = logging.getLogger("test_logger")
 BASIC_CONFIG = {"system_log": {"max_entries": 2}}
@@ -103,7 +104,9 @@ async def async_setup_system_log(hass, config) -> WatchLogErrorHandler:
     return WatchLogErrorHandler.instances.pop()
 
 
-async def test_normal_logs(hass, hass_ws_client):
+async def test_normal_logs(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that debug and info are not logged."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -115,7 +118,9 @@ async def test_normal_logs(hass, hass_ws_client):
     assert len([msg for msg in logs if msg["level"] in ("DEBUG", "INFO")]) == 0
 
 
-async def test_exception(hass, hass_ws_client):
+async def test_exception(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that exceptions are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -126,7 +131,7 @@ async def test_exception(hass, hass_ws_client):
     assert_log(log, "exception message", "log message", "ERROR")
 
 
-async def test_warning(hass, hass_ws_client):
+async def test_warning(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -> None:
     """Test that warning are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -136,7 +141,9 @@ async def test_warning(hass, hass_ws_client):
     assert_log(log, "", "warning message", "WARNING")
 
 
-async def test_warning_good_format(hass, hass_ws_client):
+async def test_warning_good_format(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that warning with good format arguments are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -147,7 +154,9 @@ async def test_warning_good_format(hass, hass_ws_client):
     assert_log(log, "", "warning message: test", "WARNING")
 
 
-async def test_warning_missing_format_args(hass, hass_ws_client):
+async def test_warning_missing_format_args(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that warning with missing format arguments are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -158,7 +167,7 @@ async def test_warning_missing_format_args(hass, hass_ws_client):
     assert_log(log, "", ["warning message missing a format arg %s"], "WARNING")
 
 
-async def test_error(hass, hass_ws_client):
+async def test_error(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -> None:
     """Test that errors are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -169,7 +178,7 @@ async def test_error(hass, hass_ws_client):
     assert_log(log, "", "error message", "ERROR")
 
 
-async def test_config_not_fire_event(hass):
+async def test_config_not_fire_event(hass: HomeAssistant) -> None:
     """Test that errors are not posted as events with default config."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -188,7 +197,7 @@ async def test_config_not_fire_event(hass):
     assert len(events) == 0
 
 
-async def test_error_posted_as_event(hass):
+async def test_error_posted_as_event(hass: HomeAssistant) -> None:
     """Test that error are posted as events."""
     watcher = await async_setup_system_log(
         hass, {"system_log": {"max_entries": 2, "fire_event": True}}
@@ -206,7 +215,9 @@ async def test_error_posted_as_event(hass):
     assert_log(events[0].data, "", "error message", "ERROR")
 
 
-async def test_critical(hass, hass_ws_client):
+async def test_critical(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that critical are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -217,7 +228,9 @@ async def test_critical(hass, hass_ws_client):
     assert_log(log, "", "critical message", "CRITICAL")
 
 
-async def test_remove_older_logs(hass, hass_ws_client):
+async def test_remove_older_logs(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that older logs are rotated out."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -235,7 +248,9 @@ def log_msg(nr=2):
     _LOGGER.error("error message %s", nr)
 
 
-async def test_dedupe_logs(hass, hass_ws_client):
+async def test_dedupe_logs(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that duplicate log entries are dedupe."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -274,7 +289,9 @@ async def test_dedupe_logs(hass, hass_ws_client):
     )
 
 
-async def test_clear_logs(hass, hass_ws_client):
+async def test_clear_logs(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the log can be cleared via a service call."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -286,7 +303,7 @@ async def test_clear_logs(hass, hass_ws_client):
     await get_error_log(hass_ws_client)
 
 
-async def test_write_log(hass):
+async def test_write_log(hass: HomeAssistant) -> None:
     """Test that error propagates to logger."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -301,7 +318,7 @@ async def test_write_log(hass):
     assert logger.method_calls[0] == ("error", ("test_message",))
 
 
-async def test_write_choose_logger(hass):
+async def test_write_choose_logger(hass: HomeAssistant) -> None:
     """Test that correct logger is chosen."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -316,7 +333,7 @@ async def test_write_choose_logger(hass):
     mock_logging.assert_called_once_with("myLogger")
 
 
-async def test_write_choose_level(hass):
+async def test_write_choose_level(hass: HomeAssistant) -> None:
     """Test that correct logger is chosen."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -332,7 +349,9 @@ async def test_write_choose_level(hass):
     assert logger.method_calls[0] == ("debug", ("test_message",))
 
 
-async def test_unknown_path(hass, hass_ws_client):
+async def test_unknown_path(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test error logged from unknown path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     await hass.async_block_till_done()
@@ -363,7 +382,9 @@ async def async_log_error_from_test_path(hass, path, watcher):
         await wait_empty
 
 
-async def test_homeassistant_path(hass, hass_ws_client):
+async def test_homeassistant_path(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test error logged from Home Assistant path."""
 
     with patch(
@@ -378,7 +399,9 @@ async def test_homeassistant_path(hass, hass_ws_client):
     assert log["source"] == ["component/component.py", 5]
 
 
-async def test_config_path(hass, hass_ws_client):
+async def test_config_path(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test error logged from config path."""
 
     with patch.object(hass.config, "config_dir", new="config"):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests:
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
