### PR TITLE
Bump pyinsteon to 1.3.1

### DIFF
--- a/homeassistant/components/insteon/api/aldb.py
+++ b/homeassistant/components/insteon/api/aldb.py
@@ -4,12 +4,6 @@ from typing import Any
 
 from pyinsteon import devices
 from pyinsteon.constants import ALDBStatus
-from pyinsteon.topics import (
-    ALDB_STATUS_CHANGED,
-    DEVICE_LINK_CONTROLLER_CREATED,
-    DEVICE_LINK_RESPONDER_CREATED,
-)
-from pyinsteon.utils import subscribe_topic, unsubscribe_topic
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
@@ -271,33 +265,31 @@ async def websocket_notify_on_aldb_status(
         return
 
     @callback
-    def record_added(controller, responder, group):
+    def record_added(record, sender, deleted):
         """Forward ALDB events to websocket."""
         forward_data = {"type": "record_loaded"}
         connection.send_message(websocket_api.event_message(msg["id"], forward_data))
 
     @callback
-    def aldb_loaded():
+    def aldb_loaded(status):
         """Forward ALDB loaded event to websocket."""
         forward_data = {
             "type": "status_changed",
-            "is_loading": device.aldb.status == ALDBStatus.LOADING,
+            "is_loading": status == ALDBStatus.LOADING,
         }
         connection.send_message(websocket_api.event_message(msg["id"], forward_data))
 
     @callback
     def async_cleanup() -> None:
         """Remove signal listeners."""
-        unsubscribe_topic(record_added, f"{DEVICE_LINK_CONTROLLER_CREATED}.{device.id}")
-        unsubscribe_topic(record_added, f"{DEVICE_LINK_RESPONDER_CREATED}.{device.id}")
-        unsubscribe_topic(aldb_loaded, f"{device.id}.{ALDB_STATUS_CHANGED}")
+        device.aldb.unsubscribe_record_changed(record_added)
+        device.aldb.unsubscribe_status_changed(aldb_loaded)
 
         forward_data = {"type": "unsubscribed"}
         connection.send_message(websocket_api.event_message(msg["id"], forward_data))
 
     connection.subscriptions[msg["id"]] = async_cleanup
-    subscribe_topic(record_added, f"{DEVICE_LINK_CONTROLLER_CREATED}.{device.id}")
-    subscribe_topic(record_added, f"{DEVICE_LINK_RESPONDER_CREATED}.{device.id}")
-    subscribe_topic(aldb_loaded, f"{device.id}.{ALDB_STATUS_CHANGED}")
+    device.aldb.subscribe_record_changed(record_added)
+    device.aldb.subscribe_status_changed(aldb_loaded)
 
     connection.send_result(msg[ID])

--- a/homeassistant/components/insteon/ipdb.py
+++ b/homeassistant/components/insteon/ipdb.py
@@ -1,5 +1,5 @@
 """Utility methods for the Insteon platform."""
-from pyinsteon.device_types import (
+from pyinsteon.device_types.ipdb import (
     AccessControl_Morningstar,
     ClimateControl_Thermostat,
     ClimateControl_WirelessThermostat,

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -17,7 +17,7 @@
   "iot_class": "local_push",
   "loggers": ["pyinsteon", "pypubsub"],
   "requirements": [
-    "pyinsteon==1.2.0",
+    "pyinsteon==1.3.1",
     "insteon-frontend-home-assistant==0.2.0"
   ],
   "usb": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1684,7 +1684,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.2.0
+pyinsteon==1.3.1
 
 # homeassistant.components.intesishome
 pyintesishome==1.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1209,7 +1209,7 @@ pyialarm==2.2.0
 pyicloud==1.0.0
 
 # homeassistant.components.insteon
-pyinsteon==1.2.0
+pyinsteon==1.3.1
 
 # homeassistant.components.ipma
 pyipma==3.0.5

--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyinsteon.address import Address
 from pyinsteon.constants import ALDBStatus, ResponseStatus
-from pyinsteon.device_types import (
+from pyinsteon.device_types.ipdb import (
     AccessControl_Morningstar,
     DimmableLightingControl_KeypadLinc_8,
     GeneralController_RemoteLinc,

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 from pyinsteon import pub
 from pyinsteon.address import Address
-from pyinsteon.topics import ALDB_RECORD_RECEIVED, ALDB_STATUS_CHANGED
+from pyinsteon.constants import ALDBStatus
+from pyinsteon.topics import ALDB_LINK_CHANGED, ALDB_STATUS_CHANGED
 import pytest
 
 from homeassistant.components import insteon
@@ -223,7 +224,7 @@ async def test_notify_on_aldb_status(hass, hass_ws_client, aldb_data):
         msg = await ws_client.receive_json()
         assert msg["success"]
 
-        pub.sendMessage(f"333333.{ALDB_STATUS_CHANGED}")
+        pub.sendMessage(f"333333.{ALDB_STATUS_CHANGED}", status=ALDBStatus.LOADED)
         msg = await ws_client.receive_json()
         assert msg["event"]["type"] == "status_changed"
         assert not msg["event"]["is_loading"]
@@ -245,8 +246,8 @@ async def test_notify_on_aldb_record_added(hass, hass_ws_client, aldb_data):
         assert msg["success"]
 
         pub.sendMessage(
-            f"333333.{ALDB_RECORD_RECEIVED}",
-            record=None,
+            f"333333.{ALDB_LINK_CHANGED}",
+            record="some record",
             sender=Address("11.11.11"),
             deleted=False,
         )

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from pyinsteon import pub
 from pyinsteon.address import Address
-from pyinsteon.topics import ALDB_STATUS_CHANGED, DEVICE_LINK_CONTROLLER_CREATED
+from pyinsteon.topics import ALDB_RECORD_RECEIVED, ALDB_STATUS_CHANGED
 import pytest
 
 from homeassistant.components import insteon
@@ -245,10 +245,10 @@ async def test_notify_on_aldb_record_added(hass, hass_ws_client, aldb_data):
         assert msg["success"]
 
         pub.sendMessage(
-            f"{DEVICE_LINK_CONTROLLER_CREATED}.333333",
-            controller=Address("11.11.11"),
-            responder=Address("33.33.33"),
-            group=100,
+            f"333333.{ALDB_RECORD_RECEIVED}",
+            record=None,
+            sender=Address("11.11.11"),
+            deleted=False,
         )
         msg = await ws_client.receive_json()
         assert msg["event"]["type"] == "record_loaded"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump the `pyinsteon` dependency to 1.3.1 to address underlying bugs and performance improvements.

Changelog: https://github.com/pyinsteon/pyinsteon/compare/1.2.0...1.3.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
