### PR TITLE
Clean up unnecessary registry mocks from mqtt tests

### DIFF
--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -1131,7 +1131,6 @@ async def help_test_entity_id_update_subscriptions(
     mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
-    entity_registry: er.EntityRegistry,
     topics: list[str] | None = None,
 ) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
@@ -1145,6 +1144,7 @@ async def help_test_entity_id_update_subscriptions(
         config[mqtt.DOMAIN][domain]["state_topic"] = "test-topic"
         topics = ["avty-topic", "test-topic"]
     assert len(topics) > 0
+    entity_registry = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -1180,7 +1180,6 @@ async def help_test_entity_id_update_discovery_update(
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
-    entity_registry: er.EntityRegistry,
     topic: str | None = None,
 ) -> None:
     """Test MQTT discovery update after entity_id is updated."""
@@ -1194,6 +1193,7 @@ async def help_test_entity_id_update_discovery_update(
         config[mqtt.DOMAIN][domain]["availability_topic"] = "avty-topic"
         topic = "avty-topic"
 
+    entity_registry = er.async_get(hass)
     data = json.dumps(config[mqtt.DOMAIN][domain])
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
@@ -1488,8 +1488,6 @@ async def help_test_entity_debug_info_update_entity_id(
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test debug_info.
 
@@ -1502,6 +1500,8 @@ async def help_test_entity_debug_info_update_entity_id(
     config["unique_id"] = "veryunique"
     config["platform"] = "mqtt"
 
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_fire_mqtt_message, mock_registry
+from tests.common import MockConfigEntry, async_fire_mqtt_message
 from tests.typing import MqttMockHAClientGenerator
 
 DEFAULT_CONFIG_DEVICE_INFO_ID = {
@@ -1131,6 +1131,7 @@ async def help_test_entity_id_update_subscriptions(
     mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
+    entity_registry: er.EntityRegistry,
     topics: list[str] | None = None,
 ) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
@@ -1144,7 +1145,6 @@ async def help_test_entity_id_update_subscriptions(
         config[mqtt.DOMAIN][domain]["state_topic"] = "test-topic"
         topics = ["avty-topic", "test-topic"]
     assert len(topics) > 0
-    registry = mock_registry(hass, {})
 
     assert await async_setup_component(
         hass,
@@ -1161,7 +1161,9 @@ async def help_test_entity_id_update_subscriptions(
         mqtt_mock.async_subscribe.assert_any_call(topic, ANY, ANY, ANY)
     mqtt_mock.async_subscribe.reset_mock()
 
-    registry.async_update_entity(f"{domain}.test", new_entity_id=f"{domain}.milk")
+    entity_registry.async_update_entity(
+        f"{domain}.test", new_entity_id=f"{domain}.milk"
+    )
     await hass.async_block_till_done()
 
     state = hass.states.get(f"{domain}.test")
@@ -1178,6 +1180,7 @@ async def help_test_entity_id_update_discovery_update(
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
+    entity_registry: er.EntityRegistry,
     topic: str | None = None,
 ) -> None:
     """Test MQTT discovery update after entity_id is updated."""
@@ -1191,8 +1194,6 @@ async def help_test_entity_id_update_discovery_update(
         config[mqtt.DOMAIN][domain]["availability_topic"] = "avty-topic"
         topic = "avty-topic"
 
-    ent_registry = mock_registry(hass, {})
-
     data = json.dumps(config[mqtt.DOMAIN][domain])
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
@@ -1205,7 +1206,9 @@ async def help_test_entity_id_update_discovery_update(
     state = hass.states.get(f"{domain}.test")
     assert state and state.state == STATE_UNAVAILABLE
 
-    ent_registry.async_update_entity(f"{domain}.test", new_entity_id=f"{domain}.milk")
+    entity_registry.async_update_entity(
+        f"{domain}.test", new_entity_id=f"{domain}.milk"
+    )
     await hass.async_block_till_done()
 
     config[mqtt.DOMAIN][domain]["availability_topic"] = f"{topic}_2"
@@ -1485,6 +1488,8 @@ async def help_test_entity_debug_info_update_entity_id(
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     domain: str,
     config: ConfigType,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test debug_info.
 
@@ -1497,14 +1502,11 @@ async def help_test_entity_debug_info_update_entity_id(
     config["unique_id"] = "veryunique"
     config["platform"] = "mqtt"
 
-    dev_registry = dr.async_get(hass)
-    ent_registry = mock_registry(hass, {})
-
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")})
+    device = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1521,7 +1523,9 @@ async def help_test_entity_debug_info_update_entity_id(
     ]
     assert len(debug_info_data["triggers"]) == 0
 
-    ent_registry.async_update_entity(f"{domain}.test", new_entity_id=f"{domain}.milk")
+    entity_registry.async_update_entity(
+        f"{domain}.test", new_entity_id=f"{domain}.milk"
+    )
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -15,7 +15,7 @@ from .test_common import (
     help_test_setup_manual_entity_from_yaml,
 )
 
-from tests.common import async_fire_mqtt_message, mock_device_registry, mock_registry
+from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
     mqtt.DOMAIN: {
@@ -32,18 +32,6 @@ def device_tracker_platform_only():
     """Only setup the device_tracker platform to speed up tests."""
     with patch("homeassistant.components.mqtt.PLATFORMS", [Platform.DEVICE_TRACKER]):
         yield
-
-
-@pytest.fixture
-def device_reg(hass: HomeAssistant):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture
-def entity_reg(hass: HomeAssistant):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 async def test_discover_device_tracker(
@@ -222,8 +210,8 @@ async def test_device_tracker_discovery_update(
 async def test_cleanup_device_tracker(
     hass: HomeAssistant,
     hass_ws_client,
-    device_reg,
-    entity_reg,
+    device_registry,
+    entity_registry,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test discovered device is cleaned up when removed from registry."""
@@ -242,9 +230,9 @@ async def test_cleanup_device_tracker(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
-    entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
+    entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
     assert entity_entry is not None
 
     state = hass.states.get("device_tracker.mqtt_unique")
@@ -266,9 +254,9 @@ async def test_cleanup_device_tracker(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
-    entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
+    entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
     assert entity_entry is None
 
     # Verify state is removed

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -21,22 +21,8 @@ from tests.common import (
     async_fire_mqtt_message,
     async_get_device_automations,
     async_mock_service,
-    mock_device_registry,
-    mock_registry,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
-
-
-@pytest.fixture
-def device_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture
-def entity_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 @pytest.fixture
@@ -56,7 +42,7 @@ def binary_sensor_and_sensor_only():
 
 
 async def test_get_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test we get the expected triggers from a discovered mqtt device."""
     await mqtt_mock_entry_no_yaml_config()
@@ -71,7 +57,7 @@ async def test_get_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -90,7 +76,7 @@ async def test_get_triggers(
 
 
 async def test_get_unknown_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test we don't get unknown triggers."""
     await mqtt_mock_entry_no_yaml_config()
@@ -103,7 +89,7 @@ async def test_get_unknown_triggers(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -135,7 +121,7 @@ async def test_get_unknown_triggers(
 
 
 async def test_get_non_existing_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test getting non existing triggers."""
     await mqtt_mock_entry_no_yaml_config()
@@ -148,7 +134,7 @@ async def test_get_non_existing_triggers(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
@@ -157,7 +143,7 @@ async def test_get_non_existing_triggers(
 
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test bad discovery message."""
     await mqtt_mock_entry_no_yaml_config()
@@ -172,7 +158,7 @@ async def test_discover_bad_triggers(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")}) is None
+    assert device_registry.async_get_device({("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     data1 = (
@@ -186,7 +172,7 @@ async def test_discover_bad_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -205,7 +191,7 @@ async def test_discover_bad_triggers(
 
 
 async def test_update_remove_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers can be updated and removed."""
     await mqtt_mock_entry_no_yaml_config()
@@ -234,7 +220,7 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers1 = [
         {
             "platform": "device",
@@ -267,12 +253,12 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", "")
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
 async def test_if_fires_on_mqtt_message(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, calls, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers firing."""
     await mqtt_mock_entry_no_yaml_config()
@@ -295,7 +281,7 @@ async def test_if_fires_on_mqtt_message(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data2)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -348,7 +334,7 @@ async def test_if_fires_on_mqtt_message(
 
 
 async def test_if_fires_on_mqtt_message_template(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, calls, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers firing."""
     await mqtt_mock_entry_no_yaml_config()
@@ -373,7 +359,7 @@ async def test_if_fires_on_mqtt_message_template(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data2)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -426,7 +412,7 @@ async def test_if_fires_on_mqtt_message_template(
 
 
 async def test_if_fires_on_mqtt_message_late_discover(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, calls, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers firing of MQTT device triggers discovered after setup."""
     await mqtt_mock_entry_no_yaml_config()
@@ -453,7 +439,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -510,7 +496,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
 
 
 async def test_if_fires_on_mqtt_message_after_update(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, calls, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers firing after update."""
     await mqtt_mock_entry_no_yaml_config()
@@ -530,7 +516,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -587,7 +573,7 @@ async def test_if_fires_on_mqtt_message_after_update(
 
 
 async def test_no_resubscribe_same_topic(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test subscription to topics without change."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -600,7 +586,7 @@ async def test_no_resubscribe_same_topic(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -632,7 +618,7 @@ async def test_no_resubscribe_same_topic(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, calls, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test triggers not firing after removal."""
     await mqtt_mock_entry_no_yaml_config()
@@ -645,7 +631,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -696,7 +682,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass: HomeAssistant,
     hass_ws_client,
-    device_reg,
+    device_registry,
     calls,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
@@ -717,7 +703,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -767,7 +753,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 
 async def test_attach_remove(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test attach and removal of trigger."""
     await mqtt_mock_entry_no_yaml_config()
@@ -781,7 +767,7 @@ async def test_attach_remove(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -823,7 +809,7 @@ async def test_attach_remove(
 
 
 async def test_attach_remove_late(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test attach and removal of trigger ."""
     await mqtt_mock_entry_no_yaml_config()
@@ -842,7 +828,7 @@ async def test_attach_remove_late(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -887,7 +873,7 @@ async def test_attach_remove_late(
 
 
 async def test_attach_remove_late2(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test attach and removal of trigger ."""
     await mqtt_mock_entry_no_yaml_config()
@@ -906,7 +892,7 @@ async def test_attach_remove_late2(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -1061,8 +1047,7 @@ async def test_entity_device_info_update(
 async def test_cleanup_trigger(
     hass: HomeAssistant,
     hass_ws_client,
-    device_reg,
-    entity_reg,
+    device_registry,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test trigger discovery topic is cleaned when device is removed from registry."""
@@ -1083,7 +1068,7 @@ async def test_cleanup_trigger(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1107,7 +1092,7 @@ async def test_cleanup_trigger(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
     # Verify retained discovery topic has been cleared
@@ -1117,7 +1102,7 @@ async def test_cleanup_trigger(
 
 
 async def test_cleanup_device(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry when trigger is removed."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1134,7 +1119,7 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1146,12 +1131,12 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_several_triggers(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry when the last trigger is removed."""
     await mqtt_mock_entry_no_yaml_config()
@@ -1179,7 +1164,7 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1193,7 +1178,7 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1206,12 +1191,12 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_with_entity1(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry for device with entity.
 
@@ -1241,7 +1226,7 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1253,7 +1238,7 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1265,12 +1250,12 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_with_entity2(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry for device with entity.
 
@@ -1300,7 +1285,7 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1312,7 +1297,7 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1324,7 +1309,7 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -1406,7 +1391,7 @@ async def test_trigger_debug_info(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, calls, device_reg, mqtt_mock, tmp_path
+    hass: HomeAssistant, calls, device_registry, mqtt_mock, tmp_path
 ) -> None:
     """Test unloading the MQTT entry."""
 
@@ -1419,7 +1404,7 @@ async def test_unload_entry(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -43,8 +43,6 @@ from tests.common import (
     MockConfigEntry,
     async_fire_mqtt_message,
     async_fire_time_changed,
-    mock_device_registry,
-    mock_registry,
     mock_restore_cache,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
@@ -69,18 +67,6 @@ def sensor_platforms_only():
 @pytest.fixture(autouse=True)
 def mock_storage(hass_storage):
     """Autouse hass_storage for the TestCase tests."""
-
-
-@pytest.fixture
-def device_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture
-def entity_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 @pytest.fixture
@@ -1897,7 +1883,7 @@ async def test_mqtt_subscribes_topics_on_connect(
 
 
 async def test_setup_entry_with_config_override(
-    hass, device_reg, mqtt_mock_entry_with_yaml_config
+    hass, device_registry, mqtt_mock_entry_with_yaml_config
 ):
     """Test if the MQTT component loads with no config and config entry can be setup."""
     data = (
@@ -1920,12 +1906,12 @@ async def test_setup_entry_with_config_override(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
 
 async def test_update_incomplete_entry(
-    hass: HomeAssistant, device_reg, mqtt_client_mock, caplog
+    hass: HomeAssistant, device_registry, mqtt_client_mock, caplog
 ):
     """Test if the MQTT component loads when config entry data is incomplete."""
     data = (
@@ -1958,11 +1944,11 @@ async def test_update_incomplete_entry(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
 
-async def test_fail_no_broker(hass, device_reg, mqtt_client_mock, caplog):
+async def test_fail_no_broker(hass, device_registry, mqtt_client_mock, caplog):
     """Test if the MQTT component loads when broker configuration is missing."""
     # Config entry data is incomplete
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={})
@@ -2091,7 +2077,7 @@ async def test_dump_service(hass, mqtt_mock_entry_no_yaml_config):
 
 
 async def test_mqtt_ws_remove_discovered_device(
-    hass, device_reg, entity_reg, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
 ):
     """Test MQTT websocket device removal."""
     assert await async_setup_component(hass, "config", {})
@@ -2108,7 +2094,7 @@ async def test_mqtt_ws_remove_discovered_device(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -2125,12 +2111,12 @@ async def test_mqtt_ws_remove_discovered_device(
     assert response["success"]
 
     # Verify device entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
 async def test_mqtt_ws_get_device_debug_info(
-    hass, device_reg, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
 ):
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2157,7 +2143,7 @@ async def test_mqtt_ws_get_device_debug_info(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -2193,7 +2179,7 @@ async def test_mqtt_ws_get_device_debug_info(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.CAMERA])
 async def test_mqtt_ws_get_device_debug_info_binary(
-    hass, device_reg, hass_ws_client, mqtt_mock_entry_no_yaml_config
+    hass, device_registry, hass_ws_client, mqtt_mock_entry_no_yaml_config
 ):
     """Test MQTT websocket device debug info."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2209,7 +2195,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     small_png = (
@@ -2423,7 +2409,7 @@ async def test_debug_info_multiple_entities_triggers(
 
 
 async def test_debug_info_non_mqtt(
-    hass, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass, device_registry, entity_registry, mqtt_mock_entry_no_yaml_config
 ):
     """Test we get empty debug_info for a device with non MQTT entities."""
     await mqtt_mock_entry_no_yaml_config()
@@ -2433,12 +2419,12 @@ async def test_debug_info_non_mqtt(
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
-    device_entry = device_reg.async_get_or_create(
+    device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in DEVICE_CLASSES:
-        entity_reg.async_get_or_create(
+        entity_registry.async_get_or_create(
             DOMAIN,
             "test",
             platform.ENTITIES[device_class].unique_id,

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -19,8 +19,6 @@ from tests.common import (
     MockConfigEntry,
     async_fire_mqtt_message,
     async_get_device_automations,
-    mock_device_registry,
-    mock_registry,
 )
 
 DEFAULT_CONFIG_DEVICE = {
@@ -55,18 +53,6 @@ def binary_sensor_only():
 
 
 @pytest.fixture
-def device_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture
-def entity_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
-
-
-@pytest.fixture
 def tag_mock():
     """Fixture to mock tag."""
     with patch("homeassistant.components.tag.async_scan_tag") as mock_tag:
@@ -76,8 +62,7 @@ def tag_mock():
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_tag(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry,
     mqtt_mock_entry_no_yaml_config,
     tag_mock,
 ) -> None:
@@ -89,13 +74,13 @@ async def test_discover_bad_tag(
     data0 = '{ "device":{"identifiers":["0AFFD2"]}, "topics": "foobar/tag_scanned" }'
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")}) is None
+    assert device_registry.async_get_device({("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
     await hass.async_block_till_done()
@@ -103,7 +88,7 @@ async def test_discover_bad_tag(
 
 
 async def test_if_fires_on_mqtt_message_with_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning, with device."""
     await mqtt_mock_entry_no_yaml_config()
@@ -111,7 +96,7 @@ async def test_if_fires_on_mqtt_message_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -120,7 +105,7 @@ async def test_if_fires_on_mqtt_message_with_device(
 
 
 async def test_if_fires_on_mqtt_message_without_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning, without device."""
     await mqtt_mock_entry_no_yaml_config()
@@ -136,7 +121,7 @@ async def test_if_fires_on_mqtt_message_without_device(
 
 
 async def test_if_fires_on_mqtt_message_with_template(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning, with device."""
     await mqtt_mock_entry_no_yaml_config()
@@ -144,7 +129,7 @@ async def test_if_fires_on_mqtt_message_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -153,7 +138,7 @@ async def test_if_fires_on_mqtt_message_with_template(
 
 
 async def test_strip_tag_id(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test strip whitespace from tag_id."""
     await mqtt_mock_entry_no_yaml_config()
@@ -169,7 +154,7 @@ async def test_strip_tag_id(
 
 
 async def test_if_fires_on_mqtt_message_after_update_with_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
@@ -181,7 +166,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -216,7 +201,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_device(
 
 
 async def test_if_fires_on_mqtt_message_after_update_without_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
@@ -260,7 +245,7 @@ async def test_if_fires_on_mqtt_message_after_update_without_device(
 
 
 async def test_if_fires_on_mqtt_message_after_update_with_template(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning after update."""
     await mqtt_mock_entry_no_yaml_config()
@@ -271,7 +256,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -306,7 +291,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
 
 
 async def test_no_resubscribe_same_topic(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test subscription to topics without change."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
@@ -314,7 +299,7 @@ async def test_no_resubscribe_same_topic(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")})
+    assert device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     call_count = mqtt_mock.async_subscribe.call_count
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
@@ -323,7 +308,7 @@ async def test_no_resubscribe_same_topic(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning after removal."""
     await mqtt_mock_entry_no_yaml_config()
@@ -331,7 +316,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -357,7 +342,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_without_device(
-    hass: HomeAssistant, device_reg, mqtt_mock_entry_no_yaml_config, tag_mock
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config, tag_mock
 ) -> None:
     """Test tag scanning not firing after removal."""
     await mqtt_mock_entry_no_yaml_config()
@@ -392,7 +377,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_without_device(
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass: HomeAssistant,
     hass_ws_client,
-    device_reg,
+    device_registry,
     mqtt_mock_entry_no_yaml_config,
     tag_mock,
 ) -> None:
@@ -406,7 +391,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -540,8 +525,7 @@ async def test_entity_device_info_update(
 async def test_cleanup_tag(
     hass: HomeAssistant,
     hass_ws_client,
-    device_reg,
-    entity_reg,
+    device_registry,
     mqtt_mock_entry_no_yaml_config,
 ) -> None:
     """Test tag discovery topic is cleaned when device is removed from registry."""
@@ -555,7 +539,7 @@ async def test_cleanup_tag(
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)
 
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections=set(),
         identifiers={("mqtt", "helloworld")},
@@ -578,20 +562,20 @@ async def test_cleanup_tag(
     await hass.async_block_till_done()
 
     # Verify device registry entries are created
-    device_entry1 = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry1 is not None
     assert device_entry1.config_entries == {config_entry.entry_id, mqtt_entry.entry_id}
-    device_entry2 = device_reg.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
     assert device_entry2 is not None
 
     # Remove other config entry from the device
-    device_reg.async_update_device(
+    device_registry.async_update_device(
         device_entry1.id, remove_config_entry_id=config_entry.entry_id
     )
-    device_entry1 = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry1 is not None
     assert device_entry1.config_entries == {mqtt_entry.entry_id}
-    device_entry2 = device_reg.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
     assert device_entry2 is not None
     mqtt_mock.async_publish.assert_not_called()
 
@@ -611,9 +595,9 @@ async def test_cleanup_tag(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry1 = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry1 is None
-    device_entry2 = device_reg.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
     assert device_entry2 is not None
 
     # Verify retained discovery topic has been cleared
@@ -623,7 +607,7 @@ async def test_cleanup_tag(
 
 
 async def test_cleanup_device(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry when tag is removed."""
     await mqtt_mock_entry_no_yaml_config()
@@ -637,21 +621,20 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_several_tags(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry,
     mqtt_mock_entry_no_yaml_config,
     tag_mock,
 ) -> None:
@@ -673,14 +656,14 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     # Fake tag scan.
@@ -693,12 +676,12 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_with_entity_and_trigger_1(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry for device with tag, entity and trigger.
 
@@ -736,7 +719,7 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -748,7 +731,7 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", "")
@@ -758,12 +741,12 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
 async def test_cleanup_device_with_entity2(
-    hass: HomeAssistant, device_reg, entity_reg, mqtt_mock_entry_no_yaml_config
+    hass: HomeAssistant, device_registry, mqtt_mock_entry_no_yaml_config
 ) -> None:
     """Test removal from device registry for device with tag, entity and trigger.
 
@@ -801,7 +784,7 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -816,14 +799,14 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -872,7 +855,7 @@ async def test_update_with_bad_config_not_breaks_discovery(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, device_reg, mqtt_mock, tag_mock, tmp_path
+    hass: HomeAssistant, device_registry, mqtt_mock, tag_mock, tmp_path
 ) -> None:
     """Test unloading the MQTT entry."""
 
@@ -880,7 +863,7 @@ async def test_unload_entry(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan, should be processed
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes unneeded mocking of registries from the MQTT tests. The hass instance has those already nowadays.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
