### PR TITLE
Bump renault-api to 0.1.12

### DIFF
--- a/homeassistant/components/renault/__init__.py
+++ b/homeassistant/components/renault/__init__.py
@@ -1,5 +1,6 @@
 """Support for Renault devices."""
 import aiohttp
+from renault_api.gigya.exceptions import GigyaException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -18,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         login_success = await renault_hub.attempt_login(
             config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD]
         )
-    except aiohttp.ClientConnectionError as exc:
+    except (aiohttp.ClientConnectionError, GigyaException) as exc:
         raise ConfigEntryNotReady() from exc
 
     if not login_success:

--- a/homeassistant/components/renault/manifest.json
+++ b/homeassistant/components/renault/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["renault_api"],
   "quality_scale": "platinum",
-  "requirements": ["renault-api==0.1.11"]
+  "requirements": ["renault-api==0.1.12"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2228,7 +2228,7 @@ raspyrfm-client==1.2.8
 regenmaschine==2022.11.0
 
 # homeassistant.components.renault
-renault-api==0.1.11
+renault-api==0.1.12
 
 # homeassistant.components.reolink
 reolink-aio==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1573,7 +1573,7 @@ radiotherm==2.1.0
 regenmaschine==2022.11.0
 
 # homeassistant.components.renault
-renault-api==0.1.11
+renault-api==0.1.12
 
 # homeassistant.components.reolink
 reolink-aio==0.4.0

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -1,10 +1,11 @@
 """Tests for Renault setup process."""
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import patch
 
 import aiohttp
 import pytest
-from renault_api.gigya.exceptions import InvalidCredentialsException
+from renault_api.gigya.exceptions import GigyaException, InvalidCredentialsException
 
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -58,8 +59,9 @@ async def test_setup_entry_bad_password(
     assert not hass.data.get(DOMAIN)
 
 
+@pytest.mark.parametrize("side_effect", [aiohttp.ClientConnectionError, GigyaException])
 async def test_setup_entry_exception(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: ConfigEntry, side_effect: Any
 ) -> None:
     """Test ConfigEntryNotReady when API raises an exception during entry setup."""
     # In this case we are testing the condition where async_setup_entry raises


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Main fix: https://github.com/hacf-fr/renault-api/pull/789

Release notes: https://github.com/hacf-fr/renault-api/releases/tag/v0.1.12
Compare: https://github.com/hacf-fr/renault-api/compare/v0.1.11...v0.1.12


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
