### PR TITLE
Add type hints to requests_mock

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -112,6 +112,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
     "recorder_db_url": "str",
     "recorder_mock": "Recorder",
+    "requests_mock": "requests_mock.Mocker",
 }
 _TEST_FUNCTION_MATCH = TypeHintMatch(
     function_name="test_*",

--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import forecastio
 from requests.exceptions import ConnectionError as ConnectError
+import requests_mock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -68,7 +69,9 @@ INVALID_CONFIG_LANG = {
 }
 
 
-async def test_setup_with_config(hass, requests_mock):
+async def test_setup_with_config(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test the platform setup with configuration."""
     with patch("homeassistant.components.darksky.sensor.forecastio.load_forecast"):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
@@ -106,7 +109,9 @@ async def test_setup_with_invalid_language_config(hass: HomeAssistant) -> None:
     assert state is None
 
 
-async def test_setup_bad_api_key(hass, requests_mock):
+async def test_setup_bad_api_key(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test for handling a bad API key."""
     # The Dark Sky API wrapper that we use raises an HTTP error
     # when you try to use a bad (or no) API key.
@@ -137,7 +142,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
         assert state is None
 
 
-async def test_setup(hass, requests_mock):
+async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test for successfully setting up the forecast.io platform."""
     with patch(
         "forecastio.api.get_forecast", wraps=forecastio.api.get_forecast

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import forecastio
 from requests.exceptions import ConnectionError as ConnectError
+import requests_mock
 
 from homeassistant.components import weather
 from homeassistant.core import HomeAssistant
@@ -12,7 +13,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import load_fixture
 
 
-async def test_setup(hass, requests_mock):
+async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test for successfully setting up the forecast.io platform."""
     with patch(
         "forecastio.api.get_forecast", wraps=forecastio.api.get_forecast

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ import freezegun
 import multidict
 import pytest
 import pytest_socket
-import requests_mock as _requests_mock
+import requests_mock
 
 from homeassistant import core as ha, loader, runner, util
 from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY
@@ -490,10 +490,10 @@ async def stop_hass(
             await event_loop.shutdown_default_executor()
 
 
-@pytest.fixture
-def requests_mock():
+@pytest.fixture(name="requests_mock")
+def requests_mock_fixture() -> Generator[requests_mock.Mocker, None, None]:
     """Fixture to provide a requests mocker."""
-    with _requests_mock.mock() as m:
+    with requests_mock.mock() as m:
         yield m
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to requests_mock

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
