### PR TITLE
 Add more bitwise operations as template helpers

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1845,6 +1845,16 @@ def regex_findall(value, find="", ignorecase=False):
     return _regex_cache(find, flags).findall(value)
 
 
+def bitwise_lshift(value, num):
+    """Perform a bitwise left shift operation."""
+    return value << num
+
+
+def bitwise_rshift(value, num):
+    """Perform a bitwise right shift operation."""
+    return value >> num
+
+
 def bitwise_and(first_value, second_value):
     """Perform a bitwise and operation."""
     return first_value & second_value
@@ -2100,6 +2110,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["regex_findall_index"] = regex_findall_index
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
+        self.filters["bitwise_lshift"] = bitwise_lshift
+        self.filters["bitwise_rshift"] = bitwise_rshift
         self.filters["pack"] = struct_pack
         self.filters["unpack"] = struct_unpack
         self.filters["ord"] = ord

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1904,6 +1904,56 @@ def test_regex_findall_index(hass: HomeAssistant) -> None:
     assert tpl.async_render() == "LHR"
 
 
+def test_bitwise_lshift(hass: HomeAssistant) -> None:
+    """Test bitwise_lshift method."""
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_lshift(8) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 8 << 8
+    tpl = template.Template(
+        """
+{{ 10 | bitwise_lshift(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 10 << 2
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_lshift(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 8 << 2
+
+
+def test_bitwise_rshift(hass: HomeAssistant) -> None:
+    """Test bitwise_rshift method."""
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_rshift(8) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 8 >> 8
+    tpl = template.Template(
+        """
+{{ 10 | bitwise_rshift(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 10 >> 2
+    tpl = template.Template(
+        """
+{{ 8 | bitwise_rshift(2) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == 8 >> 2
+
+
 def test_bitwise_and(hass: HomeAssistant) -> None:
     """Test bitwise_and method."""
     tpl = template.Template(


### PR DESCRIPTION
Implement 2 new helper templates: bitwise_lshift and bitwise_rshift.

I'm currently writing integration for a device available via MQTT. 

Device propagates a RGBW state using 32 bit integer. With `bitwise_lshift` filter, I would be able to create following template:

```
mqtt:
  light:
    - name: "Office light"
      state_topic: "office/light/status"
      command_topic: "office/light/rgbw"
      rgbw_command_template: >
        {%- set newValue = red -%}
        {%- set newValue = newValue + (green | bitwise_lshift(8)) -%}
        {%- set newValue = newValue + (blue | bitwise_lshift(16)) -%}
        {%- set newValue = newValue + (white | bitwise_lshift(24)) -%}
        {{ newValue }}
```

For implementation, I followed exact steps of this PR: #16833
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: [#26168](https://github.com/home-assistant/home-assistant.io/pull/26168)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
