### PR TITLE
Add homeassistant.reload_all service

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -286,7 +286,20 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
         Additionally, it also calls the `homeasssitant.reload_core_config`
         service, as that reloads the core YAML configuration, and the
         `frontend.reload_themes` service, as that reloads the themes.
+
+        We only do so, if there are no configuration errors.
         """
+
+        if errors := await conf_util.async_check_ha_config_file(hass):
+            _LOGGER.error(
+                "The system cannot reload because the configuration is not valid: %s",
+                errors,
+            )
+            raise HomeAssistantError(
+                "Cannot quick reload all YAML configurations because the "
+                f"configuration is not valid: {errors}"
+            )
+
         services = hass.services.async_services()
         tasks = [
             hass.services.async_call(

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -12,6 +12,7 @@ import homeassistant.components as comps
 from homeassistant.components.homeassistant import (
     ATTR_ENTRY_ID,
     SERVICE_CHECK_CONFIG,
+    SERVICE_RELOAD_ALL,
     SERVICE_RELOAD_CORE_CONFIG,
     SERVICE_SET_LOCATION,
 )
@@ -565,3 +566,23 @@ async def test_save_persistent_states(hass: HomeAssistant) -> None:
             blocking=True,
         )
         assert mock_save.called
+
+
+async def test_reload_all(hass: HomeAssistant) -> None:
+    """Test reload_all service."""
+    await async_setup_component(hass, "homeassistant", {})
+    test1 = async_mock_service(hass, "test1", "reload")
+    test2 = async_mock_service(hass, "test2", "reload")
+    test3 = async_mock_service(hass, "test3", "not_reload")
+    test4 = async_mock_service(hass, "notify", "reload")
+
+    await hass.services.async_call(
+        "homeassistant",
+        SERVICE_RELOAD_ALL,
+        blocking=True,
+    )
+
+    assert len(test1) == 1
+    assert len(test2) == 1
+    assert len(test3) == 0
+    assert len(test4) == 0

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -575,6 +575,7 @@ async def test_reload_all(hass: HomeAssistant) -> None:
     test2 = async_mock_service(hass, "test2", "reload")
     test3 = async_mock_service(hass, "test3", "not_reload")
     test4 = async_mock_service(hass, "notify", "reload")
+    test5 = async_mock_service(hass, "homeassistant", "reload_core_config")
 
     await hass.services.async_call(
         "homeassistant",
@@ -586,3 +587,4 @@ async def test_reload_all(hass: HomeAssistant) -> None:
     assert len(test2) == 1
     assert len(test3) == 0
     assert len(test4) == 0
+    assert len(test5) == 1

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -568,7 +568,9 @@ async def test_save_persistent_states(hass: HomeAssistant) -> None:
         assert mock_save.called
 
 
-async def test_reload_all(hass: HomeAssistant) -> None:
+async def test_reload_all(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test reload_all service."""
     await async_setup_component(hass, "homeassistant", {})
     test1 = async_mock_service(hass, "test1", "reload")
@@ -578,15 +580,48 @@ async def test_reload_all(hass: HomeAssistant) -> None:
     core_config = async_mock_service(hass, "homeassistant", "reload_core_config")
     themes = async_mock_service(hass, "frontend", "reload_themes")
 
-    await hass.services.async_call(
-        "homeassistant",
-        SERVICE_RELOAD_ALL,
-        blocking=True,
-    )
+    with patch(
+        "homeassistant.config.async_check_ha_config_file",
+        return_value=None,
+    ) as mock_async_check_ha_config_file:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_RELOAD_ALL,
+            blocking=True,
+        )
 
+    assert mock_async_check_ha_config_file.called
     assert len(test1) == 1
     assert len(test2) == 1
     assert len(no_reload) == 0
     assert len(notify) == 0
+    assert len(core_config) == 1
+    assert len(themes) == 1
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            "Cannot quick reload all YAML configurations because the configuration is "
+            "not valid: Oh no, drama!"
+        ),
+    ), patch(
+        "homeassistant.config.async_check_ha_config_file",
+        return_value="Oh no, drama!",
+    ) as mock_async_check_ha_config_file:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_RELOAD_ALL,
+            blocking=True,
+        )
+
+    assert mock_async_check_ha_config_file.called
+    assert (
+        "The system cannot reload because the configuration is not valid: Oh no, drama!"
+        in caplog.text
+    )
+
+    # None have been called again
+    assert len(test1) == 1
+    assert len(test2) == 1
     assert len(core_config) == 1
     assert len(themes) == 1

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -573,9 +573,10 @@ async def test_reload_all(hass: HomeAssistant) -> None:
     await async_setup_component(hass, "homeassistant", {})
     test1 = async_mock_service(hass, "test1", "reload")
     test2 = async_mock_service(hass, "test2", "reload")
-    test3 = async_mock_service(hass, "test3", "not_reload")
-    test4 = async_mock_service(hass, "notify", "reload")
-    test5 = async_mock_service(hass, "homeassistant", "reload_core_config")
+    no_reload = async_mock_service(hass, "test3", "not_reload")
+    notify = async_mock_service(hass, "notify", "reload")
+    core_config = async_mock_service(hass, "homeassistant", "reload_core_config")
+    themes = async_mock_service(hass, "frontend", "reload_themes")
 
     await hass.services.async_call(
         "homeassistant",
@@ -585,6 +586,7 @@ async def test_reload_all(hass: HomeAssistant) -> None:
 
     assert len(test1) == 1
     assert len(test2) == 1
-    assert len(test3) == 0
-    assert len(test4) == 0
-    assert len(test5) == 1
+    assert len(no_reload) == 0
+    assert len(notify) == 0
+    assert len(core_config) == 1
+    assert len(themes) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the `homeassistant.reload_all` service, which can be used to reload YAML configuration for all active domains.

To support: https://github.com/home-assistant/frontend/pull/15337

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26184

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
