### PR TITLE
Add type hints to integration tests (t-z)

### DIFF
--- a/tests/components/tado/test_binary_sensor.py
+++ b/tests/components/tado/test_binary_sensor.py
@@ -1,11 +1,11 @@
 """The sensor tests for the tado platform."""
-
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
-async def test_air_con_create_binary_sensors(hass):
+async def test_air_con_create_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of aircon sensors."""
 
     await async_init_integration(hass)
@@ -23,7 +23,7 @@ async def test_air_con_create_binary_sensors(hass):
     assert state.state == STATE_OFF
 
 
-async def test_heater_create_binary_sensors(hass):
+async def test_heater_create_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of heater sensors."""
 
     await async_init_integration(hass)
@@ -44,7 +44,7 @@ async def test_heater_create_binary_sensors(hass):
     assert state.state == STATE_OFF
 
 
-async def test_water_heater_create_binary_sensors(hass):
+async def test_water_heater_create_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of water heater sensors."""
 
     await async_init_integration(hass)
@@ -59,7 +59,7 @@ async def test_water_heater_create_binary_sensors(hass):
     assert state.state == STATE_ON
 
 
-async def test_home_create_binary_sensors(hass):
+async def test_home_create_binary_sensors(hass: HomeAssistant) -> None:
     """Test creation of home binary sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/tado/test_climate.py
+++ b/tests/components/tado/test_climate.py
@@ -1,9 +1,10 @@
 """The sensor tests for the tado platform."""
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
-async def test_air_con(hass):
+async def test_air_con(hass: HomeAssistant) -> None:
     """Test creation of aircon climate."""
 
     await async_init_integration(hass)
@@ -32,7 +33,7 @@ async def test_air_con(hass):
     assert all(item in state.attributes.items() for item in expected_attributes.items())
 
 
-async def test_heater(hass):
+async def test_heater(hass: HomeAssistant) -> None:
     """Test creation of heater climate."""
 
     await async_init_integration(hass)
@@ -59,7 +60,7 @@ async def test_heater(hass):
     assert all(item in state.attributes.items() for item in expected_attributes.items())
 
 
-async def test_smartac_with_swing(hass):
+async def test_smartac_with_swing(hass: HomeAssistant) -> None:
     """Test creation of smart ac with swing climate."""
 
     await async_init_integration(hass)

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.tado.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -21,7 +22,7 @@ def _get_mock_tado_api(getMe=None):
     return mock_tado
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we can setup though the user path."""
 
     result = await hass.config_entries.flow.async_init(
@@ -54,7 +55,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -77,7 +78,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -100,7 +101,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_no_homes(hass):
+async def test_no_homes(hass: HomeAssistant) -> None:
     """Test we handle no homes error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -121,7 +122,7 @@ async def test_no_homes(hass):
     assert result2["errors"] == {"base": "no_homes"}
 
 
-async def test_form_homekit(hass):
+async def test_form_homekit(hass: HomeAssistant) -> None:
     """Test that we abort from homekit if tado is already setup."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/tado/test_sensor.py
+++ b/tests/components/tado/test_sensor.py
@@ -1,9 +1,10 @@
 """The sensor tests for the tado platform."""
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
-async def test_air_con_create_sensors(hass):
+async def test_air_con_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of aircon sensors."""
 
     await async_init_integration(hass)
@@ -21,7 +22,7 @@ async def test_air_con_create_sensors(hass):
     assert state.state == "60.9"
 
 
-async def test_home_create_sensors(hass):
+async def test_home_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of home sensors."""
 
     await async_init_integration(hass)
@@ -36,7 +37,7 @@ async def test_home_create_sensors(hass):
     assert state.state == "fog"
 
 
-async def test_heater_create_sensors(hass):
+async def test_heater_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of heater sensors."""
 
     await async_init_integration(hass)
@@ -51,7 +52,7 @@ async def test_heater_create_sensors(hass):
     assert state.state == "45.2"
 
 
-async def test_water_heater_create_sensors(hass):
+async def test_water_heater_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of water heater sensors."""
 
     await async_init_integration(hass)

--- a/tests/components/tado/test_water_heater.py
+++ b/tests/components/tado/test_water_heater.py
@@ -1,9 +1,10 @@
 """The sensor tests for the tado platform."""
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
-async def test_water_heater_create_sensors(hass):
+async def test_water_heater_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of water heater."""
 
     await async_init_integration(hass)

--- a/tests/components/telegram/test_notify.py
+++ b/tests/components/telegram/test_notify.py
@@ -5,12 +5,13 @@ from homeassistant import config as hass_config
 import homeassistant.components.notify as notify
 from homeassistant.components.telegram import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_fixture_path
 
 
-async def test_reload_notify(hass):
+async def test_reload_notify(hass: HomeAssistant) -> None:
     """Verify we can reload the notify service."""
 
     with patch("homeassistant.components.telegram_bot.async_setup", return_value=True):

--- a/tests/components/telegram_bot/test_broadcast.py
+++ b/tests/components/telegram_bot/test_broadcast.py
@@ -1,8 +1,9 @@
 """Test Telegram broadcast."""
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setting up Telegram broadcast."""
     assert await async_setup_component(
         hass,

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.tellduslive import (
 )
 from homeassistant.config_entries import SOURCE_DISCOVERY
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -56,7 +57,7 @@ def mock_tellduslive(supports_local_api, authorize):
         yield Session, tellduslive_supports_local_api
 
 
-async def test_abort_if_already_setup(hass):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if TelldusLive is already setup."""
     flow = init_config_flow(hass)
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
@@ -699,7 +699,9 @@ async def test_invalid_availability_template_keeps_component_available(
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
-async def test_no_update_template_match_all(hass, caplog):
+async def test_no_update_template_match_all(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we do not update sensors that match on all."""
 
     hass.state = CoreState.not_running

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_ICON,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component
@@ -20,7 +21,7 @@ _TEST_BUTTON = "button.template_button"
 _TEST_OPTIONS_BUTTON = "button.test"
 
 
-async def test_missing_optional_config(hass):
+async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -42,7 +43,7 @@ async def test_missing_optional_config(hass):
     _verify(hass, STATE_UNKNOWN)
 
 
-async def test_missing_required_keys(hass):
+async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -124,7 +125,7 @@ async def test_all_optional_config(hass, calls):
     assert er.async_get_entity_id("button", "template", "test-test")
 
 
-async def test_name_template(hass):
+async def test_name_template(hass: HomeAssistant) -> None:
     """Test: name template."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -154,7 +155,7 @@ async def test_name_template(hass):
     )
 
 
-async def test_unique_id(hass):
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test: unique id is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -1,5 +1,4 @@
 """The tests for the Template number platform."""
-
 from homeassistant import setup
 from homeassistant.components.input_number import (
     ATTR_VALUE as INPUT_NUMBER_ATTR_VALUE,
@@ -15,7 +14,7 @@ from homeassistant.components.number import (
     SERVICE_SET_VALUE as NUMBER_SERVICE_SET_VALUE,
 )
 from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component, async_capture_events
@@ -42,7 +41,7 @@ _VALUE_INPUT_NUMBER_CONFIG = {
 }
 
 
-async def test_missing_optional_config(hass):
+async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -66,7 +65,7 @@ async def test_missing_optional_config(hass):
     _verify(hass, 4, 1, 0.0, 100.0)
 
 
-async def test_missing_required_keys(hass):
+async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -101,7 +100,7 @@ async def test_missing_required_keys(hass):
     assert hass.states.async_all("number") == []
 
 
-async def test_all_optional_config(hass):
+async def test_all_optional_config(hass: HomeAssistant) -> None:
     """Test: including all optional templates is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -264,7 +263,7 @@ async def test_templates_with_entities(hass, calls):
     assert calls[-1].data["value"] == 2
 
 
-async def test_trigger_number(hass):
+async def test_trigger_number(hass: HomeAssistant) -> None:
     """Test trigger based template number."""
     events = async_capture_events(hass, "test_number_event")
     assert await setup.async_setup_component(
@@ -346,7 +345,7 @@ def _verify(
     assert attributes.get(ATTR_MIN) == float(expected_minimum)
 
 
-async def test_icon_template(hass):
+async def test_icon_template(hass: HomeAssistant) -> None:
     """Test template numbers with icon templates."""
     with assert_setup_component(1, "input_number"):
         assert await setup.async_setup_component(
@@ -403,7 +402,7 @@ async def test_icon_template(hass):
     assert state.attributes[ATTR_ICON] == "mdi:greater"
 
 
-async def test_icon_template_with_trigger(hass):
+async def test_icon_template_with_trigger(hass: HomeAssistant) -> None:
     """Test template numbers with icon templates."""
     with assert_setup_component(1, "input_number"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -14,7 +14,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION as SELECT_SERVICE_SELECT_OPTION,
 )
 from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component, async_capture_events
@@ -24,7 +24,7 @@ _TEST_SELECT = "select.template_select"
 _OPTION_INPUT_SELECT = "input_select.option"
 
 
-async def test_missing_optional_config(hass):
+async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -48,7 +48,7 @@ async def test_missing_optional_config(hass):
     _verify(hass, "a", ["a", "b"])
 
 
-async def test_multiple_configs(hass):
+async def test_multiple_configs(hass: HomeAssistant) -> None:
     """Test: multiple select entities get created."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(
@@ -80,7 +80,7 @@ async def test_multiple_configs(hass):
     _verify(hass, "a", ["a", "b"], f"{_TEST_SELECT}_2")
 
 
-async def test_missing_required_keys(hass):
+async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
@@ -229,7 +229,7 @@ async def test_templates_with_entities(hass, calls):
     assert calls[-1].data["option"] == "c"
 
 
-async def test_trigger_select(hass):
+async def test_trigger_select(hass: HomeAssistant) -> None:
     """Test trigger based template select."""
     events = async_capture_events(hass, "test_number_event")
     assert await setup.async_setup_component(
@@ -294,7 +294,7 @@ def _verify(hass, expected_current_option, expected_options, entity_name=_TEST_S
     assert attributes.get(SELECT_ATTR_OPTIONS) == expected_options
 
 
-async def test_template_icon_with_entities(hass):
+async def test_template_icon_with_entities(hass: HomeAssistant) -> None:
     """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(
@@ -357,7 +357,7 @@ async def test_template_icon_with_entities(hass):
     assert state.attributes[ATTR_ICON] == "mdi:less"
 
 
-async def test_template_icon_with_trigger(hass):
+async def test_template_icon_with_trigger(hass: HomeAssistant) -> None:
     """Test trigger based template select."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, CoreState, State, callback
+from homeassistant.core import Context, CoreState, HomeAssistant, State, callback
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.template import Template
@@ -312,7 +312,7 @@ async def test_setup_valid_device_class(hass, start_ha):
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_creating_sensor_loads_group(hass):
+async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
     """Test setting up template sensor loads group component first."""
     order = []
     after_dep_event = Event()
@@ -445,7 +445,9 @@ async def test_invalid_availability_template_keeps_component_available(
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
-async def test_no_template_match_all(hass, caplog):
+async def test_no_template_match_all(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we allow static templates."""
     hass.states.async_set("sensor.test_sensor", "startup")
 
@@ -917,7 +919,9 @@ async def test_self_referencing_entity_picture_loop(hass, start_ha, caplog_setup
     assert int(state.state) == 1
 
 
-async def test_self_referencing_icon_with_no_loop(hass, caplog):
+async def test_self_referencing_icon_with_no_loop(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a self referencing icon that does not loop."""
 
     hass.states.async_set("sensor.heartworm_high_80", 10)
@@ -1214,7 +1218,7 @@ async def test_config_top_level(hass, start_ha):
     assert state.attributes["state_class"] == "measurement"
 
 
-async def test_trigger_entity_available(hass):
+async def test_trigger_entity_available(hass: HomeAssistant) -> None:
     """Test trigger entity availability works."""
     assert await async_setup_component(
         hass,
@@ -1255,7 +1259,7 @@ async def test_trigger_entity_available(hass):
     assert state.state == "unavailable"
 
 
-async def test_trigger_entity_device_class_parsing_works(hass):
+async def test_trigger_entity_device_class_parsing_works(hass: HomeAssistant) -> None:
     """Test trigger entity device class parsing works."""
     assert await async_setup_component(
         hass,
@@ -1299,7 +1303,7 @@ async def test_trigger_entity_device_class_parsing_works(hass):
     assert ts_state.state == now.isoformat(timespec="seconds")
 
 
-async def test_trigger_entity_device_class_errors_works(hass):
+async def test_trigger_entity_device_class_errors_works(hass: HomeAssistant) -> None:
     """Test trigger entity device class errors works."""
     assert await async_setup_component(
         hass,
@@ -1342,7 +1346,7 @@ async def test_trigger_entity_device_class_errors_works(hass):
     assert ts_state.state == STATE_UNKNOWN
 
 
-async def test_entity_device_class_parsing_works(hass):
+async def test_entity_device_class_parsing_works(hass: HomeAssistant) -> None:
     """Test entity device class parsing works."""
     # State of timestamp sensors are always in UTC
     now = dt_util.utcnow()
@@ -1381,7 +1385,7 @@ async def test_entity_device_class_parsing_works(hass):
     assert ts_state.state == now.isoformat(timespec="seconds")
 
 
-async def test_entity_device_class_errors_works(hass):
+async def test_entity_device_class_errors_works(hass: HomeAssistant) -> None:
     """Test entity device class errors works."""
     assert await async_setup_component(
         hass,

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -1,5 +1,5 @@
 """The tests for the  Template switch platform."""
-
+import pytest
 
 from homeassistant import setup
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -11,7 +11,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, mock_component, mock_restore_cache
@@ -34,7 +34,7 @@ OPTIMISTIC_SWITCH_CONFIG = {
 }
 
 
-async def test_template_state_text(hass):
+async def test_template_state_text(hass: HomeAssistant) -> None:
     """Test the state text of a template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -70,7 +70,7 @@ async def test_template_state_text(hass):
     assert state.state == STATE_OFF
 
 
-async def test_template_state_boolean_on(hass):
+async def test_template_state_boolean_on(hass: HomeAssistant) -> None:
     """Test the setting of the state with boolean on."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -97,7 +97,7 @@ async def test_template_state_boolean_on(hass):
     assert state.state == STATE_ON
 
 
-async def test_template_state_boolean_off(hass):
+async def test_template_state_boolean_off(hass: HomeAssistant) -> None:
     """Test the setting of the state with off."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -124,7 +124,7 @@ async def test_template_state_boolean_off(hass):
     assert state.state == STATE_OFF
 
 
-async def test_icon_template(hass):
+async def test_icon_template(hass: HomeAssistant) -> None:
     """Test icon template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -162,7 +162,7 @@ async def test_icon_template(hass):
     assert state.attributes["icon"] == "mdi:check"
 
 
-async def test_entity_picture_template(hass):
+async def test_entity_picture_template(hass: HomeAssistant) -> None:
     """Test entity_picture template."""
     with assert_setup_component(1, "switch"):
         assert await async_setup_component(
@@ -200,7 +200,7 @@ async def test_entity_picture_template(hass):
     assert state.attributes["entity_picture"] == "/local/switch.png"
 
 
-async def test_template_syntax_error(hass):
+async def test_template_syntax_error(hass: HomeAssistant) -> None:
     """Test templating syntax error."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -226,7 +226,7 @@ async def test_template_syntax_error(hass):
     assert hass.states.async_all("switch") == []
 
 
-async def test_invalid_name_does_not_create(hass):
+async def test_invalid_name_does_not_create(hass: HomeAssistant) -> None:
     """Test invalid name."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -252,7 +252,7 @@ async def test_invalid_name_does_not_create(hass):
     assert hass.states.async_all("switch") == []
 
 
-async def test_invalid_switch_does_not_create(hass):
+async def test_invalid_switch_does_not_create(hass: HomeAssistant) -> None:
     """Test invalid switch."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -273,7 +273,7 @@ async def test_invalid_switch_does_not_create(hass):
     assert hass.states.async_all("switch") == []
 
 
-async def test_no_switches_does_not_create(hass):
+async def test_no_switches_does_not_create(hass: HomeAssistant) -> None:
     """Test if there are no switches no creation."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -287,7 +287,7 @@ async def test_no_switches_does_not_create(hass):
     assert hass.states.async_all("switch") == []
 
 
-async def test_missing_on_does_not_create(hass):
+async def test_missing_on_does_not_create(hass: HomeAssistant) -> None:
     """Test missing on."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -320,7 +320,7 @@ async def test_missing_on_does_not_create(hass):
     assert hass.states.async_all("switch") == []
 
 
-async def test_missing_off_does_not_create(hass):
+async def test_missing_off_does_not_create(hass: HomeAssistant) -> None:
     """Test missing off."""
     with assert_setup_component(0, "switch"):
         assert await async_setup_component(
@@ -515,7 +515,7 @@ async def test_off_action_optimistic(hass, calls):
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Test state restoration."""
     mock_restore_cache(
         hass,
@@ -556,7 +556,7 @@ async def test_restore_state(hass):
     assert state.state == STATE_OFF
 
 
-async def test_available_template_with_entities(hass):
+async def test_available_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability templates with values from other entities."""
     await setup.async_setup_component(
         hass,
@@ -592,7 +592,9 @@ async def test_available_template_with_entities(hass):
     assert hass.states.get("switch.test_template_switch").state == STATE_UNAVAILABLE
 
 
-async def test_invalid_availability_template_keeps_component_available(hass, caplog):
+async def test_invalid_availability_template_keeps_component_available(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an invalid availability keeps the device available."""
     await setup.async_setup_component(
         hass,
@@ -619,7 +621,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
     assert "UndefinedError: 'x' is undefined" in caplog.text
 
 
-async def test_unique_id(hass):
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one switch per id."""
     await setup.async_setup_component(
         hass,

--- a/tests/components/template/test_template_entity.py
+++ b/tests/components/template/test_template_entity.py
@@ -2,10 +2,11 @@
 import pytest
 
 from homeassistant.components.template import template_entity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import template
 
 
-async def test_template_entity_requires_hass_set(hass):
+async def test_template_entity_requires_hass_set(hass: HomeAssistant) -> None:
     """Test template entity requires hass to be set before accepting templates."""
     entity = template_entity.TemplateEntity(hass)
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -11,6 +11,7 @@ from homeassistant.components.vacuum import (
     STATE_RETURNING,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
 from tests.common import assert_setup_component
@@ -311,7 +312,7 @@ async def test_unique_id(hass, start_ha):
     assert len(hass.states.async_all("vacuum")) == 1
 
 
-async def test_unused_services(hass):
+async def test_unused_services(hass: HomeAssistant) -> None:
     """Test calling unused services should not crash."""
     await _register_basic_vacuum(hass)
 

--- a/tests/components/tesla_wall_connector/test_init.py
+++ b/tests/components/tesla_wall_connector/test_init.py
@@ -24,7 +24,7 @@ async def test_init_while_offline(hass: HomeAssistant) -> None:
     assert entry.state == config_entries.ConfigEntryState.SETUP_RETRY
 
 
-async def test_load_unload(hass):
+async def test_load_unload(hass: HomeAssistant) -> None:
     """Config entry can be unloaded."""
 
     entry = await create_wall_connector_entry(hass)

--- a/tests/components/text/test_device_action.py
+++ b/tests/components/text/test_device_action.py
@@ -5,6 +5,7 @@ import voluptuous_serialize
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.text import DOMAIN, device_action
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -130,7 +131,7 @@ async def test_get_action_no_state(hass, device_reg, entity_reg):
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass):
+async def test_action(hass: HomeAssistant) -> None:
     """Test for actions."""
     hass.states.async_set("text.entity", 0.5, {"min_value": 0.0, "max_value": 1.0})
 
@@ -166,7 +167,7 @@ async def test_action(hass):
     assert len(calls) == 1
 
 
-async def test_capabilities(hass):
+async def test_capabilities(hass: HomeAssistant) -> None:
     """Test getting capabilities."""
     capabilities = await device_action.async_get_action_capabilities(
         hass,

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.components.text import (
     _async_set_value,
 )
 from homeassistant.const import MAX_LENGTH_STATE_STATE
-from homeassistant.core import ServiceCall, State
+from homeassistant.core import HomeAssistant, ServiceCall, State
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
 
@@ -41,7 +41,7 @@ class MockTextEntity(TextEntity):
         self._attr_native_value = value
 
 
-async def test_text_default(hass):
+async def test_text_default(hass: HomeAssistant) -> None:
     """Test text entity with defaults."""
     text = MockTextEntity()
     text.hass = hass
@@ -56,7 +56,7 @@ async def test_text_default(hass):
     assert text.state == "test"
 
 
-async def test_text_new_min_max_pattern(hass):
+async def test_text_new_min_max_pattern(hass: HomeAssistant) -> None:
     """Test text entity with new min, max, and pattern."""
     text = MockTextEntity(native_min=-1, native_max=500, pattern=r"[a-z]")
     text.hass = hass
@@ -69,7 +69,7 @@ async def test_text_new_min_max_pattern(hass):
     }
 
 
-async def test_text_set_value(hass):
+async def test_text_set_value(hass: HomeAssistant) -> None:
     """Test text entity with set_value service."""
     text = MockTextEntity(native_min=1, native_max=5, pattern=r"[a-z]")
     text.hass = hass
@@ -96,7 +96,7 @@ async def test_text_set_value(hass):
     assert text.state == "test2"
 
 
-async def test_text_value_outside_bounds(hass):
+async def test_text_value_outside_bounds(hass: HomeAssistant) -> None:
     """Test text entity with value that is outside min and max."""
     with pytest.raises(ValueError):
         _ = MockTextEntity(

--- a/tests/components/text/test_reproduce_state.py
+++ b/tests/components/text/test_reproduce_state.py
@@ -1,4 +1,6 @@
 """Test reproduce state for Text entities."""
+import pytest
+
 from homeassistant.components.text.const import (
     ATTR_MAX,
     ATTR_MIN,
@@ -7,7 +9,7 @@ from homeassistant.components.text.const import (
     DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
@@ -16,7 +18,9 @@ VALID_TEXT1 = "Hello"
 VALID_TEXT2 = "World"
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Text states."""
 
     hass.states.async_set(

--- a/tests/components/thermobeacon/test_config_flow.py
+++ b/tests/components/thermobeacon/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the ThermoBeacon config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.thermobeacon.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_THERMOBEACON_SERVICE_INFO, THERMOBEACON_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_THERMOBEACON_SERVICE_INFO, THERMOBEACON_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_bluetooth_not_thermobeacon(hass):
+async def test_async_step_bluetooth_not_thermobeacon(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not thermobeacon."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_thermobeacon(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.thermobeacon.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.thermobeacon.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/thermobeacon/test_sensor.py
+++ b/tests/components/thermobeacon/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the ThermoBeacon sensors."""
-
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermobeacon.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import THERMOBEACON_SERVICE_INFO
 
@@ -11,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/thermopro/test_config_flow.py
+++ b/tests/components/thermopro/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the ThermoPro config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.thermopro.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_THERMOPRO_SERVICE_INFO, TP357_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_THERMOPRO_SERVICE_INFO, TP357_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
 
 
-async def test_async_step_bluetooth_not_thermopro(hass):
+async def test_async_step_bluetooth_not_thermopro(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not thermopro."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_thermopro(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.thermopro.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "4125DDBA-2774-4851-9889-6AADDD4CAC3D"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.thermopro.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,8 +1,8 @@
 """Test the ThermoPro config flow."""
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import TP357_SERVICE_INFO
 
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/threshold/test_binary_sensor.py
+++ b/tests/components/threshold/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the threshold sensor platform."""
+import pytest
 
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
@@ -6,10 +7,11 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_sensor_upper(hass):
+async def test_sensor_upper(hass: HomeAssistant) -> None:
     """Test if source is above threshold."""
     config = {
         "binary_sensor": {
@@ -55,7 +57,7 @@ async def test_sensor_upper(hass):
     assert state.state == "off"
 
 
-async def test_sensor_lower(hass):
+async def test_sensor_lower(hass: HomeAssistant) -> None:
     """Test if source is below threshold."""
     config = {
         "binary_sensor": {
@@ -88,7 +90,7 @@ async def test_sensor_lower(hass):
     assert state.state == "on"
 
 
-async def test_sensor_hysteresis(hass):
+async def test_sensor_hysteresis(hass: HomeAssistant) -> None:
     """Test if source is above threshold using hysteresis."""
     config = {
         "binary_sensor": {
@@ -143,7 +145,7 @@ async def test_sensor_hysteresis(hass):
     assert state.state == "on"
 
 
-async def test_sensor_in_range_no_hysteresis(hass):
+async def test_sensor_in_range_no_hysteresis(hass: HomeAssistant) -> None:
     """Test if source is within the range."""
     config = {
         "binary_sensor": {
@@ -193,7 +195,7 @@ async def test_sensor_in_range_no_hysteresis(hass):
     assert state.state == "off"
 
 
-async def test_sensor_in_range_with_hysteresis(hass):
+async def test_sensor_in_range_with_hysteresis(hass: HomeAssistant) -> None:
     """Test if source is within the range."""
     config = {
         "binary_sensor": {
@@ -294,7 +296,9 @@ async def test_sensor_in_range_with_hysteresis(hass):
     assert state.state == "on"
 
 
-async def test_sensor_in_range_unknown_state(hass, caplog):
+async def test_sensor_in_range_unknown_state(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if source is within the range."""
     config = {
         "binary_sensor": {
@@ -346,7 +350,7 @@ async def test_sensor_in_range_unknown_state(hass, caplog):
     assert "State is not numerical" not in caplog.text
 
 
-async def test_sensor_lower_zero_threshold(hass):
+async def test_sensor_lower_zero_threshold(hass: HomeAssistant) -> None:
     """Test if a lower threshold of zero is set."""
     config = {
         "binary_sensor": {
@@ -377,7 +381,7 @@ async def test_sensor_lower_zero_threshold(hass):
     assert state.state == "on"
 
 
-async def test_sensor_upper_zero_threshold(hass):
+async def test_sensor_upper_zero_threshold(hass: HomeAssistant) -> None:
     """Test if an upper threshold of zero is set."""
     config = {
         "binary_sensor": {

--- a/tests/components/tilt_ble/test_config_flow.py
+++ b/tests/components/tilt_ble/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the Tilt config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.tilt_ble.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import NOT_TILT_SERVICE_INFO, TILT_GREEN_SERVICE_INFO
@@ -11,7 +11,7 @@ from . import NOT_TILT_SERVICE_INFO, TILT_GREEN_SERVICE_INFO
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -32,7 +32,7 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "F6:0F:28:F2:1F:CB"
 
 
-async def test_async_step_bluetooth_not_tilt(hass):
+async def test_async_step_bluetooth_not_tilt(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not tilt."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_step_bluetooth_not_tilt(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -53,7 +53,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.tilt_ble.config_flow.async_discovered_service_info",
@@ -78,7 +78,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "F6:0F:28:F2:1F:CB"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.tilt_ble.config_flow.async_discovered_service_info",
@@ -108,7 +108,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +147,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -164,7 +166,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -2,10 +2,11 @@
 from unittest.mock import patch
 
 import homeassistant.components.time_date.sensor as time_date
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 
-async def test_intervals(hass):
+async def test_intervals(hass: HomeAssistant) -> None:
     """Test timing intervals of sensors."""
     device = time_date.TimeDateSensor(hass, "time")
     now = dt_util.utc_from_timestamp(45.5)
@@ -31,7 +32,7 @@ async def test_intervals(hass):
     assert next_time > now
 
 
-async def test_states(hass):
+async def test_states(hass: HomeAssistant) -> None:
     """Test states of sensors."""
     hass.config.set_time_zone("UTC")
 
@@ -67,7 +68,7 @@ async def test_states(hass):
     assert device.state == "2017-05-18T00:54:00"
 
 
-async def test_states_non_default_timezone(hass):
+async def test_states_non_default_timezone(hass: HomeAssistant) -> None:
     """Test states of sensors in a timezone other than UTC."""
     hass.config.set_time_zone("America/New_York")
 
@@ -102,7 +103,7 @@ async def test_states_non_default_timezone(hass):
 
 
 # pylint: disable=no-member
-async def test_timezone_intervals(hass):
+async def test_timezone_intervals(hass: HomeAssistant) -> None:
     """Test date sensor behavior in a timezone besides UTC."""
     hass.config.set_time_zone("America/New_York")
 
@@ -158,7 +159,7 @@ async def test_timezone_intervals_empty_parameter(utcnow_mock, hass):
     assert next_time.timestamp() == dt_util.as_timestamp("2017-11-14 00:00:00-07:00")
 
 
-async def test_icons(hass):
+async def test_icons(hass: HomeAssistant) -> None:
     """Test attributes of sensors."""
     device = time_date.TimeDateSensor(hass, "time")
     assert device.icon == "mdi:clock"

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the timer component."""
-
 from datetime import timedelta
 import logging
 from unittest.mock import patch
@@ -43,7 +42,7 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.restore_state import (
@@ -92,7 +91,7 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_config(hass):
+async def test_config(hass: HomeAssistant) -> None:
     """Test config."""
     invalid_configs = [None, 1, {}, {"name with space": None}]
 
@@ -100,7 +99,7 @@ async def test_config(hass):
         assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
 
 
-async def test_config_options(hass):
+async def test_config_options(hass: HomeAssistant) -> None:
     """Test configuration options."""
     count_start = len(hass.states.async_entity_ids())
 
@@ -147,7 +146,7 @@ async def test_config_options(hass):
     )
 
 
-async def test_methods_and_events(hass):
+async def test_methods_and_events(hass: HomeAssistant) -> None:
     """Test methods and events."""
     hass.state = CoreState.starting
 
@@ -202,7 +201,7 @@ async def test_methods_and_events(hass):
             assert len(results) == expectedEvents
 
 
-async def test_start_service(hass):
+async def test_start_service(hass: HomeAssistant) -> None:
     """Test the start/stop service."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"test1": {CONF_DURATION: 10}}})
 
@@ -242,7 +241,7 @@ async def test_start_service(hass):
     assert state.attributes[ATTR_REMAINING] == "0:00:15"
 
 
-async def test_wait_till_timer_expires(hass):
+async def test_wait_till_timer_expires(hass: HomeAssistant) -> None:
     """Test for a timer to end."""
     hass.state = CoreState.starting
 
@@ -286,7 +285,7 @@ async def test_wait_till_timer_expires(hass):
     assert len(results) == 2
 
 
-async def test_no_initial_state_and_no_restore_state(hass):
+async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> None:
     """Ensure that entity is create without initial and restore feature."""
     hass.state = CoreState.starting
 
@@ -393,7 +392,7 @@ async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     assert ATTR_FRIENDLY_NAME not in state_3.attributes
 
 
-async def test_timer_restarted_event(hass):
+async def test_timer_restarted_event(hass: HomeAssistant) -> None:
     """Ensure restarted event is called after starting a paused or running timer."""
     hass.state = CoreState.starting
 
@@ -460,7 +459,7 @@ async def test_timer_restarted_event(hass):
     assert len(results) == 4
 
 
-async def test_state_changed_when_timer_restarted(hass):
+async def test_state_changed_when_timer_restarted(hass: HomeAssistant) -> None:
     """Ensure timer's state changes when it restarted."""
     hass.state = CoreState.starting
 
@@ -662,7 +661,7 @@ async def test_setup_no_config(hass, hass_admin_user):
     assert count_start == len(hass.states.async_entity_ids())
 
 
-async def test_restore_idle(hass):
+async def test_restore_idle(hass: HomeAssistant) -> None:
     """Test entity restore logic when timer is idle."""
     utc_now = utcnow()
     stored_state = StoredState(
@@ -702,7 +701,7 @@ async def test_restore_idle(hass):
     assert entity.extra_state_attributes[ATTR_RESTORE]
 
 
-async def test_restore_paused(hass):
+async def test_restore_paused(hass: HomeAssistant) -> None:
     """Test entity restore logic when timer is paused."""
     utc_now = utcnow()
     stored_state = StoredState(
@@ -742,7 +741,7 @@ async def test_restore_paused(hass):
     assert entity.extra_state_attributes[ATTR_RESTORE]
 
 
-async def test_restore_active_resume(hass):
+async def test_restore_active_resume(hass: HomeAssistant) -> None:
     """Test entity restore logic when timer is active and end time is after startup."""
     events = async_capture_events(hass, EVENT_TIMER_RESTARTED)
     assert not events
@@ -793,7 +792,7 @@ async def test_restore_active_resume(hass):
     assert len(events) == 1
 
 
-async def test_restore_active_finished_outside_grace(hass):
+async def test_restore_active_finished_outside_grace(hass: HomeAssistant) -> None:
     """Test entity restore logic: timer is active, ended while Home Assistant was stopped."""
     events = async_capture_events(hass, EVENT_TIMER_FINISHED)
     assert not events

--- a/tests/components/timer/test_reproduce_state.py
+++ b/tests/components/timer/test_reproduce_state.py
@@ -1,4 +1,6 @@
 """Test reproduce state for Timer."""
+import pytest
+
 from homeassistant.components.timer import (
     ATTR_DURATION,
     SERVICE_CANCEL,
@@ -8,13 +10,15 @@ from homeassistant.components.timer import (
     STATUS_IDLE,
     STATUS_PAUSED,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Timer states."""
     hass.states.async_set("timer.entity_idle", STATUS_IDLE, {})
     hass.states.async_set("timer.entity_paused", STATUS_PAUSED, {})

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -34,7 +34,7 @@ def hass_tz_info(hass):
     return dt_util.get_time_zone(hass.config.time_zone)
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test the setup."""
     config = {
         "binary_sensor": [
@@ -58,7 +58,7 @@ async def test_setup(hass):
         assert await async_setup_component(hass, "binary_sensor", config)
 
 
-async def test_setup_no_sensors(hass):
+async def test_setup_no_sensors(hass: HomeAssistant) -> None:
     """Test setup with no sensors."""
     with assert_setup_component(0):
         assert await async_setup_component(
@@ -67,7 +67,7 @@ async def test_setup_no_sensors(hass):
 
 
 @freeze_time("2019-01-10 18:43:00-08:00")
-async def test_in_period_on_start(hass):
+async def test_in_period_on_start(hass: HomeAssistant) -> None:
     """Test simple setting."""
     config = {
         "binary_sensor": [
@@ -87,7 +87,9 @@ async def test_in_period_on_start(hass):
 
 
 @freeze_time("2019-01-10 22:30:00-08:00")
-async def test_midnight_turnover_before_midnight_inside_period(hass):
+async def test_midnight_turnover_before_midnight_inside_period(
+    hass: HomeAssistant,
+) -> None:
     """Test midnight turnover setting before midnight inside period ."""
     config = {
         "binary_sensor": [
@@ -129,7 +131,9 @@ async def test_midnight_turnover_after_midnight_inside_period(
 
 
 @freeze_time("2019-01-10 20:30:00-08:00")
-async def test_midnight_turnover_before_midnight_outside_period(hass):
+async def test_midnight_turnover_before_midnight_outside_period(
+    hass: HomeAssistant,
+) -> None:
     """Test midnight turnover setting before midnight outside period."""
     config = {
         "binary_sensor": [
@@ -144,7 +148,7 @@ async def test_midnight_turnover_before_midnight_outside_period(hass):
 
 
 @freeze_time("2019-01-10 10:00:00-08:00")
-async def test_after_happens_tomorrow(hass):
+async def test_after_happens_tomorrow(hass: HomeAssistant) -> None:
     """Test when both before and after are in the future, and after is later than before."""
     config = {
         "binary_sensor": [
@@ -624,7 +628,9 @@ async def test_dst(hass, freezer, hass_tz_info):
 
 @freeze_time("2019-01-10 18:43:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
-async def test_simple_before_after_does_not_loop_utc_not_in_range(hass):
+async def test_simple_before_after_does_not_loop_utc_not_in_range(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -648,7 +654,9 @@ async def test_simple_before_after_does_not_loop_utc_not_in_range(hass):
 
 @freeze_time("2019-01-10 22:43:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
-async def test_simple_before_after_does_not_loop_utc_in_range(hass):
+async def test_simple_before_after_does_not_loop_utc_in_range(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -672,7 +680,9 @@ async def test_simple_before_after_does_not_loop_utc_in_range(hass):
 
 @freeze_time("2019-01-11 06:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
-async def test_simple_before_after_does_not_loop_utc_fire_at_before(hass):
+async def test_simple_before_after_does_not_loop_utc_fire_at_before(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -696,7 +706,9 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_before(hass):
 
 @freeze_time("2019-01-10 22:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
-async def test_simple_before_after_does_not_loop_utc_fire_at_after(hass):
+async def test_simple_before_after_does_not_loop_utc_fire_at_after(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -720,7 +732,9 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_after(hass):
 
 @freeze_time("2019-01-10 22:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
-async def test_simple_before_after_does_not_loop_utc_both_before_now(hass):
+async def test_simple_before_after_does_not_loop_utc_both_before_now(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -744,7 +758,9 @@ async def test_simple_before_after_does_not_loop_utc_both_before_now(hass):
 
 @freeze_time("2019-01-10 17:43:00+01:00")
 @pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
-async def test_simple_before_after_does_not_loop_berlin_not_in_range(hass):
+async def test_simple_before_after_does_not_loop_berlin_not_in_range(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [
@@ -768,7 +784,9 @@ async def test_simple_before_after_does_not_loop_berlin_not_in_range(hass):
 
 @freeze_time("2019-01-11 00:43:00+01:00")
 @pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
-async def test_simple_before_after_does_not_loop_berlin_in_range(hass):
+async def test_simple_before_after_does_not_loop_berlin_in_range(
+    hass: HomeAssistant,
+) -> None:
     """Test simple before after."""
     config = {
         "binary_sensor": [

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.toon.const import CONF_AGREEMENT, CONF_MIGRATE, DO
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
@@ -31,7 +32,7 @@ async def setup_component(hass):
         await hass.async_block_till_done()
 
 
-async def test_abort_if_no_configuration(hass):
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     """Test abort if no app is configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -29,7 +29,7 @@ from .common import (
 from tests.common import MockConfigEntry
 
 
-async def test_user(hass):
+async def test_user(hass: HomeAssistant) -> None:
     """Test user step."""
     # user starts with no data entered, so show the user form
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +42,7 @@ async def test_user(hass):
     assert result["step_id"] == "user"
 
 
-async def test_user_show_locations(hass):
+async def test_user_show_locations(hass: HomeAssistant) -> None:
     """Test user locations form."""
     # user/pass provided, so check if valid then ask for usercodes on locations form
     responses = [
@@ -92,7 +92,7 @@ async def test_user_show_locations(hass):
         assert mock_request.call_count == 6
 
 
-async def test_abort_if_already_setup(hass):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test abort if the account is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -112,7 +112,7 @@ async def test_abort_if_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_login_failed(hass):
+async def test_login_failed(hass: HomeAssistant) -> None:
     """Test when we have errors during login."""
     with patch(
         "homeassistant.components.totalconnect.config_flow.TotalConnectClient"
@@ -128,7 +128,7 @@ async def test_login_failed(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_reauth(hass):
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -171,7 +171,7 @@ async def test_reauth(hass):
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_no_locations(hass):
+async def test_no_locations(hass: HomeAssistant) -> None:
     """Test with no user locations."""
     responses = [
         RESPONSE_AUTHENTICATE,

--- a/tests/components/totalconnect/test_diagnostics.py
+++ b/tests/components/totalconnect/test_diagnostics.py
@@ -1,13 +1,16 @@
 """Test TotalConnect diagnostics."""
-
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from .common import LOCATION_ID, init_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, hass_client):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test config entry diagnostics."""
     entry = await init_integration(hass)
 

--- a/tests/components/totalconnect/test_init.py
+++ b/tests/components/totalconnect/test_init.py
@@ -5,6 +5,7 @@ from total_connect_client.exceptions import AuthenticationError
 
 from homeassistant.components.totalconnect.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import CONFIG_DATA
@@ -12,7 +13,7 @@ from .common import CONFIG_DATA
 from tests.common import MockConfigEntry
 
 
-async def test_reauth_started(hass):
+async def test_reauth_started(hass: HomeAssistant) -> None:
     """Test that reauth is started when we have login errors."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -246,7 +246,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
     }
 
 
-async def test_discovered_by_discovery_and_dhcp(hass):
+async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
     """Test we get the form with discovery and abort for dhcp source when we get both."""
 
     with _patch_discovery(), _patch_single_discovery():

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -25,7 +25,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_configuring_tplink_causes_discovery(hass):
+async def test_configuring_tplink_causes_discovery(hass: HomeAssistant) -> None:
     """Test that specifying empty config does discovery."""
     with patch("homeassistant.components.tplink.Discover.discover") as discover:
         discover.return_value = {MagicMock(): MagicMock()}
@@ -47,7 +47,7 @@ async def test_configuring_tplink_causes_discovery(hass):
         assert len(discover.mock_calls) == call_count * 4
 
 
-async def test_config_entry_reload(hass):
+async def test_config_entry_reload(hass: HomeAssistant) -> None:
     """Test that a config entry can be reloaded."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
@@ -62,7 +62,7 @@ async def test_config_entry_reload(hass):
         assert already_migrated_config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_config_entry_retry(hass):
+async def test_config_entry_retry(hass: HomeAssistant) -> None:
     """Test that a config entry can be retried."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS

--- a/tests/components/traccar/test_device_tracker.py
+++ b/tests/components/traccar/test_device_tracker.py
@@ -15,12 +15,13 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events
 
 
-async def test_import_events_catch_all(hass):
+async def test_import_events_catch_all(hass: HomeAssistant) -> None:
     """Test importing all events and firing them in HA using their event types."""
     conf_dict = {
         DOMAIN: TRACCAR_PLATFORM_SCHEMA(

--- a/tests/components/tractive/test_config_flow.py
+++ b/tests/components/tractive/test_config_flow.py
@@ -98,7 +98,7 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_reauthentication(hass):
+async def test_reauthentication(hass: HomeAssistant) -> None:
     """Test Tractive reauthentication."""
     old_entry = MockConfigEntry(
         domain="tractive",
@@ -136,7 +136,7 @@ async def test_reauthentication(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reauthentication_failure(hass):
+async def test_reauthentication_failure(hass: HomeAssistant) -> None:
     """Test Tractive reauthentication failure."""
     old_entry = MockConfigEntry(
         domain="tractive",
@@ -174,7 +174,7 @@ async def test_reauthentication_failure(hass):
     assert result2["errors"]["base"] == "invalid_auth"
 
 
-async def test_reauthentication_unknown_failure(hass):
+async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:
     """Test Tractive reauthentication failure."""
     old_entry = MockConfigEntry(
         domain="tractive",
@@ -212,7 +212,7 @@ async def test_reauthentication_unknown_failure(hass):
     assert result2["errors"]["base"] == "unknown"
 
 
-async def test_reauthentication_failure_no_existing_entry(hass):
+async def test_reauthentication_failure_no_existing_entry(hass: HomeAssistant) -> None:
     """Test Tractive reauthentication with no existing entry."""
     old_entry = MockConfigEntry(
         domain="tractive",

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
 from homeassistant.components.tradfri import config_flow
+from homeassistant.core import HomeAssistant
 
 from . import TRADFRI_PATH
 
@@ -128,7 +129,7 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     }
 
 
-async def test_discovery_duplicate_aborted(hass):
+async def test_discovery_duplicate_aborted(hass: HomeAssistant) -> None:
     """Test a duplicate discovery host aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain="tradfri", data={"host": "some-host"}, unique_id="homekit-id"
@@ -155,7 +156,7 @@ async def test_discovery_duplicate_aborted(hass):
     assert entry.data["host"] == "new-host"
 
 
-async def test_import_duplicate_aborted(hass):
+async def test_import_duplicate_aborted(hass: HomeAssistant) -> None:
     """Test a duplicate import host is ignored."""
     MockConfigEntry(domain="tradfri", data={"host": "some-host"}).add_to_hass(hass)
 
@@ -204,7 +205,7 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_discovery_updates_unique_id(hass):
+async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate discovery host aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain="tradfri",

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -67,7 +67,7 @@ async def test_device_already_configured(
     assert result2["reason"] == "already_configured"
 
 
-async def test_name_already_configured(hass):
+async def test_name_already_configured(hass: HomeAssistant) -> None:
     """Test name is already configured."""
     entry = MockConfigEntry(
         domain=transmission.DOMAIN,

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from homeassistant import config as hass_config, setup
 from homeassistant.components.trend.const import DOMAIN
 from homeassistant.const import SERVICE_RELOAD, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
@@ -378,7 +379,7 @@ class TestTrendBinarySensor:
         assert self.hass.states.all("binary_sensor") == []
 
 
-async def test_reload(hass):
+async def test_reload(hass: HomeAssistant) -> None:
     """Verify we can reload trend sensors."""
     hass.states.async_set("sensor.test_state", 1234)
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -16,11 +16,13 @@ from homeassistant.components.media_player import (
     MediaType,
 )
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util.network import normalize_url
 
 from tests.common import assert_setup_component, async_mock_service
+from tests.typing import ClientSessionGenerator
 
 ORIG_WRITE_TAGS = tts.SpeechManager.write_tags
 
@@ -176,7 +178,9 @@ async def test_setup_component_and_test_service_with_config_language_special(
     ).is_file()
 
 
-async def test_setup_component_and_test_service_with_wrong_conf_language(hass):
+async def test_setup_component_and_test_service_with_wrong_conf_language(
+    hass: HomeAssistant,
+) -> None:
     """Set up the demo platform and call service with wrong config."""
     config = {tts.DOMAIN: {"platform": "demo", "language": "ru"}}
 
@@ -352,7 +356,9 @@ async def test_setup_component_and_test_service_with_service_options_wrong(
     ).is_file()
 
 
-async def test_setup_component_and_test_service_with_base_url_set(hass):
+async def test_setup_component_and_test_service_with_base_url_set(
+    hass: HomeAssistant,
+) -> None:
     """Set up the demo platform with ``base_url`` set and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -498,7 +504,9 @@ async def test_setup_component_and_test_service_with_receive_voice_german(
     assert await req.read() == demo_data
 
 
-async def test_setup_component_and_web_view_wrong_file(hass, hass_client):
+async def test_setup_component_and_web_view_wrong_file(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and receive wrong file from web."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 
@@ -513,7 +521,9 @@ async def test_setup_component_and_web_view_wrong_file(hass, hass_client):
     assert req.status == HTTPStatus.NOT_FOUND
 
 
-async def test_setup_component_and_web_view_wrong_filename(hass, hass_client):
+async def test_setup_component_and_web_view_wrong_filename(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and receive wrong filename from web."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 
@@ -620,7 +630,7 @@ async def test_setup_component_test_with_cache_dir(
     )
 
 
-async def test_setup_component_test_with_error_on_get_tts(hass):
+async def test_setup_component_test_with_error_on_get_tts(hass: HomeAssistant) -> None:
     """Set up demo platform with wrong get_tts_audio."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 
@@ -657,7 +667,9 @@ async def test_setup_component_load_cache_retrieve_without_mem_cache(
     assert await req.read() == demo_data
 
 
-async def test_setup_component_and_web_get_url(hass, hass_client):
+async def test_setup_component_and_web_get_url(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and receive file from web."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 
@@ -677,7 +689,9 @@ async def test_setup_component_and_web_get_url(hass, hass_client):
     }
 
 
-async def test_setup_component_and_web_get_url_bad_config(hass, hass_client):
+async def test_setup_component_and_web_get_url_bad_config(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and receive wrong file from web."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player.errors import BrowseError
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -29,7 +30,7 @@ async def mock_get_tts_audio(hass):
         yield mock_get_tts
 
 
-async def test_browsing(hass):
+async def test_browsing(hass: HomeAssistant) -> None:
     """Test browsing TTS media source."""
     item = await media_source.async_browse_media(hass, "media-source://tts")
     assert item is not None
@@ -96,7 +97,7 @@ async def test_resolving(hass, mock_get_tts_audio):
     assert mock_get_tts_audio.mock_calls[0][2]["options"] == {"voice": "Paulus"}
 
 
-async def test_resolving_errors(hass):
+async def test_resolving_errors(hass: HomeAssistant) -> None:
     """Test resolving."""
     # No message added
     with pytest.raises(media_source.Unresolvable):

--- a/tests/components/tts/test_notify.py
+++ b/tests/components/tts/test_notify.py
@@ -10,6 +10,7 @@ from homeassistant.components.media_player import (
 import homeassistant.components.notify as notify
 import homeassistant.components.tts as tts
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -29,7 +30,7 @@ async def internal_url_mock(hass):
     )
 
 
-async def test_setup_platform(hass):
+async def test_setup_platform(hass: HomeAssistant) -> None:
     """Set up the tts platform ."""
     config = {
         notify.DOMAIN: {
@@ -45,7 +46,7 @@ async def test_setup_platform(hass):
     assert hass.services.has_service(notify.DOMAIN, "tts_test")
 
 
-async def test_setup_component_and_test_service(hass):
+async def test_setup_component_and_test_service(hass: HomeAssistant) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -2,10 +2,14 @@
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import twilio
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+
+from tests.typing import ClientSessionGenerator
 
 
-async def test_config_flow_registers_webhook(hass, hass_client_no_auth):
+async def test_config_flow_registers_webhook(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test setting up Twilio and sending webhook."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -10,13 +10,14 @@ from homeassistant.components.twinkly.const import (
     DOMAIN as TWINKLY_DOMAIN,
 )
 from homeassistant.const import CONF_MODEL
+from homeassistant.core import HomeAssistant
 
 from . import TEST_MODEL, ClientMock
 
 from tests.common import MockConfigEntry
 
 
-async def test_invalid_host(hass):
+async def test_invalid_host(hass: HomeAssistant) -> None:
     """Test the failure when invalid host provided."""
     client = ClientMock()
     client.is_offline = True
@@ -39,7 +40,7 @@ async def test_invalid_host(hass):
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
-async def test_success_flow(hass):
+async def test_success_flow(hass: HomeAssistant) -> None:
     """Test that an entity is created when the flow completes."""
     client = ClientMock()
     with patch(
@@ -68,7 +69,7 @@ async def test_success_flow(hass):
     }
 
 
-async def test_dhcp_can_confirm(hass):
+async def test_dhcp_can_confirm(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow can confirm right away."""
     client = ClientMock()
     with patch(
@@ -89,7 +90,7 @@ async def test_dhcp_can_confirm(hass):
     assert result["step_id"] == "discovery_confirm"
 
 
-async def test_dhcp_success(hass):
+async def test_dhcp_success(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow success."""
     client = ClientMock()
     with patch(
@@ -121,7 +122,7 @@ async def test_dhcp_success(hass):
     }
 
 
-async def test_dhcp_already_exists(hass):
+async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
     """Test DHCP discovery flow that fails to connect."""
     client = ClientMock()
 

--- a/tests/components/twitch/test_twitch.py
+++ b/tests/components/twitch/test_twitch.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.components import sensor
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 ENTITY_ID = "sensor.channel123"
@@ -48,7 +49,7 @@ def make_data(data):
     return {"data": data, "total": len(data)}
 
 
-async def test_init(hass):
+async def test_init(hass: HomeAssistant) -> None:
     """Test initial config."""
 
     twitch_mock = MagicMock()
@@ -72,7 +73,7 @@ async def test_init(hass):
     assert sensor_state.attributes["followers"] == 24
 
 
-async def test_offline(hass):
+async def test_offline(hass: HomeAssistant) -> None:
     """Test offline state."""
 
     twitch_mock = MagicMock()
@@ -93,7 +94,7 @@ async def test_offline(hass):
     assert sensor_state.attributes["entity_picture"] == "logo.png"
 
 
-async def test_streaming(hass):
+async def test_streaming(hass: HomeAssistant) -> None:
     """Test streaming state."""
 
     twitch_mock = MagicMock()
@@ -116,7 +117,7 @@ async def test_streaming(hass):
     assert sensor_state.attributes["title"] == "Title"
 
 
-async def test_oauth_without_sub_and_follow(hass):
+async def test_oauth_without_sub_and_follow(hass: HomeAssistant) -> None:
     """Test state with oauth."""
 
     twitch_mock = MagicMock()
@@ -145,7 +146,7 @@ async def test_oauth_without_sub_and_follow(hass):
     assert sensor_state.attributes["following"] is False
 
 
-async def test_oauth_with_sub(hass):
+async def test_oauth_with_sub(hass: HomeAssistant) -> None:
     """Test state with oauth and sub."""
 
     twitch_mock = MagicMock()
@@ -177,7 +178,7 @@ async def test_oauth_with_sub(hass):
     assert sensor_state.attributes["following"] is False
 
 
-async def test_oauth_with_follow(hass):
+async def test_oauth_with_follow(hass: HomeAssistant) -> None:
     """Test state with oauth and follow."""
 
     twitch_mock = MagicMock()

--- a/tests/components/uk_transport/test_sensor.py
+++ b/tests/components/uk_transport/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.uk_transport.sensor import (
     CONF_API_APP_KEY,
     UkTransportSensor,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import now
 
@@ -43,7 +44,7 @@ VALID_CONFIG = {
 }
 
 
-async def test_bus(hass):
+async def test_bus(hass: HomeAssistant) -> None:
     """Test for operational uk_transport sensor with proper attributes."""
     with requests_mock.Mocker() as mock_req:
         uri = re.compile(UkTransportSensor.TRANSPORT_API_URL_BASE + "*")
@@ -65,7 +66,7 @@ async def test_bus(hass):
         assert None is not direction_re.search(bus["direction"])
 
 
-async def test_train(hass):
+async def test_train(hass: HomeAssistant) -> None:
     """Test for operational uk_transport sensor with proper attributes."""
     with requests_mock.Mocker() as mock_req, patch(
         "homeassistant.util.dt.now", return_value=now().replace(hour=13)

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test UniFi Network config flow."""
-
 import socket
 from unittest.mock import patch
 
@@ -31,10 +30,12 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     CONTENT_TYPE_JSON,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_controller import setup_unifi_integration
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 CLIENTS = [{"mac": "00:00:00:00:00:01"}]
 
@@ -162,7 +163,9 @@ async def test_flow_works_negative_discovery(hass, aioclient_mock, mock_discover
     }
 
 
-async def test_flow_multiple_sites(hass, aioclient_mock):
+async def test_flow_multiple_sites(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow works when finding multiple sites."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -208,7 +211,9 @@ async def test_flow_multiple_sites(hass, aioclient_mock):
     assert result["data_schema"]({"site": "2"})
 
 
-async def test_flow_raise_already_configured(hass, aioclient_mock):
+async def test_flow_raise_already_configured(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     await setup_unifi_integration(hass, aioclient_mock)
 
@@ -255,7 +260,9 @@ async def test_flow_raise_already_configured(hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_flow_aborts_configuration_updated(hass, aioclient_mock):
+async def test_flow_aborts_configuration_updated(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     entry = MockConfigEntry(
         domain=UNIFI_DOMAIN, data={"host": "1.2.3.4", "site": "office"}, unique_id="2"
@@ -309,7 +316,9 @@ async def test_flow_aborts_configuration_updated(hass, aioclient_mock):
     assert result["reason"] == "configuration_updated"
 
 
-async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):
+async def test_flow_fails_user_credentials_faulty(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -336,7 +345,9 @@ async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):
     assert result["errors"] == {"base": "faulty_credentials"}
 
 
-async def test_flow_fails_controller_unavailable(hass, aioclient_mock):
+async def test_flow_fails_controller_unavailable(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -363,7 +374,9 @@ async def test_flow_fails_controller_unavailable(hass, aioclient_mock):
     assert result["errors"] == {"base": "service_unavailable"}
 
 
-async def test_reauth_flow_update_configuration(hass, aioclient_mock):
+async def test_reauth_flow_update_configuration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify reauth flow can update controller configuration."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
@@ -421,7 +434,9 @@ async def test_reauth_flow_update_configuration(hass, aioclient_mock):
     assert config_entry.data[CONF_PASSWORD] == "new_pass"
 
 
-async def test_advanced_option_flow(hass, aioclient_mock):
+async def test_advanced_option_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test advanced config flow options."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -494,7 +509,9 @@ async def test_advanced_option_flow(hass, aioclient_mock):
     }
 
 
-async def test_simple_option_flow(hass, aioclient_mock):
+async def test_simple_option_flow(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test simple config flow options."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -530,7 +547,9 @@ async def test_simple_option_flow(hass, aioclient_mock):
     }
 
 
-async def test_option_flow_integration_not_setup(hass, aioclient_mock):
+async def test_option_flow_integration_not_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test advanced config flow options."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
 
@@ -541,7 +560,7 @@ async def test_option_flow_integration_not_setup(hass, aioclient_mock):
     assert result["reason"] == "integration_not_setup"
 
 
-async def test_form_ssdp(hass):
+async def test_form_ssdp(hass: HomeAssistant) -> None:
     """Test we get the form with ssdp source."""
 
     result = await hass.config_entries.flow.async_init(
@@ -581,7 +600,7 @@ async def test_form_ssdp(hass):
     }
 
 
-async def test_form_ssdp_aborts_if_host_already_exists(hass):
+async def test_form_ssdp_aborts_if_host_already_exists(hass: HomeAssistant) -> None:
     """Test we abort if the host is already configured."""
 
     entry = MockConfigEntry(
@@ -607,7 +626,7 @@ async def test_form_ssdp_aborts_if_host_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_ssdp_aborts_if_serial_already_exists(hass):
+async def test_form_ssdp_aborts_if_serial_already_exists(hass: HomeAssistant) -> None:
     """Test we abort if the serial is already configured."""
 
     entry = MockConfigEntry(
@@ -634,7 +653,7 @@ async def test_form_ssdp_aborts_if_serial_already_exists(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_ssdp_gets_form_with_ignored_entry(hass):
+async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> None:
     """Test we can still setup if there is an ignored entry."""
 
     entry = MockConfigEntry(
@@ -671,13 +690,13 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass):
     }
 
 
-async def test_discover_unifi_positive(hass):
+async def test_discover_unifi_positive(hass: HomeAssistant) -> None:
     """Verify positive run of UniFi discovery."""
     with patch("socket.gethostbyname", return_value=True):
         assert await _async_discover_unifi(hass)
 
 
-async def test_discover_unifi_negative(hass):
+async def test_discover_unifi_negative(hass: HomeAssistant) -> None:
     """Verify negative run of UniFi discovery."""
     with patch("socket.gethostbyname", side_effect=socket.gaierror):
         assert await _async_discover_unifi(hass) is None

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -1,5 +1,4 @@
 """Test UniFi Network."""
-
 import asyncio
 from copy import deepcopy
 from datetime import timedelta
@@ -39,6 +38,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     CONTENT_TYPE_JSON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -46,6 +46,7 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 DEFAULT_CONFIG_ENTRY_ID = "1"
 DEFAULT_HOST = "1.2.3.4"
@@ -209,7 +210,9 @@ async def setup_unifi_integration(
     return config_entry
 
 
-async def test_controller_setup(hass, aioclient_mock):
+async def test_controller_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Successful setup."""
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
@@ -247,7 +250,9 @@ async def test_controller_setup(hass, aioclient_mock):
     assert controller.signal_heartbeat_missed == "unifi-heartbeat-missed"
 
 
-async def test_controller_mac(hass, aioclient_mock):
+async def test_controller_mac(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that it is possible to identify controller mac."""
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[CONTROLLER_HOST]
@@ -264,7 +269,7 @@ async def test_controller_mac(hass, aioclient_mock):
     assert device_entry.configuration_url == controller.api.url
 
 
-async def test_controller_not_accessible(hass):
+async def test_controller_not_accessible(hass: HomeAssistant) -> None:
     """Retry to login gets scheduled when connection fails."""
     with patch(
         "homeassistant.components.unifi.controller.get_unifi_controller",
@@ -274,7 +279,7 @@ async def test_controller_not_accessible(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_controller_trigger_reauth_flow(hass):
+async def test_controller_trigger_reauth_flow(hass: HomeAssistant) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.unifi.get_unifi_controller",
@@ -285,7 +290,7 @@ async def test_controller_trigger_reauth_flow(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_controller_unknown_error(hass):
+async def test_controller_unknown_error(hass: HomeAssistant) -> None:
     """Unknown errors are handled."""
     with patch(
         "homeassistant.components.unifi.controller.get_unifi_controller",
@@ -295,7 +300,9 @@ async def test_controller_unknown_error(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_config_entry_updated(hass, aioclient_mock):
+async def test_config_entry_updated(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Calling reset when the entry has been setup."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
@@ -316,7 +323,9 @@ async def test_config_entry_updated(hass, aioclient_mock):
     unsub()
 
 
-async def test_reset_after_successful_setup(hass, aioclient_mock):
+async def test_reset_after_successful_setup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Calling reset when the entry has been setup."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
@@ -327,7 +336,9 @@ async def test_reset_after_successful_setup(hass, aioclient_mock):
     assert result is True
 
 
-async def test_reset_fails(hass, aioclient_mock):
+async def test_reset_fails(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Calling reset when the entry has been setup can return false."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
@@ -459,7 +470,7 @@ async def test_reconnect_mechanism_exceptions(
         mock_reconnect.assert_called_once()
 
 
-async def test_get_unifi_controller(hass):
+async def test_get_unifi_controller(hass: HomeAssistant) -> None:
     """Successful call."""
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", return_value=True
@@ -467,7 +478,7 @@ async def test_get_unifi_controller(hass):
         assert await get_unifi_controller(hass, ENTRY_CONFIG)
 
 
-async def test_get_unifi_controller_verify_ssl_false(hass):
+async def test_get_unifi_controller_verify_ssl_false(hass: HomeAssistant) -> None:
     """Successful call with verify ssl set to false."""
     controller_data = dict(ENTRY_CONFIG)
     controller_data[CONF_VERIFY_SSL] = False

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,5 +1,4 @@
 """The tests for the UniFi Network device tracker platform."""
-
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -18,15 +17,19 @@ from homeassistant.components.unifi.const import (
     DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from .test_controller import ENTRY_CONFIG, setup_unifi_integration
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_no_entities(hass, aioclient_mock):
+async def test_no_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(hass, aioclient_mock)
 

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -4,26 +4,30 @@ from unittest.mock import patch
 from homeassistant.components import unifi
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_controller import DEFAULT_CONFIG_ENTRY_ID, setup_unifi_integration
 
 from tests.common import flush_store
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_setup_with_no_config(hass):
+async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that we do not discover anything or try to set up a controller."""
     assert await async_setup_component(hass, UNIFI_DOMAIN, {}) is True
     assert UNIFI_DOMAIN not in hass.data
 
 
-async def test_successful_config_entry(hass, aioclient_mock):
+async def test_successful_config_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that configured options for a host are loaded via config entry."""
     await setup_unifi_integration(hass, aioclient_mock, unique_id=None)
     assert hass.data[UNIFI_DOMAIN]
 
 
-async def test_setup_entry_fails_config_entry_not_ready(hass):
+async def test_setup_entry_fails_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.unifi.get_unifi_controller",
@@ -34,7 +38,7 @@ async def test_setup_entry_fails_config_entry_not_ready(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_setup_entry_fails_trigger_reauth_flow(hass):
+async def test_setup_entry_fails_trigger_reauth_flow(hass: HomeAssistant) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.unifi.get_unifi_controller",
@@ -46,7 +50,9 @@ async def test_setup_entry_fails_trigger_reauth_flow(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_unload_entry(hass, aioclient_mock):
+async def test_unload_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test being able to unload an entry."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     assert hass.data[UNIFI_DOMAIN]

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,5 +1,4 @@
 """UniFi Network sensor platform tests."""
-
 from copy import deepcopy
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -18,6 +17,7 @@ from homeassistant.components.unifi.const import (
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
@@ -26,6 +26,7 @@ import homeassistant.util.dt as dt_util
 from .test_controller import setup_unifi_integration
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 DEVICE_1 = {
     "board_rev": 2,
@@ -96,7 +97,9 @@ DEVICE_1 = {
 }
 
 
-async def test_no_clients(hass, aioclient_mock):
+async def test_no_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(
         hass,

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -1,5 +1,4 @@
 """deCONZ service tests."""
-
 from unittest.mock import patch
 
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
@@ -9,12 +8,17 @@ from homeassistant.components.unifi.services import (
     SUPPORTED_SERVICES,
 )
 from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .test_controller import setup_unifi_integration
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_service_setup_and_unload(hass, aioclient_mock):
+
+async def test_service_setup_and_unload(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify service setup works."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     for service in SUPPORTED_SERVICES:
@@ -44,7 +48,9 @@ async def test_service_setup_and_unload_not_called_if_multiple_integrations_dete
     assert remove_service_mock.call_count == 2
 
 
-async def test_reconnect_client(hass, aioclient_mock):
+async def test_reconnect_client(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify call to reconnect client is performed as expected."""
     clients = [
         {
@@ -77,7 +83,9 @@ async def test_reconnect_client(hass, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_reconnect_non_existant_device(hass, aioclient_mock):
+async def test_reconnect_non_existant_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if device does not exist."""
     await setup_unifi_integration(hass, aioclient_mock)
 
@@ -92,7 +100,9 @@ async def test_reconnect_non_existant_device(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_reconnect_device_without_mac(hass, aioclient_mock):
+async def test_reconnect_device_without_mac(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if device does not have a known mac."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
 
@@ -113,7 +123,9 @@ async def test_reconnect_device_without_mac(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_reconnect_client_controller_unavailable(hass, aioclient_mock):
+async def test_reconnect_client_controller_unavailable(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if controller is unavailable."""
     clients = [
         {
@@ -147,7 +159,9 @@ async def test_reconnect_client_controller_unavailable(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_reconnect_client_unknown_mac(hass, aioclient_mock):
+async def test_reconnect_client_unknown_mac(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if trying to reconnect a mac unknown to controller."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
 
@@ -168,7 +182,9 @@ async def test_reconnect_client_unknown_mac(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_reconnect_wired_client(hass, aioclient_mock):
+async def test_reconnect_wired_client(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if client is wired."""
     clients = [
         {
@@ -197,7 +213,9 @@ async def test_reconnect_wired_client(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_remove_clients(hass, aioclient_mock):
+async def test_remove_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify removing different variations of clients work."""
     clients = [
         {
@@ -251,7 +269,9 @@ async def test_remove_clients(hass, aioclient_mock):
     assert await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_remove_clients_controller_unavailable(hass, aioclient_mock):
+async def test_remove_clients_controller_unavailable(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if controller is unavailable."""
     clients = [
         {
@@ -272,7 +292,9 @@ async def test_remove_clients_controller_unavailable(hass, aioclient_mock):
     assert aioclient_mock.call_count == 0
 
 
-async def test_remove_clients_no_call_on_empty_list(hass, aioclient_mock):
+async def test_remove_clients_no_call_on_empty_list(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Verify no call is made if no fitting client has been added to the list."""
     clients = [
         {

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1,5 +1,4 @@
 """UniFi Network switch platform tests."""
-
 from copy import deepcopy
 from datetime import timedelta
 
@@ -28,6 +27,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityCategory
@@ -42,6 +42,7 @@ from .test_controller import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 CLIENT_1 = {
     "hostname": "client_1",
@@ -576,7 +577,9 @@ OUTLET_UP1 = {
 }
 
 
-async def test_no_clients(hass, aioclient_mock):
+async def test_no_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(
         hass,
@@ -592,7 +595,9 @@ async def test_no_clients(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_controller_not_client(hass, aioclient_mock):
+async def test_controller_not_client(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that the controller doesn't become a switch."""
     await setup_unifi_integration(
         hass,
@@ -607,7 +612,9 @@ async def test_controller_not_client(hass, aioclient_mock):
     assert cloudkey is None
 
 
-async def test_not_admin(hass, aioclient_mock):
+async def test_not_admin(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that switch platform only work on an admin account."""
     description = deepcopy(DESCRIPTION)
     description[0]["site_role"] = "not admin"
@@ -623,7 +630,9 @@ async def test_not_admin(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_switches(hass, aioclient_mock):
+async def test_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -1017,7 +1026,9 @@ async def test_new_client_discovered_on_block_control(
     assert hass.states.get("switch.block_client_1") is not None
 
 
-async def test_option_block_clients(hass, aioclient_mock):
+async def test_option_block_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the changes to option reflects accordingly."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -1060,7 +1071,9 @@ async def test_option_block_clients(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_option_remove_switches(hass, aioclient_mock):
+async def test_option_remove_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test removal of DPI switch when options updated."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -1177,7 +1190,9 @@ async def test_poe_port_switches(hass, aioclient_mock, mock_unifi_websocket):
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_OFF
 
 
-async def test_remove_poe_client_switches(hass, aioclient_mock):
+async def test_remove_poe_client_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test old PoE client switches are removed."""
 
     config_entry = config_entries.ConfigEntry(

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -24,8 +24,11 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_controller import DESCRIPTION, setup_unifi_integration
+
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 DEVICE_1 = {
     "board_rev": 3,
@@ -57,7 +60,9 @@ DEVICE_2 = {
 }
 
 
-async def test_no_entities(hass, aioclient_mock):
+async def test_no_entities(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(hass, aioclient_mock)
 
@@ -125,7 +130,9 @@ async def test_device_updates(hass, aioclient_mock, mock_unifi_websocket):
     assert device_1_state.attributes[ATTR_IN_PROGRESS] is False
 
 
-async def test_not_admin(hass, aioclient_mock):
+async def test_not_admin(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that the INSTALL feature is not available on a non-admin account."""
     description = deepcopy(DESCRIPTION)
     description[0]["site_role"] = "not admin"
@@ -145,7 +152,9 @@ async def test_not_admin(hass, aioclient_mock):
     )
 
 
-async def test_install(hass, aioclient_mock):
+async def test_install(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test the device update install call."""
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[DEVICE_1]

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
@@ -277,7 +277,7 @@ def config_children_and_attr(mock_states):
     }
 
 
-async def test_config_children_only(hass):
+async def test_config_children_only(hass: HomeAssistant) -> None:
     """Check config with only children."""
     config_start = copy(CONFIG_CHILDREN_ONLY)
     del config_start["platform"]
@@ -298,7 +298,7 @@ async def test_config_children_and_attr(hass, config_children_and_attr):
     assert config_start == config
 
 
-async def test_config_no_name(hass):
+async def test_config_no_name(hass: HomeAssistant) -> None:
     """Check config with no Name entry."""
     response = True
     try:
@@ -308,7 +308,7 @@ async def test_config_no_name(hass):
     assert not response
 
 
-async def test_config_bad_children(hass):
+async def test_config_bad_children(hass: HomeAssistant) -> None:
     """Check config with bad children entry."""
     config_no_children = {"name": "test", "platform": "universal"}
     config_bad_children = {"name": "test", "children": {}, "platform": "universal"}
@@ -320,7 +320,7 @@ async def test_config_bad_children(hass):
     assert [] == config_bad_children["children"]
 
 
-async def test_config_bad_commands(hass):
+async def test_config_bad_commands(hass: HomeAssistant) -> None:
     """Check config with bad commands entry."""
     config = {"name": "test", "platform": "universal"}
 
@@ -328,7 +328,7 @@ async def test_config_bad_commands(hass):
     assert {} == config["commands"]
 
 
-async def test_config_bad_attributes(hass):
+async def test_config_bad_attributes(hass: HomeAssistant) -> None:
     """Check config with bad attributes."""
     config = {"name": "test", "platform": "universal"}
 
@@ -336,7 +336,7 @@ async def test_config_bad_attributes(hass):
     assert {} == config["attributes"]
 
 
-async def test_config_bad_key(hass):
+async def test_config_bad_key(hass: HomeAssistant) -> None:
     """Check config with bad key."""
     config = {"name": "test", "asdf": 5, "platform": "universal"}
 
@@ -344,7 +344,7 @@ async def test_config_bad_key(hass):
     assert "asdf" not in config
 
 
-async def test_platform_setup(hass):
+async def test_platform_setup(hass: HomeAssistant) -> None:
     """Test platform setup."""
     config = {"name": "test", "platform": "universal"}
     bad_config = {"platform": "universal"}
@@ -370,7 +370,7 @@ async def test_platform_setup(hass):
     assert entities[0].name == "test"
 
 
-async def test_master_state(hass):
+async def test_master_state(hass: HomeAssistant) -> None:
     """Test master state property."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -442,7 +442,7 @@ async def test_active_child_state(hass, mock_states):
     assert mock_states.mock_mp_2.entity_id == ump._child_state.entity_id
 
 
-async def test_name(hass):
+async def test_name(hass: HomeAssistant) -> None:
     """Test name property."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -451,7 +451,7 @@ async def test_name(hass):
     assert config["name"] == ump.name
 
 
-async def test_polling(hass):
+async def test_polling(hass: HomeAssistant) -> None:
     """Test should_poll property."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -1048,7 +1048,7 @@ async def test_service_call_to_command(hass, mock_states):
     assert len(service) == 1
 
 
-async def test_state_template(hass):
+async def test_state_template(hass: HomeAssistant) -> None:
     """Test with a simple valid state template."""
     hass.states.async_set("sensor.test_sensor", STATE_ON)
 
@@ -1074,7 +1074,7 @@ async def test_state_template(hass):
     assert hass.states.get("media_player.tv").state == STATE_OFF
 
 
-async def test_device_class(hass):
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test device_class property."""
     hass.states.async_set("sensor.test_sensor", "on")
 
@@ -1093,7 +1093,7 @@ async def test_device_class(hass):
     assert hass.states.get("media_player.tv").attributes["device_class"] == "tv"
 
 
-async def test_unique_id(hass):
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id property."""
     hass.states.async_set("sensor.test_sensor", "on")
 
@@ -1113,7 +1113,7 @@ async def test_unique_id(hass):
     assert er.async_get("media_player.tv").unique_id == "universal_master_bed_tv"
 
 
-async def test_invalid_state_template(hass):
+async def test_invalid_state_template(hass: HomeAssistant) -> None:
     """Test invalid state template sets state to None."""
     hass.states.async_set("sensor.test_sensor", "on")
 
@@ -1139,7 +1139,7 @@ async def test_invalid_state_template(hass):
     assert hass.states.get("media_player.tv").state == STATE_UNKNOWN
 
 
-async def test_master_state_with_template(hass):
+async def test_master_state_with_template(hass: HomeAssistant) -> None:
     """Test the state_template option."""
     hass.states.async_set("input_boolean.test", STATE_OFF)
     hass.states.async_set("media_player.mock1", STATE_OFF)
@@ -1182,7 +1182,7 @@ async def test_master_state_with_template(hass):
     assert events[0].context == context
 
 
-async def test_reload(hass):
+async def test_reload(hass: HomeAssistant) -> None:
     """Test reloading the media player from yaml."""
     hass.states.async_set("input_boolean.test", STATE_OFF)
     hass.states.async_set("media_player.mock1", STATE_OFF)

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the UPB Control config flow."""
-
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.upb.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
 def mocked_upb(sync_complete=True, config_ok=True):
@@ -38,7 +38,7 @@ async def valid_tcp_flow(hass, sync_complete=True, config_ok=True):
     return result
 
 
-async def test_full_upb_flow_with_serial_port(hass):
+async def test_full_upb_flow_with_serial_port(hass: HomeAssistant) -> None:
     """Test a full UPB config flow with serial port."""
 
     with mocked_upb(), patch(
@@ -69,7 +69,7 @@ async def test_full_upb_flow_with_serial_port(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_with_tcp_upb(hass):
+async def test_form_user_with_tcp_upb(hass: HomeAssistant) -> None:
     """Test we can setup a serial upb."""
     result = await valid_tcp_flow(hass)
     assert result["type"] == "create_entry"
@@ -77,7 +77,7 @@ async def test_form_user_with_tcp_upb(hass):
     await hass.async_block_till_done()
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     from asyncio import TimeoutError
 
@@ -91,14 +91,14 @@ async def test_form_cannot_connect(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_missing_upb_file(hass):
+async def test_form_missing_upb_file(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await valid_tcp_flow(hass, config_ok=False)
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_upb_file"}
 
 
-async def test_form_user_with_already_configured(hass):
+async def test_form_user_with_already_configured(hass: HomeAssistant) -> None:
     """Test we can setup a TCP upb."""
     _ = await valid_tcp_flow(hass)
     result2 = await valid_tcp_flow(hass)
@@ -107,7 +107,7 @@ async def test_form_user_with_already_configured(hass):
     await hass.async_block_till_done()
 
 
-async def test_form_import(hass):
+async def test_form_import(hass: HomeAssistant) -> None:
     """Test we get the form with import source."""
 
     with mocked_upb(), patch(
@@ -127,7 +127,7 @@ async def test_form_import(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_junk_input(hass):
+async def test_form_junk_input(hass: HomeAssistant) -> None:
     """Test we get the form with import source."""
 
     with mocked_upb():

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the UpCloud config flow."""
-
 from unittest.mock import patch
 
 import requests.exceptions
@@ -9,6 +8,7 @@ from upcloud_api import UpCloudAPIError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.upcloud.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -22,7 +22,7 @@ FIXTURE_USER_INPUT_OPTIONS = {
 }
 
 
-async def test_show_set_form(hass):
+async def test_show_set_form(hass: HomeAssistant) -> None:
     """Test that the setup form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
@@ -75,7 +75,7 @@ async def test_success(hass, requests_mock):
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options produce expected data."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -7,9 +7,12 @@ import pytest
 
 from homeassistant.components import usb
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import conbee_device, slae_sh_device
+
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="operating_system")
@@ -156,7 +159,9 @@ async def test_removal_by_observer_before_started(hass, operating_system):
     await hass.async_block_till_done()
 
 
-async def test_discovered_by_websocket_scan(hass, hass_ws_client):
+async def test_discovered_by_websocket_scan(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "3039"}]
 
@@ -232,7 +237,9 @@ async def test_discovered_by_websocket_scan_limited_by_description_matcher(
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
 
 
-async def test_most_targeted_matcher_wins(hass, hass_ws_client):
+async def test_most_targeted_matcher_wins(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the most targeted matcher is used."""
     new_usb = [
         {"domain": "less", "vid": "3039", "pid": "3039"},
@@ -522,7 +529,9 @@ async def test_discovered_by_websocket_rejected_with_empty_serial_number_only(
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_discovered_by_websocket_scan_match_vid_only(hass, hass_ws_client):
+async def test_discovered_by_websocket_scan_match_vid_only(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan only matching vid."""
     new_usb = [{"domain": "test1", "vid": "3039"}]
 
@@ -558,7 +567,9 @@ async def test_discovered_by_websocket_scan_match_vid_only(hass, hass_ws_client)
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
 
 
-async def test_discovered_by_websocket_scan_match_vid_wrong_pid(hass, hass_ws_client):
+async def test_discovered_by_websocket_scan_match_vid_wrong_pid(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan only matching vid but wrong pid."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "9999"}]
 
@@ -593,7 +604,9 @@ async def test_discovered_by_websocket_scan_match_vid_wrong_pid(hass, hass_ws_cl
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_discovered_by_websocket_no_vid_pid(hass, hass_ws_client):
+async def test_discovered_by_websocket_no_vid_pid(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan with no vid or pid."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "9999"}]
 
@@ -835,7 +848,9 @@ def test_human_readable_device_name() -> None:
     assert "8A2A" in name
 
 
-async def test_async_is_plugged_in(hass, hass_ws_client):
+async def test_async_is_plugged_in(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test async_is_plugged_in."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "3039"}]
 
@@ -906,7 +921,9 @@ async def test_async_is_plugged_in_case_enforcement(hass, matcher):
             usb.async_is_plugged_in(hass, matcher)
 
 
-async def test_web_socket_triggers_discovery_request_callbacks(hass, hass_ws_client):
+async def test_web_socket_triggers_discovery_request_callbacks(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the websocket call triggers a discovery request callback."""
     mock_callback = Mock()
 
@@ -938,7 +955,9 @@ async def test_web_socket_triggers_discovery_request_callbacks(hass, hass_ws_cli
         assert len(mock_callback.mock_calls) == 1
 
 
-async def test_initial_scan_callback(hass, hass_ws_client):
+async def test_initial_scan_callback(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test it's possible to register a callback when the initial scan is done."""
     mock_callback_1 = Mock()
     mock_callback_2 = Mock()
@@ -971,7 +990,9 @@ async def test_initial_scan_callback(hass, hass_ws_client):
         cancel_2()
 
 
-async def test_cancel_initial_scan_callback(hass, hass_ws_client):
+async def test_cancel_initial_scan_callback(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test it's possible to cancel an initial scan callback."""
     mock_callback = Mock()
 

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     UnitOfLength,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -91,7 +92,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -216,7 +217,7 @@ async def test_setup(hass):
             assert len(all_states) == 0
 
 
-async def test_setup_with_custom_location(hass):
+async def test_setup_with_custom_location(hass: HomeAssistant) -> None:
     """Test the setup with a custom location."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 20.5, (-31.1, 150.1))

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -30,7 +30,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import MockConfigEntry, mock_restore_cache
 
 
-async def test_restore_state(hass):
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Test utility sensor restore state."""
     config = {
         "utility_meter": {
@@ -175,7 +175,7 @@ async def test_services(hass, meter):
     assert state.state == "4"
 
 
-async def test_services_config_entry(hass):
+async def test_services_config_entry(hass: HomeAssistant) -> None:
     """Test energy sensor reset service."""
     config_entry = MockConfigEntry(
         data={},
@@ -299,7 +299,7 @@ async def test_services_config_entry(hass):
     assert state.state == "4"
 
 
-async def test_cron(hass):
+async def test_cron(hass: HomeAssistant) -> None:
     """Test cron pattern."""
 
     config = {
@@ -314,7 +314,7 @@ async def test_cron(hass):
     assert await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_cron_and_meter(hass):
+async def test_cron_and_meter(hass: HomeAssistant) -> None:
     """Test cron pattern and meter type fails."""
     config = {
         "utility_meter": {
@@ -329,7 +329,7 @@ async def test_cron_and_meter(hass):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_both_cron_and_meter(hass):
+async def test_both_cron_and_meter(hass: HomeAssistant) -> None:
     """Test cron pattern and meter type passes in different meter."""
     config = {
         "utility_meter": {
@@ -347,7 +347,7 @@ async def test_both_cron_and_meter(hass):
     assert await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_cron_and_offset(hass):
+async def test_cron_and_offset(hass: HomeAssistant) -> None:
     """Test cron pattern and offset fails."""
 
     config = {
@@ -363,7 +363,7 @@ async def test_cron_and_offset(hass):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_bad_cron(hass):
+async def test_bad_cron(hass: HomeAssistant) -> None:
     """Test bad cron pattern."""
 
     config = {
@@ -373,7 +373,7 @@ async def test_bad_cron(hass):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_setup_missing_discovery(hass):
+async def test_setup_missing_discovery(hass: HomeAssistant) -> None:
     """Test setup with configuration missing discovery_info."""
     assert not await um_select.async_setup_platform(hass, {CONF_PLATFORM: DOMAIN}, None)
     assert not await um_sensor.async_setup_platform(hass, {CONF_PLATFORM: DOMAIN}, None)

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfEnergy,
 )
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -324,7 +324,7 @@ async def test_init(hass, yaml_config, config_entry_config):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
 
 
-async def test_unique_id(hass):
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id configuration option."""
     yaml_config = {
         "utility_meter": {
@@ -993,7 +993,7 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         assert state.state == "9"
 
 
-async def test_self_reset_cron_pattern(hass):
+async def test_self_reset_cron_pattern(hass: HomeAssistant) -> None:
     """Test cron pattern reset of meter."""
     config = {
         "utility_meter": {
@@ -1004,70 +1004,70 @@ async def test_self_reset_cron_pattern(hass):
     await _test_self_reset(hass, config, "2017-01-31T23:59:00.000000+00:00")
 
 
-async def test_self_reset_quarter_hourly(hass):
+async def test_self_reset_quarter_hourly(hass: HomeAssistant) -> None:
     """Test quarter-hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarter-hourly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_quarter_hourly_first_quarter(hass):
+async def test_self_reset_quarter_hourly_first_quarter(hass: HomeAssistant) -> None:
     """Test quarter-hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarter-hourly"), "2017-12-31T23:14:00.000000+00:00"
     )
 
 
-async def test_self_reset_quarter_hourly_second_quarter(hass):
+async def test_self_reset_quarter_hourly_second_quarter(hass: HomeAssistant) -> None:
     """Test quarter-hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarter-hourly"), "2017-12-31T23:29:00.000000+00:00"
     )
 
 
-async def test_self_reset_quarter_hourly_third_quarter(hass):
+async def test_self_reset_quarter_hourly_third_quarter(hass: HomeAssistant) -> None:
     """Test quarter-hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarter-hourly"), "2017-12-31T23:44:00.000000+00:00"
     )
 
 
-async def test_self_reset_hourly(hass):
+async def test_self_reset_hourly(hass: HomeAssistant) -> None:
     """Test hourly reset of meter."""
     await _test_self_reset(
         hass, gen_config("hourly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_daily(hass):
+async def test_self_reset_daily(hass: HomeAssistant) -> None:
     """Test daily reset of meter."""
     await _test_self_reset(
         hass, gen_config("daily"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_weekly(hass):
+async def test_self_reset_weekly(hass: HomeAssistant) -> None:
     """Test weekly reset of meter."""
     await _test_self_reset(
         hass, gen_config("weekly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_monthly(hass):
+async def test_self_reset_monthly(hass: HomeAssistant) -> None:
     """Test monthly reset of meter."""
     await _test_self_reset(
         hass, gen_config("monthly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_bimonthly(hass):
+async def test_self_reset_bimonthly(hass: HomeAssistant) -> None:
     """Test bimonthly reset of meter occurs on even months."""
     await _test_self_reset(
         hass, gen_config("bimonthly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_no_reset_bimonthly(hass):
+async def test_self_no_reset_bimonthly(hass: HomeAssistant) -> None:
     """Test bimonthly reset of meter does not occur on odd months."""
     await _test_self_reset(
         hass,
@@ -1077,21 +1077,21 @@ async def test_self_no_reset_bimonthly(hass):
     )
 
 
-async def test_self_reset_quarterly(hass):
+async def test_self_reset_quarterly(hass: HomeAssistant) -> None:
     """Test quarterly reset of meter."""
     await _test_self_reset(
         hass, gen_config("quarterly"), "2017-03-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_reset_yearly(hass):
+async def test_self_reset_yearly(hass: HomeAssistant) -> None:
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass, gen_config("yearly"), "2017-12-31T23:59:00.000000+00:00"
     )
 
 
-async def test_self_no_reset_yearly(hass):
+async def test_self_no_reset_yearly(hass: HomeAssistant) -> None:
     """Test yearly reset of meter does not occur after 1st January."""
     await _test_self_reset(
         hass,
@@ -1101,7 +1101,7 @@ async def test_self_no_reset_yearly(hass):
     )
 
 
-async def test_reset_yearly_offset(hass):
+async def test_reset_yearly_offset(hass: HomeAssistant) -> None:
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,
@@ -1110,7 +1110,7 @@ async def test_reset_yearly_offset(hass):
     )
 
 
-async def test_no_reset_yearly_offset(hass):
+async def test_no_reset_yearly_offset(hass: HomeAssistant) -> None:
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,
@@ -1120,7 +1120,7 @@ async def test_no_reset_yearly_offset(hass):
     )
 
 
-async def test_bad_offset(hass):
+async def test_bad_offset(hass: HomeAssistant) -> None:
     """Test bad offset of meter."""
     assert not await async_setup_component(
         hass, DOMAIN, gen_config("monthly", timedelta(days=31))

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -106,7 +107,7 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass):
+async def test_action(hass: HomeAssistant) -> None:
     """Test for turn_on and turn_off actions."""
     assert await async_setup_component(
         hass,

--- a/tests/components/vacuum/test_reproduce_state.py
+++ b/tests/components/vacuum/test_reproduce_state.py
@@ -1,4 +1,6 @@
 """Test reproduce state for Vacuum."""
+import pytest
+
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
     SERVICE_PAUSE,
@@ -18,7 +20,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
@@ -27,7 +29,9 @@ FAN_SPEED_LOW = "low"
 FAN_SPEED_HIGH = "high"
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Vacuum states."""
     hass.states.async_set("vacuum.entity_off", STATE_OFF, {})
     hass.states.async_set("vacuum.entity_on", STATE_ON, {})

--- a/tests/components/venstar/test_climate.py
+++ b/tests/components/venstar/test_climate.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration, mock_venstar_devices
 
@@ -13,7 +14,7 @@ EXPECTED_BASE_SUPPORTED_FEATURES = (
 
 
 @mock_venstar_devices
-async def test_colortouch(hass):
+async def test_colortouch(hass: HomeAssistant) -> None:
     """Test interfacing with a venstar colortouch with attached humidifier."""
 
     with patch("homeassistant.components.venstar.VENSTAR_SLEEP", new=0):
@@ -49,7 +50,7 @@ async def test_colortouch(hass):
 
 
 @mock_venstar_devices
-async def test_t2000(hass):
+async def test_t2000(hass: HomeAssistant) -> None:
     """Test interfacing with a venstar T2000 presently turned off."""
 
     with patch("homeassistant.components.venstar.VENSTAR_SLEEP", new=0):

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_async_step_finish_error(hass: HomeAssistant) -> None:
         }
 
 
-async def test_options(hass):
+async def test_options(hass: HomeAssistant) -> None:
     """Test updating options."""
     base_url = "http://127.0.0.1/"
     entry = MockConfigEntry(

--- a/tests/components/vesync/test_config_flow.py
+++ b/tests/components/vesync/test_config_flow.py
@@ -4,11 +4,12 @@ from unittest.mock import patch
 from homeassistant import data_entry_flow
 from homeassistant.components.vesync import DOMAIN, config_flow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_abort_already_setup(hass):
+async def test_abort_already_setup(hass: HomeAssistant) -> None:
     """Test if we abort because component is already setup."""
     flow = config_flow.VeSyncFlowHandler()
     flow.hass = hass
@@ -21,7 +22,7 @@ async def test_abort_already_setup(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_invalid_login_error(hass):
+async def test_invalid_login_error(hass: HomeAssistant) -> None:
     """Test if we return error for invalid username and password."""
     test_dict = {CONF_USERNAME: "user", CONF_PASSWORD: "pass"}
     flow = config_flow.VeSyncFlowHandler()
@@ -33,7 +34,7 @@ async def test_invalid_login_error(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_config_flow_user_input(hass):
+async def test_config_flow_user_input(hass: HomeAssistant) -> None:
     """Test config flow with user input."""
     flow = config_flow.VeSyncFlowHandler()
     flow.hass = hass

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -14,7 +14,7 @@ from . import ENTRY_CONFIG, MOCK_MAC
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -70,7 +70,7 @@ async def test_invalid_login(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_dhcp(hass):
+async def test_form_dhcp(hass: HomeAssistant) -> None:
     """Test we can setup from dhcp."""
 
     result = await hass.config_entries.flow.async_init(
@@ -109,7 +109,7 @@ async def test_form_dhcp(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_dhcp_single_instance_allowed(hass):
+async def test_dhcp_single_instance_allowed(hass: HomeAssistant) -> None:
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -130,7 +130,7 @@ async def test_dhcp_single_instance_allowed(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_user_input_single_instance_allowed(hass):
+async def test_user_input_single_instance_allowed(hass: HomeAssistant) -> None:
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -6,9 +6,10 @@ import vilfo
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.vilfo.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_ID, CONF_MAC
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     mock_mac = "FF-00-00-00-00-00"
@@ -39,7 +40,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -60,7 +61,7 @@ async def test_form_invalid_auth(hass):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -89,7 +90,7 @@ async def test_form_cannot_connect(hass):
     assert result3["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_wrong_host(hass):
+async def test_form_wrong_host(hass: HomeAssistant) -> None:
     """Test we handle wrong host errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -100,7 +101,7 @@ async def test_form_wrong_host(hass):
     assert result["errors"] == {"host": "wrong_host"}
 
 
-async def test_form_already_configured(hass):
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test that we handle already configured exceptions appropriately."""
     first_flow_result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -133,7 +134,7 @@ async def test_form_already_configured(hass):
     assert second_flow_result2["reason"] == "already_configured"
 
 
-async def test_form_unexpected_exception(hass):
+async def test_form_unexpected_exception(hass: HomeAssistant) -> None:
     """Test that we handle unexpected exceptions."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -151,7 +152,7 @@ async def test_form_unexpected_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_validate_input_returns_data(hass):
+async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
     """Test we handle the MAC address being resolved or not."""
     mock_data = {"host": "testadmin.vilfo.com", "access_token": "test-token"}
     mock_data_with_ip = {"host": "192.168.0.1", "access_token": "test-token"}

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -12,11 +12,13 @@ from homeassistant.components.media_player import (
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
 from tests.components.tts.conftest import mutagen_mock  # noqa: F401
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 URL = "https://api.voicerss.org/"
 FORM_DATA = {
@@ -46,7 +48,7 @@ def cleanup_cache(hass):
         shutil.rmtree(default_tts)
 
 
-async def test_setup_component(hass):
+async def test_setup_component(hass: HomeAssistant) -> None:
     """Test setup component."""
     config = {tts.DOMAIN: {"platform": "voicerss", "api_key": "1234567xx"}}
 
@@ -55,7 +57,7 @@ async def test_setup_component(hass):
         await hass.async_block_till_done()
 
 
-async def test_setup_component_without_api_key(hass):
+async def test_setup_component_without_api_key(hass: HomeAssistant) -> None:
     """Test setup component without api key."""
     config = {tts.DOMAIN: {"platform": "voicerss"}}
 
@@ -64,7 +66,9 @@ async def test_setup_component_without_api_key(hass):
         await hass.async_block_till_done()
 
 
-async def test_service_say(hass, aioclient_mock):
+async def test_service_say(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -93,7 +97,9 @@ async def test_service_say(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
 
 
-async def test_service_say_german_config(hass, aioclient_mock):
+async def test_service_say_german_config(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with german code in the config."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -128,7 +134,9 @@ async def test_service_say_german_config(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[0][2] == form_data
 
 
-async def test_service_say_german_service(hass, aioclient_mock):
+async def test_service_say_german_service(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with german code in the service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -158,7 +166,9 @@ async def test_service_say_german_service(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[0][2] == form_data
 
 
-async def test_service_say_error(hass, aioclient_mock):
+async def test_service_say_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with http response 400."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -186,7 +196,9 @@ async def test_service_say_error(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
 
 
-async def test_service_say_timeout(hass, aioclient_mock):
+async def test_service_say_timeout(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with http timeout."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -214,7 +226,9 @@ async def test_service_say_timeout(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[0][2] == FORM_DATA
 
 
-async def test_service_say_error_msg(hass, aioclient_mock):
+async def test_service_say_error_msg(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with http error api message."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.volumio.config_flow import CannotConnectError
 from homeassistant.components.volumio.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -35,7 +36,7 @@ TEST_DISCOVERY_RESULT = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -63,7 +64,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_updates_unique_id(hass):
+async def test_form_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate id aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -100,7 +101,7 @@ async def test_form_updates_unique_id(hass):
     assert entry.data == {**TEST_SYSTEM_INFO, **TEST_CONNECTION}
 
 
-async def test_empty_system_info(hass):
+async def test_empty_system_info(hass: HomeAssistant) -> None:
     """Test old volumio versions with empty system info."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -133,7 +134,7 @@ async def test_empty_system_info(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -152,7 +153,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_exception(hass):
+async def test_form_exception(hass: HomeAssistant) -> None:
     """Test we handle generic error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -171,7 +172,7 @@ async def test_form_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_discovery(hass):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test discovery flow works."""
 
     result = await hass.config_entries.flow.async_init(
@@ -201,7 +202,7 @@ async def test_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_discovery_cannot_connect(hass):
+async def test_discovery_cannot_connect(hass: HomeAssistant) -> None:
     """Test discovery aborts if cannot connect."""
 
     result = await hass.config_entries.flow.async_init(
@@ -221,7 +222,7 @@ async def test_discovery_cannot_connect(hass):
     assert result2["reason"] == "cannot_connect"
 
 
-async def test_discovery_duplicate_data(hass):
+async def test_discovery_duplicate_data(hass: HomeAssistant) -> None:
     """Test discovery aborts if same mDNS packet arrives."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=TEST_DISCOVERY
@@ -236,7 +237,7 @@ async def test_discovery_duplicate_data(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_discovery_updates_unique_id(hass):
+async def test_discovery_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate discovery id aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/vulcan/test_config_flow.py
+++ b/tests/components/vulcan/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.vulcan import config_flow, const, register
 from homeassistant.components.vulcan.config_flow import ClientConnectionError, Keystore
 from homeassistant.const import CONF_PIN, CONF_REGION, CONF_TOKEN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -29,7 +30,7 @@ fake_account = Account(
 )
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     flow = config_flow.VulcanFlowHandler()
     flow.hass = hass
@@ -519,7 +520,9 @@ async def test_multiple_config_entries_using_saved_credentials_4(mock_student, h
     assert len(mock_setup_entry.mock_calls) == 3
 
 
-async def test_multiple_config_entries_without_valid_saved_credentials(hass):
+async def test_multiple_config_entries_without_valid_saved_credentials(
+    hass: HomeAssistant,
+) -> None:
     """Test a unsuccessful config flow for multiple config entries without valid saved credentials."""
     MockConfigEntry(
         entry_id="456",
@@ -613,7 +616,9 @@ async def test_multiple_config_entries_using_saved_credentials_with_connections_
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_multiple_config_entries_using_saved_credentials_with_unknown_error(hass):
+async def test_multiple_config_entries_using_saved_credentials_with_unknown_error(
+    hass: HomeAssistant,
+) -> None:
     """Test a unsuccessful config flow for multiple config entries without valid saved credentials."""
     MockConfigEntry(
         entry_id="456",

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.water_heater import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -106,7 +107,7 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass):
+async def test_action(hass: HomeAssistant) -> None:
     """Test for turn_on and turn_off actions."""
     assert await async_setup_component(
         hass,

--- a/tests/components/water_heater/test_reproduce_state.py
+++ b/tests/components/water_heater/test_reproduce_state.py
@@ -1,4 +1,6 @@
 """Test reproduce state for Water heater."""
+import pytest
+
 from homeassistant.components.water_heater import (
     ATTR_AWAY_MODE,
     ATTR_OPERATION_MODE,
@@ -10,13 +12,15 @@ from homeassistant.components.water_heater import (
     STATE_GAS,
 )
 from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass, caplog):
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reproducing Water heater states."""
     hass.states.async_set("water_heater.entity_off", STATE_OFF, {})
     hass.states.async_set("water_heater.entity_on", STATE_ON, {ATTR_TEMPERATURE: 45})

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -1,5 +1,4 @@
 """Test Waze Travel Time sensors."""
-
 from WazeRouteCalculator import WRCError
 import pytest
 
@@ -14,6 +13,7 @@ from homeassistant.components.waze_travel_time.const import (
     DOMAIN,
     IMPERIAL_UNITS,
 )
+from homeassistant.core import HomeAssistant
 
 from .const import MOCK_CONFIG
 
@@ -53,7 +53,7 @@ def mock_update_keyerror_fixture(mock_wrc):
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
 @pytest.mark.usefixtures("mock_update", "mock_config")
-async def test_sensor(hass):
+async def test_sensor(hass: HomeAssistant) -> None:
     """Test that sensor works."""
     assert hass.states.get("sensor.waze_travel_time").state == "150"
     assert (
@@ -94,7 +94,7 @@ async def test_sensor(hass):
     ],
 )
 @pytest.mark.usefixtures("mock_update", "mock_config")
-async def test_imperial(hass):
+async def test_imperial(hass: HomeAssistant) -> None:
     """Test that the imperial option works."""
     assert hass.states.get("sensor.waze_travel_time").attributes[
         "distance"
@@ -102,7 +102,9 @@ async def test_imperial(hass):
 
 
 @pytest.mark.usefixtures("mock_update_wrcerror")
-async def test_sensor_failed_wrcerror(hass, caplog):
+async def test_sensor_failed_wrcerror(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that sensor update fails with log message."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"
@@ -116,7 +118,9 @@ async def test_sensor_failed_wrcerror(hass, caplog):
 
 
 @pytest.mark.usefixtures("mock_update_keyerror")
-async def test_sensor_failed_keyerror(hass, caplog):
+async def test_sensor_failed_keyerror(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that sensor update fails with log message."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, options=DEFAULT_OPTIONS, entry_id="test"

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components import webhook
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -40,7 +41,7 @@ async def test_unregistering_webhook(hass, mock_client):
     assert len(hooks) == 1
 
 
-async def test_generate_webhook_url(hass):
+async def test_generate_webhook_url(hass: HomeAssistant) -> None:
     """Test we generate a webhook url correctly."""
     await async_process_ha_core_config(
         hass,
@@ -51,7 +52,7 @@ async def test_generate_webhook_url(hass):
     assert url == "https://example.com/api/webhook/some_id"
 
 
-async def test_async_generate_path(hass):
+async def test_async_generate_path(hass: HomeAssistant) -> None:
     """Test generating just the path component of the url correctly."""
     path = webhook.async_generate_path("some_id")
     assert path == "/api/webhook/some_id"

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -17,7 +18,9 @@ async def setup_http(hass):
     await hass.async_block_till_done()
 
 
-async def test_webhook_json(hass, hass_client_no_auth):
+async def test_webhook_json(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test triggering with a JSON webhook."""
     events = []
 
@@ -56,7 +59,9 @@ async def test_webhook_json(hass, hass_client_no_auth):
     assert events[0].data["id"] == 0
 
 
-async def test_webhook_post(hass, hass_client_no_auth):
+async def test_webhook_post(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test triggering with a POST webhook."""
     events = []
 
@@ -91,7 +96,9 @@ async def test_webhook_post(hass, hass_client_no_auth):
     assert events[0].data["hello"] == "yo world"
 
 
-async def test_webhook_query(hass, hass_client_no_auth):
+async def test_webhook_query(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test triggering with a query POST webhook."""
     events = []
 
@@ -126,7 +133,9 @@ async def test_webhook_query(hass, hass_client_no_auth):
     assert events[0].data["hello"] == "yo world"
 
 
-async def test_webhook_multiple(hass, hass_client_no_auth):
+async def test_webhook_multiple(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test triggering multiple triggers with a POST webhook."""
     events1 = []
     events2 = []
@@ -181,7 +190,9 @@ async def test_webhook_multiple(hass, hass_client_no_auth):
     assert events2[0].data["hello"] == "yo2 world"
 
 
-async def test_webhook_reload(hass, hass_client_no_auth):
+async def test_webhook_reload(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test reloading a webhook."""
     events = []
 

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -11,6 +11,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
@@ -146,7 +147,9 @@ async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect,
     assert error in caplog.text
 
 
-async def test_no_discovery_info(hass, caplog):
+async def test_no_discovery_info(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setup without discovery info."""
     assert NOTIFY_DOMAIN not in hass.config.components
     assert await async_setup_component(

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -15,11 +15,12 @@ from homeassistant.components.websocket_api.const import (
     SIGNAL_WEBSOCKET_DISCONNECTED,
     URL,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -138,7 +139,9 @@ async def test_auth_active_user_inactive(hass, hass_client_no_auth, hass_access_
         assert auth_msg["type"] == TYPE_AUTH_INVALID
 
 
-async def test_auth_active_with_password_not_allow(hass, hass_client_no_auth):
+async def test_auth_active_with_password_not_allow(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()
@@ -174,7 +177,9 @@ async def test_auth_legacy_support_with_password(
         assert auth_msg["type"] == TYPE_AUTH_INVALID
 
 
-async def test_auth_with_invalid_token(hass, hass_client_no_auth):
+async def test_auth_with_invalid_token(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -24,6 +24,7 @@ from homeassistant.loader import async_get_integration
 from homeassistant.setup import DATA_SETUP_TIME, async_setup_component
 
 from tests.common import MockEntity, MockEntityPlatform, async_mock_service
+from tests.typing import WebSocketGenerator
 
 STATE_KEY_SHORT_NAMES = {
     "entity_id": "e",
@@ -1974,7 +1975,9 @@ async def test_client_message_coalescing(hass, websocket_client, hass_admin_user
     await hass.async_block_till_done()
 
 
-async def test_integration_descriptions(hass, hass_ws_client):
+async def test_integration_descriptions(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can get integration descriptions."""
     assert await async_setup_component(hass, "config", {})
     ws_client = await hass_ws_client(hass)

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -1,15 +1,14 @@
 """Test Websocket API messages module."""
-
 from homeassistant.components.websocket_api.messages import (
     _cached_event_message as lru_event_cache,
     cached_event_message,
     message_to_json,
 )
 from homeassistant.const import EVENT_STATE_CHANGED
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
 
-async def test_cached_event_message(hass):
+async def test_cached_event_message(hass: HomeAssistant) -> None:
     """Test that we cache event messages."""
 
     events = []
@@ -47,7 +46,7 @@ async def test_cached_event_message(hass):
     assert cache_info.currsize == 2
 
 
-async def test_cached_event_message_with_different_idens(hass):
+async def test_cached_event_message_with_different_idens(hass: HomeAssistant) -> None:
     """Test that we cache event messages when the subscrition idens differ."""
 
     events = []

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_TYPE,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -98,7 +99,7 @@ async def test_get_triggers(hass, wemo_entity):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_fires_on_long_press(hass):
+async def test_fires_on_long_press(hass: HomeAssistant) -> None:
     """Test wemo long press trigger firing."""
     assert await setup_automation(hass, MOCK_DEVICE_ID, EVENT_TYPE_LONG_PRESS)
     calls = async_mock_service(hass, "test", "automation")

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -6,6 +6,7 @@ import pywemo
 
 from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, WemoDiscovery
 from homeassistant.components.wemo.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
@@ -21,12 +22,12 @@ from .conftest import (
 from tests.common import async_fire_time_changed
 
 
-async def test_config_no_config(hass):
+async def test_config_no_config(hass: HomeAssistant) -> None:
     """Component setup succeeds when there are no config entry for the domain."""
     assert await async_setup_component(hass, DOMAIN, {})
 
 
-async def test_config_no_static(hass):
+async def test_config_no_static(hass: HomeAssistant) -> None:
     """Component setup succeeds when there are no static config entries."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_DISCOVERY: False}})
 
@@ -89,7 +90,7 @@ async def test_static_config_without_port(hass, pywemo_device):
     assert len(entity_entries) == 1
 
 
-async def test_static_config_with_invalid_host(hass):
+async def test_static_config_with_invalid_host(hass: HomeAssistant) -> None:
     """Component setup fails if a static host is invalid."""
     setup_success = await async_setup_component(
         hass,

--- a/tests/components/wiffi/test_config_flow.py
+++ b/tests/components/wiffi/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.wiffi.const import DOMAIN
 from homeassistant.const import CONF_PORT, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
@@ -112,7 +113,7 @@ async def test_form_start_server_failed(hass, start_server_failed):
     assert result2["reason"] == "start_server_failed"
 
 
-async def test_option_flow(hass):
+async def test_option_flow(hass: HomeAssistant) -> None:
     """Test option flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
     entry.add_to_hass(hass)

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components import dhcp
 from homeassistant.components.wiz.config_flow import CONF_DEVICE
 from homeassistant.components.wiz.const import DOMAIN
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -42,7 +43,7 @@ INTEGRATION_DISCOVERY = {
 }
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -71,7 +72,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_flow_enters_dns_name(hass):
+async def test_user_flow_enters_dns_name(hass: HomeAssistant) -> None:
     """Test we reject dns names and want ips."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -137,7 +138,7 @@ async def test_user_form_exceptions(hass, side_effect, error_base):
     assert result2["errors"] == {"base": error_base}
 
 
-async def test_form_updates_unique_id(hass):
+async def test_form_updates_unique_id(hass: HomeAssistant) -> None:
     """Test a duplicate id aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -340,7 +341,7 @@ async def test_discovered_by_dhcp_or_integration_discovery_avoid_waiting_for_ret
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_setup_via_discovery(hass):
+async def test_setup_via_discovery(hass: HomeAssistant) -> None:
     """Test setting up via discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -409,7 +410,7 @@ async def test_setup_via_discovery(hass):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_setup_via_discovery_cannot_connect(hass):
+async def test_setup_via_discovery_cannot_connect(hass: HomeAssistant) -> None:
     """Test setting up via discovery and we fail to connect to the discovered device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -441,7 +442,7 @@ async def test_setup_via_discovery_cannot_connect(hass):
     assert result3["reason"] == "cannot_connect"
 
 
-async def test_setup_via_discovery_exception_finds_nothing(hass):
+async def test_setup_via_discovery_exception_finds_nothing(hass: HomeAssistant) -> None:
     """Test we do not find anything if discovery throws."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -462,7 +463,7 @@ async def test_setup_via_discovery_exception_finds_nothing(hass):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_with_firmware_update(hass):
+async def test_discovery_with_firmware_update(hass: HomeAssistant) -> None:
     """Test we check the device again between first discovery and config entry creation."""
     with _patch_wizlight(
         device=None,

--- a/tests/components/wiz/test_diagnostics.py
+++ b/tests/components/wiz/test_diagnostics.py
@@ -1,10 +1,15 @@
 """Test WiZ diagnostics."""
+from homeassistant.core import HomeAssistant
+
 from . import async_setup_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_diagnostics(hass, hass_client):
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test generating diagnostics for a config entry."""
     _, entry = await async_setup_integration(hass)
     diag = await get_diagnostics_for_config_entry(hass, hass_client, entry)

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.wolflink.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -32,7 +33,7 @@ INPUT_CONFIG = {
 DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
 
 
-async def test_show_form(hass):
+async def test_show_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -42,7 +43,7 @@ async def test_show_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_device_step_form(hass):
+async def test_device_step_form(hass: HomeAssistant) -> None:
     """Test we get the second step of config."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -56,7 +57,7 @@ async def test_device_step_form(hass):
     assert result["step_id"] == "device"
 
 
-async def test_create_entry(hass):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test entity creation from device step."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -76,7 +77,7 @@ async def test_create_entry(hass):
     assert result_create_entry["data"] == CONFIG
 
 
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -90,7 +91,7 @@ async def test_form_invalid_auth(hass):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -104,7 +105,7 @@ async def test_form_cannot_connect(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_exception(hass):
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
@@ -118,7 +119,7 @@ async def test_form_unknown_exception(hass):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_already_configured_error(hass):
+async def test_already_configured_error(hass: HomeAssistant) -> None:
     """Test already configured while creating entry."""
     with patch(
         "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",

--- a/tests/components/ws66i/test_config_flow.py
+++ b/tests/components/ws66i/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.components.ws66i.const import (
     INIT_OPTIONS_DEFAULT,
 )
 from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
 
 from .test_media_player import AttrDict
 
@@ -22,7 +23,7 @@ from tests.common import MockConfigEntry
 CONFIG = {CONF_IP_ADDRESS: "1.1.1.1"}
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -53,7 +54,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -70,7 +71,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_wrong_ip(hass):
+async def test_form_wrong_ip(hass: HomeAssistant) -> None:
     """Test cannot connect error with bad IP."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -87,7 +88,7 @@ async def test_form_wrong_ip(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_generic_exception(hass):
+async def test_generic_exception(hass: HomeAssistant) -> None:
     """Test generic exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -104,7 +105,7 @@ async def test_generic_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     conf = {CONF_IP_ADDRESS: "1.1.1.1", CONF_SOURCES: INIT_OPTIONS_DEFAULT}
 

--- a/tests/components/ws66i/test_init.py
+++ b/tests/components/ws66i/test_init.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from homeassistant.components.ws66i.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 from .test_media_player import (
     MOCK_CONFIG,
@@ -16,7 +17,7 @@ from tests.common import MockConfigEntry
 ZONE_1_ID = "media_player.zone_11"
 
 
-async def test_cannot_connect(hass):
+async def test_cannot_connect(hass: HomeAssistant) -> None:
     """Test connection error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS
@@ -34,7 +35,7 @@ async def test_cannot_connect(hass):
         assert hass.states.get(ZONE_1_ID) is None
 
 
-async def test_cannot_connect_2(hass):
+async def test_cannot_connect_2(hass: HomeAssistant) -> None:
     """Test connection error pt 2."""
     # Another way to test same case as test_cannot_connect
     ws66i = MockWs66i()
@@ -55,7 +56,7 @@ async def test_cannot_connect_2(hass):
         assert hass.states.get(ZONE_1_ID) is None
 
 
-async def test_unload_config_entry(hass):
+async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test unloading config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS

--- a/tests/components/ws66i/test_media_player.py
+++ b/tests/components/ws66i/test_media_player.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -117,7 +118,7 @@ class MockWs66i:
         self.zones[zone.zone] = AttrDict(zone)
 
 
-async def test_setup_success(hass):
+async def test_setup_success(hass: HomeAssistant) -> None:
     """Test connection success."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, options=MOCK_OPTIONS
@@ -173,7 +174,7 @@ async def _call_media_player_service(hass, name, data):
     )
 
 
-async def test_update(hass):
+async def test_update(hass: HomeAssistant) -> None:
     """Test updating values from ws66i."""
     ws66i = MockWs66i()
     _ = await _setup_ws66i_with_options(hass, ws66i)
@@ -202,7 +203,7 @@ async def test_update(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "three"
 
 
-async def test_failed_update(hass):
+async def test_failed_update(hass: HomeAssistant) -> None:
     """Test updating failure from ws66i."""
     ws66i = MockWs66i()
     _ = await _setup_ws66i_with_options(hass, ws66i)
@@ -245,7 +246,7 @@ async def test_failed_update(hass):
     assert state.attributes[ATTR_INPUT_SOURCE] == "three"
 
 
-async def test_supported_features(hass):
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test supported features property."""
     await _setup_ws66i(hass, MockWs66i())
 
@@ -261,7 +262,7 @@ async def test_supported_features(hass):
     )
 
 
-async def test_source_list(hass):
+async def test_source_list(hass: HomeAssistant) -> None:
     """Test source list property."""
     await _setup_ws66i(hass, MockWs66i())
 
@@ -272,7 +273,7 @@ async def test_source_list(hass):
     )
 
 
-async def test_source_list_with_options(hass):
+async def test_source_list_with_options(hass: HomeAssistant) -> None:
     """Test source list property."""
     await _setup_ws66i_with_options(hass, MockWs66i())
 
@@ -281,7 +282,7 @@ async def test_source_list_with_options(hass):
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == list(MOCK_SOURCE_DIC.values())
 
 
-async def test_select_source(hass):
+async def test_select_source(hass: HomeAssistant) -> None:
     """Test source selection methods."""
     ws66i = MockWs66i()
     await _setup_ws66i_with_options(hass, ws66i)
@@ -294,7 +295,7 @@ async def test_select_source(hass):
     assert ws66i.zones[11].source == 3
 
 
-async def test_source_select(hass):
+async def test_source_select(hass: HomeAssistant) -> None:
     """Test source selection simulated from keypad."""
     ws66i = MockWs66i()
     _ = await _setup_ws66i_with_options(hass, ws66i)
@@ -309,7 +310,7 @@ async def test_source_select(hass):
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "five"
 
 
-async def test_turn_on_off(hass):
+async def test_turn_on_off(hass: HomeAssistant) -> None:
     """Test turning on the zone."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
@@ -321,7 +322,7 @@ async def test_turn_on_off(hass):
     assert ws66i.zones[11].power
 
 
-async def test_mute_volume(hass):
+async def test_mute_volume(hass: HomeAssistant) -> None:
     """Test mute functionality."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
@@ -340,7 +341,7 @@ async def test_mute_volume(hass):
     assert ws66i.zones[11].mute
 
 
-async def test_volume_up_down(hass):
+async def test_volume_up_down(hass: HomeAssistant) -> None:
     """Test increasing volume by one."""
     ws66i = MockWs66i()
     _ = await _setup_ws66i(hass, ws66i)
@@ -383,7 +384,7 @@ async def test_volume_up_down(hass):
     assert ws66i.zones[11].volume == MAX_VOL - 1
 
 
-async def test_volume_while_mute(hass):
+async def test_volume_while_mute(hass: HomeAssistant) -> None:
     """Test increasing volume by one."""
     ws66i = MockWs66i()
     _ = await _setup_ws66i(hass, ws66i)
@@ -438,7 +439,7 @@ async def test_volume_while_mute(hass):
     assert not ws66i.zones[11].mute
 
 
-async def test_first_run_with_available_zones(hass):
+async def test_first_run_with_available_zones(hass: HomeAssistant) -> None:
     """Test first run with all zones available."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
@@ -449,7 +450,7 @@ async def test_first_run_with_available_zones(hass):
     assert not entry.disabled
 
 
-async def test_first_run_with_failing_zones(hass):
+async def test_first_run_with_failing_zones(hass: HomeAssistant) -> None:
     """Test first run with failed zones."""
     ws66i = MockWs66i()
 
@@ -465,7 +466,7 @@ async def test_first_run_with_failing_zones(hass):
     assert entry is None
 
 
-async def test_register_all_entities(hass):
+async def test_register_all_entities(hass: HomeAssistant) -> None:
     """Test run with all entities registered."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
@@ -479,7 +480,7 @@ async def test_register_all_entities(hass):
     assert not entry.disabled
 
 
-async def test_register_entities_in_1_amp_only(hass):
+async def test_register_entities_in_1_amp_only(hass: HomeAssistant) -> None:
     """Test run with only zones 11-16 registered."""
     ws66i = MockWs66i(fail_zone_check=[21])
     await _setup_ws66i(hass, ws66i)

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.wsdot.sensor import (
     RESOURCE,
     SCAN_INTERVAL,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
@@ -24,7 +25,7 @@ config = {
 }
 
 
-async def test_setup_with_config(hass):
+async def test_setup_with_config(hass: HomeAssistant) -> None:
     """Test the platform setup with configuration."""
     assert await async_setup_component(hass, "sensor", {"wsdot": config})
 

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.xbox.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
@@ -12,7 +13,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
-async def test_abort_if_existing_entry(hass):
+async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     """Check flow abort when an entry already exist."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.xiaomi_aqara import config_flow, const
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
 
 ZEROCONF_NAME = "name"
 ZEROCONF_PROP = "properties"
@@ -76,7 +77,7 @@ def get_mock_discovery(
     return gateway_discovery
 
 
-async def test_config_flow_user_success(hass):
+async def test_config_flow_user_success(hass: HomeAssistant) -> None:
     """Test a successful config flow initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -113,7 +114,7 @@ async def test_config_flow_user_success(hass):
     }
 
 
-async def test_config_flow_user_multiple_success(hass):
+async def test_config_flow_user_multiple_success(hass: HomeAssistant) -> None:
     """Test a successful config flow initialized by the user with multiple gateways discovered."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -165,7 +166,7 @@ async def test_config_flow_user_multiple_success(hass):
     }
 
 
-async def test_config_flow_user_no_key_success(hass):
+async def test_config_flow_user_no_key_success(hass: HomeAssistant) -> None:
     """Test a successful config flow initialized by the user without a key."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -202,7 +203,7 @@ async def test_config_flow_user_no_key_success(hass):
     }
 
 
-async def test_config_flow_user_host_mac_success(hass):
+async def test_config_flow_user_host_mac_success(hass: HomeAssistant) -> None:
     """Test a successful config flow initialized by the user with a host and mac specified."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -249,7 +250,7 @@ async def test_config_flow_user_host_mac_success(hass):
     }
 
 
-async def test_config_flow_user_discovery_error(hass):
+async def test_config_flow_user_discovery_error(hass: HomeAssistant) -> None:
     """Test a failed config flow initialized by the user with no gateways discovered."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -275,7 +276,7 @@ async def test_config_flow_user_discovery_error(hass):
     assert result["errors"] == {"base": "discovery_error"}
 
 
-async def test_config_flow_user_invalid_interface(hass):
+async def test_config_flow_user_invalid_interface(hass: HomeAssistant) -> None:
     """Test a failed config flow initialized by the user with an invalid interface."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -301,7 +302,7 @@ async def test_config_flow_user_invalid_interface(hass):
     assert result["errors"] == {const.CONF_INTERFACE: "invalid_interface"}
 
 
-async def test_config_flow_user_invalid_host(hass):
+async def test_config_flow_user_invalid_host(hass: HomeAssistant) -> None:
     """Test a failed config flow initialized by the user with an invalid host."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -331,7 +332,7 @@ async def test_config_flow_user_invalid_host(hass):
     assert result["errors"] == {"host": "invalid_host"}
 
 
-async def test_config_flow_user_invalid_mac(hass):
+async def test_config_flow_user_invalid_mac(hass: HomeAssistant) -> None:
     """Test a failed config flow initialized by the user with an invalid mac."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -361,7 +362,7 @@ async def test_config_flow_user_invalid_mac(hass):
     assert result["errors"] == {"mac": "invalid_mac"}
 
 
-async def test_config_flow_user_invalid_key(hass):
+async def test_config_flow_user_invalid_key(hass: HomeAssistant) -> None:
     """Test a failed config flow initialized by the user with an invalid key."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -396,7 +397,7 @@ async def test_config_flow_user_invalid_key(hass):
     assert result["errors"] == {const.CONF_KEY: "invalid_key"}
 
 
-async def test_zeroconf_success(hass):
+async def test_zeroconf_success(hass: HomeAssistant) -> None:
     """Test a successful zeroconf discovery of a xiaomi aqara gateway."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -443,7 +444,7 @@ async def test_zeroconf_success(hass):
     }
 
 
-async def test_zeroconf_missing_data(hass):
+async def test_zeroconf_missing_data(hass: HomeAssistant) -> None:
     """Test a failed zeroconf discovery because of missing data."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -463,7 +464,7 @@ async def test_zeroconf_missing_data(hass):
     assert result["reason"] == "not_xiaomi_aqara"
 
 
-async def test_zeroconf_unknown_device(hass):
+async def test_zeroconf_unknown_device(hass: HomeAssistant) -> None:
     """Test a failed zeroconf discovery because of a unknown device."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -1,7 +1,7 @@
 """Test Xiaomi binary sensors."""
-
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 
 from . import make_advertisement
 
@@ -9,7 +9,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
-async def test_door_problem_sensors(hass):
+async def test_door_problem_sensors(hass: HomeAssistant) -> None:
     """Test setting up a door binary sensor with additional problem sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -53,7 +53,7 @@ async def test_door_problem_sensors(hass):
     await hass.async_block_till_done()
 
 
-async def test_light_motion(hass):
+async def test_light_motion(hass: HomeAssistant) -> None:
     """Test setting up a light and motion binary sensor."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -89,7 +89,7 @@ async def test_light_motion(hass):
     await hass.async_block_till_done()
 
 
-async def test_moisture(hass):
+async def test_moisture(hass: HomeAssistant) -> None:
     """Test setting up a moisture binary sensor."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -123,7 +123,7 @@ async def test_moisture(hass):
     await hass.async_block_till_done()
 
 
-async def test_opening(hass):
+async def test_opening(hass: HomeAssistant) -> None:
     """Test setting up a opening binary sensor."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -158,7 +158,7 @@ async def test_opening(hass):
     await hass.async_block_till_done()
 
 
-async def test_opening_problem_sensors(hass):
+async def test_opening_problem_sensors(hass: HomeAssistant) -> None:
     """Test setting up a opening binary sensor with additional problem sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -213,7 +213,7 @@ async def test_opening_problem_sensors(hass):
     await hass.async_block_till_done()
 
 
-async def test_smoke(hass):
+async def test_smoke(hass: HomeAssistant) -> None:
     """Test setting up a smoke binary sensor."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Xiaomi config flow."""
-
 import asyncio
 from unittest.mock import patch
 
@@ -8,6 +7,7 @@ from xiaomi_ble import XiaomiBluetoothDeviceData as DeviceData
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.xiaomi_ble.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
@@ -23,7 +23,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_async_step_bluetooth_valid_device(hass):
+async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -44,7 +44,9 @@ async def test_async_step_bluetooth_valid_device(hass):
     assert result2["result"].unique_id == "00:81:F9:DD:6F:C1"
 
 
-async def test_async_step_bluetooth_valid_device_but_missing_payload(hass):
+async def test_async_step_bluetooth_valid_device_but_missing_payload(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device but missing payload."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_process_advertisements",
@@ -70,7 +72,9 @@ async def test_async_step_bluetooth_valid_device_but_missing_payload(hass):
     assert result2["result"].unique_id == "A4:C1:38:56:53:84"
 
 
-async def test_async_step_bluetooth_valid_device_but_missing_payload_then_full(hass):
+async def test_async_step_bluetooth_valid_device_but_missing_payload_then_full(
+    hass: HomeAssistant,
+) -> None:
     """Test discovering a valid device. Payload is too short, but later we get full one."""
 
     async def _async_process_advertisements(
@@ -108,7 +112,7 @@ async def test_async_step_bluetooth_valid_device_but_missing_payload_then_full(h
     assert result2["result"].unique_id == "A4:C1:38:56:53:84"
 
 
-async def test_async_step_bluetooth_during_onboarding(hass):
+async def test_async_step_bluetooth_during_onboarding(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth during onboarding."""
     with patch(
         "homeassistant.components.xiaomi_ble.async_setup_entry", return_value=True
@@ -130,7 +134,9 @@ async def test_async_step_bluetooth_during_onboarding(hass):
     assert len(mock_onboarding.mock_calls) == 1
 
 
-async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
+async def test_async_step_bluetooth_valid_device_legacy_encryption(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with legacy encryption."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -153,7 +159,9 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption(hass):
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
 
-async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key(hass):
+async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with legacy encryption and invalid key."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -219,7 +227,9 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key_len
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
 
-async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
+async def test_async_step_bluetooth_valid_device_v4_encryption(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with v4 encryption."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -243,7 +253,9 @@ async def test_async_step_bluetooth_valid_device_v4_encryption(hass):
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key(hass):
+async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with v4 encryption and wrong key."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -277,7 +289,9 @@ async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key(hass):
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key_length(hass):
+async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key_length(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with v4 encryption and wrong key length."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -311,7 +325,7 @@ async def test_async_step_bluetooth_valid_device_v4_encryption_wrong_key_length(
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_bluetooth_not_xiaomi(hass):
+async def test_async_step_bluetooth_not_xiaomi(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth not xiaomi."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -322,7 +336,7 @@ async def test_async_step_bluetooth_not_xiaomi(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_async_step_user_no_devices_found(hass):
+async def test_async_step_user_no_devices_found(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -332,7 +346,7 @@ async def test_async_step_user_no_devices_found(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_no_devices_found_2(hass):
+async def test_async_step_user_no_devices_found_2(hass: HomeAssistant) -> None:
     """Test setup from service info cache with no devices found.
 
     This variant tests with a non-Xiaomi device known to us.
@@ -349,7 +363,7 @@ async def test_async_step_user_no_devices_found_2(hass):
         assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_user_with_found_devices(hass):
+async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -374,7 +388,7 @@ async def test_async_step_user_with_found_devices(hass):
     assert result2["result"].unique_id == "58:2D:34:35:93:21"
 
 
-async def test_async_step_user_short_payload(hass):
+async def test_async_step_user_short_payload(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found but short payloads."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -409,7 +423,7 @@ async def test_async_step_user_short_payload(hass):
     assert result3["result"].unique_id == "A4:C1:38:56:53:84"
 
 
-async def test_async_step_user_short_payload_then_full(hass):
+async def test_async_step_user_short_payload_then_full(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -456,7 +470,9 @@ async def test_async_step_user_short_payload_then_full(hass):
     assert result2["data"] == {"bindkey": "a115210eed7a88e50ad52662e732a9fb"}
 
 
-async def test_async_step_user_with_found_devices_v4_encryption(hass):
+async def test_async_step_user_with_found_devices_v4_encryption(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with v4 encryption."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -490,7 +506,9 @@ async def test_async_step_user_with_found_devices_v4_encryption(hass):
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_user_with_found_devices_v4_encryption_wrong_key(hass):
+async def test_async_step_user_with_found_devices_v4_encryption_wrong_key(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with v4 encryption and wrong key."""
     # Get a list of devices
     with patch(
@@ -536,7 +554,9 @@ async def test_async_step_user_with_found_devices_v4_encryption_wrong_key(hass):
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_user_with_found_devices_v4_encryption_wrong_key_length(hass):
+async def test_async_step_user_with_found_devices_v4_encryption_wrong_key_length(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with v4 encryption and wrong key length."""
     # Get a list of devices
     with patch(
@@ -584,7 +604,9 @@ async def test_async_step_user_with_found_devices_v4_encryption_wrong_key_length
     assert result2["result"].unique_id == "54:EF:44:E3:9C:BC"
 
 
-async def test_async_step_user_with_found_devices_legacy_encryption(hass):
+async def test_async_step_user_with_found_devices_legacy_encryption(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with legacy encryption."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -707,7 +729,7 @@ async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key_le
     assert result2["result"].unique_id == "F8:24:41:C5:98:8B"
 
 
-async def test_async_step_user_device_added_between_steps(hass):
+async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -737,7 +759,9 @@ async def test_async_step_user_device_added_between_steps(hass):
     assert result2["reason"] == "already_configured"
 
 
-async def test_async_step_user_with_found_devices_already_setup(hass):
+async def test_async_step_user_with_found_devices_already_setup(
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -757,7 +781,7 @@ async def test_async_step_user_with_found_devices_already_setup(hass):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_async_step_bluetooth_devices_already_setup(hass):
+async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -> None:
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -774,7 +798,7 @@ async def test_async_step_bluetooth_devices_already_setup(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_bluetooth_already_in_progress(hass):
+async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -793,7 +817,9 @@ async def test_async_step_bluetooth_already_in_progress(hass):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -829,7 +855,7 @@ async def test_async_step_user_takes_precedence_over_discovery(hass):
     assert not hass.config_entries.flow.async_progress(DOMAIN)
 
 
-async def test_async_step_reauth_legacy(hass):
+async def test_async_step_reauth_legacy(hass: HomeAssistant) -> None:
     """Test reauth with a legacy key."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -878,7 +904,7 @@ async def test_async_step_reauth_legacy(hass):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_async_step_reauth_legacy_wrong_key(hass):
+async def test_async_step_reauth_legacy_wrong_key(hass: HomeAssistant) -> None:
     """Test reauth with a bad legacy key, and that we can recover."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -935,7 +961,7 @@ async def test_async_step_reauth_legacy_wrong_key(hass):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_async_step_reauth_v4(hass):
+async def test_async_step_reauth_v4(hass: HomeAssistant) -> None:
     """Test reauth with a v4 key."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -984,7 +1010,7 @@ async def test_async_step_reauth_v4(hass):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_async_step_reauth_v4_wrong_key(hass):
+async def test_async_step_reauth_v4_wrong_key(hass: HomeAssistant) -> None:
     """Test reauth for v4 with a bad key, and that we can recover."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1041,7 +1067,7 @@ async def test_async_step_reauth_v4_wrong_key(hass):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_async_step_reauth_abort_early(hass):
+async def test_async_step_reauth_abort_early(hass: HomeAssistant) -> None:
     """Test we can abort the reauth if there is no encryption.
 
     (This can't currently happen in practice).

--- a/tests/components/xiaomi_ble/test_device_trigger.py
+++ b/tests/components/xiaomi_ble/test_device_trigger.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -59,7 +59,7 @@ async def _async_setup_xiaomi_device(hass, mac: str):
     return config_entry
 
 
-async def test_event_motion_detected(hass):
+async def test_event_motion_detected(hass: HomeAssistant) -> None:
     """Make sure that a motion detected event is fired."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -82,7 +82,7 @@ async def test_event_motion_detected(hass):
     await hass.async_block_till_done()
 
 
-async def test_get_triggers(hass):
+async def test_get_triggers(hass: HomeAssistant) -> None:
     """Test that we get the expected triggers from a Xiaomi BLE motion sensor."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -118,7 +118,7 @@ async def test_get_triggers(hass):
     await hass.async_block_till_done()
 
 
-async def test_get_triggers_for_invalid_xiami_ble_device(hass):
+async def test_get_triggers_for_invalid_xiami_ble_device(hass: HomeAssistant) -> None:
     """Test that we don't get triggers for an invalid device."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -149,7 +149,7 @@ async def test_get_triggers_for_invalid_xiami_ble_device(hass):
     await hass.async_block_till_done()
 
 
-async def test_get_triggers_for_invalid_device_id(hass):
+async def test_get_triggers_for_invalid_device_id(hass: HomeAssistant) -> None:
     """Test that we don't get triggers when using an invalid device_id."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -236,7 +236,9 @@ async def test_if_fires_on_motion_detected(hass, calls):
     await hass.async_block_till_done()
 
 
-async def test_automation_with_invalid_trigger_type(hass, caplog):
+async def test_automation_with_invalid_trigger_type(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for automation with invalid trigger type."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -282,7 +284,9 @@ async def test_automation_with_invalid_trigger_type(hass, caplog):
     await hass.async_block_till_done()
 
 
-async def test_automation_with_invalid_trigger_event_property(hass, caplog):
+async def test_automation_with_invalid_trigger_event_property(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for automation with invalid trigger event property."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -1,8 +1,8 @@
 """Test Xiaomi BLE sensors."""
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.xiaomi_ble.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.core import HomeAssistant
 
 from . import HHCCJCY10_SERVICE_INFO, MMC_T201_1_SERVICE_INFO, make_advertisement
 
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
 
-async def test_sensors(hass):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -39,7 +39,7 @@ async def test_sensors(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_formaldeyhde(hass):
+async def test_xiaomi_formaldeyhde(hass: HomeAssistant) -> None:
     """Make sure that formldehyde sensors are correctly mapped."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -75,7 +75,7 @@ async def test_xiaomi_formaldeyhde(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_consumable(hass):
+async def test_xiaomi_consumable(hass: HomeAssistant) -> None:
     """Make sure that consumable sensors are correctly mapped."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -111,7 +111,7 @@ async def test_xiaomi_consumable(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_battery_voltage(hass):
+async def test_xiaomi_battery_voltage(hass: HomeAssistant) -> None:
     """Make sure that battery voltage sensors are correctly mapped."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -152,7 +152,7 @@ async def test_xiaomi_battery_voltage(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01(hass):
+async def test_xiaomi_HHCCJCY01(hass: HomeAssistant) -> None:
     """This device has multiple advertisements before all sensors are visible. Test that this works."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -230,7 +230,7 @@ async def test_xiaomi_HHCCJCY01(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01_not_connectable(hass):
+async def test_xiaomi_HHCCJCY01_not_connectable(hass: HomeAssistant) -> None:
     """This device has multiple advertisements before all sensors are visible but not connectable."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -311,7 +311,9 @@ async def test_xiaomi_HHCCJCY01_not_connectable(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(hass):
+async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(
+    hass: HomeAssistant,
+) -> None:
     """This device has multiple advertisements before all sensors are visible and some sources are connectable."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -397,7 +399,7 @@ async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(hass):
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_CGDK2(hass):
+async def test_xiaomi_CGDK2(hass: HomeAssistant) -> None:
     """This device has encrypion so we need to retrieve its bindkey from the configentry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -434,7 +436,7 @@ async def test_xiaomi_CGDK2(hass):
     await hass.async_block_till_done()
 
 
-async def test_hhcc_HHCCJCY10(hass):
+async def test_hhcc_HHCCJCY10(hass: HomeAssistant) -> None:
     """This device used a different UUID compared to the other Xiaomi sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
 from homeassistant.components.xiaomi_miio import const
 from homeassistant.const import CONF_HOST, CONF_MODEL, CONF_TOKEN
+from homeassistant.core import HomeAssistant
 
 from . import TEST_MAC
 
@@ -103,7 +104,7 @@ def get_mock_info(
     return gateway_info
 
 
-async def test_config_flow_step_gateway_connect_error(hass):
+async def test_config_flow_step_gateway_connect_error(hass: HomeAssistant) -> None:
     """Test config flow, gateway connection error."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -136,7 +137,7 @@ async def test_config_flow_step_gateway_connect_error(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_config_flow_gateway_success(hass):
+async def test_config_flow_gateway_success(hass: HomeAssistant) -> None:
     """Test a successful config flow."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -174,7 +175,7 @@ async def test_config_flow_gateway_success(hass):
     }
 
 
-async def test_config_flow_gateway_cloud_success(hass):
+async def test_config_flow_gateway_cloud_success(hass: HomeAssistant) -> None:
     """Test a successful config flow using cloud."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -207,7 +208,7 @@ async def test_config_flow_gateway_cloud_success(hass):
     }
 
 
-async def test_config_flow_gateway_cloud_multiple_success(hass):
+async def test_config_flow_gateway_cloud_multiple_success(hass: HomeAssistant) -> None:
     """Test a successful config flow using cloud with multiple devices."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -253,7 +254,7 @@ async def test_config_flow_gateway_cloud_multiple_success(hass):
     }
 
 
-async def test_config_flow_gateway_cloud_incomplete(hass):
+async def test_config_flow_gateway_cloud_incomplete(hass: HomeAssistant) -> None:
     """Test a failed config flow using incomplete cloud credentials."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -276,7 +277,7 @@ async def test_config_flow_gateway_cloud_incomplete(hass):
     assert result["errors"] == {"base": "cloud_credentials_incomplete"}
 
 
-async def test_config_flow_gateway_cloud_login_error(hass):
+async def test_config_flow_gateway_cloud_login_error(hass: HomeAssistant) -> None:
     """Test a failed config flow using cloud login error."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -337,7 +338,7 @@ async def test_config_flow_gateway_cloud_login_error(hass):
     assert result["reason"] == "unknown"
 
 
-async def test_config_flow_gateway_cloud_no_devices(hass):
+async def test_config_flow_gateway_cloud_no_devices(hass: HomeAssistant) -> None:
     """Test a failed config flow using cloud with no devices."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -381,7 +382,7 @@ async def test_config_flow_gateway_cloud_no_devices(hass):
     assert result["reason"] == "unknown"
 
 
-async def test_config_flow_gateway_cloud_missing_token(hass):
+async def test_config_flow_gateway_cloud_missing_token(hass: HomeAssistant) -> None:
     """Test a failed config flow using cloud with a missing token."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -419,7 +420,7 @@ async def test_config_flow_gateway_cloud_missing_token(hass):
     assert result["reason"] == "incomplete_info"
 
 
-async def test_zeroconf_gateway_success(hass):
+async def test_zeroconf_gateway_success(hass: HomeAssistant) -> None:
     """Test a successful zeroconf discovery of a gateway."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -462,7 +463,7 @@ async def test_zeroconf_gateway_success(hass):
     }
 
 
-async def test_zeroconf_unknown_device(hass):
+async def test_zeroconf_unknown_device(hass: HomeAssistant) -> None:
     """Test a failed zeroconf discovery because of a unknown device."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -482,7 +483,7 @@ async def test_zeroconf_unknown_device(hass):
     assert result["reason"] == "not_xiaomi_miio"
 
 
-async def test_zeroconf_no_data(hass):
+async def test_zeroconf_no_data(hass: HomeAssistant) -> None:
     """Test a failed zeroconf discovery because of no data."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -502,7 +503,7 @@ async def test_zeroconf_no_data(hass):
     assert result["reason"] == "not_xiaomi_miio"
 
 
-async def test_zeroconf_missing_data(hass):
+async def test_zeroconf_missing_data(hass: HomeAssistant) -> None:
     """Test a failed zeroconf discovery because of missing data."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
@@ -522,7 +523,7 @@ async def test_zeroconf_missing_data(hass):
     assert result["reason"] == "not_xiaomi_miio"
 
 
-async def test_config_flow_step_device_connect_error(hass):
+async def test_config_flow_step_device_connect_error(hass: HomeAssistant) -> None:
     """Test config flow, device connection error."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -555,7 +556,7 @@ async def test_config_flow_step_device_connect_error(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_config_flow_step_unknown_device(hass):
+async def test_config_flow_step_unknown_device(hass: HomeAssistant) -> None:
     """Test config flow, unknown device error."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -590,7 +591,7 @@ async def test_config_flow_step_unknown_device(hass):
     assert result["errors"] == {"base": "unknown_device"}
 
 
-async def test_config_flow_step_device_manual_model_error(hass):
+async def test_config_flow_step_device_manual_model_error(hass: HomeAssistant) -> None:
     """Test config flow, device connection error, model None."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -635,7 +636,7 @@ async def test_config_flow_step_device_manual_model_error(hass):
     assert result["reason"] == "unknown"
 
 
-async def test_config_flow_step_device_manual_model_succes(hass):
+async def test_config_flow_step_device_manual_model_succes(hass: HomeAssistant) -> None:
     """Test config flow, device connection error, manual model."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -838,33 +839,33 @@ async def zeroconf_device_success(hass, zeroconf_name_to_test, model_to_test):
     }
 
 
-async def test_config_flow_plug_success(hass):
+async def test_config_flow_plug_success(hass: HomeAssistant) -> None:
     """Test a successful config flow for a plug."""
     test_plug_model = const.MODELS_SWITCH[0]
     await config_flow_device_success(hass, test_plug_model)
 
 
-async def test_zeroconf_plug_success(hass):
+async def test_zeroconf_plug_success(hass: HomeAssistant) -> None:
     """Test a successful zeroconf discovery of a plug."""
     test_plug_model = const.MODELS_SWITCH[0]
     test_zeroconf_name = const.MODELS_SWITCH[0].replace(".", "-")
     await zeroconf_device_success(hass, test_zeroconf_name, test_plug_model)
 
 
-async def test_config_flow_vacuum_success(hass):
+async def test_config_flow_vacuum_success(hass: HomeAssistant) -> None:
     """Test a successful config flow for a vacuum."""
     test_vacuum_model = const.MODELS_VACUUM[0]
     await config_flow_device_success(hass, test_vacuum_model)
 
 
-async def test_zeroconf_vacuum_success(hass):
+async def test_zeroconf_vacuum_success(hass: HomeAssistant) -> None:
     """Test a successful zeroconf discovery of a vacuum."""
     test_vacuum_model = const.MODELS_VACUUM[0]
     test_zeroconf_name = const.MODELS_VACUUM[0].replace(".", "-")
     await zeroconf_device_success(hass, test_zeroconf_name, test_vacuum_model)
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -904,7 +905,7 @@ async def test_options_flow(hass):
     }
 
 
-async def test_options_flow_incomplete(hass):
+async def test_options_flow_incomplete(hass: HomeAssistant) -> None:
     """Test specifying incomplete settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
@@ -942,7 +943,7 @@ async def test_options_flow_incomplete(hass):
     assert result["errors"] == {"base": "cloud_credentials_incomplete"}
 
 
-async def test_reauth(hass):
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test a reauth flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -12,12 +12,14 @@ from homeassistant.components.media_player import (
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
 from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
     mutagen_mock,
 )
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 URL = "https://tts.voicetech.yandex.net/generate?"
 
@@ -40,7 +42,7 @@ def cleanup_cache(hass):
         shutil.rmtree(default_tts)
 
 
-async def test_setup_component(hass):
+async def test_setup_component(hass: HomeAssistant) -> None:
     """Test setup component."""
     config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}
 
@@ -49,7 +51,7 @@ async def test_setup_component(hass):
         await hass.async_block_till_done()
 
 
-async def test_setup_component_without_api_key(hass):
+async def test_setup_component_without_api_key(hass: HomeAssistant) -> None:
     """Test setup component without api key."""
     config = {tts.DOMAIN: {"platform": "yandextts"}}
 
@@ -58,7 +60,9 @@ async def test_setup_component_without_api_key(hass):
         await hass.async_block_till_done()
 
 
-async def test_service_say(hass, aioclient_mock):
+async def test_service_say(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -90,7 +94,9 @@ async def test_service_say(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_russian_config(hass, aioclient_mock):
+async def test_service_say_russian_config(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -129,7 +135,9 @@ async def test_service_say_russian_config(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_russian_service(hass, aioclient_mock):
+async def test_service_say_russian_service(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -165,7 +173,9 @@ async def test_service_say_russian_service(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_timeout(hass, aioclient_mock):
+async def test_service_say_timeout(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -205,7 +215,9 @@ async def test_service_say_timeout(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_http_error(hass, aioclient_mock):
+async def test_service_say_http_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -243,7 +255,9 @@ async def test_service_say_http_error(hass, aioclient_mock):
         await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
 
 
-async def test_service_say_specified_speaker(hass, aioclient_mock):
+async def test_service_say_specified_speaker(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -281,7 +295,9 @@ async def test_service_say_specified_speaker(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_specified_emotion(hass, aioclient_mock):
+async def test_service_say_specified_emotion(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -320,7 +336,9 @@ async def test_service_say_specified_emotion(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_specified_low_speed(hass, aioclient_mock):
+async def test_service_say_specified_low_speed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -355,7 +373,9 @@ async def test_service_say_specified_low_speed(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_specified_speed(hass, aioclient_mock):
+async def test_service_say_specified_speed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -388,7 +408,9 @@ async def test_service_say_specified_speed(hass, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_say_specified_options(hass, aioclient_mock):
+async def test_service_say_specified_options(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test service call say with options."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -454,7 +454,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
     }
 
 
-async def test_discovered_by_homekit_and_dhcp(hass):
+async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
     """Test we get the form with homekit and abort for dhcp source when we get both."""
 
     mocked_bulb = _mocked_bulb()
@@ -630,7 +630,7 @@ async def test_discovered_by_dhcp_or_homekit_failed_to_get_id(hass, source, data
     assert result["reason"] == "cannot_connect"
 
 
-async def test_discovered_ssdp(hass):
+async def test_discovered_ssdp(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from ssdp."""
 
     mocked_bulb = _mocked_bulb()
@@ -675,7 +675,7 @@ async def test_discovered_ssdp(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_discovered_zeroconf(hass):
+async def test_discovered_zeroconf(hass: HomeAssistant) -> None:
     """Test we can setup when discovered from zeroconf."""
 
     mocked_bulb = _mocked_bulb()

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -356,7 +356,9 @@ async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_async_listen_error_late_discovery(hass, caplog):
+async def test_async_listen_error_late_discovery(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the async listen error."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
     config_entry.add_to_hass(hass)
@@ -381,7 +383,9 @@ async def test_async_listen_error_late_discovery(hass, caplog):
     assert config_entry.data[CONF_DETECTED_MODEL] == MODEL
 
 
-async def test_fail_to_fetch_initial_state(hass, caplog):
+async def test_fail_to_fetch_initial_state(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test failing to fetch initial state results in a retry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, **CONFIG_ENTRY_DATA}
@@ -409,7 +413,9 @@ async def test_fail_to_fetch_initial_state(hass, caplog):
     assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_unload_before_discovery(hass, caplog):
+async def test_unload_before_discovery(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test unloading before discovery."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
     config_entry.add_to_hass(hass)

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -17,7 +17,7 @@ CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
 
 
-async def test_abort_if_no_configuration(hass):
+async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     """Check flow abort when no configuration."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
@@ -857,7 +858,7 @@ async def test_homekit_controller_still_discovered_unpaired_for_polling(
     assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
 
 
-async def test_info_from_service_non_utf8(hass):
+async def test_info_from_service_non_utf8(hass: HomeAssistant) -> None:
     """Test info_from_service handles non UTF-8 property keys and values correctly."""
     service_type = "_test._tcp.local."
     info = zeroconf.info_from_service(
@@ -872,7 +873,7 @@ async def test_info_from_service_non_utf8(hass):
     assert raw_info["non-utf8-value"] is NON_UTF8_VALUE
 
 
-async def test_info_from_service_with_addresses(hass):
+async def test_info_from_service_with_addresses(hass: HomeAssistant) -> None:
     """Test info_from_service does not throw when there are no addresses."""
     service_type = "_test._tcp.local."
     info = zeroconf.info_from_service(
@@ -881,7 +882,9 @@ async def test_info_from_service_with_addresses(hass):
     assert info is None
 
 
-async def test_info_from_service_with_link_local_address_first(hass):
+async def test_info_from_service_with_link_local_address_first(
+    hass: HomeAssistant,
+) -> None:
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -890,7 +893,9 @@ async def test_info_from_service_with_link_local_address_first(hass):
     assert info.host == "192.168.66.12"
 
 
-async def test_info_from_service_with_unspecified_address_first(hass):
+async def test_info_from_service_with_unspecified_address_first(
+    hass: HomeAssistant,
+) -> None:
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -899,7 +904,9 @@ async def test_info_from_service_with_unspecified_address_first(hass):
     assert info.host == "192.168.66.12"
 
 
-async def test_info_from_service_with_unspecified_address_only(hass):
+async def test_info_from_service_with_unspecified_address_only(
+    hass: HomeAssistant,
+) -> None:
     """Test that the unspecified address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -908,7 +915,9 @@ async def test_info_from_service_with_unspecified_address_only(hass):
     assert info is None
 
 
-async def test_info_from_service_with_link_local_address_second(hass):
+async def test_info_from_service_with_link_local_address_second(
+    hass: HomeAssistant,
+) -> None:
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -917,7 +926,9 @@ async def test_info_from_service_with_link_local_address_second(hass):
     assert info.host == "192.168.66.12"
 
 
-async def test_info_from_service_with_link_local_address_only(hass):
+async def test_info_from_service_with_link_local_address_only(
+    hass: HomeAssistant,
+) -> None:
     """Test that the link local address is ignored."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -926,7 +937,7 @@ async def test_info_from_service_with_link_local_address_only(hass):
     assert info is None
 
 
-async def test_info_from_service_prefers_ipv4(hass):
+async def test_info_from_service_prefers_ipv4(hass: HomeAssistant) -> None:
     """Test that ipv4 addresses are preferred."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")
@@ -935,7 +946,7 @@ async def test_info_from_service_prefers_ipv4(hass):
     assert info.host == "192.168.66.12"
 
 
-async def test_info_from_service_can_return_ipv6(hass):
+async def test_info_from_service_can_return_ipv6(hass: HomeAssistant) -> None:
     """Test that IPv6-only devices can be discovered."""
     service_type = "_test._tcp.local."
     service_info = get_service_info_mock(service_type, f"test.{service_type}")

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -5,9 +5,10 @@ import pyzerproc
 
 from homeassistant import config_entries
 from homeassistant.components.zerproc.config_flow import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_flow_success(hass):
+async def test_flow_success(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -39,7 +40,7 @@ async def test_flow_success(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_no_devices_found(hass):
+async def test_flow_no_devices_found(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -69,7 +70,7 @@ async def test_flow_no_devices_found(hass):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_flow_exceptions_caught(hass):
+async def test_flow_exceptions_caught(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for ZHA config flow."""
-
 import copy
 from datetime import timedelta
 import json
@@ -33,6 +32,7 @@ from homeassistant.config_entries import (
     SOURCE_ZEROCONF,
 )
 from homeassistant.const import CONF_SOURCE
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
@@ -118,7 +118,7 @@ def com_port(device="/dev/ttyUSB1234"):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_zeroconf_discovery_znp(hass):
+async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.200",
@@ -216,7 +216,7 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"bellows.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_efr32_via_zeroconf(hass):
+async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- efr32 radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.200",
@@ -266,7 +266,7 @@ async def test_efr32_via_zeroconf(hass):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_zeroconf_ip_change(hass):
+async def test_discovery_via_zeroconf_ip_change(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -305,7 +305,7 @@ async def test_discovery_via_zeroconf_ip_change(hass):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_zeroconf_ip_change_ignored(hass):
+async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> None:
     """Test zeroconf flow that was ignored gets updated."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -334,7 +334,7 @@ async def test_discovery_via_zeroconf_ip_change_ignored(hass):
     }
 
 
-async def test_discovery_confirm_final_abort_if_entries(hass):
+async def test_discovery_confirm_final_abort_if_entries(hass: HomeAssistant) -> None:
     """Test discovery aborts if ZHA was set up after the confirmation dialog is shown."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.200",
@@ -366,7 +366,7 @@ async def test_discovery_confirm_final_abort_if_entries(hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb(hass):
+async def test_discovery_via_usb(hass: HomeAssistant) -> None:
     """Test usb flow -- radio detected."""
     discovery_info = usb.UsbServiceInfo(
         device="/dev/ttyZIGBEE",
@@ -483,7 +483,7 @@ async def test_discovery_via_usb_no_radio(probe_mock, hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb_already_setup(hass):
+async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
     """Test usb flow -- already setup."""
 
     MockConfigEntry(
@@ -508,7 +508,7 @@ async def test_discovery_via_usb_already_setup(hass):
 
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_discovery_via_usb_path_changes(hass):
+async def test_discovery_via_usb_path_changes(hass: HomeAssistant) -> None:
     """Test usb flow already setup and the path changes."""
 
     entry = MockConfigEntry(
@@ -547,7 +547,7 @@ async def test_discovery_via_usb_path_changes(hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb_deconz_already_discovered(hass):
+async def test_discovery_via_usb_deconz_already_discovered(hass: HomeAssistant) -> None:
     """Test usb flow -- deconz discovered."""
     result = await hass.config_entries.flow.async_init(
         "deconz",
@@ -581,7 +581,7 @@ async def test_discovery_via_usb_deconz_already_discovered(hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb_deconz_already_setup(hass):
+async def test_discovery_via_usb_deconz_already_setup(hass: HomeAssistant) -> None:
     """Test usb flow -- deconz setup."""
     MockConfigEntry(domain="deconz", data={}).add_to_hass(hass)
     await hass.async_block_till_done()
@@ -603,7 +603,7 @@ async def test_discovery_via_usb_deconz_already_setup(hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb_deconz_ignored(hass):
+async def test_discovery_via_usb_deconz_ignored(hass: HomeAssistant) -> None:
     """Test usb flow -- deconz ignored."""
     MockConfigEntry(
         domain="deconz", source=config_entries.SOURCE_IGNORE, data={}
@@ -627,7 +627,7 @@ async def test_discovery_via_usb_deconz_ignored(hass):
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_usb_zha_ignored_updates(hass):
+async def test_discovery_via_usb_zha_ignored_updates(hass: HomeAssistant) -> None:
     """Test usb flow that was ignored gets updated."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -659,7 +659,7 @@ async def test_discovery_via_usb_zha_ignored_updates(hass):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_already_setup(hass):
+async def test_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.200",
@@ -689,7 +689,7 @@ async def test_discovery_already_setup(hass):
     mock_detect_radio_type(radio_type=RadioType.deconz),
 )
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_user_flow(hass):
+async def test_user_flow(hass: HomeAssistant) -> None:
     """Test user flow -- radio detected."""
 
     port = com_port()
@@ -727,7 +727,7 @@ async def test_user_flow(hass):
     mock_detect_radio_type(ret=False),
 )
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_user_flow_not_detected(hass):
+async def test_user_flow_not_detected(hass: HomeAssistant) -> None:
     """Test user flow, radio not detected."""
 
     port = com_port()
@@ -744,7 +744,7 @@ async def test_user_flow_not_detected(hass):
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_user_flow_show_form(hass):
+async def test_user_flow_show_form(hass: HomeAssistant) -> None:
     """Test user step form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -756,7 +756,7 @@ async def test_user_flow_show_form(hass):
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[]))
-async def test_user_flow_show_manual(hass):
+async def test_user_flow_show_manual(hass: HomeAssistant) -> None:
     """Test user flow manual entry when no comport detected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -767,7 +767,7 @@ async def test_user_flow_show_manual(hass):
     assert result["step_id"] == "manual_pick_radio_type"
 
 
-async def test_user_flow_manual(hass):
+async def test_user_flow_manual(hass: HomeAssistant) -> None:
     """Test user flow manual entry."""
 
     result = await hass.config_entries.flow.async_init(
@@ -792,7 +792,7 @@ async def test_pick_radio_flow(hass, radio_type):
     assert result["step_id"] == "manual_port_config"
 
 
-async def test_user_flow_existing_config_entry(hass):
+async def test_user_flow_existing_config_entry(hass: HomeAssistant) -> None:
     """Test if config entry already exists."""
     MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
@@ -999,7 +999,7 @@ async def test_hardware(onboarded, hass):
     }
 
 
-async def test_hardware_already_setup(hass):
+async def test_hardware_already_setup(hass: HomeAssistant) -> None:
     """Test hardware flow -- already setup."""
 
     MockConfigEntry(
@@ -1643,7 +1643,7 @@ async def test_options_flow_defaults(async_setup_entry, async_unload_effect, has
     ),
 )
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_options_flow_defaults_socket(hass):
+async def test_options_flow_defaults_socket(hass: HomeAssistant) -> None:
     """Test options flow defaults work even for serial ports that can't be listed."""
 
     entry = MockConfigEntry(

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     ATTR_PERSONS,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 
@@ -57,7 +57,7 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_setup_no_zones_still_adds_home_zone(hass):
+async def test_setup_no_zones_still_adds_home_zone(hass: HomeAssistant) -> None:
     """Test if no config is passed in we still get the home zone."""
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": None})
     assert len(hass.states.async_entity_ids("zone")) == 1
@@ -68,7 +68,7 @@ async def test_setup_no_zones_still_adds_home_zone(hass):
     assert not state.attributes.get("passive", False)
 
 
-async def test_setup(hass):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test a successful setup."""
     info = {
         "name": "Test Zone",
@@ -88,7 +88,7 @@ async def test_setup(hass):
     assert info["passive"] == state.attributes["passive"]
 
 
-async def test_setup_zone_skips_home_zone(hass):
+async def test_setup_zone_skips_home_zone(hass: HomeAssistant) -> None:
     """Test that zone named Home should override hass home zone."""
     info = {"name": "Home", "latitude": 1.1, "longitude": -2.2}
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
@@ -98,14 +98,14 @@ async def test_setup_zone_skips_home_zone(hass):
     assert info["name"] == state.name
 
 
-async def test_setup_name_can_be_same_on_multiple_zones(hass):
+async def test_setup_name_can_be_same_on_multiple_zones(hass: HomeAssistant) -> None:
     """Test that zone named Home should override hass home zone."""
     info = {"name": "Test Zone", "latitude": 1.1, "longitude": -2.2}
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": [info, info]})
     assert len(hass.states.async_entity_ids("zone")) == 3
 
 
-async def test_active_zone_skips_passive_zones(hass):
+async def test_active_zone_skips_passive_zones(hass: HomeAssistant) -> None:
     """Test active and passive zones."""
     assert await setup.async_setup_component(
         hass,
@@ -127,7 +127,7 @@ async def test_active_zone_skips_passive_zones(hass):
     assert active is None
 
 
-async def test_active_zone_skips_passive_zones_2(hass):
+async def test_active_zone_skips_passive_zones_2(hass: HomeAssistant) -> None:
     """Test active and passive zones."""
     assert await setup.async_setup_component(
         hass,
@@ -148,7 +148,9 @@ async def test_active_zone_skips_passive_zones_2(hass):
     assert active.entity_id == "zone.active_zone"
 
 
-async def test_active_zone_prefers_smaller_zone_if_same_distance(hass):
+async def test_active_zone_prefers_smaller_zone_if_same_distance(
+    hass: HomeAssistant,
+) -> None:
     """Test zone size preferences."""
     latitude = 32.880600
     longitude = -117.237561
@@ -177,7 +179,9 @@ async def test_active_zone_prefers_smaller_zone_if_same_distance(hass):
     assert active.entity_id == "zone.small_zone"
 
 
-async def test_active_zone_prefers_smaller_zone_if_same_distance_2(hass):
+async def test_active_zone_prefers_smaller_zone_if_same_distance_2(
+    hass: HomeAssistant,
+) -> None:
     """Test zone size preferences."""
     latitude = 32.880600
     longitude = -117.237561
@@ -200,7 +204,7 @@ async def test_active_zone_prefers_smaller_zone_if_same_distance_2(hass):
     assert active.entity_id == "zone.smallest_zone"
 
 
-async def test_in_zone_works_for_passive_zones(hass):
+async def test_in_zone_works_for_passive_zones(hass: HomeAssistant) -> None:
     """Test working in passive zones."""
     latitude = 32.880600
     longitude = -117.237561
@@ -223,7 +227,7 @@ async def test_in_zone_works_for_passive_zones(hass):
     assert zone.in_zone(hass.states.get("zone.passive_zone"), latitude, longitude)
 
 
-async def test_core_config_update(hass):
+async def test_core_config_update(hass: HomeAssistant) -> None:
     """Test updating core config will update home zone."""
     assert await setup.async_setup_component(hass, "zone", {})
 
@@ -464,7 +468,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.attributes["passive"] is True
 
 
-async def test_import_config_entry(hass):
+async def test_import_config_entry(hass: HomeAssistant) -> None:
     """Test we import config entry and then delete it."""
     entry = MockConfigEntry(
         domain="zone",
@@ -491,12 +495,12 @@ async def test_import_config_entry(hass):
     assert state.attributes[ATTR_ICON] == "mdi:from-config-entry"
 
 
-async def test_zone_empty_setup(hass):
+async def test_zone_empty_setup(hass: HomeAssistant) -> None:
     """Set up zone with empty config."""
     assert await setup.async_setup_component(hass, DOMAIN, {"zone": {}})
 
 
-async def test_unavailable_zone(hass):
+async def test_unavailable_zone(hass: HomeAssistant) -> None:
     """Test active zone with unavailable zones."""
     assert await setup.async_setup_component(hass, DOMAIN, {"zone": {}})
     hass.states.async_set("zone.bla", "unavailable", {"restored": True})
@@ -506,7 +510,7 @@ async def test_unavailable_zone(hass):
     assert zone.in_zone(hass.states.get("zone.bla"), 0, 0) is False
 
 
-async def test_state(hass):
+async def test_state(hass: HomeAssistant) -> None:
     """Test the state of a zone."""
     info = {
         "name": "Test Zone",

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import ADDON_SLUG, DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -181,7 +182,7 @@ def mock_usb_serial_by_id_fixture() -> Generator[MagicMock, None, None]:
         yield mock_usb_serial_by_id
 
 
-async def test_manual(hass):
+async def test_manual(hass: HomeAssistant) -> None:
     """Test we create an entry with manual step."""
 
     result = await hass.config_entries.flow.async_init(
@@ -281,7 +282,7 @@ async def test_manual_errors(hass, integration, url, error, flow, flow_params):
     assert result["errors"] == {"base": error}
 
 
-async def test_manual_already_configured(hass):
+async def test_manual_already_configured(hass: HomeAssistant) -> None:
     """Test that only one unique instance is allowed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -928,7 +929,7 @@ async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_op
     assert result["reason"] == "already_configured"
 
 
-async def test_usb_discovery_requires_supervisor(hass):
+async def test_usb_discovery_requires_supervisor(hass: HomeAssistant) -> None:
     """Test usb discovery flow is aborted when there is no supervisor."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -2605,7 +2606,7 @@ async def test_import_addon_installed(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf(hass):
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test zeroconf discovery."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -9,6 +9,7 @@ from homeassistant.components.zwave_js.discovery import (
 from homeassistant.components.zwave_js.discovery_data_template import (
     DynamicCurrentTempClimateDataTemplate,
 )
+from homeassistant.core import HomeAssistant
 
 
 async def test_iblinds_v2(hass, client, iblinds_v2, integration):
@@ -76,7 +77,7 @@ async def test_fortrez_ssa3_siren(hass, client, fortrezz_ssa3_siren, integration
     assert hass.states.get("select.siren_and_strobe_alarm") is not None
 
 
-async def test_firmware_version_range_exception(hass):
+async def test_firmware_version_range_exception(hass: HomeAssistant) -> None:
     """Test FirmwareVersionRange exception."""
     with pytest.raises(ValueError):
         ZWaveDiscoverySchema(

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -15,6 +15,7 @@ from homeassistant.components.zwave_js.triggers.trigger_helpers import (
     async_bypass_dynamic_config_validation,
 )
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.setup import async_setup_component
 
@@ -954,7 +955,7 @@ async def test_zwave_js_event_invalid_config_entry_id(
     caplog.clear()
 
 
-async def test_async_validate_trigger_config(hass):
+async def test_async_validate_trigger_config(hass: HomeAssistant) -> None:
     """Test async_validate_trigger_config."""
     mock_platform = AsyncMock()
     with patch(
@@ -966,7 +967,7 @@ async def test_async_validate_trigger_config(hass):
         mock_platform.async_validate_trigger_config.assert_awaited()
 
 
-async def test_invalid_trigger_configs(hass):
+async def test_invalid_trigger_configs(hass: HomeAssistant) -> None:
     """Test invalid trigger configs."""
     with pytest.raises(vol.Invalid):
         await async_validate_trigger_config(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to integration tests:
- return type: `None`
- `hass` argument : `HomeAssistant`
- `aioclient_mock` argument : `AiohttpClientMocker`
- `aiohttp_client` argument : `ClientSessionGenerator`
- `caplog` argument : `pytest.LogCaptureFixture`
- `hass_client` argument : `ClientSessionGenerator`
- `hass_client_no_auth` argument : `ClientSessionGenerator`
- `hass_ws_client` argument : `WebSocketGenerator`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
