### PR TITLE
Add missed type hints on MQTT platform tests

### DIFF
--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -783,7 +783,7 @@ async def test_invalid_discovery_prefix(
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     mock_try_connection,
     mock_reload_after_entry_update,
-) -> HomeAssistant:
+) -> None:
     """Test setting an invalid discovery prefix."""
     mqtt_mock = await mqtt_mock_entry_no_yaml_config()
     mock_try_connection.return_value = True
@@ -1160,7 +1160,7 @@ async def test_try_connection_with_advanced_parameters(
     tmp_path: Path,
     mock_ssl_context,
     mock_process_uploaded_file,
-) -> HomeAssistant:
+) -> None:
     """Test config flow with advanced parameters from config."""
 
     with open(tmp_path / "client.crt", "wb") as certfile:

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -10,7 +10,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt import _LOGGER, DOMAIN, debug_info
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -28,7 +28,7 @@ from tests.typing import MqttMockHAClient, MqttMockHAClientGenerator, WebSocketG
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -154,11 +154,11 @@ def light_platform_only():
 class JsonValidator:
     """Helper to compare JSON."""
 
-    def __init__(self, jsondata):
+    def __init__(self, jsondata) -> None:
         """Initialize JSON validator."""
         self.jsondata = jsondata
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Compare JSON data."""
         return json.loads(self.jsondata) == json.loads(other)
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -79,7 +79,6 @@ light:
   brightness_scale: 99
 """
 import copy
-import json
 from pathlib import Path
 from unittest.mock import call, patch
 
@@ -98,6 +97,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.json import JsonValueType, json_loads
 from homeassistant.setup import async_setup_component
 
 from .test_common import (
@@ -154,13 +154,13 @@ def light_platform_only():
 class JsonValidator:
     """Helper to compare JSON."""
 
-    def __init__(self, jsondata) -> None:
+    def __init__(self, jsondata: JsonValueType) -> None:
         """Initialize JSON validator."""
         self.jsondata = jsondata
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: JsonValueType) -> bool:
         """Compare JSON data."""
-        return json.loads(self.jsondata) == json.loads(other)
+        return json_loads(self.jsondata) == json_loads(other)
 
 
 async def test_fail_setup_if_no_command_topic(

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -44,7 +44,7 @@ async def test_availability_with_shared_state_topic(
     events = []
 
     @callback
-    def test_callback(event):
+    def test_callback(event) -> None:
         events.append(event)
 
     hass.bus.async_listen(EVENT_STATE_CHANGED, test_callback)

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -1,6 +1,7 @@
 """The tests for the MQTT siren platform."""
 import copy
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -66,7 +67,11 @@ def siren_platform_only():
         yield
 
 
-async def async_turn_on(hass, entity_id=ENTITY_MATCH_ALL, parameters={}) -> None:
+async def async_turn_on(
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    parameters: dict[str, Any] = {},
+) -> None:
     """Turn all or specified siren on."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     data.update(parameters)
@@ -74,7 +79,9 @@ async def async_turn_on(hass, entity_id=ENTITY_MATCH_ALL, parameters={}) -> None
     await hass.services.async_call(siren.DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
-async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL) -> None:
+async def async_turn_off(
+    hass: HomeAssistant, entity_id: str = ENTITY_MATCH_ALL
+) -> None:
     """Turn all or specified siren off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some type hints were missed but exposed with:
`pylint --disable=all --enable=hass-argument-type,hass-return-type --ignore-missing-annotations=n tests/components/mqtt/`
These are addressed in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
