### PR TITLE
Block legacy get-mac in preference of getmac

### DIFF
--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -8,7 +8,6 @@ import logging
 
 from aiokef import AsyncKefSpeaker
 from aiokef.aiokef import DSP_OPTION_MAPPING
-import getmac
 from getmac import get_mac_address
 import voluptuous as vol
 
@@ -118,7 +117,6 @@ async def async_setup_platform(
     )
 
     mode = get_ip_mode(host)
-    getmac.getmac.FORCE_METHOD="ArpFile"
     mac = await hass.async_add_executor_job(partial(get_mac_address, **{mode: host}))
     if mac is None:
         raise PlatformNotReady("Cannot get the ip address of kef speaker.")

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -8,6 +8,7 @@ import logging
 
 from aiokef import AsyncKefSpeaker
 from aiokef.aiokef import DSP_OPTION_MAPPING
+import getmac
 from getmac import get_mac_address
 import voluptuous as vol
 
@@ -117,6 +118,7 @@ async def async_setup_platform(
     )
 
     mode = get_ip_mode(host)
+    getmac.getmac.FORCE_METHOD="ArpFile"
     mac = await hass.async_add_executor_job(partial(get_mac_address, **{mode: host}))
     if mac is None:
         raise PlatformNotReady("Cannot get the ip address of kef speaker.")

--- a/homeassistant/components/vilfo/manifest.json
+++ b/homeassistant/components/vilfo/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vilfo",
   "iot_class": "local_polling",
   "loggers": ["vilfo"],
-  "requirements": ["vilfo-api-client==0.3.2"]
+  "requirements": ["vilfo-api-client==0.4.1"]
 }

--- a/homeassistant/components/vilfo/manifest.json
+++ b/homeassistant/components/vilfo/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vilfo",
   "iot_class": "local_polling",
   "loggers": ["vilfo"],
-  "requirements": ["vilfo-api-client==0.4.1"]
+  "requirements": ["vilfo-api-client==0.3.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -179,3 +179,7 @@ pysnmp==1000000000.0.0
 # pyminiaudio 1.58 is missing files in the package
 # https://github.com/irmen/pyminiaudio/issues/67
 miniaudio==1.57
+
+# The get-mac package has been replaced with getmac. Installing get-mac alongside getmac
+# breaks getmac due to them both sharing the same python package name inside 'getmac'.
+get-mac==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2604,7 +2604,7 @@ velbus-aio==2023.2.0
 venstarcolortouch==0.19
 
 # homeassistant.components.vilfo
-vilfo-api-client==0.3.2
+vilfo-api-client==0.4.1
 
 # homeassistant.components.voip
 voip-utils==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1892,7 +1892,7 @@ velbus-aio==2023.2.0
 venstarcolortouch==0.19
 
 # homeassistant.components.vilfo
-vilfo-api-client==0.3.2
+vilfo-api-client==0.4.1
 
 # homeassistant.components.voip
 voip-utils==0.0.7

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -183,6 +183,10 @@ pysnmp==1000000000.0.0
 # pyminiaudio 1.58 is missing files in the package
 # https://github.com/irmen/pyminiaudio/issues/67
 miniaudio==1.57
+
+# The get-mac package has been replaced with getmac. Installing get-mac alongside getmac
+# breaks getmac due to them both sharing the same python package name inside 'getmac'.
+get-mac==1000000000.0.0
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -21,9 +21,12 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch("vilfo.Client.ping", return_value=None), patch(
-        "vilfo.Client.get_board_information", return_value=None), patch(
-        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
-            "vilfo.Client.resolve_mac_address", return_value=mock_mac), patch(
+        "vilfo.Client.get_board_information", return_value=None
+    ), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version
+    ), patch(
+        "vilfo.Client.resolve_mac_address", return_value=mock_mac
+    ), patch(
         "homeassistant.components.vilfo.async_setup_entry"
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
@@ -31,6 +34,8 @@ async def test_form(hass: HomeAssistant) -> None:
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
         )
         await hass.async_block_till_done()
+    print("out")
+    print(result2)
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testadmin.vilfo.com"
     assert result2["data"] == {
@@ -112,8 +117,10 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         "vilfo.Client.get_board_information",
         return_value=None,
     ), patch(
-        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
-            "vilfo.Client.resolve_mac_address", return_value=None):
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version
+    ), patch(
+        "vilfo.Client.resolve_mac_address", return_value=None
+    ):
         first_flow_result2 = await hass.config_entries.flow.async_configure(
             first_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -127,8 +134,10 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         "vilfo.Client.get_board_information",
         return_value=None,
     ), patch(
-        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
-            "vilfo.Client.resolve_mac_address", return_value=None):
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version
+    ), patch(
+        "vilfo.Client.resolve_mac_address", return_value=None
+    ):
         second_flow_result2 = await hass.config_entries.flow.async_configure(
             second_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -167,8 +176,11 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
 
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information", return_value=None
-    ), patch("vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
-            "vilfo.Client.resolve_mac_address", return_value=None):
+    ), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version
+    ), patch(
+        "vilfo.Client.resolve_mac_address", return_value=None
+    ):
         result = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )
@@ -180,8 +192,11 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
 
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information", return_value=None
-    ), patch("vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
-        "vilfo.Client.resolve_mac_address", return_value=mock_mac):
+    ), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version
+    ), patch(
+        "vilfo.Client.resolve_mac_address", return_value=mock_mac
+    ):
         result2 = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -13,6 +13,7 @@ async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     mock_mac = "FF-00-00-00-00-00"
+    firmware_version = "1.1.0"
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -20,8 +21,9 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch("vilfo.Client.ping", return_value=None), patch(
-        "vilfo.Client.get_board_information", return_value=None
-    ), patch("vilfo.Client.resolve_mac_address", return_value=mock_mac), patch(
+        "vilfo.Client.get_board_information", return_value=None), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
+            "vilfo.Client.resolve_mac_address", return_value=mock_mac), patch(
         "homeassistant.components.vilfo.async_setup_entry"
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
@@ -29,7 +31,8 @@ async def test_form(hass: HomeAssistant) -> None:
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
         )
         await hass.async_block_till_done()
-
+    print('out')
+    print(result2)
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testadmin.vilfo.com"
     assert result2["data"] == {
@@ -106,11 +109,13 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
     first_flow_result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-
+    firmware_version = "1.1.0"
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information",
         return_value=None,
-    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
+    ), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
+            "vilfo.Client.resolve_mac_address", return_value=None):
         first_flow_result2 = await hass.config_entries.flow.async_configure(
             first_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -123,7 +128,9 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information",
         return_value=None,
-    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
+    ), patch(
+        "vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
+            "vilfo.Client.resolve_mac_address", return_value=None):
         second_flow_result2 = await hass.config_entries.flow.async_configure(
             second_flow_result1["flow_id"],
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
@@ -158,10 +165,12 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
     mock_data_with_ip = {"host": "192.168.0.1", "access_token": "test-token"}
     mock_data_with_ipv6 = {"host": "2001:db8::1428:57ab", "access_token": "test-token"}
     mock_mac = "FF-00-00-00-00-00"
+    firmware_version = "1.1.0"
 
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information", return_value=None
-    ), patch("vilfo.Client.resolve_mac_address", return_value=None):
+    ), patch("vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
+            "vilfo.Client.resolve_mac_address", return_value=None):
         result = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )
@@ -173,7 +182,8 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
 
     with patch("vilfo.Client.ping", return_value=None), patch(
         "vilfo.Client.get_board_information", return_value=None
-    ), patch("vilfo.Client.resolve_mac_address", return_value=mock_mac):
+    ), patch("vilfo.Client.resolve_firmware_version", return_value=firmware_version), patch(
+        "vilfo.Client.resolve_mac_address", return_value=mock_mac):
         result2 = await hass.components.vilfo.config_flow.validate_input(
             hass, data=mock_data
         )

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -34,8 +34,7 @@ async def test_form(hass: HomeAssistant) -> None:
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
         )
         await hass.async_block_till_done()
-    print("out")
-    print(result2)
+
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testadmin.vilfo.com"
     assert result2["data"] == {

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -31,8 +31,6 @@ async def test_form(hass: HomeAssistant) -> None:
             {CONF_HOST: "testadmin.vilfo.com", CONF_ACCESS_TOKEN: "test-token"},
         )
         await hass.async_block_till_done()
-    print('out')
-    print(result2)
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testadmin.vilfo.com"
     assert result2["data"] == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove references to the now deprecated get-mac python library, in favor of the newer getmac library. The getmac library author has recommended users of the old get-mac library move to the new getmac one instead as the old library will cease to receive updates in the near future.

Additionally the two libraries, internally share the same 'getmac' python package, so when installed on the same system, conflict with each other (with get-mac overruling getmac seemingly). This is causing integrations which require fixes in the latest getmac library to fail as get-mac is masking those updates.

get-mac is also added to the package constraints to prevent it from being installed in the future, which may be considered a breaking change for any other integrations not in the core, which still use get-mac as a dependency. They would need to move to use getmac instead in order to be compatible with HA after this is merged.

https://github.com/ManneW/vilfo-api-client-python/compare/v0.3.2...0.4.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87146
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
