### PR TITLE
Add hass and `None` return type on MQTT platform tests

### DIFF
--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -165,7 +166,9 @@ def alarm_control_panel_platform_only():
         ),
     ],
 )
-async def test_fail_setup_without_state_or_command_topic(hass, config, valid):
+async def test_fail_setup_without_state_or_command_topic(
+    hass: HomeAssistant, config, valid
+) -> None:
     """Test for failing setup with no state or command topic."""
     assert (
         await async_setup_component(
@@ -177,7 +180,9 @@ async def test_fail_setup_without_state_or_command_topic(hass, config, valid):
     )
 
 
-async def test_update_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_update_state_via_state_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test updating with via state topic."""
     assert await async_setup_component(
         hass,
@@ -208,8 +213,8 @@ async def test_update_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_conf
 
 
 async def test_ignore_update_state_if_unknown_via_state_topic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test ignoring updates via state topic."""
     assert await async_setup_component(
         hass,
@@ -240,8 +245,8 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
     ],
 )
 async def test_publish_mqtt_no_code(
-    hass, mqtt_mock_entry_with_yaml_config, service, payload
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, service, payload
+) -> None:
     """Test publishing of MQTT messages when no code is configured."""
     assert await async_setup_component(
         hass,
@@ -274,8 +279,8 @@ async def test_publish_mqtt_no_code(
     ],
 )
 async def test_publish_mqtt_with_code(
-    hass, mqtt_mock_entry_with_yaml_config, service, payload
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, service, payload
+) -> None:
     """Test publishing of MQTT messages when code is configured."""
     assert await async_setup_component(
         hass,
@@ -327,8 +332,8 @@ async def test_publish_mqtt_with_code(
     ],
 )
 async def test_publish_mqtt_with_remote_code(
-    hass, mqtt_mock_entry_with_yaml_config, service, payload
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, service, payload
+) -> None:
     """Test publishing of MQTT messages when remode code is configured."""
     assert await async_setup_component(
         hass,
@@ -371,8 +376,8 @@ async def test_publish_mqtt_with_remote_code(
     ],
 )
 async def test_publish_mqtt_with_remote_code_text(
-    hass, mqtt_mock_entry_with_yaml_config, service, payload
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, service, payload
+) -> None:
     """Test publishing of MQTT messages when remote text code is configured."""
     assert await async_setup_component(
         hass,
@@ -415,8 +420,12 @@ async def test_publish_mqtt_with_remote_code_text(
     ],
 )
 async def test_publish_mqtt_with_code_required_false(
-    hass, mqtt_mock_entry_with_yaml_config, service, payload, disable_code
-):
+    hass: HomeAssistant,
+    mqtt_mock_entry_with_yaml_config,
+    service,
+    payload,
+    disable_code,
+) -> None:
     """Test publishing of MQTT messages when code is configured.
 
     code_arm_required = False / code_disarm_required = False /
@@ -464,8 +473,8 @@ async def test_publish_mqtt_with_code_required_false(
 
 
 async def test_disarm_publishes_mqtt_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test publishing of MQTT messages while disarmed.
 
     When command_template set to output json
@@ -490,8 +499,8 @@ async def test_disarm_publishes_mqtt_with_template(
 
 
 async def test_update_state_via_state_topic_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test updating with template_value via state topic."""
     assert await async_setup_component(
         hass,
@@ -524,7 +533,9 @@ async def test_update_state_via_state_topic_template(
     assert state.state == STATE_ALARM_ARMED_AWAY
 
 
-async def test_attributes_code_number(hass, mqtt_mock_entry_with_yaml_config):
+async def test_attributes_code_number(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = CODE_NUMBER
@@ -540,7 +551,9 @@ async def test_attributes_code_number(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_attributes_remote_code_number(hass, mqtt_mock_entry_with_yaml_config):
+async def test_attributes_remote_code_number(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG_REMOTE_CODE)
     config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = "REMOTE_CODE"
@@ -556,7 +569,9 @@ async def test_attributes_remote_code_number(hass, mqtt_mock_entry_with_yaml_con
     )
 
 
-async def test_attributes_code_text(hass, mqtt_mock_entry_with_yaml_config):
+async def test_attributes_code_text(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test attributes which are not supported by the vacuum."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config[mqtt.DOMAIN][alarm_control_panel.DOMAIN]["code"] = CODE_TEXT
@@ -573,8 +588,8 @@ async def test_attributes_code_text(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass,
@@ -584,7 +599,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass,
@@ -594,7 +611,9 @@ async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass,
@@ -604,7 +623,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass,
@@ -615,8 +636,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass,
@@ -627,8 +648,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -639,7 +660,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass,
@@ -650,8 +673,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -663,8 +686,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -675,7 +698,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -686,7 +711,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one alarm per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -711,7 +736,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_alarm(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_alarm(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered alarm_control_panel."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
     await help_test_discovery_removal(
@@ -720,8 +747,8 @@ async def test_discovery_removal_alarm(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_alarm_topic_and_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered alarm_control_panel."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
@@ -755,8 +782,8 @@ async def test_discovery_update_alarm_topic_and_template(
 
 
 async def test_discovery_update_alarm_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered alarm_control_panel."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
@@ -788,8 +815,8 @@ async def test_discovery_update_alarm_template(
 
 
 async def test_discovery_update_unchanged_alarm(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered alarm_control_panel."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][alarm_control_panel.DOMAIN])
     config1["name"] = "Beer"
@@ -809,7 +836,9 @@ async def test_discovery_update_unchanged_alarm(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -835,8 +864,8 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass, mqtt_mock_entry_with_yaml_config, caplog, topic, value
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, topic, value
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -849,7 +878,9 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT alarm control panel device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass,
@@ -859,7 +890,9 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT alarm control panel device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass,
@@ -869,7 +902,9 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass,
@@ -879,7 +914,9 @@ async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass,
@@ -889,7 +926,9 @@ async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass,
@@ -899,7 +938,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass,
@@ -909,7 +950,9 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_c
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -945,7 +988,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -955,7 +998,7 @@ async def test_publishing_with_custom_encoding(
     template,
     tpl_par,
     tpl_output,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = alarm_control_panel.DOMAIN
     config = DEFAULT_CONFIG
@@ -976,7 +1019,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = alarm_control_panel.DOMAIN
     config = DEFAULT_CONFIG
@@ -985,14 +1030,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = alarm_control_panel.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = alarm_control_panel.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -72,8 +72,8 @@ def binary_sensor_platform_only():
 
 
 async def test_setting_sensor_value_expires_availability_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
@@ -106,8 +106,8 @@ async def test_setting_sensor_value_expires_availability_topic(
 
 
 async def test_setting_sensor_value_expires(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
@@ -133,7 +133,7 @@ async def test_setting_sensor_value_expires(
     await expires_helper(hass)
 
 
-async def expires_helper(hass):
+async def expires_helper(hass: HomeAssistant) -> None:
     """Run the basic expiry code."""
     realnow = dt_util.utcnow()
     now = datetime(realnow.year + 1, 1, 1, 1, tzinfo=dt_util.UTC)
@@ -185,8 +185,8 @@ async def expires_helper(hass):
 
 
 async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test that binary_sensor with expire_after set behaves correctly on discovery and discovery update."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -266,8 +266,8 @@ async def test_expiration_on_discovery_and_discovery_update_of_binary_sensor(
 
 
 async def test_setting_sensor_value_via_mqtt_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -304,8 +304,8 @@ async def test_setting_sensor_value_via_mqtt_message(
 
 
 async def test_invalid_sensor_value_via_mqtt_message(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -346,8 +346,8 @@ async def test_invalid_sensor_value_via_mqtt_message(
 
 
 async def test_setting_sensor_value_via_mqtt_message_and_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -381,8 +381,8 @@ async def test_setting_sensor_value_via_mqtt_message_and_template(
 
 
 async def test_setting_sensor_value_via_mqtt_message_and_template2(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -420,8 +420,8 @@ async def test_setting_sensor_value_via_mqtt_message_and_template2(
 
 
 async def test_setting_sensor_value_via_mqtt_message_and_template_and_raw_state_encoding(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test processing a raw value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -455,8 +455,8 @@ async def test_setting_sensor_value_via_mqtt_message_and_template_and_raw_state_
 
 
 async def test_setting_sensor_value_via_mqtt_message_empty_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -488,7 +488,9 @@ async def test_setting_sensor_value_via_mqtt_message_empty_template(
     assert state.state == STATE_ON
 
 
-async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
+async def test_valid_device_class(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of a valid sensor class."""
     assert await async_setup_component(
         hass,
@@ -510,7 +512,7 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("device_class") == "motion"
 
 
-async def test_invalid_device_class(hass, caplog):
+async def test_invalid_device_class(hass: HomeAssistant, caplog) -> None:
     """Test the setting of an invalid sensor class."""
     assert not await async_setup_component(
         hass,
@@ -529,8 +531,8 @@ async def test_invalid_device_class(hass, caplog):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass,
@@ -540,7 +542,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass,
@@ -550,7 +554,9 @@ async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass,
@@ -560,7 +566,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass,
@@ -570,7 +578,9 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
+async def test_force_update_disabled(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test force update option."""
     assert await async_setup_component(
         hass,
@@ -591,12 +601,12 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event) -> None:
         """Verify event got called."""
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "ON")
     await hass.async_block_till_done()
@@ -607,7 +617,9 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
     assert len(events) == 1
 
 
-async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
+async def test_force_update_enabled(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test force update option."""
     assert await async_setup_component(
         hass,
@@ -629,12 +641,12 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event) -> None:
         """Verify event got called."""
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "ON")
     await hass.async_block_till_done()
@@ -645,7 +657,7 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
     assert len(events) == 2
 
 
-async def test_off_delay(hass, mqtt_mock_entry_with_yaml_config):
+async def test_off_delay(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test off_delay option."""
     assert await async_setup_component(
         hass,
@@ -668,12 +680,12 @@ async def test_off_delay(hass, mqtt_mock_entry_with_yaml_config):
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event) -> None:
         """Verify event got called."""
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "ON")
     await hass.async_block_till_done()
@@ -695,8 +707,8 @@ async def test_off_delay(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass,
@@ -706,7 +718,9 @@ async def test_setting_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass,
@@ -717,8 +731,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -730,8 +744,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -742,7 +756,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -753,7 +769,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one sensor per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -777,8 +793,8 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_discovery_removal_binary_sensor(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered binary_sensor."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
     await help_test_discovery_removal(
@@ -787,8 +803,8 @@ async def test_discovery_removal_binary_sensor(
 
 
 async def test_discovery_update_binary_sensor_topic_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered binary_sensor."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
@@ -824,8 +840,8 @@ async def test_discovery_update_binary_sensor_topic_template(
 
 
 async def test_discovery_update_binary_sensor_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered binary_sensor."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
@@ -872,14 +888,14 @@ async def test_discovery_update_binary_sensor_template(
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -895,8 +911,8 @@ async def test_encoding_subscribable_topics(
 
 
 async def test_discovery_update_unchanged_binary_sensor(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered binary_sensor."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][binary_sensor.DOMAIN])
     config1["name"] = "Beer"
@@ -916,7 +932,9 @@ async def test_discovery_update_unchanged_binary_sensor(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer",' '  "off_delay": -1 }'
     data2 = '{ "name": "Milk",' '  "state_topic": "test_topic" }'
@@ -930,7 +948,9 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT binary sensor device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass,
@@ -940,7 +960,9 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT binary sensor device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass,
@@ -950,7 +972,9 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass,
@@ -960,7 +984,9 @@ async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass,
@@ -970,7 +996,9 @@ async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass,
@@ -980,7 +1008,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass,
@@ -990,7 +1020,9 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_c
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -1001,7 +1033,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = binary_sensor.DOMAIN
     config = DEFAULT_CONFIG
@@ -1015,7 +1049,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     [("ON", "on", "OFF", "off"), ("OFF", "off", "ON", "on")],
 )
 async def test_cleanup_triggers_and_restoring_state(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     tmp_path,
@@ -1024,7 +1058,7 @@ async def test_cleanup_triggers_and_restoring_state(
     state1,
     payload2,
     state2,
-):
+) -> None:
     """Test cleanup old triggers at reloading and restoring the state."""
     domain = binary_sensor.DOMAIN
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
@@ -1076,8 +1110,8 @@ async def test_cleanup_triggers_and_restoring_state(
 
 
 async def test_skip_restoring_state_with_over_due_expire_trigger(
-    hass, mqtt_mock_entry_with_yaml_config, freezer
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, freezer
+) -> None:
     """Test restoring a state with over due expire timer."""
 
     freezer.move_to("2022-02-02 12:02:00+01:00")
@@ -1086,7 +1120,7 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     config3["name"] = "test3"
     config3["expire_after"] = 10
     config3["state_topic"] = "test-topic3"
-    fake_state = ha.State(
+    fake_state = State(
         "binary_sensor.test3",
         "on",
         {},
@@ -1103,14 +1137,16 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = binary_sensor.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = binary_sensor.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -54,7 +55,9 @@ def button_platform_only():
 
 
 @pytest.mark.freeze_time("2021-11-08 13:31:44+00:00")
-async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending MQTT commands."""
     assert await async_setup_component(
         hass,
@@ -93,7 +96,9 @@ async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == "2021-11-08T13:31:44+00:00"
 
 
-async def test_command_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_command_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of MQTT commands through a command template."""
     assert await async_setup_component(
         hass,
@@ -130,22 +135,26 @@ async def test_command_template(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -168,7 +177,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -192,8 +203,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
@@ -201,15 +212,17 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG, None
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, button.DOMAIN, DEFAULT_CONFIG
@@ -217,8 +230,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -230,8 +243,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -242,7 +255,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -253,7 +268,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one button per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -276,7 +291,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_button(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_button(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered button."""
     data = '{ "name": "test", "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -284,7 +301,9 @@ async def test_discovery_removal_button(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_button(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_button(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered button."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][button.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][button.DOMAIN])
@@ -302,8 +321,8 @@ async def test_discovery_update_button(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_button(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered button."""
     data1 = (
         '{ "name": "Beer",'
@@ -324,7 +343,9 @@ async def test_discovery_update_unchanged_button(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
@@ -333,42 +354,54 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT button device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT button device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, button.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -381,7 +414,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_invalid_device_class(hass):
+async def test_invalid_device_class(hass: HomeAssistant) -> None:
     """Test device_class option with invalid value."""
     assert not await async_setup_component(
         hass,
@@ -398,7 +431,9 @@ async def test_invalid_device_class(hass):
     )
 
 
-async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
+async def test_valid_device_class(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test device_class option with valid values."""
     assert await async_setup_component(
         hass,
@@ -442,7 +477,7 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -450,7 +485,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = button.DOMAIN
     config = DEFAULT_CONFIG
@@ -469,7 +504,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = button.DOMAIN
     config = DEFAULT_CONFIG
@@ -478,14 +515,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = button.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = button.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.components import camera, mqtt
 from homeassistant.components.mqtt.camera import MQTT_CAMERA_ATTRIBUTES_BLOCKED
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -52,8 +53,8 @@ def camera_platform_only():
 
 
 async def test_run_camera_setup(
-    hass, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload."""
     topic = "test/camera"
     await async_setup_component(
@@ -76,8 +77,8 @@ async def test_run_camera_setup(
 
 
 async def test_run_camera_b64_encoded(
-    hass, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given encoded payload."""
     topic = "test/camera"
     await async_setup_component(
@@ -108,8 +109,8 @@ async def test_run_camera_b64_encoded(
 
 
 async def test_camera_b64_encoded_with_availability(
-    hass, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, hass_client_no_auth, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability works if b64 encoding is turned on."""
     topic = "test/camera"
     topic_availability = "test/camera_availability"
@@ -146,29 +147,35 @@ async def test_camera_b64_encoded_with_availability(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
@@ -176,8 +183,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
@@ -185,8 +192,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -197,7 +204,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
@@ -205,8 +214,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -218,8 +227,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -230,7 +239,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -241,7 +252,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one camera per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -264,7 +275,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_camera(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_camera(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered camera."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][camera.DOMAIN])
     await help_test_discovery_removal(
@@ -272,7 +285,9 @@ async def test_discovery_removal_camera(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_camera(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_camera(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered camera."""
     config1 = {"name": "Beer", "topic": "test_topic"}
     config2 = {"name": "Milk", "topic": "test_topic"}
@@ -283,8 +298,8 @@ async def test_discovery_update_camera(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_camera(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered camera."""
     data1 = '{ "name": "Beer", "topic": "test_topic"}'
     with patch(
@@ -301,7 +316,9 @@ async def test_discovery_update_unchanged_camera(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "topic": "test_topic"}'
@@ -311,35 +328,45 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT camera device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT camera device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass,
@@ -350,14 +377,18 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, camera.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -370,7 +401,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = camera.DOMAIN
     config = DEFAULT_CONFIG
@@ -379,14 +412,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = camera.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = camera.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -28,6 +28,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.mqtt.climate import MQTT_CLIMATE_ATTRIBUTES_BLOCKED
 from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -100,7 +101,9 @@ def climate_platform_only():
         yield
 
 
-async def test_setup_params(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setup_params(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the initial parameters."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -117,7 +120,7 @@ async def test_setup_params(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("max_humidity") == DEFAULT_MAX_HUMIDITY
 
 
-async def test_preset_none_in_preset_modes(hass, caplog):
+async def test_preset_none_in_preset_modes(hass: HomeAssistant, caplog) -> None:
     """Test the preset mode payload reset configuration."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     config["preset_modes"].append("none")
@@ -139,7 +142,9 @@ async def test_preset_none_in_preset_modes(hass, caplog):
         ("hold_mode_state_template", "{{ value_json }}"),
     ],
 )
-async def test_preset_modes_deprecation_guard(hass, caplog, parameter, config_value):
+async def test_preset_modes_deprecation_guard(
+    hass: HomeAssistant, caplog, parameter, config_value
+) -> None:
     """Test the configuration for invalid legacy parameters."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     config[parameter] = config_value
@@ -149,7 +154,9 @@ async def test_preset_modes_deprecation_guard(hass, caplog, parameter, config_va
     assert f"[{parameter}] is an invalid option for [mqtt]. Check: mqtt->mqtt->climate->0->{parameter}"
 
 
-async def test_supported_features(hass, mqtt_mock_entry_with_yaml_config):
+async def test_supported_features(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the supported_features."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -169,7 +176,9 @@ async def test_supported_features(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("supported_features") == support
 
 
-async def test_get_hvac_modes(hass, mqtt_mock_entry_with_yaml_config):
+async def test_get_hvac_modes(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that the operation list returns the correct modes."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -188,8 +197,8 @@ async def test_get_hvac_modes(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_set_operation_bad_attr_and_state(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting operation mode without required attribute.
 
     Also check the state.
@@ -210,7 +219,9 @@ async def test_set_operation_bad_attr_and_state(
     assert state.state == "off"
 
 
-async def test_set_operation(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_operation(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of new operation mode."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -225,7 +236,9 @@ async def test_set_operation(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.assert_called_once_with("mode-topic", "cool", 0, False)
 
 
-async def test_set_operation_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_operation_pessimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting operation mode in pessimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["mode_state_topic"] = "mode-state"
@@ -249,7 +262,9 @@ async def test_set_operation_pessimistic(hass, mqtt_mock_entry_with_yaml_config)
     assert state.state == "cool"
 
 
-async def test_set_operation_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_operation_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting operation mode in optimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["mode_state_topic"] = "mode-state"
@@ -277,7 +292,9 @@ async def test_set_operation_optimistic(hass, mqtt_mock_entry_with_yaml_config):
 # CONF_POWER_COMMAND_TOPIC, CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE are deprecated,
 # support for CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE was already removed or never added
 # support was deprecated with release 2023.2 and will be removed with release 2023.8
-async def test_set_operation_with_power_command(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_operation_with_power_command(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of new operation mode with power command enabled."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["power_command_topic"] = "power-command"
@@ -304,7 +321,9 @@ async def test_set_operation_with_power_command(hass, mqtt_mock_entry_with_yaml_
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_set_fan_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_set_fan_mode_bad_attr(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting fan mode without required attribute."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -321,7 +340,9 @@ async def test_set_fan_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, cap
     assert state.attributes.get("fan_mode") == "low"
 
 
-async def test_set_fan_mode_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_fan_mode_pessimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of new fan mode in pessimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["fan_mode_state_topic"] = "fan-state"
@@ -345,7 +366,9 @@ async def test_set_fan_mode_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("fan_mode") == "high"
 
 
-async def test_set_fan_mode_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_fan_mode_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of new fan mode in optimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["fan_mode_state_topic"] = "fan-state"
@@ -370,7 +393,9 @@ async def test_set_fan_mode_optimistic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("fan_mode") == "low"
 
 
-async def test_set_fan_mode(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_fan_mode(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of new fan mode."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -384,7 +409,9 @@ async def test_set_fan_mode(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("fan_mode") == "high"
 
 
-async def test_set_swing_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_set_swing_mode_bad_attr(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting swing mode without required attribute."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -401,7 +428,9 @@ async def test_set_swing_mode_bad_attr(hass, mqtt_mock_entry_with_yaml_config, c
     assert state.attributes.get("swing_mode") == "off"
 
 
-async def test_set_swing_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_swing_pessimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting swing mode in pessimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["swing_mode_state_topic"] = "swing-state"
@@ -425,7 +454,9 @@ async def test_set_swing_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("swing_mode") == "on"
 
 
-async def test_set_swing_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_swing_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting swing mode in optimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["swing_mode_state_topic"] = "swing-state"
@@ -450,7 +481,7 @@ async def test_set_swing_optimistic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("swing_mode") == "off"
 
 
-async def test_set_swing(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_swing(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test setting of new swing mode."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -464,7 +495,9 @@ async def test_set_swing(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("swing_mode") == "on"
 
 
-async def test_set_target_temperature(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_target_temperature(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target temperature."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -501,7 +534,9 @@ async def test_set_target_temperature(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_set_target_humidity(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_target_humidity(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target humidity."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -517,8 +552,8 @@ async def test_set_target_humidity(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_set_target_temperature_pessimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target temperature."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_state_topic"] = "temperature-state"
@@ -543,8 +578,8 @@ async def test_set_target_temperature_pessimistic(
 
 
 async def test_set_target_temperature_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target temperature optimistic."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_state_topic"] = "temperature-state"
@@ -569,7 +604,9 @@ async def test_set_target_temperature_optimistic(
     assert state.attributes.get("temperature") == 18
 
 
-async def test_set_target_temperature_low_high(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_target_temperature_low_high(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the low/high target temperature."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -586,8 +623,8 @@ async def test_set_target_temperature_low_high(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_set_target_temperature_low_highpessimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the low/high target temperature."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_low_state_topic"] = "temperature-low-state"
@@ -626,8 +663,8 @@ async def test_set_target_temperature_low_highpessimistic(
 
 
 async def test_set_target_temperature_low_high_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the low/high target temperature optimistic."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["optimistic"] = True
@@ -666,7 +703,9 @@ async def test_set_target_temperature_low_high_optimistic(
     assert state.attributes.get("target_temp_high") == 25
 
 
-async def test_set_target_humidity_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_target_humidity_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target humidity optimistic."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["target_humidity_state_topic"] = "humidity-state"
@@ -690,7 +729,9 @@ async def test_set_target_humidity_optimistic(hass, mqtt_mock_entry_with_yaml_co
     assert state.attributes.get("humidity") == 53
 
 
-async def test_set_target_humidity_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_target_humidity_pessimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target humidity."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["target_humidity_state_topic"] = "humidity-state"
@@ -713,7 +754,9 @@ async def test_set_target_humidity_pessimistic(hass, mqtt_mock_entry_with_yaml_c
     assert state.attributes.get("humidity") == 80
 
 
-async def test_receive_mqtt_temperature(hass, mqtt_mock_entry_with_yaml_config):
+async def test_receive_mqtt_temperature(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test getting the current temperature via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["current_temperature_topic"] = "current_temperature"
@@ -726,7 +769,9 @@ async def test_receive_mqtt_temperature(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("current_temperature") == 47
 
 
-async def test_receive_mqtt_humidity(hass, mqtt_mock_entry_with_yaml_config):
+async def test_receive_mqtt_humidity(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test getting the current humidity via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["current_humidity_topic"] = "current_humidity"
@@ -739,7 +784,9 @@ async def test_receive_mqtt_humidity(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("current_humidity") == 35
 
 
-async def test_handle_target_humidity_received(hass, mqtt_mock_entry_with_yaml_config):
+async def test_handle_target_humidity_received(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting the target humidity via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["target_humidity_state_topic"] = "humidity-state"
@@ -756,7 +803,9 @@ async def test_handle_target_humidity_received(hass, mqtt_mock_entry_with_yaml_c
     assert state.attributes.get("humidity") == 65
 
 
-async def test_handle_action_received(hass, mqtt_mock_entry_with_yaml_config):
+async def test_handle_action_received(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test getting the action received via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["action_topic"] = "action"
@@ -780,8 +829,8 @@ async def test_handle_action_received(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_set_preset_mode_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting of the preset mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     assert await async_setup_component(hass, mqtt.DOMAIN, {mqtt.DOMAIN: config})
@@ -828,8 +877,8 @@ async def test_set_preset_mode_optimistic(
 
 
 async def test_set_preset_mode_explicit_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting of the preset mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["optimistic"] = True
@@ -878,8 +927,8 @@ async def test_set_preset_mode_explicit_optimistic(
 
 
 async def test_set_preset_mode_pessimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting of the preset mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["preset_mode_state_topic"] = "preset-mode-state"
@@ -924,7 +973,9 @@ async def test_set_preset_mode_pessimistic(
     assert state.attributes.get("preset_mode") == "home"
 
 
-async def test_set_aux_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_aux_pessimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting of the aux heating in pessimistic mode."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["aux_state_topic"] = "aux-state"
@@ -952,7 +1003,7 @@ async def test_set_aux_pessimistic(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("aux_heat") == "off"
 
 
-async def test_set_aux(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_aux(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test setting of the aux heating."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -973,29 +1024,35 @@ async def test_set_aux(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
@@ -1003,8 +1060,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_get_target_temperature_low_high_with_templates(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test getting temperature high/low with templates."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_low_state_topic"] = "temperature-state"
@@ -1040,7 +1097,9 @@ async def test_get_target_temperature_low_high_with_templates(
     assert state.attributes.get("target_temp_high") == 1032
 
 
-async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_get_with_templates(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test getting various attributes with templates."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     # By default, just unquote the JSON-strings
@@ -1157,7 +1216,9 @@ async def test_get_with_templates(hass, mqtt_mock_entry_with_yaml_config, caplog
     assert state.attributes.get("hvac_action") == "cooling"
 
 
-async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_set_and_templates(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test setting various attributes with templates."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     # Create simple templates
@@ -1245,7 +1306,9 @@ async def test_set_and_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
     assert state.attributes.get("humidity") == 82
 
 
-async def test_min_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
+async def test_min_temp_custom(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test a custom min temp."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["min_temp"] = 26
@@ -1261,7 +1324,9 @@ async def test_min_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("min_temp") == 26
 
 
-async def test_max_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
+async def test_max_temp_custom(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test a custom max temp."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["max_temp"] = 60
@@ -1277,7 +1342,9 @@ async def test_max_temp_custom(hass, mqtt_mock_entry_with_yaml_config):
     assert max_temp == 60
 
 
-async def test_min_humidity_custom(hass, mqtt_mock_entry_with_yaml_config):
+async def test_min_humidity_custom(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test a custom min humidity."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["min_humidity"] = 42
@@ -1293,7 +1360,9 @@ async def test_min_humidity_custom(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("min_humidity") == 42
 
 
-async def test_max_humidity_custom(hass, mqtt_mock_entry_with_yaml_config):
+async def test_max_humidity_custom(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test a custom max humidity."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["max_humidity"] = 58
@@ -1309,7 +1378,9 @@ async def test_max_humidity_custom(hass, mqtt_mock_entry_with_yaml_config):
     assert max_humidity == 58
 
 
-async def test_temp_step_custom(hass, mqtt_mock_entry_with_yaml_config):
+async def test_temp_step_custom(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test a custom temp step."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temp_step"] = 0.01
@@ -1325,7 +1396,9 @@ async def test_temp_step_custom(hass, mqtt_mock_entry_with_yaml_config):
     assert temp_step == 0.01
 
 
-async def test_temperature_unit(hass, mqtt_mock_entry_with_yaml_config):
+async def test_temperature_unit(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that setting temperature unit converts temperature values."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["temperature_unit"] = "F"
@@ -1342,8 +1415,8 @@ async def test_temperature_unit(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
@@ -1351,8 +1424,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -1363,7 +1436,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
@@ -1371,8 +1446,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -1384,8 +1459,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -1396,7 +1471,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -1407,7 +1484,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one climate per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -1451,14 +1528,14 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     await help_test_encoding_subscribable_topics(
@@ -1474,7 +1551,9 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_discovery_removal_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_climate(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered climate."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][climate.DOMAIN])
     await help_test_discovery_removal(
@@ -1482,7 +1561,9 @@ async def test_discovery_removal_climate(hass, mqtt_mock_entry_no_yaml_config, c
     )
 
 
-async def test_discovery_update_climate(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_climate(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered climate."""
     config1 = {"name": "Beer"}
     config2 = {"name": "Milk"}
@@ -1492,8 +1573,8 @@ async def test_discovery_update_climate(hass, mqtt_mock_entry_no_yaml_config, ca
 
 
 async def test_discovery_update_unchanged_climate(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered climate."""
     data1 = '{ "name": "Beer" }'
     with patch(
@@ -1510,7 +1591,9 @@ async def test_discovery_update_unchanged_climate(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer", "power_command_topic": "test_topic#" }'
     data2 = '{ "name": "Milk", "power_command_topic": "test_topic" }'
@@ -1519,35 +1602,45 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT climate device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT climate device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = {
         mqtt.DOMAIN: {
@@ -1567,14 +1660,18 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, climate.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     config = {
         mqtt.DOMAIN: {
@@ -1597,7 +1694,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_precision_default(hass, mqtt_mock_entry_with_yaml_config):
+async def test_precision_default(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that setting precision to tenths works as intended."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -1611,7 +1710,9 @@ async def test_precision_default(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_precision_halves(hass, mqtt_mock_entry_with_yaml_config):
+async def test_precision_halves(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that setting precision to halves works as intended."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["precision"] = 0.5
@@ -1627,7 +1728,9 @@ async def test_precision_halves(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_precision_whole(hass, mqtt_mock_entry_with_yaml_config):
+async def test_precision_whole(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that setting precision to whole works as intended."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN])
     config["climate"]["precision"] = 1.0
@@ -1727,7 +1830,7 @@ async def test_precision_whole(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -1735,7 +1838,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = climate.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1801,7 +1904,9 @@ async def test_publishing_with_custom_encoding(
         ),
     ],
 )
-async def test_humidity_configuration_validity(hass, config, valid):
+async def test_humidity_configuration_validity(
+    hass: HomeAssistant, config, valid
+) -> None:
     """Test the validity of humidity configurations."""
     assert (
         await async_setup_component(
@@ -1813,7 +1918,9 @@ async def test_humidity_configuration_validity(hass, config, valid):
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = climate.DOMAIN
     config = DEFAULT_CONFIG
@@ -1822,14 +1929,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = climate.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = climate.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -134,7 +134,7 @@ def mock_process_uploaded_file(tmp_path):
     file_id_cert = str(uuid4())
     file_id_key = str(uuid4())
 
-    def _mock_process_uploaded_file(hass, file_id):
+    def _mock_process_uploaded_file(hass: HomeAssistant, file_id) -> None:
         if file_id == file_id_ca:
             with open(tmp_path / "ca.crt", "wb") as cafile:
                 cafile.write(b"## mock CA certificate file ##")
@@ -167,8 +167,8 @@ def mock_process_uploaded_file(tmp_path):
 
 
 async def test_user_connection_works(
-    hass, mock_try_connection, mock_finish_setup, mqtt_client_mock
-):
+    hass: HomeAssistant, mock_try_connection, mock_finish_setup, mqtt_client_mock
+) -> None:
     """Test we can finish a config flow."""
     mock_try_connection.return_value = True
 
@@ -195,8 +195,8 @@ async def test_user_connection_works(
 
 
 async def test_user_v5_connection_works(
-    hass, mock_try_connection, mock_finish_setup, mqtt_client_mock
-):
+    hass: HomeAssistant, mock_try_connection, mock_finish_setup, mqtt_client_mock
+) -> None:
     """Test we can finish a config flow."""
     mock_try_connection.return_value = True
 
@@ -234,8 +234,8 @@ async def test_user_v5_connection_works(
 
 
 async def test_user_connection_fails(
-    hass, mock_try_connection_time_out, mock_finish_setup
-):
+    hass: HomeAssistant, mock_try_connection_time_out, mock_finish_setup
+) -> None:
     """Test if connection cannot be made."""
     result = await hass.config_entries.flow.async_init(
         "mqtt", context={"source": config_entries.SOURCE_USER}
@@ -256,8 +256,8 @@ async def test_user_connection_fails(
 
 
 async def test_manual_config_starts_discovery_flow(
-    hass, mock_try_connection, mock_finish_setup, mqtt_client_mock
-):
+    hass: HomeAssistant, mock_try_connection, mock_finish_setup, mqtt_client_mock
+) -> None:
     """Test manual config initiates a discovery flow."""
     # No flows in progress
     assert hass.config_entries.flow.async_progress() == []
@@ -276,11 +276,11 @@ async def test_manual_config_starts_discovery_flow(
 
 
 async def test_manual_config_set(
-    hass,
+    hass: HomeAssistant,
     mock_try_connection,
     mock_finish_setup,
     mqtt_client_mock,
-):
+) -> None:
     """Test manual config does not create an entry, and entry can be setup late."""
     # MQTT config present in yaml config
     assert await async_setup_component(hass, "mqtt", {"mqtt": {"broker": "bla"}})
@@ -322,7 +322,7 @@ async def test_manual_config_set(
     assert config_entry.title == "127.0.0.1"
 
 
-async def test_user_single_instance(hass):
+async def test_user_single_instance(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain="mqtt").add_to_hass(hass)
 
@@ -333,7 +333,7 @@ async def test_user_single_instance(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_hassio_already_configured(hass):
+async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain="mqtt").add_to_hass(hass)
 
@@ -369,7 +369,9 @@ async def test_hassio_ignored(hass: HomeAssistant) -> None:
     assert result.get("reason") == "already_configured"
 
 
-async def test_hassio_confirm(hass, mock_try_connection_success, mock_finish_setup):
+async def test_hassio_confirm(
+    hass: HomeAssistant, mock_try_connection_success, mock_finish_setup
+) -> None:
     """Test we can finish a config flow."""
     mock_try_connection.return_value = True
 
@@ -415,8 +417,8 @@ async def test_hassio_confirm(hass, mock_try_connection_success, mock_finish_set
 
 
 async def test_hassio_cannot_connect(
-    hass, mock_try_connection_time_out, mock_finish_setup
-):
+    hass: HomeAssistant, mock_try_connection_time_out, mock_finish_setup
+) -> None:
     """Test a config flow is aborted when a connection was not successful."""
     mock_try_connection.return_value = True
 
@@ -455,10 +457,10 @@ async def test_hassio_cannot_connect(
 
 
 async def test_option_flow(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection,
-):
+) -> None:
     """Test config flow options."""
     with patch(
         "homeassistant.config.async_hass_config_yaml", AsyncMock(return_value={})
@@ -552,14 +554,14 @@ async def test_option_flow(
     ],
 )
 async def test_bad_certificate(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection_success,
     tmp_path,
     mock_ssl_context,
     test_error,
     mock_process_uploaded_file,
-):
+) -> None:
     """Test bad certificate tests."""
     # Mock certificate files
     file_id = mock_process_uploaded_file.file_id
@@ -649,13 +651,13 @@ async def test_bad_certificate(
     ],
 )
 async def test_keepalive_validation(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection,
     mock_reload_after_entry_update,
     input_value,
     error,
-):
+) -> None:
     """Test validation of the keep alive option."""
 
     test_input = {
@@ -695,11 +697,11 @@ async def test_keepalive_validation(
 
 
 async def test_disable_birth_will(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection,
     mock_reload_after_entry_update,
-):
+) -> None:
     """Test disabling birth and will."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     mock_try_connection.return_value = True
@@ -766,11 +768,11 @@ async def test_disable_birth_will(
 
 
 async def test_invalid_discovery_prefix(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection,
     mock_reload_after_entry_update,
-):
+) -> HomeAssistant:
     """Test setting an invalid discovery prefix."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     mock_try_connection.return_value = True
@@ -842,11 +844,11 @@ def get_suggested(schema, key):
 
 
 async def test_option_flow_default_suggested_values(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection_success,
     mock_reload_after_entry_update,
-):
+) -> None:
     """Test config flow options has default/suggested values."""
     await mqtt_mock_entry_no_yaml_config()
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
@@ -997,13 +999,13 @@ async def test_option_flow_default_suggested_values(
     "advanced_options, step_id", [(False, "options"), (True, "broker")]
 )
 async def test_skipping_advanced_options(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_no_yaml_config,
     mock_try_connection,
     mock_reload_after_entry_update,
     advanced_options,
     step_id,
-):
+) -> None:
     """Test advanced options option."""
 
     test_input = {
@@ -1034,7 +1036,9 @@ async def test_skipping_advanced_options(
     assert result["step_id"] == step_id
 
 
-async def test_options_user_connection_fails(hass, mock_try_connection_time_out):
+async def test_options_user_connection_fails(
+    hass: HomeAssistant, mock_try_connection_time_out
+) -> None:
     """Test if connection cannot be made."""
     config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
     config_entry.add_to_hass(hass)
@@ -1063,7 +1067,9 @@ async def test_options_user_connection_fails(hass, mock_try_connection_time_out)
     }
 
 
-async def test_options_bad_birth_message_fails(hass, mock_try_connection):
+async def test_options_bad_birth_message_fails(
+    hass: HomeAssistant, mock_try_connection
+) -> None:
     """Test bad birth message."""
     config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
     config_entry.add_to_hass(hass)
@@ -1099,7 +1105,9 @@ async def test_options_bad_birth_message_fails(hass, mock_try_connection):
     }
 
 
-async def test_options_bad_will_message_fails(hass, mock_try_connection):
+async def test_options_bad_will_message_fails(
+    hass: HomeAssistant, mock_try_connection
+) -> None:
     """Test bad will message."""
     config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
     config_entry.add_to_hass(hass)
@@ -1136,12 +1144,12 @@ async def test_options_bad_will_message_fails(hass, mock_try_connection):
 
 
 async def test_try_connection_with_advanced_parameters(
-    hass,
+    hass: HomeAssistant,
     mock_try_connection_success,
     tmp_path,
     mock_ssl_context,
     mock_process_uploaded_file,
-):
+) -> HomeAssistant:
     """Test config flow with advanced parameters from config."""
 
     with open(tmp_path / "client.crt", "wb") as certfile:
@@ -1277,8 +1285,12 @@ async def test_try_connection_with_advanced_parameters(
 
 
 async def test_setup_with_advanced_settings(
-    hass, mock_try_connection, tmp_path, mock_ssl_context, mock_process_uploaded_file
-):
+    hass: HomeAssistant,
+    mock_try_connection,
+    tmp_path,
+    mock_ssl_context,
+    mock_process_uploaded_file,
+) -> None:
     """Test config flow setup with advanced parameters."""
     file_id = mock_process_uploaded_file.file_id
 
@@ -1431,8 +1443,12 @@ async def test_setup_with_advanced_settings(
 
 
 async def test_change_websockets_transport_to_tcp(
-    hass, mock_try_connection, tmp_path, mock_ssl_context, mock_process_uploaded_file
-):
+    hass: HomeAssistant,
+    mock_try_connection,
+    tmp_path,
+    mock_ssl_context,
+    mock_process_uploaded_file,
+) -> None:
     """Test option flow setup with websockets transport settings."""
     config_entry = MockConfigEntry(domain=mqtt.DOMAIN)
     config_entry.add_to_hass(hass)

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -90,7 +91,9 @@ def cover_platform_only():
         yield
 
 
-async def test_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_state_via_state_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -128,8 +131,8 @@ async def test_state_via_state_topic(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_opening_and_closing_state_via_custom_state_payload(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling opening and closing state via a custom payload."""
     assert await async_setup_component(
         hass,
@@ -174,8 +177,8 @@ async def test_opening_and_closing_state_via_custom_state_payload(
 
 
 async def test_open_closed_state_from_position_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the state after setting the position using optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -224,7 +227,9 @@ async def test_open_closed_state_from_position_optimistic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 
-async def test_position_via_position_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_position_via_position_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -263,7 +268,9 @@ async def test_position_via_position_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert state.state == STATE_OPEN
 
 
-async def test_state_via_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_state_via_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -302,7 +309,9 @@ async def test_state_via_template(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_CLOSED
 
 
-async def test_state_via_template_and_entity_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_state_via_template_and_entity_id(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -344,8 +353,8 @@ async def test_state_via_template_and_entity_id(hass, mqtt_mock_entry_with_yaml_
 
 
 async def test_state_via_template_with_json_value(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic with JSON value."""
     assert await async_setup_component(
         hass,
@@ -387,8 +396,8 @@ async def test_state_via_template_with_json_value(
 
 
 async def test_position_via_template_and_entity_id(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -443,8 +452,8 @@ async def test_position_via_template_and_entity_id(
     ],
 )
 async def test_optimistic_flag(
-    hass, mqtt_mock_entry_with_yaml_config, config, assumed_state
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, config, assumed_state
+) -> None:
     """Test assumed_state is set correctly."""
     assert await async_setup_component(
         hass,
@@ -462,7 +471,9 @@ async def test_optimistic_flag(
         assert ATTR_ASSUMED_STATE not in state.attributes
 
 
-async def test_optimistic_state_change(hass, mqtt_mock_entry_with_yaml_config):
+async def test_optimistic_state_change(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test changing state optimistically."""
     assert await async_setup_component(
         hass,
@@ -521,8 +532,8 @@ async def test_optimistic_state_change(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_optimistic_state_change_with_position(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test changing state optimistically."""
     assert await async_setup_component(
         hass,
@@ -587,7 +598,9 @@ async def test_optimistic_state_change_with_position(
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
 
 
-async def test_send_open_cover_command(hass, mqtt_mock_entry_with_yaml_config):
+async def test_send_open_cover_command(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of open_cover."""
     assert await async_setup_component(
         hass,
@@ -618,7 +631,9 @@ async def test_send_open_cover_command(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_send_close_cover_command(hass, mqtt_mock_entry_with_yaml_config):
+async def test_send_close_cover_command(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of close_cover."""
     assert await async_setup_component(
         hass,
@@ -649,7 +664,9 @@ async def test_send_close_cover_command(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_send_stop__cover_command(hass, mqtt_mock_entry_with_yaml_config):
+async def test_send_stop__cover_command(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of stop_cover."""
     assert await async_setup_component(
         hass,
@@ -680,7 +697,9 @@ async def test_send_stop__cover_command(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_current_cover_position(hass, mqtt_mock_entry_with_yaml_config):
+async def test_current_cover_position(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the current cover position."""
     assert await async_setup_component(
         hass,
@@ -733,7 +752,9 @@ async def test_current_cover_position(hass, mqtt_mock_entry_with_yaml_config):
     assert current_cover_position == 100
 
 
-async def test_current_cover_position_inverted(hass, mqtt_mock_entry_with_yaml_config):
+async def test_current_cover_position_inverted(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the current cover position."""
     assert await async_setup_component(
         hass,
@@ -797,7 +818,7 @@ async def test_current_cover_position_inverted(hass, mqtt_mock_entry_with_yaml_c
     assert hass.states.get("cover.test").state == STATE_CLOSED
 
 
-async def test_optimistic_position(hass, caplog):
+async def test_optimistic_position(hass: HomeAssistant, caplog) -> None:
     """Test optimistic position is not supported."""
     assert not await async_setup_component(
         hass,
@@ -818,7 +839,9 @@ async def test_optimistic_position(hass, caplog):
     )
 
 
-async def test_position_update(hass, mqtt_mock_entry_with_yaml_config):
+async def test_position_update(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test cover position update from received MQTT message."""
     assert await async_setup_component(
         hass,
@@ -862,8 +885,12 @@ async def test_position_update(hass, mqtt_mock_entry_with_yaml_config):
     [("{{position-1}}", 43, "42"), ("{{100-62}}", 100, "38")],
 )
 async def test_set_position_templated(
-    hass, mqtt_mock_entry_with_yaml_config, pos_template, pos_call, pos_message
-):
+    hass: HomeAssistant,
+    mqtt_mock_entry_with_yaml_config,
+    pos_template,
+    pos_call,
+    pos_message,
+) -> None:
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
@@ -901,8 +928,8 @@ async def test_set_position_templated(
 
 
 async def test_set_position_templated_and_attributes(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting cover position via template and using entities attributes."""
     assert await async_setup_component(
         hass,
@@ -946,7 +973,9 @@ async def test_set_position_templated_and_attributes(
     mqtt_mock.async_publish.assert_called_once_with("set-position-topic", "5", 0, False)
 
 
-async def test_set_tilt_templated(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_tilt_templated(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting cover tilt position via template."""
     assert await async_setup_component(
         hass,
@@ -986,8 +1015,8 @@ async def test_set_tilt_templated(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_set_tilt_templated_and_attributes(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting cover tilt position via template and using entities attributes."""
     assert await async_setup_component(
         hass,
@@ -1075,7 +1104,9 @@ async def test_set_tilt_templated_and_attributes(
     )
 
 
-async def test_set_position_untemplated(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_position_untemplated(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
@@ -1108,8 +1139,8 @@ async def test_set_position_untemplated(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_set_position_untemplated_custom_percentage_range(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting cover position via template."""
     assert await async_setup_component(
         hass,
@@ -1143,7 +1174,9 @@ async def test_set_position_untemplated_custom_percentage_range(
     mqtt_mock.async_publish.assert_called_once_with("position-topic", "62", 0, False)
 
 
-async def test_no_command_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_no_command_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test with no command topic."""
     assert await async_setup_component(
         hass,
@@ -1168,7 +1201,9 @@ async def test_no_command_topic(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get("cover.test").attributes["supported_features"] == 240
 
 
-async def test_no_payload_close(hass, mqtt_mock_entry_with_yaml_config):
+async def test_no_payload_close(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test with no close payload."""
     assert await async_setup_component(
         hass,
@@ -1192,7 +1227,9 @@ async def test_no_payload_close(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get("cover.test").attributes["supported_features"] == 9
 
 
-async def test_no_payload_open(hass, mqtt_mock_entry_with_yaml_config):
+async def test_no_payload_open(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test with no open payload."""
     assert await async_setup_component(
         hass,
@@ -1216,7 +1253,9 @@ async def test_no_payload_open(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get("cover.test").attributes["supported_features"] == 10
 
 
-async def test_no_payload_stop(hass, mqtt_mock_entry_with_yaml_config):
+async def test_no_payload_stop(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test with no stop payload."""
     assert await async_setup_component(
         hass,
@@ -1240,7 +1279,9 @@ async def test_no_payload_stop(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get("cover.test").attributes["supported_features"] == 3
 
 
-async def test_with_command_topic_and_tilt(hass, mqtt_mock_entry_with_yaml_config):
+async def test_with_command_topic_and_tilt(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test with command topic and tilt config."""
     assert await async_setup_component(
         hass,
@@ -1266,7 +1307,9 @@ async def test_with_command_topic_and_tilt(hass, mqtt_mock_entry_with_yaml_confi
     assert hass.states.get("cover.test").attributes["supported_features"] == 251
 
 
-async def test_tilt_defaults(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_defaults(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the defaults."""
     assert await async_setup_component(
         hass,
@@ -1295,7 +1338,9 @@ async def test_tilt_defaults(hass, mqtt_mock_entry_with_yaml_config):
     assert ATTR_CURRENT_TILT_POSITION not in state_attributes_dict
 
 
-async def test_tilt_via_invocation_defaults(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_via_invocation_defaults(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt defaults on close/open."""
     assert await async_setup_component(
         hass,
@@ -1379,7 +1424,9 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock_entry_with_yaml_conf
     mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", "0", 0, False)
 
 
-async def test_tilt_given_value(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_given_value(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
@@ -1469,7 +1516,9 @@ async def test_tilt_given_value(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_tilt_given_value_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_given_value_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
@@ -1547,7 +1596,9 @@ async def test_tilt_given_value_optimistic(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_tilt_given_value_altered_range(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_given_value_altered_range(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilting to a given value."""
     assert await async_setup_component(
         hass,
@@ -1625,7 +1676,9 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_tilt_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt by updating status via MQTT."""
     assert await async_setup_component(
         hass,
@@ -1664,7 +1717,9 @@ async def test_tilt_via_topic(hass, mqtt_mock_entry_with_yaml_config):
     assert current_cover_tilt_position == 50
 
 
-async def test_tilt_via_topic_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_via_topic_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt by updating status via MQTT and template."""
     assert await async_setup_component(
         hass,
@@ -1707,8 +1762,8 @@ async def test_tilt_via_topic_template(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_tilt_via_topic_template_json_value(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test tilt by updating status via MQTT and template with JSON value."""
     assert await async_setup_component(
         hass,
@@ -1756,7 +1811,9 @@ async def test_tilt_via_topic_template_json_value(
     ) in caplog.text
 
 
-async def test_tilt_via_topic_altered_range(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_via_topic_altered_range(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt status via MQTT with altered tilt range."""
     assert await async_setup_component(
         hass,
@@ -1805,8 +1862,8 @@ async def test_tilt_via_topic_altered_range(hass, mqtt_mock_entry_with_yaml_conf
 
 
 async def test_tilt_status_out_of_range_warning(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt status via MQTT tilt out of range warning message."""
     assert await async_setup_component(
         hass,
@@ -1840,8 +1897,8 @@ async def test_tilt_status_out_of_range_warning(
 
 
 async def test_tilt_status_not_numeric_warning(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt status via MQTT tilt not numeric warning message."""
     assert await async_setup_component(
         hass,
@@ -1873,8 +1930,8 @@ async def test_tilt_status_not_numeric_warning(
 
 
 async def test_tilt_via_topic_altered_range_inverted(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt status via MQTT with altered tilt range and inverted tilt position."""
     assert await async_setup_component(
         hass,
@@ -1923,8 +1980,8 @@ async def test_tilt_via_topic_altered_range_inverted(
 
 
 async def test_tilt_via_topic_template_altered_range(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt status via MQTT and template with altered tilt range."""
     assert await async_setup_component(
         hass,
@@ -1975,7 +2032,9 @@ async def test_tilt_via_topic_template_altered_range(
     assert current_cover_tilt_position == 50
 
 
-async def test_tilt_position(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_position(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt via method invocation."""
     assert await async_setup_component(
         hass,
@@ -2011,7 +2070,9 @@ async def test_tilt_position(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_tilt_position_templated(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_position_templated(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt position via template."""
     assert await async_setup_component(
         hass,
@@ -2048,7 +2109,9 @@ async def test_tilt_position_templated(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_tilt_position_altered_range(hass, mqtt_mock_entry_with_yaml_config):
+async def test_tilt_position_altered_range(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test tilt via method invocation with altered range."""
     assert await async_setup_component(
         hass,
@@ -2088,7 +2151,7 @@ async def test_tilt_position_altered_range(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_find_percentage_in_range_defaults(hass):
+async def test_find_percentage_in_range_defaults(hass: HomeAssistant) -> None:
     """Test find percentage in range with default range."""
     mqtt_cover = MqttCover(
         hass,
@@ -2131,7 +2194,7 @@ async def test_find_percentage_in_range_defaults(hass):
     assert mqtt_cover.find_percentage_in_range(44, "cover") == 44
 
 
-async def test_find_percentage_in_range_altered(hass):
+async def test_find_percentage_in_range_altered(hass: HomeAssistant) -> None:
     """Test find percentage in range with altered range."""
     mqtt_cover = MqttCover(
         hass,
@@ -2174,7 +2237,7 @@ async def test_find_percentage_in_range_altered(hass):
     assert mqtt_cover.find_percentage_in_range(120, "cover") == 40
 
 
-async def test_find_percentage_in_range_defaults_inverted(hass):
+async def test_find_percentage_in_range_defaults_inverted(hass: HomeAssistant) -> None:
     """Test find percentage in range with default range but inverted."""
     mqtt_cover = MqttCover(
         hass,
@@ -2217,7 +2280,7 @@ async def test_find_percentage_in_range_defaults_inverted(hass):
     assert mqtt_cover.find_percentage_in_range(44, "cover") == 56
 
 
-async def test_find_percentage_in_range_altered_inverted(hass):
+async def test_find_percentage_in_range_altered_inverted(hass: HomeAssistant) -> None:
     """Test find percentage in range with altered range and inverted."""
     mqtt_cover = MqttCover(
         hass,
@@ -2260,7 +2323,7 @@ async def test_find_percentage_in_range_altered_inverted(hass):
     assert mqtt_cover.find_percentage_in_range(120, "cover") == 60
 
 
-async def test_find_in_range_defaults(hass):
+async def test_find_in_range_defaults(hass: HomeAssistant) -> None:
     """Test find in range with default range."""
     mqtt_cover = MqttCover(
         hass,
@@ -2303,7 +2366,7 @@ async def test_find_in_range_defaults(hass):
     assert mqtt_cover.find_in_range_from_percent(44, "cover") == 44
 
 
-async def test_find_in_range_altered(hass):
+async def test_find_in_range_altered(hass: HomeAssistant) -> None:
     """Test find in range with altered range."""
     mqtt_cover = MqttCover(
         hass,
@@ -2346,7 +2409,7 @@ async def test_find_in_range_altered(hass):
     assert mqtt_cover.find_in_range_from_percent(40, "cover") == 120
 
 
-async def test_find_in_range_defaults_inverted(hass):
+async def test_find_in_range_defaults_inverted(hass: HomeAssistant) -> None:
     """Test find in range with default range but inverted."""
     mqtt_cover = MqttCover(
         hass,
@@ -2389,7 +2452,7 @@ async def test_find_in_range_defaults_inverted(hass):
     assert mqtt_cover.find_in_range_from_percent(56, "cover") == 44
 
 
-async def test_find_in_range_altered_inverted(hass):
+async def test_find_in_range_altered_inverted(hass: HomeAssistant) -> None:
     """Test find in range with altered range and inverted."""
     mqtt_cover = MqttCover(
         hass,
@@ -2433,36 +2496,44 @@ async def test_find_in_range_altered_inverted(hass):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
+async def test_valid_device_class(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of a valid device class."""
     assert await async_setup_component(
         hass,
@@ -2484,7 +2555,7 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("device_class") == "garage"
 
 
-async def test_invalid_device_class(hass, caplog):
+async def test_invalid_device_class(hass: HomeAssistant, caplog) -> None:
     """Test the setting of an invalid device class."""
     assert not await async_setup_component(
         hass,
@@ -2503,8 +2574,8 @@ async def test_invalid_device_class(hass, caplog):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
@@ -2512,8 +2583,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -2524,7 +2595,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
@@ -2532,8 +2605,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -2545,8 +2618,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -2557,7 +2630,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -2568,7 +2643,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique_id option only creates one cover per id."""
     config = {
         mqtt.DOMAIN: {
@@ -2591,7 +2666,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_cover(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_cover(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered cover."""
     data = '{ "name": "test", "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -2599,7 +2676,9 @@ async def test_discovery_removal_cover(hass, mqtt_mock_entry_no_yaml_config, cap
     )
 
 
-async def test_discovery_update_cover(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_cover(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered cover."""
     config1 = {"name": "Beer", "command_topic": "test_topic"}
     config2 = {"name": "Milk", "command_topic": "test_topic"}
@@ -2609,8 +2688,8 @@ async def test_discovery_update_cover(hass, mqtt_mock_entry_no_yaml_config, capl
 
 
 async def test_discovery_update_unchanged_cover(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered cover."""
     data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
     with patch(
@@ -2627,7 +2706,9 @@ async def test_discovery_update_unchanged_cover(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer", "command_topic": "test_topic#" }'
     data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
@@ -2636,49 +2717,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT cover device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT cover device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, cover.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -2691,8 +2786,8 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_state_and_position_topics_state_not_set_via_position_topic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test state is not set via position topic when both state and position topics are set."""
     assert await async_setup_component(
         hass,
@@ -2752,8 +2847,8 @@ async def test_state_and_position_topics_state_not_set_via_position_topic(
 
 
 async def test_set_state_via_position_using_stopped_state(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via position topic using stopped state."""
     assert await async_setup_component(
         hass,
@@ -2809,8 +2904,8 @@ async def test_set_state_via_position_using_stopped_state(
 
 
 async def test_position_via_position_topic_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
@@ -2847,8 +2942,8 @@ async def test_position_via_position_topic_template(
 
 
 async def test_position_via_position_topic_template_json_value(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test position by updating status via position template with a JSON value."""
     assert await async_setup_component(
         hass,
@@ -2890,7 +2985,9 @@ async def test_position_via_position_topic_template_json_value(
     ) in caplog.text
 
 
-async def test_position_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_position_template_with_entity_id(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
@@ -2932,8 +3029,8 @@ async def test_position_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_
 
 
 async def test_position_via_position_topic_template_return_json(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template and returning json."""
     assert await async_setup_component(
         hass,
@@ -2963,8 +3060,8 @@ async def test_position_via_position_topic_template_return_json(
 
 
 async def test_position_via_position_topic_template_return_json_warning(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template returning json without position attribute."""
     assert await async_setup_component(
         hass,
@@ -2994,8 +3091,8 @@ async def test_position_via_position_topic_template_return_json_warning(
 
 
 async def test_position_and_tilt_via_position_topic_template_return_json(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position and tilt by updating the position via position template."""
     assert await async_setup_component(
         hass,
@@ -3038,8 +3135,8 @@ async def test_position_and_tilt_via_position_topic_template_return_json(
 
 
 async def test_position_via_position_topic_template_all_variables(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
@@ -3086,8 +3183,8 @@ async def test_position_via_position_topic_template_all_variables(
 
 
 async def test_set_state_via_stopped_state_no_position_topic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via stopped state when no position topic."""
     assert await async_setup_component(
         hass,
@@ -3139,8 +3236,8 @@ async def test_set_state_via_stopped_state_no_position_topic(
 
 
 async def test_position_via_position_topic_template_return_invalid_json(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test position by updating status via position template and returning invalid json."""
     assert await async_setup_component(
         hass,
@@ -3166,7 +3263,9 @@ async def test_position_via_position_topic_template_return_invalid_json(
     assert ("Payload '{'position': Undefined}' is not numeric") in caplog.text
 
 
-async def test_set_position_topic_without_get_position_topic_error(hass, caplog):
+async def test_set_position_topic_without_get_position_topic_error(
+    hass: HomeAssistant, caplog
+) -> None:
     """Test error when set_position_topic is used without position_topic."""
     assert not await async_setup_component(
         hass,
@@ -3188,9 +3287,9 @@ async def test_set_position_topic_without_get_position_topic_error(hass, caplog)
 
 
 async def test_value_template_without_state_topic_error(
-    hass,
+    hass: HomeAssistant,
     caplog,
-):
+) -> None:
     """Test error when value_template is used and state_topic is missing."""
     assert not await async_setup_component(
         hass,
@@ -3210,7 +3309,9 @@ async def test_value_template_without_state_topic_error(
     ) in caplog.text
 
 
-async def test_position_template_without_position_topic_error(hass, caplog):
+async def test_position_template_without_position_topic_error(
+    hass: HomeAssistant, caplog
+) -> None:
     """Test error when position_template is used and position_topic is missing."""
     assert not await async_setup_component(
         hass,
@@ -3232,9 +3333,9 @@ async def test_position_template_without_position_topic_error(hass, caplog):
 
 
 async def test_set_position_template_without_set_position_topic(
-    hass,
+    hass: HomeAssistant,
     caplog,
-):
+) -> None:
     """Test error when set_position_template is used and set_position_topic is missing."""
     assert not await async_setup_component(
         hass,
@@ -3255,7 +3356,9 @@ async def test_set_position_template_without_set_position_topic(
     )
 
 
-async def test_tilt_command_template_without_tilt_command_topic(hass, caplog):
+async def test_tilt_command_template_without_tilt_command_topic(
+    hass: HomeAssistant, caplog
+) -> None:
     """Test error when tilt_command_template is used and tilt_command_topic is missing."""
     assert not await async_setup_component(
         hass,
@@ -3276,7 +3379,9 @@ async def test_tilt_command_template_without_tilt_command_topic(hass, caplog):
     )
 
 
-async def test_tilt_status_template_without_tilt_status_topic_topic(hass, caplog):
+async def test_tilt_status_template_without_tilt_status_topic_topic(
+    hass: HomeAssistant, caplog
+) -> None:
     """Test error when tilt_status_template is used and tilt_status_topic is missing."""
     assert not await async_setup_component(
         hass,
@@ -3324,7 +3429,7 @@ async def test_tilt_status_template_without_tilt_status_topic_topic(hass, caplog
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -3332,7 +3437,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = cover.DOMAIN
     config = DEFAULT_CONFIG
@@ -3352,7 +3457,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = cover.DOMAIN
     config = DEFAULT_CONFIG
@@ -3371,14 +3478,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -3394,14 +3501,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = cover.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = cover.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components import device_tracker, mqtt
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -34,18 +35,20 @@ def device_tracker_platform_only():
 
 
 @pytest.fixture
-def device_reg(hass):
+def device_reg(hass: HomeAssistant):
     """Return an empty, loaded, registry."""
     return mock_device_registry(hass)
 
 
 @pytest.fixture
-def entity_reg(hass):
+def entity_reg(hass: HomeAssistant):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
 
 
-async def test_discover_device_tracker(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discover_device_tracker(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test discovering an MQTT device tracker component."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -63,7 +66,9 @@ async def test_discover_device_tracker(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -89,8 +94,8 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
 
 
 async def test_non_duplicate_device_tracker_discovery(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test for a non duplicate component."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -114,7 +119,9 @@ async def test_non_duplicate_device_tracker_discovery(
     assert "Component has already been discovered: device_tracker bla" in caplog.text
 
 
-async def test_device_tracker_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_device_tracker_removal(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of component through empty discovery message."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -132,7 +139,9 @@ async def test_device_tracker_removal(hass, mqtt_mock_entry_no_yaml_config, capl
     assert state is None
 
 
-async def test_device_tracker_rediscover(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_device_tracker_rediscover(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test rediscover of removed component."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -160,8 +169,8 @@ async def test_device_tracker_rediscover(hass, mqtt_mock_entry_no_yaml_config, c
 
 
 async def test_duplicate_device_tracker_removal(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test for a non duplicate component."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -183,8 +192,8 @@ async def test_duplicate_device_tracker_removal(
 
 
 async def test_device_tracker_discovery_update(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test for a discovery update event."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -211,8 +220,12 @@ async def test_device_tracker_discovery_update(
 
 
 async def test_cleanup_device_tracker(
-    hass, hass_ws_client, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    hass_ws_client,
+    device_reg,
+    entity_reg,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test discovered device is cleaned up when removed from registry."""
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
@@ -270,8 +283,8 @@ async def test_cleanup_device_tracker(
 
 
 async def test_setting_device_tracker_value_via_mqtt_message(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of the value via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -296,8 +309,8 @@ async def test_setting_device_tracker_value_via_mqtt_message(
 
 
 async def test_setting_device_tracker_value_via_mqtt_message_and_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of the value via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -321,8 +334,8 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template(
 
 
 async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of the value via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -349,8 +362,8 @@ async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
 
 
 async def test_setting_device_tracker_location_via_mqtt_message(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of the location via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -371,8 +384,8 @@ async def test_setting_device_tracker_location_via_mqtt_message(
 
 
 async def test_setting_device_tracker_location_via_lat_lon_message(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of the latitude and longitude via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -430,8 +443,8 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
 
 
 async def test_setting_device_tracker_location_via_reset_message(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the automatic inference of zones via MQTT via reset."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -504,8 +517,8 @@ async def test_setting_device_tracker_location_via_reset_message(
 
 
 async def test_setting_device_tracker_location_via_abbr_reset_message(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test the setting of reset via abbreviated names and custom payloads via MQTT."""
     await mqtt_mock_entry_no_yaml_config()
     async_fire_mqtt_message(
@@ -546,8 +559,8 @@ async def test_setting_device_tracker_location_via_abbr_reset_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -558,7 +571,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setup_with_modern_schema(hass, mock_device_tracker_conf):
+async def test_setup_with_modern_schema(
+    hass: HomeAssistant, mock_device_tracker_conf
+) -> None:
     """Test setup using the modern schema."""
     dev_id = "jan"
     entity_id = f"{device_tracker.DOMAIN}.{dev_id}"

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -9,6 +9,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt import _LOGGER, DOMAIN, debug_info
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -55,8 +56,8 @@ def binary_sensor_and_sensor_only():
 
 
 async def test_get_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test we get the expected triggers from a discovered mqtt device."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -89,8 +90,8 @@ async def test_get_triggers(
 
 
 async def test_get_unknown_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test we don't get unknown triggers."""
     await mqtt_mock_entry_no_yaml_config()
     # Discover a sensor (without device triggers)
@@ -134,8 +135,8 @@ async def test_get_unknown_triggers(
 
 
 async def test_get_non_existing_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test getting non existing triggers."""
     await mqtt_mock_entry_no_yaml_config()
     # Discover a sensor (without device triggers)
@@ -156,8 +157,8 @@ async def test_get_non_existing_triggers(
 
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test bad discovery message."""
     await mqtt_mock_entry_no_yaml_config()
     # Test sending bad data
@@ -204,8 +205,8 @@ async def test_discover_bad_triggers(
 
 
 async def test_update_remove_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers can be updated and removed."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = {
@@ -271,8 +272,8 @@ async def test_update_remove_triggers(
 
 
 async def test_if_fires_on_mqtt_message(
-    hass, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers firing."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -347,8 +348,8 @@ async def test_if_fires_on_mqtt_message(
 
 
 async def test_if_fires_on_mqtt_message_template(
-    hass, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers firing."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -425,8 +426,8 @@ async def test_if_fires_on_mqtt_message_template(
 
 
 async def test_if_fires_on_mqtt_message_late_discover(
-    hass, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers firing of MQTT device triggers discovered after setup."""
     await mqtt_mock_entry_no_yaml_config()
     data0 = (
@@ -509,8 +510,8 @@ async def test_if_fires_on_mqtt_message_late_discover(
 
 
 async def test_if_fires_on_mqtt_message_after_update(
-    hass, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers firing after update."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -586,8 +587,8 @@ async def test_if_fires_on_mqtt_message_after_update(
 
 
 async def test_no_resubscribe_same_topic(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test subscription to topics without change."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -631,8 +632,8 @@ async def test_no_resubscribe_same_topic(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
-    hass, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test triggers not firing after removal."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -693,8 +694,12 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
-    hass, hass_ws_client, device_reg, calls, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    hass_ws_client,
+    device_reg,
+    calls,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test triggers not firing after removal."""
     assert await async_setup_component(hass, "config", {})
     assert await async_setup_component(hass, "repairs", {})
@@ -761,7 +766,9 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     assert len(calls) == 1
 
 
-async def test_attach_remove(hass, device_reg, mqtt_mock_entry_no_yaml_config):
+async def test_attach_remove(
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test attach and removal of trigger."""
     await mqtt_mock_entry_no_yaml_config()
     data1 = (
@@ -815,7 +822,9 @@ async def test_attach_remove(hass, device_reg, mqtt_mock_entry_no_yaml_config):
     assert len(calls) == 1
 
 
-async def test_attach_remove_late(hass, device_reg, mqtt_mock_entry_no_yaml_config):
+async def test_attach_remove_late(
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test attach and removal of trigger ."""
     await mqtt_mock_entry_no_yaml_config()
     data0 = (
@@ -877,7 +886,9 @@ async def test_attach_remove_late(hass, device_reg, mqtt_mock_entry_no_yaml_conf
     assert len(calls) == 1
 
 
-async def test_attach_remove_late2(hass, device_reg, mqtt_mock_entry_no_yaml_config):
+async def test_attach_remove_late2(
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test attach and removal of trigger ."""
     await mqtt_mock_entry_no_yaml_config()
     data0 = (
@@ -933,7 +944,9 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock_entry_no_yaml_con
     assert len(calls) == 0
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -969,7 +982,9 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
     assert device.sw_version == "0.1-beta"
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -1003,7 +1018,9 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
     assert device.sw_version == "0.1-beta"
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -1042,8 +1059,12 @@ async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_cleanup_trigger(
-    hass, hass_ws_client, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    hass_ws_client,
+    device_reg,
+    entity_reg,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test trigger discovery topic is cleaned when device is removed from registry."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     assert await async_setup_component(hass, "config", {})
@@ -1096,8 +1117,8 @@ async def test_cleanup_trigger(
 
 
 async def test_cleanup_device(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry when trigger is removed."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -1130,8 +1151,8 @@ async def test_cleanup_device(
 
 
 async def test_cleanup_device_several_triggers(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry when the last trigger is removed."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = {
@@ -1190,8 +1211,8 @@ async def test_cleanup_device_several_triggers(
 
 
 async def test_cleanup_device_with_entity1(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry for device with entity.
 
     Trigger removed first, then entity.
@@ -1249,8 +1270,8 @@ async def test_cleanup_device_with_entity1(
 
 
 async def test_cleanup_device_with_entity2(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry for device with entity.
 
     Entity removed first, then trigger.
@@ -1307,7 +1328,9 @@ async def test_cleanup_device_with_entity2(
     assert device_entry is None
 
 
-async def test_trigger_debug_info(hass, mqtt_mock_entry_no_yaml_config):
+async def test_trigger_debug_info(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test debug_info.
 
     This is a test helper for MQTT debug_info.
@@ -1382,7 +1405,9 @@ async def test_trigger_debug_info(hass, mqtt_mock_entry_no_yaml_config):
     assert debug_info_data["triggers"][0]["discovery_data"]["payload"] == config2
 
 
-async def test_unload_entry(hass, calls, device_reg, mqtt_mock, tmp_path) -> None:
+async def test_unload_entry(
+    hass: HomeAssistant, calls, device_reg, mqtt_mock, tmp_path
+) -> None:
     """Test unloading the MQTT entry."""
 
     data1 = (

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components import mqtt
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_fire_mqtt_message, mock_device_registry
 from tests.components.diagnostics import (
@@ -46,14 +47,14 @@ def device_tracker_sensor_only():
 
 
 @pytest.fixture
-def device_reg(hass):
+def device_reg(hass: HomeAssistant):
     """Return an empty, loaded, registry."""
     return mock_device_registry(hass)
 
 
 async def test_entry_diagnostics(
-    hass, device_reg, hass_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, hass_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test config entry diagnostics."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
@@ -172,8 +173,8 @@ async def test_entry_diagnostics(
     ],
 )
 async def test_redact_diagnostics(
-    hass, device_reg, hass_client, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, hass_client, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test redacting diagnostics."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     expected_config = dict(default_config)

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -83,7 +84,7 @@ def fan_platform_only():
         yield
 
 
-async def test_fail_setup_if_no_command_topic(hass, caplog):
+async def test_fail_setup_if_no_command_topic(hass: HomeAssistant, caplog) -> None:
     """Test if command fails with command topic."""
     assert not await async_setup_component(
         hass,
@@ -97,8 +98,8 @@ async def test_fail_setup_if_no_command_topic(hass, caplog):
 
 
 async def test_controlling_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -219,8 +220,8 @@ async def test_controlling_state_via_topic(
 
 
 async def test_controlling_state_via_topic_with_different_speed_range(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic using an alternate speed range."""
     assert await async_setup_component(
         hass,
@@ -281,8 +282,8 @@ async def test_controlling_state_via_topic_with_different_speed_range(
 
 
 async def test_controlling_state_via_topic_no_percentage_topics(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic without percentage topics."""
     assert await async_setup_component(
         hass,
@@ -338,8 +339,8 @@ async def test_controlling_state_via_topic_no_percentage_topics(
 
 
 async def test_controlling_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message (percentage mode)."""
     assert await async_setup_component(
         hass,
@@ -443,8 +444,8 @@ async def test_controlling_state_via_topic_and_json_message(
 
 
 async def test_controlling_state_via_topic_and_json_message_shared_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message using a shared topic."""
     assert await async_setup_component(
         hass,
@@ -531,8 +532,8 @@ async def test_controlling_state_via_topic_and_json_message_shared_topic(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
@@ -656,8 +657,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_commands_with_alternate_speed_range(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic using an alternate speed range."""
     assert await async_setup_component(
         hass,
@@ -762,8 +763,8 @@ async def test_sending_mqtt_commands_with_alternate_speed_range(
 
 
 async def test_sending_mqtt_commands_and_optimistic_no_legacy(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode without state topic without legacy speed command topic."""
     assert await async_setup_component(
         hass,
@@ -894,8 +895,8 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(
 
 
 async def test_sending_mqtt_command_templates_(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode without state topic without legacy speed command topic."""
     assert await async_setup_component(
         hass,
@@ -1037,8 +1038,8 @@ async def test_sending_mqtt_command_templates_(
 
 
 async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode without state topic without percentage command topic."""
     assert await async_setup_component(
         hass,
@@ -1099,8 +1100,8 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
 
 
 async def test_sending_mqtt_commands_and_explicit_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode with state topic and turn on attributes."""
     assert await async_setup_component(
         hass,
@@ -1346,14 +1347,14 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][fan.DOMAIN])
     config[ATTR_PRESET_MODES] = ["eco", "auto"]
@@ -1373,7 +1374,9 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_attributes(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes."""
     assert await async_setup_component(
         hass,
@@ -1606,8 +1609,13 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
     ],
 )
 async def test_supported_features(
-    hass, mqtt_mock_entry_with_yaml_config, name, config, success, features
-):
+    hass: HomeAssistant,
+    mqtt_mock_entry_with_yaml_config,
+    name,
+    config,
+    success,
+    features,
+) -> None:
     """Test optimistic mode without state topic."""
 
     assert (
@@ -1625,22 +1633,26 @@ async def test_supported_features(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass,
@@ -1653,7 +1665,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass,
@@ -1667,8 +1681,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
@@ -1676,8 +1690,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -1688,7 +1702,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
@@ -1696,8 +1712,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -1709,8 +1725,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -1721,14 +1737,16 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass, mqtt_mock_entry_no_yaml_config, caplog, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique_id option only creates one fan per id."""
     config = {
         mqtt.DOMAIN: {
@@ -1753,7 +1771,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_fan(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_fan(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered fan."""
     data = '{ "name": "test", "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -1761,7 +1781,9 @@ async def test_discovery_removal_fan(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_discovery_update_fan(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_fan(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered fan."""
     config1 = {"name": "Beer", "command_topic": "test_topic"}
     config2 = {"name": "Milk", "command_topic": "test_topic"}
@@ -1771,8 +1793,8 @@ async def test_discovery_update_fan(hass, mqtt_mock_entry_no_yaml_config, caplog
 
 
 async def test_discovery_update_unchanged_fan(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered fan."""
     data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
     with patch(
@@ -1789,7 +1811,9 @@ async def test_discovery_update_unchanged_fan(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "command_topic": "test_topic" }'
@@ -1799,49 +1823,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, fan.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -1893,7 +1931,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -1901,7 +1939,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = fan.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1922,7 +1960,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = fan.DOMAIN
     config = DEFAULT_CONFIG
@@ -1931,14 +1971,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = fan.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = fan.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -86,7 +87,7 @@ def humidifer_platform_only():
 
 
 async def async_turn_on(
-    hass,
+    hass: HomeAssistant,
     entity_id=ENTITY_MATCH_ALL,
 ) -> None:
     """Turn all or specified humidifier on."""
@@ -95,14 +96,16 @@ async def async_turn_on(
     await hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
-async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL) -> None:
+async def async_turn_off(hass: HomeAssistant, entity_id=ENTITY_MATCH_ALL) -> None:
     """Turn all or specified humidier off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 
     await hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
-async def async_set_mode(hass, entity_id=ENTITY_MATCH_ALL, mode: str = None) -> None:
+async def async_set_mode(
+    hass: HomeAssistant, entity_id=ENTITY_MATCH_ALL, mode: str = None
+) -> None:
     """Set mode for all or specified humidifier."""
     data = {
         key: value
@@ -114,7 +117,7 @@ async def async_set_mode(hass, entity_id=ENTITY_MATCH_ALL, mode: str = None) -> 
 
 
 async def async_set_humidity(
-    hass, entity_id=ENTITY_MATCH_ALL, humidity: int = None
+    hass: HomeAssistant, entity_id=ENTITY_MATCH_ALL, humidity: int = None
 ) -> None:
     """Set target humidity for all or specified humidifier."""
     data = {
@@ -126,7 +129,7 @@ async def async_set_humidity(
     await hass.services.async_call(DOMAIN, SERVICE_SET_HUMIDITY, data, blocking=True)
 
 
-async def test_fail_setup_if_no_command_topic(hass, caplog):
+async def test_fail_setup_if_no_command_topic(hass: HomeAssistant, caplog) -> None:
     """Test if command fails with command topic."""
     assert not await async_setup_component(
         hass,
@@ -140,8 +143,8 @@ async def test_fail_setup_if_no_command_topic(hass, caplog):
 
 
 async def test_controlling_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -245,8 +248,8 @@ async def test_controlling_state_via_topic(
 
 
 async def test_controlling_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
@@ -334,8 +337,8 @@ async def test_controlling_state_via_topic_and_json_message(
 
 
 async def test_controlling_state_via_topic_and_json_message_shared_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message using a shared topic."""
     assert await async_setup_component(
         hass,
@@ -411,8 +414,8 @@ async def test_controlling_state_via_topic_and_json_message_shared_topic(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
@@ -508,8 +511,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_command_templates_(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Testing command templates with optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
@@ -606,8 +609,8 @@ async def test_sending_mqtt_command_templates_(
 
 
 async def test_sending_mqtt_commands_and_explicit_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test optimistic mode with state topic and turn on attributes."""
     assert await async_setup_component(
         hass,
@@ -733,14 +736,14 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][humidifier.DOMAIN])
     config["modes"] = ["eco", "auto"]
@@ -758,7 +761,9 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_attributes(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes."""
     assert await async_setup_component(
         hass,
@@ -884,7 +889,7 @@ async def test_attributes(hass, mqtt_mock_entry_with_yaml_config, caplog):
         ),
     ],
 )
-async def test_validity_configurations(hass, config, valid):
+async def test_validity_configurations(hass: HomeAssistant, config, valid) -> None:
     """Test validity of configurations."""
     assert (
         await async_setup_component(
@@ -964,8 +969,13 @@ async def test_validity_configurations(hass, config, valid):
     ],
 )
 async def test_supported_features(
-    hass, mqtt_mock_entry_with_yaml_config, name, config, success, features
-):
+    hass: HomeAssistant,
+    mqtt_mock_entry_with_yaml_config,
+    name,
+    config,
+    success,
+    features,
+) -> None:
     """Test supported features."""
     assert (
         await async_setup_component(
@@ -984,22 +994,26 @@ async def test_supported_features(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass,
@@ -1012,7 +1026,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass,
@@ -1026,8 +1042,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
@@ -1035,8 +1051,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -1047,7 +1063,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
@@ -1055,8 +1073,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -1068,8 +1086,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -1080,7 +1098,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -1091,7 +1111,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique_id option only creates one fan per id."""
     config = {
         mqtt.DOMAIN: {
@@ -1119,8 +1139,8 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_discovery_removal_humidifier(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered humidifier."""
     data = '{ "name": "test", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
     await help_test_discovery_removal(
@@ -1129,8 +1149,8 @@ async def test_discovery_removal_humidifier(
 
 
 async def test_discovery_update_humidifier(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered humidifier."""
     config1 = {
         "name": "Beer",
@@ -1153,8 +1173,8 @@ async def test_discovery_update_humidifier(
 
 
 async def test_discovery_update_unchanged_humidifier(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered humidifier."""
     data1 = '{ "name": "Beer", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
     with patch(
@@ -1171,7 +1191,9 @@ async def test_discovery_update_unchanged_humidifier(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "command_topic": "test_topic", "target_humidity_command_topic": "test-topic2" }'
@@ -1180,49 +1202,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT fan device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, humidifier.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -1267,7 +1303,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -1275,7 +1311,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = humidifier.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1296,7 +1332,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = humidifier.DOMAIN
     config = DEFAULT_CONFIG
@@ -1305,14 +1343,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = humidifier.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_config_schema_validation(hass):
+async def test_config_schema_validation(hass: HomeAssistant) -> None:
     """Test invalid platform options in the config schema do not pass the config validation."""
     platform = humidifier.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][platform])
@@ -1323,7 +1361,9 @@ async def test_config_schema_validation(hass):
         CONFIG_SCHEMA({mqtt.DOMAIN: {platform: [{"bla": "bla"}]}})
 
 
-async def test_unload_config_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_config_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = humidifier.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -30,6 +30,7 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -98,7 +99,9 @@ def vacuum_platform_only():
         yield
 
 
-async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_supported_features(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that the correct supported features."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -118,7 +121,9 @@ async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config
     )
 
 
-async def test_all_commands(hass, mqtt_mock_entry_with_yaml_config):
+async def test_all_commands(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test simple commands to the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -201,8 +206,8 @@ async def test_all_commands(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_commands_without_supported_features(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test commands which are not supported by the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     services = mqttvacuum.STRING_TO_SERVICE["status"]
@@ -254,8 +259,8 @@ async def test_commands_without_supported_features(
 
 
 async def test_attributes_without_supported_features(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test attributes which are not supported by the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     services = mqttvacuum.STRING_TO_SERVICE["turn_on"]
@@ -285,7 +290,7 @@ async def test_attributes_without_supported_features(
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
 
 
-async def test_status(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -328,7 +333,9 @@ async def test_status(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_FAN_SPEED) == "min"
 
 
-async def test_status_battery(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_battery(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -349,7 +356,9 @@ async def test_status_battery(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-50"
 
 
-async def test_status_cleaning(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_cleaning(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -370,7 +379,9 @@ async def test_status_cleaning(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_ON
 
 
-async def test_status_docked(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_docked(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -391,7 +402,9 @@ async def test_status_docked(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_OFF
 
 
-async def test_status_charging(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_charging(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -412,7 +425,9 @@ async def test_status_charging(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-outline"
 
 
-async def test_status_fan_speed(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_fan_speed(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -433,7 +448,9 @@ async def test_status_fan_speed(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_FAN_SPEED) == "max"
 
 
-async def test_status_fan_speed_list(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_fan_speed_list(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -450,7 +467,9 @@ async def test_status_fan_speed_list(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == ["min", "medium", "high", "max"]
 
 
-async def test_status_no_fan_speed_list(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_no_fan_speed_list(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum.
 
     If the vacuum doesn't support fan speed, fan speed list should be None.
@@ -471,7 +490,9 @@ async def test_status_no_fan_speed_list(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
 
 
-async def test_status_error(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_error(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -499,7 +520,9 @@ async def test_status_error(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_STATUS) == "Stopped"
 
 
-async def test_battery_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_battery_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that you can use non-default templates for battery_level."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.update(
@@ -524,7 +547,9 @@ async def test_battery_template(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-50"
 
 
-async def test_status_invalid_json(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_invalid_json(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test to make sure nothing breaks if the vacuum sends bad JSON."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -543,7 +568,7 @@ async def test_status_invalid_json(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_STATUS) == "Stopped"
 
 
-async def test_missing_battery_template(hass):
+async def test_missing_battery_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_BATTERY_LEVEL_TEMPLATE)
@@ -553,7 +578,7 @@ async def test_missing_battery_template(hass):
     )
 
 
-async def test_missing_charging_template(hass):
+async def test_missing_charging_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_CHARGING_TEMPLATE)
@@ -563,7 +588,7 @@ async def test_missing_charging_template(hass):
     )
 
 
-async def test_missing_cleaning_template(hass):
+async def test_missing_cleaning_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_CLEANING_TEMPLATE)
@@ -573,7 +598,7 @@ async def test_missing_cleaning_template(hass):
     )
 
 
-async def test_missing_docked_template(hass):
+async def test_missing_docked_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_DOCKED_TEMPLATE)
@@ -583,7 +608,7 @@ async def test_missing_docked_template(hass):
     )
 
 
-async def test_missing_error_template(hass):
+async def test_missing_error_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_ERROR_TEMPLATE)
@@ -593,7 +618,7 @@ async def test_missing_error_template(hass):
     )
 
 
-async def test_missing_fan_speed_template(hass):
+async def test_missing_fan_speed_template(hass: HomeAssistant) -> None:
     """Test to make sure missing template is not allowed."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config.pop(mqttvacuum.CONF_FAN_SPEED_TEMPLATE)
@@ -604,29 +629,35 @@ async def test_missing_fan_speed_template(hass):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -634,8 +665,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -643,8 +674,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -655,7 +686,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -663,8 +696,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -676,8 +709,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -688,7 +721,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -699,7 +734,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one vacuum per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -722,7 +757,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_vacuum(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_vacuum(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered vacuum."""
     data = json.dumps(DEFAULT_CONFIG_2[mqtt.DOMAIN][vacuum.DOMAIN])
     await help_test_discovery_removal(
@@ -730,7 +767,9 @@ async def test_discovery_removal_vacuum(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_vacuum(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_vacuum(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered vacuum."""
     config1 = {"name": "Beer", "command_topic": "test_topic"}
     config2 = {"name": "Milk", "command_topic": "test_topic"}
@@ -740,8 +779,8 @@ async def test_discovery_update_vacuum(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_vacuum(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered vacuum."""
     data1 = '{ "name": "Beer", "command_topic": "test_topic" }'
     with patch(
@@ -758,7 +797,9 @@ async def test_discovery_update_unchanged_vacuum(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer",' '  "command_topic": "test_topic#" }'
     data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
@@ -767,35 +808,45 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = {
         mqtt.DOMAIN: {
@@ -817,14 +868,18 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_co
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     config = {
         mqtt.DOMAIN: {
@@ -887,7 +942,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -895,7 +950,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = vacuum.DOMAIN
     config = deepcopy(DEFAULT_CONFIG)
@@ -921,7 +976,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = vacuum.DOMAIN
     config = DEFAULT_CONFIG
@@ -952,14 +1009,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     domain = vacuum.DOMAIN
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
@@ -991,7 +1048,7 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = vacuum.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -193,7 +193,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -241,7 +241,7 @@ def light_platform_only():
         yield
 
 
-async def test_fail_setup_if_no_command_topic(hass, caplog):
+async def test_fail_setup_if_no_command_topic(hass: HomeAssistant, caplog) -> None:
     """Test if command fails with command topic."""
     assert not await async_setup_component(
         hass, mqtt.DOMAIN, {mqtt.DOMAIN: {light.DOMAIN: {"name": "test"}}}
@@ -253,8 +253,8 @@ async def test_fail_setup_if_no_command_topic(hass, caplog):
 
 
 async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test if there is no color and brightness if no topic."""
     assert await async_setup_component(
         hass,
@@ -311,7 +311,9 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_controlling_state_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling of the state via topic."""
     config = {
         light.DOMAIN: {
@@ -430,7 +432,9 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
     assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
 
 
-async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_invalid_state_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test handling of empty data via topic."""
     config = {
         light.DOMAIN: {
@@ -554,7 +558,9 @@ async def test_invalid_state_via_topic(hass, mqtt_mock_entry_with_yaml_config, c
     assert light_state.attributes["color_temp"] == 153
 
 
-async def test_brightness_controlling_scale(hass, mqtt_mock_entry_with_yaml_config):
+async def test_brightness_controlling_scale(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the brightness controlling scale."""
     assert await async_setup_component(
         hass,
@@ -603,8 +609,8 @@ async def test_brightness_controlling_scale(hass, mqtt_mock_entry_with_yaml_conf
 
 
 async def test_brightness_from_rgb_controlling_scale(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the brightness controlling scale."""
     assert await async_setup_component(
         hass,
@@ -645,8 +651,8 @@ async def test_brightness_from_rgb_controlling_scale(
 
 
 async def test_controlling_state_via_topic_with_templates(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the state with a template."""
     config = {
         light.DOMAIN: {
@@ -747,8 +753,8 @@ async def test_controlling_state_via_topic_with_templates(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of command in optimistic mode."""
     config = {
         light.DOMAIN: {
@@ -769,7 +775,7 @@ async def test_sending_mqtt_commands_and_optimistic(
         }
     }
     color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "xy"]
-    fake_state = ha.State(
+    fake_state = State(
         "light.test",
         "on",
         {
@@ -936,8 +942,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_rgb_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of RGB command with template."""
     config = {
         light.DOMAIN: {
@@ -975,8 +981,8 @@ async def test_sending_mqtt_rgb_command_with_template(
 
 
 async def test_sending_mqtt_rgbw_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of RGBW command with template."""
     config = {
         light.DOMAIN: {
@@ -1014,8 +1020,8 @@ async def test_sending_mqtt_rgbw_command_with_template(
 
 
 async def test_sending_mqtt_rgbww_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of RGBWW command with template."""
     config = {
         light.DOMAIN: {
@@ -1053,8 +1059,8 @@ async def test_sending_mqtt_rgbww_command_with_template(
 
 
 async def test_sending_mqtt_color_temp_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of Color Temp command with template."""
     config = {
         light.DOMAIN: {
@@ -1090,7 +1096,9 @@ async def test_sending_mqtt_color_temp_command_with_template(
     assert state.attributes["color_temp"] == 100
 
 
-async def test_on_command_first(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_first(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command being sent before brightness."""
     config = {
         light.DOMAIN: {
@@ -1126,7 +1134,9 @@ async def test_on_command_first(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
 
 
-async def test_on_command_last(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_last(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command being sent after brightness."""
     config = {
         light.DOMAIN: {
@@ -1161,7 +1171,9 @@ async def test_on_command_last(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
 
 
-async def test_on_command_brightness(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_brightness(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command being sent as only brightness."""
     config = {
         light.DOMAIN: {
@@ -1216,7 +1228,9 @@ async def test_on_command_brightness(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_on_command_brightness_scaled(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_brightness_scaled(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test brightness scale."""
     config = {
         light.DOMAIN: {
@@ -1286,7 +1300,9 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_on_command_rgb(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgb(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGB brightness mode."""
     config = {
         light.DOMAIN: {
@@ -1376,7 +1392,9 @@ async def test_on_command_rgb(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_on_command_rgbw(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgbw(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGBW brightness mode."""
     config = {
         light.DOMAIN: {
@@ -1466,7 +1484,9 @@ async def test_on_command_rgbw(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_on_command_rgbww(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgbww(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGBWW brightness mode."""
     config = {
         light.DOMAIN: {
@@ -1556,7 +1576,9 @@ async def test_on_command_rgbww(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_on_command_rgb_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgb_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGB brightness mode with RGB template."""
     config = {
         light.DOMAIN: {
@@ -1593,7 +1615,9 @@ async def test_on_command_rgb_template(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
 
 
-async def test_on_command_rgbw_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgbw_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGBW brightness mode with RGBW template."""
     config = {
         light.DOMAIN: {
@@ -1629,7 +1653,9 @@ async def test_on_command_rgbw_template(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
 
 
-async def test_on_command_rgbww_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_rgbww_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test on command in RGBWW brightness mode with RGBWW template."""
     config = {
         light.DOMAIN: {
@@ -1666,7 +1692,9 @@ async def test_on_command_rgbww_template(hass, mqtt_mock_entry_with_yaml_config)
     mqtt_mock.async_publish.assert_called_once_with("test_light/set", "OFF", 0, False)
 
 
-async def test_on_command_white(hass, mqtt_mock_entry_with_yaml_config):
+async def test_on_command_white(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test sending commands for RGB + white light."""
     config = {
         light.DOMAIN: {
@@ -1743,7 +1771,9 @@ async def test_on_command_white(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
+async def test_explicit_color_mode(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test explicit color mode over mqtt."""
     config = {
         light.DOMAIN: {
@@ -1891,7 +1921,9 @@ async def test_explicit_color_mode(hass, mqtt_mock_entry_with_yaml_config):
     assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
 
 
-async def test_explicit_color_mode_templated(hass, mqtt_mock_entry_with_yaml_config):
+async def test_explicit_color_mode_templated(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test templated explicit color mode over mqtt."""
     config = {
         light.DOMAIN: {
@@ -1972,7 +2004,9 @@ async def test_explicit_color_mode_templated(hass, mqtt_mock_entry_with_yaml_con
     assert light_state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
 
 
-async def test_white_state_update(hass, mqtt_mock_entry_with_yaml_config):
+async def test_white_state_update(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test state updates for RGB + white light."""
     config = {
         light.DOMAIN: {
@@ -2036,7 +2070,7 @@ async def test_white_state_update(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
 
 
-async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
+async def test_effect(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test effect."""
     config = {
         light.DOMAIN: {
@@ -2074,29 +2108,35 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -2104,8 +2144,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -2113,8 +2153,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -2125,7 +2165,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -2133,8 +2175,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -2146,8 +2188,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -2158,7 +2200,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -2169,7 +2213,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one light per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -2194,7 +2238,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_light(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_light(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered light."""
     data = (
         '{ "name": "test",'
@@ -2207,8 +2253,8 @@ async def test_discovery_removal_light(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_ignores_extra_keys(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test discovery ignores extra keys that are not blocked."""
     await mqtt_mock_entry_no_yaml_config()
     # inserted `platform` key should be ignored
@@ -2223,8 +2269,8 @@ async def test_discovery_ignores_extra_keys(
 
 
 async def test_discovery_update_light_topic_and_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     config1 = {
         "name": "Beer",
@@ -2478,8 +2524,8 @@ async def test_discovery_update_light_topic_and_template(
 
 
 async def test_discovery_update_light_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     config1 = {
         "name": "Beer",
@@ -2691,8 +2737,8 @@ async def test_discovery_update_light_template(
 
 
 async def test_discovery_update_unchanged_light(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     data1 = (
         '{ "name": "Beer",'
@@ -2713,7 +2759,9 @@ async def test_discovery_update_unchanged_light(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -2726,49 +2774,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -2779,7 +2841,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
+async def test_max_mireds(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
@@ -2886,7 +2950,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -2896,7 +2960,7 @@ async def test_publishing_with_custom_encoding(
     template,
     tpl_par,
     tpl_output,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = light.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -2921,7 +2985,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = light.DOMAIN
     config = DEFAULT_CONFIG
@@ -2961,7 +3027,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
@@ -2969,7 +3035,7 @@ async def test_encoding_subscribable_topics(
     attribute,
     attribute_value,
     init_payload,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][light.DOMAIN])
     config[CONF_EFFECT_COMMAND_TOPIC] = "light/CONF_EFFECT_COMMAND_TOPIC"
@@ -3004,7 +3070,7 @@ async def test_encoding_subscribable_topics(
     ],
 )
 async def test_encoding_subscribable_topics_brightness(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
@@ -3012,7 +3078,7 @@ async def test_encoding_subscribable_topics_brightness(
     attribute,
     attribute_value,
     init_payload,
-):
+) -> None:
     """Test handling of incoming encoded payload for a brightness only light."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][light.DOMAIN])
     config[CONF_BRIGHTNESS_COMMAND_TOPIC] = "light/CONF_BRIGHTNESS_COMMAND_TOPIC"
@@ -3032,8 +3098,8 @@ async def test_encoding_subscribable_topics_brightness(
 
 
 async def test_sending_mqtt_brightness_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of Brightness command with template."""
     config = {
         light.DOMAIN: {
@@ -3070,8 +3136,8 @@ async def test_sending_mqtt_brightness_command_with_template(
 
 
 async def test_sending_mqtt_effect_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of Effect command with template."""
     config = {
         light.DOMAIN: {
@@ -3114,8 +3180,8 @@ async def test_sending_mqtt_effect_command_with_template(
 
 
 async def test_sending_mqtt_hs_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of HS Color command with template."""
     config = {
         light.DOMAIN: {
@@ -3150,8 +3216,8 @@ async def test_sending_mqtt_hs_command_with_template(
 
 
 async def test_sending_mqtt_xy_command_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of XY Color command with template."""
     config = {
         light.DOMAIN: {
@@ -3185,14 +3251,16 @@ async def test_sending_mqtt_xy_command_with_template(
     assert state.attributes["xy_color"] == (0.151, 0.343)
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = light.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -96,7 +96,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -161,7 +161,7 @@ class JsonValidator:
         return json.loads(self.jsondata) == json.loads(other)
 
 
-async def test_fail_setup_if_no_command_topic(hass, caplog):
+async def test_fail_setup_if_no_command_topic(hass: HomeAssistant, caplog) -> None:
     """Test if setup fails with no command topic."""
     assert not await async_setup_component(
         hass,
@@ -175,7 +175,9 @@ async def test_fail_setup_if_no_command_topic(hass, caplog):
 
 
 @pytest.mark.parametrize("deprecated", ("color_temp", "hs", "rgb", "xy"))
-async def test_fail_setup_if_color_mode_deprecated(hass, caplog, deprecated):
+async def test_fail_setup_if_color_mode_deprecated(
+    hass: HomeAssistant, caplog, deprecated
+) -> None:
     """Test if setup fails if color mode is combined with deprecated config keys."""
     supported_color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "xy"]
 
@@ -210,8 +212,8 @@ async def test_fail_setup_if_color_mode_deprecated(hass, caplog, deprecated):
     ],
 )
 async def test_fail_setup_if_color_modes_invalid(
-    hass, caplog, supported_color_modes, error
-):
+    hass: HomeAssistant, caplog, supported_color_modes, error
+) -> None:
     """Test if setup fails if supported color modes is invalid."""
     config = {
         light.DOMAIN: {
@@ -231,7 +233,9 @@ async def test_fail_setup_if_color_modes_invalid(
     assert error in caplog.text
 
 
-async def test_legacy_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
+async def test_legacy_rgb_light(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test legacy RGB light flags expected features and color modes."""
     assert await async_setup_component(
         hass,
@@ -258,8 +262,8 @@ async def test_legacy_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_no_color_brightness_color_temp_if_no_topics(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for no RGB, brightness, color temp, effector XY."""
     assert await async_setup_component(
         hass,
@@ -311,7 +315,9 @@ async def test_no_color_brightness_color_temp_if_no_topics(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_controlling_state_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling of the state via topic."""
     assert await async_setup_component(
         hass,
@@ -454,8 +460,8 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_controlling_state_via_topic2(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling of the state via topic for a light supporting color mode."""
     supported_color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "white", "xy"]
 
@@ -624,10 +630,10 @@ async def test_controlling_state_via_topic2(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of command in optimistic mode."""
-    fake_state = ha.State(
+    fake_state = State(
         "light.test",
         "on",
         {
@@ -771,11 +777,11 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_commands_and_optimistic2(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of command in optimistic mode for a light supporting color mode."""
     supported_color_modes = ["color_temp", "hs", "rgb", "rgbw", "rgbww", "white", "xy"]
-    fake_state = ha.State(
+    fake_state = State(
         "light.test",
         "on",
         {
@@ -1002,7 +1008,9 @@ async def test_sending_mqtt_commands_and_optimistic2(
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_hs_color(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_hs_color(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends hs color parameters."""
     assert await async_setup_component(
         hass,
@@ -1063,7 +1071,9 @@ async def test_sending_hs_color(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_sending_rgb_color_no_brightness(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_rgb_color_no_brightness(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
     assert await async_setup_component(
         hass,
@@ -1118,7 +1128,9 @@ async def test_sending_rgb_color_no_brightness(hass, mqtt_mock_entry_with_yaml_c
     )
 
 
-async def test_sending_rgb_color_no_brightness2(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_rgb_color_no_brightness2(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
     supported_color_modes = ["rgb", "rgbw", "rgbww"]
     assert await async_setup_component(
@@ -1198,8 +1210,8 @@ async def test_sending_rgb_color_no_brightness2(hass, mqtt_mock_entry_with_yaml_
 
 
 async def test_sending_rgb_color_with_brightness(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
     assert await async_setup_component(
         hass,
@@ -1266,8 +1278,8 @@ async def test_sending_rgb_color_with_brightness(
 
 
 async def test_sending_rgb_color_with_scaled_brightness(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
     assert await async_setup_component(
         hass,
@@ -1334,7 +1346,9 @@ async def test_sending_rgb_color_with_scaled_brightness(
     )
 
 
-async def test_sending_scaled_white(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_scaled_white(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with scaled white."""
     assert await async_setup_component(
         hass,
@@ -1379,7 +1393,9 @@ async def test_sending_scaled_white(hass, mqtt_mock_entry_with_yaml_config):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_xy_color(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_xy_color(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test light.turn_on with hs color sends xy color parameters."""
     assert await async_setup_component(
         hass,
@@ -1439,7 +1455,7 @@ async def test_sending_xy_color(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
+async def test_effect(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test for effect being sent when included."""
     assert await async_setup_component(
         hass,
@@ -1503,7 +1519,9 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("effect") == "colorloop"
 
 
-async def test_flash_short_and_long(hass, mqtt_mock_entry_with_yaml_config):
+async def test_flash_short_and_long(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for flash length being sent when included."""
     assert await async_setup_component(
         hass,
@@ -1566,7 +1584,9 @@ async def test_flash_short_and_long(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_OFF
 
 
-async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
+async def test_transition(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for transition time being sent when included."""
     assert await async_setup_component(
         hass,
@@ -1614,7 +1634,9 @@ async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_OFF
 
 
-async def test_brightness_scale(hass, mqtt_mock_entry_with_yaml_config):
+async def test_brightness_scale(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for brightness scaling."""
     assert await async_setup_component(
         hass,
@@ -1657,7 +1679,9 @@ async def test_brightness_scale(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("brightness") == 255
 
 
-async def test_white_scale(hass, mqtt_mock_entry_with_yaml_config):
+async def test_white_scale(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for white scaling."""
     assert await async_setup_component(
         hass,
@@ -1716,7 +1740,9 @@ async def test_white_scale(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("brightness") == 128
 
 
-async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
+async def test_invalid_values(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that invalid color/brightness/etc. values are ignored."""
     assert await async_setup_component(
         hass,
@@ -1844,29 +1870,35 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -1874,8 +1906,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -1883,8 +1915,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -1895,7 +1927,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -1903,8 +1937,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -1916,8 +1950,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -1928,7 +1962,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -1939,7 +1975,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one light per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -1966,7 +2002,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered mqtt_json lights."""
     data = '{ "name": "test", "schema": "json", "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -1978,7 +2016,9 @@ async def test_discovery_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_discovery_update_light(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_light(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     config1 = {
         "name": "Beer",
@@ -2003,8 +2043,8 @@ async def test_discovery_update_light(hass, mqtt_mock_entry_no_yaml_config, capl
 
 
 async def test_discovery_update_unchanged_light(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     data1 = (
         '{ "name": "Beer",'
@@ -2026,7 +2066,9 @@ async def test_discovery_update_unchanged_light(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -2045,7 +2087,9 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass,
@@ -2055,7 +2099,9 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass,
@@ -2065,7 +2111,9 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass,
@@ -2075,7 +2123,9 @@ async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass,
@@ -2085,21 +2135,27 @@ async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -2112,7 +2168,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
+async def test_max_mireds(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
@@ -2157,7 +2215,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -2167,7 +2225,7 @@ async def test_publishing_with_custom_encoding(
     template,
     tpl_par,
     tpl_output,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = light.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -2190,7 +2248,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = light.DOMAIN
     config = DEFAULT_CONFIG
@@ -2212,7 +2272,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
@@ -2220,7 +2280,7 @@ async def test_encoding_subscribable_topics(
     attribute,
     attribute_value,
     init_payload,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][light.DOMAIN])
     config["color_mode"] = True
@@ -2247,7 +2307,7 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -126,7 +126,7 @@ def light_platform_only():
         ),
     ],
 )
-async def test_setup_fails(hass, caplog, test_config):
+async def test_setup_fails(hass: HomeAssistant, caplog, test_config) -> None:
     """Test that setup fails with missing required configuration items."""
     assert not await async_setup_component(
         hass,
@@ -136,7 +136,7 @@ async def test_setup_fails(hass, caplog, test_config):
     assert "Invalid config for [mqtt]" in caplog.text
 
 
-async def test_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
+async def test_rgb_light(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test RGB light flags brightness support."""
     assert await async_setup_component(
         hass,
@@ -167,7 +167,9 @@ async def test_rgb_light(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
 
 
-async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_state_change_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test state change via topic."""
     assert await async_setup_component(
         hass,
@@ -221,8 +223,8 @@ async def test_state_change_via_topic(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_state_brightness_color_effect_temp_change_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test state, bri, color, effect, color temp change."""
     assert await async_setup_component(
         hass,
@@ -332,10 +334,10 @@ async def test_state_brightness_color_effect_temp_change_via_topic(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of command in optimistic mode."""
-    fake_state = ha.State(
+    fake_state = State(
         "light.test",
         "on",
         {
@@ -474,8 +476,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_commands_non_optimistic_brightness_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending of command in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -596,7 +598,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     state = hass.states.get("light.test")
 
 
-async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
+async def test_effect(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test effect sent over MQTT in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -649,7 +651,7 @@ async def test_effect(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("effect") == "colorloop"
 
 
-async def test_flash(hass, mqtt_mock_entry_with_yaml_config):
+async def test_flash(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test flash sent over MQTT in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -698,7 +700,9 @@ async def test_flash(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_ON
 
 
-async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
+async def test_transition(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test for transition time being sent when included."""
     assert await async_setup_component(
         hass,
@@ -740,7 +744,9 @@ async def test_transition(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_OFF
 
 
-async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
+async def test_invalid_values(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that invalid values are ignored."""
     assert await async_setup_component(
         hass,
@@ -836,29 +842,35 @@ async def test_invalid_values(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -866,8 +878,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -875,8 +887,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -887,7 +899,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
@@ -895,8 +909,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -908,8 +922,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -920,7 +934,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -931,7 +947,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one light per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -962,7 +978,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered mqtt_json lights."""
     data = (
         '{ "name": "test",'
@@ -976,7 +994,9 @@ async def test_discovery_removal(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_discovery_update_light(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_light(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     config1 = {
         "name": "Beer",
@@ -1000,8 +1020,8 @@ async def test_discovery_update_light(hass, mqtt_mock_entry_no_yaml_config, capl
 
 
 async def test_discovery_update_unchanged_light(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered light."""
     data1 = (
         '{ "name": "Beer",'
@@ -1025,7 +1045,9 @@ async def test_discovery_update_unchanged_light(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -1041,49 +1063,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT light device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, light.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     config = {
         mqtt.DOMAIN: {
@@ -1106,7 +1142,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
+async def test_max_mireds(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting min_mireds and max_mireds."""
     config = {
         light.DOMAIN: {
@@ -1153,7 +1191,7 @@ async def test_max_mireds(hass, mqtt_mock_entry_with_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -1163,7 +1201,7 @@ async def test_publishing_with_custom_encoding(
     template,
     tpl_par,
     tpl_output,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = light.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -1186,7 +1224,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = light.DOMAIN
     config = DEFAULT_CONFIG
@@ -1202,7 +1242,7 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
@@ -1210,7 +1250,7 @@ async def test_encoding_subscribable_topics(
     attribute,
     attribute_value,
     init_payload,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][light.DOMAIN])
     config["state_template"] = "{{ value }}"
@@ -1228,14 +1268,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = light.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = light.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -80,8 +80,8 @@ def lock_platform_only():
     ],
 )
 async def test_controlling_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config, payload, lock_state
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, payload, lock_state
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -126,8 +126,8 @@ async def test_controlling_state_via_topic(
     ],
 )
 async def test_controlling_non_default_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config, payload, lock_state
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, payload, lock_state
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -171,8 +171,8 @@ async def test_controlling_non_default_state_via_topic(
     ],
 )
 async def test_controlling_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config, payload, lock_state
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, payload, lock_state
+) -> None:
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
@@ -216,8 +216,8 @@ async def test_controlling_state_via_topic_and_json_message(
     ],
 )
 async def test_controlling_non_default_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config, payload, lock_state
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, payload, lock_state
+) -> None:
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
@@ -252,8 +252,8 @@ async def test_controlling_non_default_state_via_topic_and_json_message(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
@@ -300,8 +300,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_mqtt_commands_with_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test sending commands with template."""
     assert await async_setup_component(
         hass,
@@ -361,8 +361,8 @@ async def test_sending_mqtt_commands_with_template(
 
 
 async def test_sending_mqtt_commands_and_explicit_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test optimistic mode without state topic."""
     assert await async_setup_component(
         hass,
@@ -411,8 +411,8 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
 
 
 async def test_sending_mqtt_commands_support_open_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test open function of the lock without state topic."""
     assert await async_setup_component(
         hass,
@@ -471,8 +471,8 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
 
 
 async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test open function of the lock without state topic."""
     assert await async_setup_component(
         hass,
@@ -639,29 +639,35 @@ async def test_sending_mqtt_commands_pessimistic(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
@@ -669,8 +675,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
@@ -678,8 +684,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -690,7 +696,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
@@ -698,8 +706,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -711,8 +719,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -723,14 +731,16 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass, mqtt_mock_entry_no_yaml_config, caplog, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one lock per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -755,7 +765,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_lock(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_lock(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered lock."""
     data = '{ "name": "test",' '  "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -763,7 +775,9 @@ async def test_discovery_removal_lock(hass, mqtt_mock_entry_no_yaml_config, capl
     )
 
 
-async def test_discovery_update_lock(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_lock(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered lock."""
     config1 = {
         "name": "Beer",
@@ -783,8 +797,8 @@ async def test_discovery_update_lock(hass, mqtt_mock_entry_no_yaml_config, caplo
 
 
 async def test_discovery_update_unchanged_lock(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered lock."""
     data1 = (
         '{ "name": "Beer",'
@@ -805,7 +819,9 @@ async def test_discovery_update_unchanged_lock(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
@@ -814,49 +830,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT lock device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT lock device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, lock.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -881,7 +911,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -889,7 +919,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = lock.DOMAIN
     config = DEFAULT_CONFIG
@@ -908,7 +938,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = lock.DOMAIN
     config = DEFAULT_CONFIG
@@ -924,14 +956,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -946,14 +978,18 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass, caplog, tmp_path):
+async def test_setup_manual_entity_from_yaml(
+    hass: HomeAssistant, caplog, tmp_path
+) -> None:
     """Test setup manual configured MQTT entity."""
     platform = lock.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = lock.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.components import mqtt, sensor
 from homeassistant.const import EVENT_STATE_CHANGED, Platform
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_mqtt_message
@@ -12,9 +12,9 @@ from tests.common import async_fire_mqtt_message
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
 async def test_availability_with_shared_state_topic(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
-):
+) -> None:
     """Test the state is not changed twice.
 
     When an entity with a shared state_topic and availability_topic becomes available
@@ -42,11 +42,11 @@ async def test_availability_with_shared_state_topic(
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event):
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "100")
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     Platform,
     UnitOfTemperature,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -75,7 +75,9 @@ def number_platform_only():
         yield
 
 
-async def test_run_number_setup(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_number_setup(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload."""
     topic = "test/number"
     await async_setup_component(
@@ -125,7 +127,9 @@ async def test_run_number_setup(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
 
 
-async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_value_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload with a template."""
     topic = "test/number"
     await async_setup_component(
@@ -167,7 +171,9 @@ async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == "unknown"
 
 
-async def test_restore_native_value(hass, mqtt_mock_entry_with_yaml_config):
+async def test_restore_native_value(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that the stored native_value is restored."""
     topic = "test/number"
 
@@ -180,7 +186,7 @@ async def test_restore_native_value(hass, mqtt_mock_entry_with_yaml_config):
     }
 
     mock_restore_cache_with_extra_data(
-        hass, ((ha.State("number.test_number", "abc"), RESTORE_DATA),)
+        hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
     assert await async_setup_component(
         hass,
@@ -204,7 +210,9 @@ async def test_restore_native_value(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 
-async def test_run_number_service_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_number_service_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in optimistic mode."""
     topic = "test/number"
 
@@ -217,7 +225,7 @@ async def test_run_number_service_optimistic(hass, mqtt_mock_entry_with_yaml_con
     }
 
     mock_restore_cache_with_extra_data(
-        hass, ((ha.State("number.test_number", "abc"), RESTORE_DATA),)
+        hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
     assert await async_setup_component(
         hass,
@@ -279,8 +287,8 @@ async def test_run_number_service_optimistic(hass, mqtt_mock_entry_with_yaml_con
 
 
 async def test_run_number_service_optimistic_with_command_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in optimistic mode and with a command_template."""
     topic = "test/number"
 
@@ -293,7 +301,7 @@ async def test_run_number_service_optimistic_with_command_template(
     }
 
     mock_restore_cache_with_extra_data(
-        hass, ((ha.State("number.test_number", "abc"), RESTORE_DATA),)
+        hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
     assert await async_setup_component(
         hass,
@@ -357,7 +365,9 @@ async def test_run_number_service_optimistic_with_command_template(
     assert state.state == "42.1"
 
 
-async def test_run_number_service(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_number_service(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in non optimistic mode."""
     cmd_topic = "test/number/set"
     state_topic = "test/number"
@@ -394,8 +404,8 @@ async def test_run_number_service(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_run_number_service_with_command_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in non optimistic mode and with a command_template."""
     cmd_topic = "test/number/set"
     state_topic = "test/number"
@@ -435,29 +445,35 @@ async def test_run_number_service_with_command_template(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
@@ -465,8 +481,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
@@ -474,8 +490,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -486,7 +502,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
@@ -494,8 +512,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -507,8 +525,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -519,7 +537,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -530,7 +550,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one number per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -555,7 +575,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_number(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_number(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered number."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][number.DOMAIN])
     await help_test_discovery_removal(
@@ -563,7 +585,9 @@ async def test_discovery_removal_number(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_number(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_number(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered number."""
     config1 = {
         "name": "Beer",
@@ -582,8 +606,8 @@ async def test_discovery_update_number(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_number(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered number."""
     data1 = (
         '{ "name": "Beer", "state_topic": "test-topic", "command_topic": "test-topic"}'
@@ -602,7 +626,9 @@ async def test_discovery_update_unchanged_number(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -614,49 +640,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT number device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT number device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -670,7 +710,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     )
 
 
-async def test_min_max_step_attributes(hass, mqtt_mock_entry_with_yaml_config):
+async def test_min_max_step_attributes(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test min/max/step attributes."""
     topic = "test/number"
     await async_setup_component(
@@ -698,7 +740,7 @@ async def test_min_max_step_attributes(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get(ATTR_STEP) == 20
 
 
-async def test_invalid_min_max_attributes(hass, caplog):
+async def test_invalid_min_max_attributes(hass: HomeAssistant, caplog) -> None:
     """Test invalid min/max attributes."""
     topic = "test/number"
     assert not await async_setup_component(
@@ -720,7 +762,9 @@ async def test_invalid_min_max_attributes(hass, caplog):
     assert f"'{CONF_MAX}' must be > '{CONF_MIN}'" in caplog.text
 
 
-async def test_default_mode(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_mode(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test default mode."""
     topic = "test/number"
     await async_setup_component(
@@ -744,7 +788,9 @@ async def test_default_mode(hass, mqtt_mock_entry_with_yaml_config):
 
 
 @pytest.mark.parametrize("mode", ("auto", "box", "slider"))
-async def test_mode(hass, mqtt_mock_entry_with_yaml_config, mode):
+async def test_mode(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, mode
+) -> None:
     """Test mode."""
     topic = "test/number"
     await async_setup_component(
@@ -769,7 +815,7 @@ async def test_mode(hass, mqtt_mock_entry_with_yaml_config, mode):
 
 
 @pytest.mark.parametrize("mode,valid", [("bleh", False), ("auto", True)])
-async def test_invalid_mode(hass, mode, valid):
+async def test_invalid_mode(hass: HomeAssistant, mode, valid) -> None:
     """Test invalid mode."""
     topic = "test/number"
     assert (
@@ -792,8 +838,8 @@ async def test_invalid_mode(hass, mode, valid):
 
 
 async def test_mqtt_payload_not_a_number_warning(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test warning for MQTT payload which is not a number."""
     topic = "test/number"
     assert await async_setup_component(
@@ -820,8 +866,8 @@ async def test_mqtt_payload_not_a_number_warning(
 
 
 async def test_mqtt_payload_out_of_range_error(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test error when MQTT payload is out of min/max range."""
     topic = "test/number"
     await async_setup_component(
@@ -864,7 +910,7 @@ async def test_mqtt_payload_out_of_range_error(
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -872,7 +918,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = NUMBER_DOMAIN
     config = DEFAULT_CONFIG
@@ -891,7 +937,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = number.DOMAIN
     config = DEFAULT_CONFIG
@@ -908,14 +956,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -930,14 +978,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = number.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = number.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components import mqtt, scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN, Platform
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -44,9 +44,11 @@ def scene_platform_only():
         yield
 
 
-async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending MQTT commands."""
-    fake_state = ha.State("scene.test", STATE_UNKNOWN)
+    fake_state = State("scene.test", STATE_UNKNOWN)
     mock_restore_cache(hass, (fake_state,))
 
     assert await async_setup_component(
@@ -77,22 +79,26 @@ async def test_sending_mqtt_commands(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, scene.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -115,7 +121,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -138,7 +146,7 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one scene per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -161,7 +169,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_scene(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_scene(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered scene."""
     data = '{ "name": "test",' '  "command_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -169,7 +179,9 @@ async def test_discovery_removal_scene(hass, mqtt_mock_entry_no_yaml_config, cap
     )
 
 
-async def test_discovery_update_payload(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_payload(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered scene."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][scene.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][scene.DOMAIN])
@@ -189,8 +201,8 @@ async def test_discovery_update_payload(hass, mqtt_mock_entry_no_yaml_config, ca
 
 
 async def test_discovery_update_unchanged_scene(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered scene."""
     data1 = '{ "name": "Beer",' '  "command_topic": "test_topic" }'
     with patch(
@@ -207,7 +219,9 @@ async def test_discovery_update_unchanged_scene(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk",' '  "command_topic": "test_topic" }'
@@ -216,7 +230,9 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = scene.DOMAIN
     config = DEFAULT_CONFIG
@@ -225,14 +241,16 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = scene.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = scene.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -73,7 +73,9 @@ def select_platform_only():
         yield
 
 
-async def test_run_select_setup(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_select_setup(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload."""
     topic = "test/select"
     await async_setup_component(
@@ -108,7 +110,9 @@ async def test_run_select_setup(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == "beer"
 
 
-async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_value_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload with a template."""
     topic = "test/select"
     await async_setup_component(
@@ -151,11 +155,13 @@ async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_run_select_service_optimistic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_select_service_optimistic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in optimistic mode."""
     topic = "test/select"
 
-    fake_state = ha.State("select.test_select", "milk")
+    fake_state = State("select.test_select", "milk")
     mock_restore_cache(hass, (fake_state,))
 
     assert await async_setup_component(
@@ -192,12 +198,12 @@ async def test_run_select_service_optimistic(hass, mqtt_mock_entry_with_yaml_con
 
 
 async def test_run_select_service_optimistic_with_command_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in optimistic mode and with a command_template."""
     topic = "test/select"
 
-    fake_state = ha.State("select.test_select", "milk")
+    fake_state = State("select.test_select", "milk")
     mock_restore_cache(hass, (fake_state,))
 
     assert await async_setup_component(
@@ -236,7 +242,9 @@ async def test_run_select_service_optimistic_with_command_template(
     assert state.state == "beer"
 
 
-async def test_run_select_service(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_select_service(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in non optimistic mode."""
     cmd_topic = "test/select/set"
     state_topic = "test/select"
@@ -274,8 +282,8 @@ async def test_run_select_service(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_run_select_service_with_command_template(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that set_value service works in non optimistic mode and with a command_template."""
     cmd_topic = "test/select/set"
     state_topic = "test/select"
@@ -314,29 +322,35 @@ async def test_run_select_service_with_command_template(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
@@ -344,8 +358,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
@@ -353,8 +367,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -365,7 +379,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
@@ -373,8 +389,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -386,8 +402,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -398,7 +414,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -409,7 +427,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one select per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -436,7 +454,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_select(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_select(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered select."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][select.DOMAIN])
     await help_test_discovery_removal(
@@ -444,7 +464,9 @@ async def test_discovery_removal_select(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_select(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_select(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered select."""
     config1 = {
         "name": "Beer",
@@ -465,8 +487,8 @@ async def test_discovery_update_select(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_select(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered select."""
     data1 = '{ "name": "Beer", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["milk", "beer"]}'
     with patch(
@@ -483,7 +505,9 @@ async def test_discovery_update_unchanged_select(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic", "options": ["milk", "beer"]}'
@@ -493,49 +517,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT select device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT select device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, select.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -550,7 +588,9 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
 
 
 @pytest.mark.parametrize("options", [["milk", "beer"], ["milk"], []])
-async def test_options_attributes(hass, mqtt_mock_entry_with_yaml_config, options):
+async def test_options_attributes(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, options
+) -> None:
     """Test options attribute."""
     topic = "test/select"
     await async_setup_component(
@@ -575,8 +615,8 @@ async def test_options_attributes(hass, mqtt_mock_entry_with_yaml_config, option
 
 
 async def test_mqtt_payload_not_an_option_warning(
-    hass, caplog, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test warning for MQTT payload which is not a valid option."""
     topic = "test/select"
     await async_setup_component(
@@ -619,7 +659,7 @@ async def test_mqtt_payload_not_an_option_warning(
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -627,7 +667,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = select.DOMAIN
     config = DEFAULT_CONFIG
@@ -647,7 +687,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = select.DOMAIN
     config = DEFAULT_CONFIG
@@ -664,14 +706,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     config = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][select.DOMAIN])
     config["options"] = ["milk", "beer"]
@@ -688,14 +730,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = select.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = select.DOMAIN
     config = DEFAULT_CONFIG
@@ -705,7 +749,7 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
 
 
 async def test_persistent_state_after_reconfig(
-    hass: ha.HomeAssistant, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test of the state is persistent after reconfiguring the select options."""
     await mqtt_mock_entry_no_yaml_config()

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     Platform,
     UnitOfTemperature,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -80,8 +80,8 @@ def sensor_platform_only():
 
 
 async def test_setting_sensor_value_via_mqtt_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -136,14 +136,14 @@ async def test_setting_sensor_value_via_mqtt_message(
     ],
 )
 async def test_setting_sensor_native_value_handling_via_mqtt_message(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     device_class,
     native_value,
     state_value,
     log,
-):
+) -> None:
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
         hass,
@@ -170,7 +170,7 @@ async def test_setting_sensor_native_value_handling_via_mqtt_message(
 
 
 async def test_setting_numeric_sensor_native_value_handling_via_mqtt_message(
-    hass: ha.HomeAssistant,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
 ) -> None:
     """Test the setting of a numeric sensor value via MQTT."""
@@ -225,8 +225,8 @@ async def test_setting_numeric_sensor_native_value_handling_via_mqtt_message(
 
 
 async def test_setting_sensor_value_expires_availability_topic(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
@@ -259,8 +259,8 @@ async def test_setting_sensor_value_expires_availability_topic(
 
 
 async def test_setting_sensor_value_expires(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the expiration of the value."""
     assert await async_setup_component(
         hass,
@@ -287,7 +287,7 @@ async def test_setting_sensor_value_expires(
     await expires_helper(hass, caplog)
 
 
-async def expires_helper(hass, caplog):
+async def expires_helper(hass: HomeAssistant, caplog) -> None:
     """Run the basic expiry code."""
     realnow = dt_util.utcnow()
     now = datetime(realnow.year + 1, 1, 1, 1, tzinfo=dt_util.UTC)
@@ -339,8 +339,8 @@ async def expires_helper(hass, caplog):
 
 
 async def test_setting_sensor_value_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
@@ -371,8 +371,8 @@ async def test_setting_sensor_value_via_mqtt_json_message(
 
 
 async def test_setting_sensor_value_via_mqtt_json_message_and_default_current_state(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT with fall back to current state."""
     assert await async_setup_component(
         hass,
@@ -404,8 +404,8 @@ async def test_setting_sensor_value_via_mqtt_json_message_and_default_current_st
 
 
 async def test_setting_sensor_last_reset_via_mqtt_message(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
@@ -437,8 +437,8 @@ async def test_setting_sensor_last_reset_via_mqtt_message(
 
 @pytest.mark.parametrize("datestring", ["2020-21-02 08:11:00", "Hello there!"])
 async def test_setting_sensor_bad_last_reset_via_mqtt_message(
-    hass, caplog, datestring, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, caplog, datestring, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
@@ -465,8 +465,8 @@ async def test_setting_sensor_bad_last_reset_via_mqtt_message(
 
 
 async def test_setting_sensor_empty_last_reset_via_mqtt_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
@@ -492,8 +492,8 @@ async def test_setting_sensor_empty_last_reset_via_mqtt_message(
 
 
 async def test_setting_sensor_last_reset_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
@@ -523,8 +523,8 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(
 
 @pytest.mark.parametrize("extra", [{}, {"last_reset_topic": "test-topic"}])
 async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
-    hass, mqtt_mock_entry_with_yaml_config, caplog, extra
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, extra
+) -> None:
     """Test the setting of the value via MQTT with JSON payload."""
     assert await async_setup_component(
         hass,
@@ -563,7 +563,9 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
     )
 
 
-async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
+async def test_force_update_disabled(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test force update option."""
     assert await async_setup_component(
         hass,
@@ -583,11 +585,11 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event) -> None:
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "100")
     await hass.async_block_till_done()
@@ -598,7 +600,9 @@ async def test_force_update_disabled(hass, mqtt_mock_entry_with_yaml_config):
     assert len(events) == 1
 
 
-async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
+async def test_force_update_enabled(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test force update option."""
     assert await async_setup_component(
         hass,
@@ -619,11 +623,11 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
 
     events = []
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def test_callback(event) -> None:
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)
 
     async_fire_mqtt_message(hass, "test-topic", "100")
     await hass.async_block_till_done()
@@ -635,22 +639,26 @@ async def test_force_update_enabled(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -658,8 +666,8 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
 
 
 async def test_default_availability_list_payload(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -667,8 +675,8 @@ async def test_default_availability_list_payload(
 
 
 async def test_default_availability_list_payload_all(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload_all(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -676,15 +684,15 @@ async def test_default_availability_list_payload_all(
 
 
 async def test_default_availability_list_payload_any(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_list_payload_any(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_list_single(hass, caplog):
+async def test_default_availability_list_single(hass: HomeAssistant, caplog) -> None:
     """Test availability list and availability_topic are mutually exclusive."""
     await help_test_default_availability_list_single(
         hass,
@@ -694,21 +702,27 @@ async def test_default_availability_list_single(hass, caplog):
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_discovery_update_availability(hass, mqtt_mock_entry_no_yaml_config):
+async def test_discovery_update_availability(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test availability discovery update."""
     await help_test_discovery_update_availability(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_device_class(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device_class option with invalid value."""
     assert await async_setup_component(
         hass,
@@ -730,7 +744,9 @@ async def test_invalid_device_class(hass, mqtt_mock_entry_no_yaml_config):
     assert state is None
 
 
-async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
+async def test_valid_device_class(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test device_class option with valid values."""
     assert await async_setup_component(
         hass,
@@ -764,7 +780,9 @@ async def test_valid_device_class(hass, mqtt_mock_entry_with_yaml_config):
     assert "device_class" not in state.attributes
 
 
-async def test_invalid_state_class(hass, mqtt_mock_entry_no_yaml_config):
+async def test_invalid_state_class(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test state_class option with invalid value."""
     assert await async_setup_component(
         hass,
@@ -786,7 +804,9 @@ async def test_invalid_state_class(hass, mqtt_mock_entry_no_yaml_config):
     assert state is None
 
 
-async def test_valid_state_class(hass, mqtt_mock_entry_with_yaml_config):
+async def test_valid_state_class(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test state_class option with valid values."""
     assert await async_setup_component(
         hass,
@@ -821,8 +841,8 @@ async def test_valid_state_class(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -830,8 +850,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -842,7 +862,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -850,8 +872,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -863,8 +885,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -875,7 +897,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -886,7 +910,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one sensor per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -909,7 +933,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_sensor(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_sensor(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered sensor."""
     data = '{ "name": "test", "state_topic": "test_topic" }'
     await help_test_discovery_removal(
@@ -918,8 +944,8 @@ async def test_discovery_removal_sensor(hass, mqtt_mock_entry_no_yaml_config, ca
 
 
 async def test_discovery_update_sensor_topic_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered sensor."""
     config = {"name": "test", "state_topic": "test_topic"}
     config1 = copy.deepcopy(config)
@@ -953,8 +979,8 @@ async def test_discovery_update_sensor_topic_template(
 
 
 async def test_discovery_update_sensor_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered sensor."""
     config = {"name": "test", "state_topic": "test_topic"}
     config1 = copy.deepcopy(config)
@@ -986,8 +1012,8 @@ async def test_discovery_update_sensor_template(
 
 
 async def test_discovery_update_unchanged_sensor(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered sensor."""
     data1 = '{ "name": "Beer", "state_topic": "test_topic" }'
     with patch(
@@ -1004,7 +1030,9 @@ async def test_discovery_update_unchanged_sensor(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer", "state_topic": "test_topic#" }'
     data2 = '{ "name": "Milk", "state_topic": "test_topic" }'
@@ -1013,49 +1041,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_hub(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_hub(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor device registry integration."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -1083,42 +1125,54 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock_entry_no_yaml_config)
     assert device.via_device_id == hub.id
 
 
-async def test_entity_debug_info(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_max_messages(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_max_messages(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_max_messages(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG, None
     )
 
 
-async def test_entity_debug_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_update_entity_id(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_update_entity_id(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT sensor debug info."""
     await help_test_entity_debug_info_update_entity_id(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_disabled_by_default(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_disabled_by_default(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test entity disabled by default."""
     await help_test_entity_disabled_by_default(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
@@ -1126,14 +1180,18 @@ async def test_entity_disabled_by_default(hass, mqtt_mock_entry_no_yaml_config):
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_entity_category(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_category(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test entity category."""
     await help_test_entity_category(
         hass, mqtt_mock_entry_no_yaml_config, sensor.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_value_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_value_template_with_entity_id(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the access to attributes in value_template via the entity_id."""
     assert await async_setup_component(
         hass,
@@ -1163,7 +1221,9 @@ async def test_value_template_with_entity_id(hass, mqtt_mock_entry_with_yaml_con
     assert state.state == "101"
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = sensor.DOMAIN
     config = DEFAULT_CONFIG
@@ -1173,8 +1233,8 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
 
 
 async def test_cleanup_triggers_and_restoring_state(
-    hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, freezer
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path, freezer
+) -> None:
     """Test cleanup old triggers at reloading and restoring the state."""
     domain = sensor.DOMAIN
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][domain])
@@ -1231,8 +1291,8 @@ async def test_cleanup_triggers_and_restoring_state(
 
 
 async def test_skip_restoring_state_with_over_due_expire_trigger(
-    hass, mqtt_mock_entry_with_yaml_config, freezer
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, freezer
+) -> None:
     """Test restoring a state with over due expire timer."""
 
     freezer.move_to("2022-02-02 12:02:00+01:00")
@@ -1241,7 +1301,7 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     config3["name"] = "test3"
     config3["expire_after"] = 10
     config3["state_topic"] = "test-topic3"
-    fake_state = ha.State(
+    fake_state = State(
         "sensor.test3",
         "300",
         {},
@@ -1267,14 +1327,14 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -1290,14 +1350,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = sensor.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = sensor.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -78,7 +79,9 @@ async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL) -> None:
     await hass.services.async_call(siren.DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
-async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_controlling_state_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -114,8 +117,8 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending MQTT commands in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -158,8 +161,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_controlling_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
@@ -199,8 +202,8 @@ async def test_controlling_state_via_topic_and_json_message(
 
 
 async def test_controlling_state_and_attributes_with_json_message_without_template(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test the controlling state via topic and JSON message without a value template."""
     assert await async_setup_component(
         hass,
@@ -279,8 +282,8 @@ async def test_controlling_state_and_attributes_with_json_message_without_templa
 
 
 async def test_filtering_not_supported_attributes_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting attributes with support flags optimistic."""
     config = {
         "command_topic": "command-topic",
@@ -364,8 +367,8 @@ async def test_filtering_not_supported_attributes_optimistic(
 
 
 async def test_filtering_not_supported_attributes_via_state(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test setting attributes with support flags via state."""
     config = {
         "command_topic": "command-topic",
@@ -443,22 +446,26 @@ async def test_filtering_not_supported_attributes_via_state(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -483,7 +490,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -508,7 +517,9 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_state_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the state payload."""
     assert await async_setup_component(
         hass,
@@ -546,8 +557,8 @@ async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
@@ -555,15 +566,17 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG, {}
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
@@ -571,8 +584,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -584,8 +597,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -596,7 +609,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -607,7 +622,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one siren per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -632,7 +647,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_siren(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_siren(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered siren."""
     data = (
         '{ "name": "test",'
@@ -645,8 +662,8 @@ async def test_discovery_removal_siren(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_siren_topic_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered siren."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
@@ -682,8 +699,8 @@ async def test_discovery_update_siren_topic_template(
 
 
 async def test_discovery_update_siren_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered siren."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
@@ -716,7 +733,9 @@ async def test_discovery_update_siren_template(
     )
 
 
-async def test_command_templates(hass, mqtt_mock_entry_with_yaml_config, caplog):
+async def test_command_templates(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test siren with command templates optimistic."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][siren.DOMAIN])
     config1["name"] = "Beer"
@@ -797,8 +816,8 @@ async def test_command_templates(hass, mqtt_mock_entry_with_yaml_config, caplog)
 
 
 async def test_discovery_update_unchanged_siren(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered siren."""
     data1 = (
         '{ "name": "Beer",'
@@ -820,7 +839,9 @@ async def test_discovery_update_unchanged_siren(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -833,49 +854,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT siren device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT siren device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, siren.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -907,7 +942,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -915,7 +950,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with command templates and different encoding."""
     domain = siren.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -935,7 +970,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = siren.DOMAIN
     config = DEFAULT_CONFIG
@@ -951,14 +988,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -973,14 +1010,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = siren.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = siren.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -27,6 +27,7 @@ from homeassistant.components.vacuum import (
     STATE_DOCKED,
 )
 from homeassistant.const import CONF_NAME, ENTITY_MATCH_ALL, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -89,7 +90,9 @@ def vacuum_platform_only():
         yield
 
 
-async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_supported_features(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that the correct supported features."""
     assert await async_setup_component(hass, mqtt.DOMAIN, DEFAULT_CONFIG)
     await hass.async_block_till_done()
@@ -101,7 +104,9 @@ async def test_default_supported_features(hass, mqtt_mock_entry_with_yaml_config
     )
 
 
-async def test_all_commands(hass, mqtt_mock_entry_with_yaml_config):
+async def test_all_commands(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test simple commands send to the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -176,8 +181,8 @@ async def test_all_commands(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_commands_without_supported_features(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test commands which are not supported by the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     services = mqttvacuum.STRING_TO_SERVICE["status"]
@@ -237,7 +242,7 @@ async def test_commands_without_supported_features(
     mqtt_mock.async_publish.assert_not_called()
 
 
-async def test_status(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test status updates from the vacuum."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -284,7 +289,9 @@ async def test_status(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_no_fan_vacuum(hass, mqtt_mock_entry_with_yaml_config):
+async def test_no_fan_vacuum(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test status updates from the vacuum when fan is not supported."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     del config[mqttvacuum.CONF_FAN_SPEED_LIST]
@@ -338,7 +345,9 @@ async def test_no_fan_vacuum(hass, mqtt_mock_entry_with_yaml_config):
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_status_invalid_json(hass, mqtt_mock_entry_with_yaml_config):
+async def test_status_invalid_json(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test to make sure nothing breaks if the vacuum sends bad JSON."""
     config = deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][vacuum.DOMAIN])
     config[mqttvacuum.CONF_SUPPORTED_FEATURES] = services_to_strings(
@@ -357,29 +366,35 @@ async def test_status_invalid_json(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -387,8 +402,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -396,8 +411,8 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass,
@@ -408,7 +423,9 @@ async def test_setting_blocked_attribute_via_mqtt_json_message(
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
@@ -416,8 +433,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -429,8 +446,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -441,7 +458,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -452,7 +471,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one vacuum per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -477,7 +496,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_vacuum(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_vacuum(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered vacuum."""
     data = '{ "schema": "state", "name": "test", "command_topic": "test_topic"}'
     await help_test_discovery_removal(
@@ -485,7 +506,9 @@ async def test_discovery_removal_vacuum(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_vacuum(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_vacuum(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered vacuum."""
     config1 = {"schema": "state", "name": "Beer", "command_topic": "test_topic"}
     config2 = {"schema": "state", "name": "Milk", "command_topic": "test_topic"}
@@ -495,8 +518,8 @@ async def test_discovery_update_vacuum(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_vacuum(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered vacuum."""
     data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic"}'
     with patch(
@@ -513,7 +536,9 @@ async def test_discovery_update_unchanged_vacuum(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic#"}'
     data2 = '{ "schema": "state", "name": "Milk", "command_topic": "test_topic"}'
@@ -522,49 +547,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT vacuum device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, vacuum.DOMAIN, DEFAULT_CONFIG_2
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -618,7 +657,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -626,7 +665,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = vacuum.DOMAIN
     config = deepcopy(DEFAULT_CONFIG)
@@ -657,7 +696,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = vacuum.DOMAIN
     config = DEFAULT_CONFIG
@@ -684,14 +725,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -707,7 +748,7 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = vacuum.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -8,7 +8,7 @@ from homeassistant.components.mqtt.subscription import (
     async_subscribe_topics,
     async_unsubscribe_topics,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
 from tests.common import async_fire_mqtt_message
 
@@ -20,7 +20,9 @@ def no_platforms():
         yield
 
 
-async def test_subscribe_topics(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_subscribe_topics(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test subscription to topics."""
     await mqtt_mock_entry_no_yaml_config()
     calls1 = []
@@ -69,7 +71,9 @@ async def test_subscribe_topics(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert len(calls2) == 1
 
 
-async def test_modify_topics(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_modify_topics(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test modification of topics."""
     await mqtt_mock_entry_no_yaml_config()
     calls1 = []
@@ -132,7 +136,9 @@ async def test_modify_topics(hass, mqtt_mock_entry_no_yaml_config, caplog):
     assert len(calls2) == 1
 
 
-async def test_qos_encoding_default(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_qos_encoding_default(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test default qos and encoding."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
@@ -150,7 +156,9 @@ async def test_qos_encoding_default(hass, mqtt_mock_entry_no_yaml_config, caplog
     mqtt_mock.async_subscribe.assert_called_with("test-topic1", ANY, 0, "utf-8")
 
 
-async def test_qos_encoding_custom(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_qos_encoding_custom(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test custom qos and encoding."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
@@ -175,7 +183,9 @@ async def test_qos_encoding_custom(hass, mqtt_mock_entry_no_yaml_config, caplog)
     mqtt_mock.async_subscribe.assert_called_with("test-topic1", ANY, 1, "utf-16")
 
 
-async def test_no_change(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_no_change(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test subscription to topics without change."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
-import homeassistant.core as ha
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -61,7 +61,9 @@ def switch_platform_only():
         yield
 
 
-async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_controlling_state_via_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic."""
     assert await async_setup_component(
         hass,
@@ -104,10 +106,10 @@ async def test_controlling_state_via_topic(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending MQTT commands in optimistic mode."""
-    fake_state = ha.State("switch.test", "on")
+    fake_state = State("switch.test", "on")
     mock_restore_cache(hass, (fake_state,))
 
     assert await async_setup_component(
@@ -151,8 +153,8 @@ async def test_sending_mqtt_commands_and_optimistic(
 
 
 async def test_sending_inital_state_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the initial state in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -175,8 +177,8 @@ async def test_sending_inital_state_and_optimistic(
 
 
 async def test_controlling_state_via_topic_and_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(
         hass,
@@ -217,22 +219,26 @@ async def test_controlling_state_via_topic_and_json_message(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -257,7 +263,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -282,7 +290,9 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
     )
 
 
-async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_state_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the state payload."""
     assert await async_setup_component(
         hass,
@@ -320,8 +330,8 @@ async def test_custom_state_payload(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
@@ -329,15 +339,17 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG, {}
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
@@ -345,8 +357,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -358,8 +370,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -370,7 +382,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -381,7 +395,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one switch per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -406,7 +420,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_switch(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_switch(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered switch."""
     data = (
         '{ "name": "test",'
@@ -419,8 +435,8 @@ async def test_discovery_removal_switch(hass, mqtt_mock_entry_no_yaml_config, ca
 
 
 async def test_discovery_update_switch_topic_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered switch."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][switch.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][switch.DOMAIN])
@@ -456,8 +472,8 @@ async def test_discovery_update_switch_topic_template(
 
 
 async def test_discovery_update_switch_template(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered switch."""
     config1 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][switch.DOMAIN])
     config2 = copy.deepcopy(DEFAULT_CONFIG[mqtt.DOMAIN][switch.DOMAIN])
@@ -491,8 +507,8 @@ async def test_discovery_update_switch_template(
 
 
 async def test_discovery_update_unchanged_switch(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered switch."""
     data1 = (
         '{ "name": "Beer",'
@@ -514,7 +530,9 @@ async def test_discovery_update_unchanged_switch(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -527,49 +545,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT switch device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT switch device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, switch.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass,
@@ -600,7 +632,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -608,7 +640,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = switch.DOMAIN
     config = DEFAULT_CONFIG
@@ -627,7 +659,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = switch.DOMAIN
     config = DEFAULT_CONFIG
@@ -643,14 +677,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -665,14 +699,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = switch.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = switch.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -75,8 +75,12 @@ def tag_mock():
 
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_tag(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock_entry_no_yaml_config,
+    tag_mock,
+) -> None:
     """Test bad discovery message."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = copy.deepcopy(DEFAULT_CONFIG_DEVICE)
@@ -99,8 +103,8 @@ async def test_discover_bad_tag(
 
 
 async def test_if_fires_on_mqtt_message_with_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning, with device."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG_DEVICE)
@@ -116,8 +120,8 @@ async def test_if_fires_on_mqtt_message_with_device(
 
 
 async def test_if_fires_on_mqtt_message_without_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning, without device."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -132,8 +136,8 @@ async def test_if_fires_on_mqtt_message_without_device(
 
 
 async def test_if_fires_on_mqtt_message_with_template(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning, with device."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG_JSON)
@@ -148,7 +152,9 @@ async def test_if_fires_on_mqtt_message_with_template(
     tag_mock.assert_called_once_with(ANY, DEFAULT_TAG_ID, device_entry.id)
 
 
-async def test_strip_tag_id(hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock):
+async def test_strip_tag_id(
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test strip whitespace from tag_id."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -163,8 +169,8 @@ async def test_strip_tag_id(hass, device_reg, mqtt_mock_entry_no_yaml_config, ta
 
 
 async def test_if_fires_on_mqtt_message_after_update_with_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = copy.deepcopy(DEFAULT_CONFIG_DEVICE)
@@ -210,8 +216,8 @@ async def test_if_fires_on_mqtt_message_after_update_with_device(
 
 
 async def test_if_fires_on_mqtt_message_after_update_without_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -254,8 +260,8 @@ async def test_if_fires_on_mqtt_message_after_update_without_device(
 
 
 async def test_if_fires_on_mqtt_message_after_update_with_template(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = copy.deepcopy(DEFAULT_CONFIG_JSON)
@@ -300,8 +306,8 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
 
 
 async def test_no_resubscribe_same_topic(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test subscription to topics without change."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG_DEVICE)
@@ -317,8 +323,8 @@ async def test_no_resubscribe_same_topic(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning after removal."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG_DEVICE)
@@ -351,8 +357,8 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_without_device(
-    hass, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+) -> None:
     """Test tag scanning not firing after removal."""
     await mqtt_mock_entry_no_yaml_config()
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -384,12 +390,12 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_without_device(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
-    hass,
+    hass: HomeAssistant,
     hass_ws_client,
     device_reg,
     mqtt_mock_entry_no_yaml_config,
     tag_mock,
-):
+) -> None:
     """Test tag scanning after removal."""
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
@@ -426,7 +432,9 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     tag_mock.assert_not_called()
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -459,7 +467,9 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_
     assert device.sw_version == "0.1-beta"
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT device registry integration."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -490,7 +500,9 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_
     assert device.sw_version == "0.1-beta"
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await mqtt_mock_entry_no_yaml_config()
     registry = dr.async_get(hass)
@@ -526,8 +538,12 @@ async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_cleanup_tag(
-    hass, hass_ws_client, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant,
+    hass_ws_client,
+    device_reg,
+    entity_reg,
+    mqtt_mock_entry_no_yaml_config,
+) -> None:
     """Test tag discovery topic is cleaned when device is removed from registry."""
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
@@ -607,8 +623,8 @@ async def test_cleanup_tag(
 
 
 async def test_cleanup_device(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry when tag is removed."""
     await mqtt_mock_entry_no_yaml_config()
     config = {
@@ -633,8 +649,12 @@ async def test_cleanup_device(
 
 
 async def test_cleanup_device_several_tags(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config, tag_mock
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock_entry_no_yaml_config,
+    tag_mock,
+) -> None:
     """Test removal from device registry when the last tag is removed."""
     await mqtt_mock_entry_no_yaml_config()
     config1 = {
@@ -678,8 +698,8 @@ async def test_cleanup_device_several_tags(
 
 
 async def test_cleanup_device_with_entity_and_trigger_1(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry for device with tag, entity and trigger.
 
     Tag removed first, then trigger and entity.
@@ -743,8 +763,8 @@ async def test_cleanup_device_with_entity_and_trigger_1(
 
 
 async def test_cleanup_device_with_entity2(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test removal from device registry for device with tag, entity and trigger.
 
     Trigger and entity removed first, then tag.
@@ -851,7 +871,9 @@ async def test_update_with_bad_config_not_breaks_discovery(
     tag_mock.assert_called_once_with(ANY, "12345", ANY)
 
 
-async def test_unload_entry(hass, device_reg, mqtt_mock, tag_mock, tmp_path) -> None:
+async def test_unload_entry(
+    hass: HomeAssistant, device_reg, mqtt_mock, tag_mock, tmp_path
+) -> None:
     """Test unloading the MQTT entry."""
 
     config = copy.deepcopy(DEFAULT_CONFIG_DEVICE)

--- a/tests/components/mqtt/test_text.py
+++ b/tests/components/mqtt/test_text.py
@@ -114,7 +114,7 @@ async def test_controlling_state_via_topic(
 
 
 async def test_controlling_validation_state_via_topic(
-    hass, mqtt_mock_entry_with_yaml_config
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
 ) -> None:
     """Test the validation of a received state."""
     assert await async_setup_component(
@@ -211,8 +211,8 @@ async def test_attribute_validation_max_not_greater_then_max_state_length(
 
 
 async def test_sending_mqtt_commands_and_optimistic(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the sending MQTT commands in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -253,7 +253,9 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.state == "some new state"
 
 
-async def test_set_text_validation(hass, mqtt_mock_entry_with_yaml_config):
+async def test_set_text_validation(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the initial state in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -296,22 +298,26 @@ async def test_set_text_validation(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -334,7 +340,9 @@ async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_conf
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     config = {
         mqtt.DOMAIN: {
@@ -358,8 +366,8 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, text.DOMAIN, DEFAULT_CONFIG
@@ -367,15 +375,17 @@ async def test_setting_attribute_via_mqtt_json_message(
 
 
 async def test_setting_blocked_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_no_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_blocked_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG, {}
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, text.DOMAIN, DEFAULT_CONFIG
@@ -383,8 +393,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -396,8 +406,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -408,7 +418,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -419,7 +431,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one text per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -444,7 +456,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_text(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_text(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered text entity."""
     data = (
         '{ "name": "test",'
@@ -456,7 +470,9 @@ async def test_discovery_removal_text(hass, mqtt_mock_entry_no_yaml_config, capl
     )
 
 
-async def test_discovery_text_update(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_text_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered text entity."""
     config1 = {
         "name": "Beer",
@@ -475,8 +491,8 @@ async def test_discovery_text_update(hass, mqtt_mock_entry_no_yaml_config, caplo
 
 
 async def test_discovery_update_unchanged_update(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered update."""
     data1 = '{ "name": "Beer", "state_topic": "text-topic", "command_topic": "command-topic"}'
     with patch(
@@ -492,7 +508,9 @@ async def test_discovery_update_unchanged_update(
         )
 
 
-async def test_discovery_update_text(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_text(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered text entity."""
     config1 = {"name": "Beer", "command_topic": "cmd-topic1"}
     config2 = {"name": "Milk", "command_topic": "cmd-topic2"}
@@ -502,8 +520,8 @@ async def test_discovery_update_text(hass, mqtt_mock_entry_no_yaml_config, caplo
 
 
 async def test_discovery_update_unchanged_climate(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered text entity."""
     data1 = '{ "name": "Beer", "command_topic": "cmd-topic" }'
     with patch(
@@ -520,7 +538,9 @@ async def test_discovery_update_unchanged_climate(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = (
@@ -533,49 +553,63 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT text device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT text device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock_entry_with_yaml_config):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
         hass, mqtt_mock_entry_with_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_debug_info_message(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
         hass, mqtt_mock_entry_no_yaml_config, text.DOMAIN, DEFAULT_CONFIG, None
@@ -595,7 +629,7 @@ async def test_entity_debug_info_message(hass, mqtt_mock_entry_no_yaml_config):
     ],
 )
 async def test_publishing_with_custom_encoding(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     service,
@@ -603,7 +637,7 @@ async def test_publishing_with_custom_encoding(
     parameters,
     payload,
     template,
-):
+) -> None:
     """Test publishing MQTT payload with different encoding."""
     domain = text.DOMAIN
     config = DEFAULT_CONFIG
@@ -622,7 +656,9 @@ async def test_publishing_with_custom_encoding(
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = text.DOMAIN
     config = DEFAULT_CONFIG
@@ -638,14 +674,14 @@ async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_pa
     ],
 )
 async def test_encoding_subscribable_topics(
-    hass,
+    hass: HomeAssistant,
     mqtt_mock_entry_with_yaml_config,
     caplog,
     topic,
     value,
     attribute,
     attribute_value,
-):
+) -> None:
     """Test handling of incoming encoded payload."""
     await help_test_encoding_subscribable_topics(
         hass,
@@ -660,14 +696,16 @@ async def test_encoding_subscribable_topics(
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = text.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = text.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -5,6 +5,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_mqtt_message, async_mock_service, mock_component
@@ -12,7 +13,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant):
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -25,13 +26,13 @@ def no_platforms():
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass, mqtt_mock_entry_no_yaml_config):
+async def setup_comp(hass: HomeAssistant, mqtt_mock_entry_no_yaml_config):
     """Initialize components."""
     mock_component(hass, "group")
     return await mqtt_mock_entry_no_yaml_config()
 
 
-async def test_if_fires_on_topic_match(hass, calls):
+async def test_if_fires_on_topic_match(hass: HomeAssistant, calls) -> None:
     """Test if message is fired on topic match."""
     assert await async_setup_component(
         hass,
@@ -69,7 +70,7 @@ async def test_if_fires_on_topic_match(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_topic_and_payload_match(hass, calls):
+async def test_if_fires_on_topic_and_payload_match(hass: HomeAssistant, calls) -> None:
     """Test if message is fired on topic and payload match."""
     assert await async_setup_component(
         hass,
@@ -91,7 +92,7 @@ async def test_if_fires_on_topic_and_payload_match(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_topic_and_payload_match2(hass, calls):
+async def test_if_fires_on_topic_and_payload_match2(hass: HomeAssistant, calls) -> None:
     """Test if message is fired on topic and payload match.
 
     Make sure a payload which would render as a non string can still be matched.
@@ -116,7 +117,9 @@ async def test_if_fires_on_topic_and_payload_match2(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_templated_topic_and_payload_match(hass, calls):
+async def test_if_fires_on_templated_topic_and_payload_match(
+    hass: HomeAssistant, calls
+) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
         hass,
@@ -146,7 +149,7 @@ async def test_if_fires_on_templated_topic_and_payload_match(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_payload_template(hass, calls):
+async def test_if_fires_on_payload_template(hass: HomeAssistant, calls) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
         hass,
@@ -177,7 +180,7 @@ async def test_if_fires_on_payload_template(hass, calls):
     assert len(calls) == 1
 
 
-async def test_non_allowed_templates(hass, calls, caplog):
+async def test_non_allowed_templates(hass: HomeAssistant, calls, caplog) -> None:
     """Test non allowed function in template."""
     assert await async_setup_component(
         hass,
@@ -199,7 +202,9 @@ async def test_non_allowed_templates(hass, calls, caplog):
     )
 
 
-async def test_if_not_fires_on_topic_but_no_payload_match(hass, calls):
+async def test_if_not_fires_on_topic_but_no_payload_match(
+    hass: HomeAssistant, calls
+) -> None:
     """Test if message is not fired on topic but no payload."""
     assert await async_setup_component(
         hass,
@@ -221,7 +226,7 @@ async def test_if_not_fires_on_topic_but_no_payload_match(hass, calls):
     assert len(calls) == 0
 
 
-async def test_encoding_default(hass, calls, setup_comp):
+async def test_encoding_default(hass: HomeAssistant, calls, setup_comp) -> None:
     """Test default encoding."""
     assert await async_setup_component(
         hass,
@@ -237,7 +242,7 @@ async def test_encoding_default(hass, calls, setup_comp):
     setup_comp.async_subscribe.assert_called_with("test-topic", ANY, 0, "utf-8")
 
 
-async def test_encoding_custom(hass, calls, setup_comp):
+async def test_encoding_custom(hass: HomeAssistant, calls, setup_comp) -> None:
     """Test default encoding."""
     assert await async_setup_component(
         hass,

--- a/tests/components/mqtt/test_update.py
+++ b/tests/components/mqtt/test_update.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -62,7 +63,9 @@ def update_platform_only():
         yield
 
 
-async def test_run_update_setup(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_update_setup(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
@@ -110,7 +113,9 @@ async def test_run_update_setup(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("latest_version") == "2.0.0"
 
 
-async def test_run_update_setup_float(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_update_setup_float(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload when the version is parsable as a number."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
@@ -158,7 +163,9 @@ async def test_run_update_setup_float(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("latest_version") == "2.0"
 
 
-async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_value_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload with a template."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
@@ -204,7 +211,9 @@ async def test_value_template(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("latest_version") == "2.0.0"
 
 
-async def test_value_template_float(hass, mqtt_mock_entry_with_yaml_config):
+async def test_value_template_float(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that it fetches the given payload with a template when the version is parsable as a number."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
@@ -250,7 +259,9 @@ async def test_value_template_float(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("latest_version") == "2.0"
 
 
-async def test_empty_json_state_message(hass, mqtt_mock_entry_with_yaml_config):
+async def test_empty_json_state_message(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test an empty JSON payload."""
     state_topic = "test/state-topic"
     await async_setup_component(
@@ -276,7 +287,9 @@ async def test_empty_json_state_message(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_json_state_message(hass, mqtt_mock_entry_with_yaml_config):
+async def test_json_state_message(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test whether it fetches data from a JSON payload."""
     state_topic = "test/state-topic"
     await async_setup_component(
@@ -330,7 +343,9 @@ async def test_json_state_message(hass, mqtt_mock_entry_with_yaml_config):
     assert state.attributes.get("entity_picture") == "https://example.com/icon2.png"
 
 
-async def test_json_state_message_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_json_state_message_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test whether it fetches data from a JSON payload with template."""
     state_topic = "test/state-topic"
     await async_setup_component(
@@ -368,7 +383,9 @@ async def test_json_state_message_with_template(hass, mqtt_mock_entry_with_yaml_
     assert state.attributes.get("latest_version") == "2.0.0"
 
 
-async def test_run_install_service(hass, mqtt_mock_entry_with_yaml_config):
+async def test_run_install_service(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test that install service works."""
     installed_version_topic = "test/installed-version"
     latest_version_topic = "test/latest-version"
@@ -411,29 +428,35 @@ async def test_run_install_service(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability after MQTT disconnection."""
     await help_test_availability_when_connection_lost(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_availability_without_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_availability_without_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability without defined availability topic."""
     await help_test_availability_without_topic(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_default_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_default_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by default payload with defined topic."""
     await help_test_default_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_config):
+async def test_custom_availability_payload(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test availability by custom payload with defined topic."""
     await help_test_custom_availability_payload(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
@@ -441,15 +464,17 @@ async def test_custom_availability_payload(hass, mqtt_mock_entry_with_yaml_confi
 
 
 async def test_setting_attribute_via_mqtt_json_message(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_via_mqtt_json_message(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_config):
+async def test_setting_attribute_with_template(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config
+) -> None:
     """Test the setting of attribute via MQTT with JSON payload."""
     await help_test_setting_attribute_with_template(
         hass, mqtt_mock_entry_with_yaml_config, update.DOMAIN, DEFAULT_CONFIG
@@ -457,8 +482,8 @@ async def test_setting_attribute_with_template(hass, mqtt_mock_entry_with_yaml_c
 
 
 async def test_update_with_json_attrs_not_dict(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_not_dict(
         hass,
@@ -470,8 +495,8 @@ async def test_update_with_json_attrs_not_dict(
 
 
 async def test_update_with_json_attrs_bad_json(
-    hass, mqtt_mock_entry_with_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog
+) -> None:
     """Test attributes get extracted from a JSON result."""
     await help_test_update_with_json_attrs_bad_json(
         hass,
@@ -482,7 +507,9 @@ async def test_update_with_json_attrs_bad_json(
     )
 
 
-async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_attr(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered MQTTAttributes."""
     await help_test_discovery_update_attr(
         hass,
@@ -493,7 +520,7 @@ async def test_discovery_update_attr(hass, mqtt_mock_entry_no_yaml_config, caplo
     )
 
 
-async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
+async def test_unique_id(hass: HomeAssistant, mqtt_mock_entry_with_yaml_config) -> None:
     """Test unique id option only creates one update per unique_id."""
     config = {
         mqtt.DOMAIN: {
@@ -518,7 +545,9 @@ async def test_unique_id(hass, mqtt_mock_entry_with_yaml_config):
     )
 
 
-async def test_discovery_removal_update(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_removal_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test removal of discovered update."""
     data = json.dumps(DEFAULT_CONFIG[mqtt.DOMAIN][update.DOMAIN])
     await help_test_discovery_removal(
@@ -526,7 +555,9 @@ async def test_discovery_removal_update(hass, mqtt_mock_entry_no_yaml_config, ca
     )
 
 
-async def test_discovery_update_update(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_update_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered update."""
     config1 = {
         "name": "Beer",
@@ -545,8 +576,8 @@ async def test_discovery_update_update(hass, mqtt_mock_entry_no_yaml_config, cap
 
 
 async def test_discovery_update_unchanged_update(
-    hass, mqtt_mock_entry_no_yaml_config, caplog
-):
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test update of discovered update."""
     data1 = '{ "name": "Beer", "state_topic": "installed-topic", "latest_version_topic": "latest-topic"}'
     with patch(
@@ -563,7 +594,9 @@ async def test_discovery_update_unchanged_update(
 
 
 @pytest.mark.no_fail_on_log_exception
-async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
+async def test_discovery_broken(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, caplog
+) -> None:
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
     data2 = '{ "name": "Milk", "state_topic": "installed-topic", "latest_version_topic": "latest-topic" }'
@@ -573,49 +606,61 @@ async def test_discovery_broken(hass, mqtt_mock_entry_no_yaml_config, caplog):
     )
 
 
-async def test_entity_device_info_with_connection(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_connection(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT update device registry integration."""
     await help_test_entity_device_info_with_connection(
         hass, mqtt_mock_entry_no_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_with_identifier(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_with_identifier(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT update device registry integration."""
     await help_test_entity_device_info_with_identifier(
         hass, mqtt_mock_entry_no_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry update."""
     await help_test_entity_device_info_update(
         hass, mqtt_mock_entry_no_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_device_info_remove(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_device_info_remove(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry_no_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock_entry_no_yaml_config):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock_entry_no_yaml_config, update.DOMAIN, DEFAULT_CONFIG
     )
 
 
-async def test_setup_manual_entity_from_yaml(hass):
+async def test_setup_manual_entity_from_yaml(hass: HomeAssistant) -> None:
     """Test setup manual configured MQTT entity."""
     platform = update.DOMAIN
     await help_test_setup_manual_entity_from_yaml(hass, DEFAULT_CONFIG)
     assert hass.states.get(f"{platform}.test")
 
 
-async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, tmp_path
+) -> None:
     """Test unloading the config entry."""
     domain = update.DOMAIN
     config = DEFAULT_CONFIG
@@ -624,7 +669,9 @@ async def test_unload_entry(hass, mqtt_mock_entry_with_yaml_config, tmp_path):
     )
 
 
-async def test_reloadable(hass, mqtt_mock_entry_with_yaml_config, caplog, tmp_path):
+async def test_reloadable(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config, caplog, tmp_path
+) -> None:
     """Test reloading the MQTT platform."""
     domain = update.DOMAIN
     config = DEFAULT_CONFIG

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import mqtt
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
@@ -29,8 +30,8 @@ def mock_temp_dir():
     ],
 )
 async def test_async_create_certificate_temp_files(
-    hass, mock_temp_dir, option, content, file_created
-):
+    hass: HomeAssistant, mock_temp_dir, option, content, file_created
+) -> None:
     """Test creating and reading certificate files."""
     config = {option: content}
     await mqtt.util.async_create_certificate_temp_files(hass, config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add hass and `None` return type on MQTT platform tests.
The hints for has and `None` return type other test modules are covered in separate PR's.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
