### PR TITLE
Add type hints to integration tests (part 2)

### DIFF
--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -13,6 +13,7 @@ from homeassistant.components.analytics.const import (
     ATTR_STATISTICS,
     ATTR_USAGE,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.const import ATTR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import IntegrationNotFound
@@ -509,7 +510,7 @@ async def test_send_with_no_energy(
 
 
 async def test_send_with_no_energy_config(
-    recorder_mock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    recorder_mock: Recorder, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
@@ -533,7 +534,7 @@ async def test_send_with_no_energy_config(
 
 
 async def test_send_with_energy_config(
-    recorder_mock, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    recorder_mock: Recorder, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)

--- a/tests/components/automation/test_recorder.py
+++ b/tests/components/automation/test_recorder.py
@@ -11,6 +11,7 @@ from homeassistant.components.automation import (
     ATTR_MODE,
     CONF_ID,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
@@ -27,7 +28,9 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_exclude_attributes(recorder_mock, hass: HomeAssistant, calls) -> None:
+async def test_exclude_attributes(
+    recorder_mock: Recorder, hass: HomeAssistant, calls
+) -> None:
     """Test automation registered attributes to be excluded."""
     assert await async_setup_component(
         hass,

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -25,12 +25,14 @@ async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     assert AXIS_DOMAIN not in hass.data
 
 
-async def test_no_binary_sensors(hass, setup_config_entry):
+async def test_no_binary_sensors(hass: HomeAssistant, setup_config_entry) -> None:
     """Test that no sensors in Axis results in no sensor entities."""
     assert not hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)
 
 
-async def test_binary_sensors(hass, setup_config_entry, mock_rtsp_event):
+async def test_binary_sensors(
+    hass: HomeAssistant, setup_config_entry, mock_rtsp_event
+) -> None:
     """Test that sensors are loaded properly."""
     mock_rtsp_event(
         topic="tns1:Device/tnsaxis:Sensor/PIR",

--- a/tests/components/axis/test_camera.py
+++ b/tests/components/axis/test_camera.py
@@ -28,7 +28,7 @@ async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     assert AXIS_DOMAIN not in hass.data
 
 
-async def test_camera(hass, setup_config_entry):
+async def test_camera(hass: HomeAssistant, setup_config_entry) -> None:
     """Test that Axis camera platform is loaded properly."""
     assert len(hass.states.async_entity_ids(CAMERA_DOMAIN)) == 1
 
@@ -48,7 +48,9 @@ async def test_camera(hass, setup_config_entry):
 
 
 @pytest.mark.parametrize("options", [{CONF_STREAM_PROFILE: "profile_1"}])
-async def test_camera_with_stream_profile(hass, setup_config_entry):
+async def test_camera_with_stream_profile(
+    hass: HomeAssistant, setup_config_entry
+) -> None:
     """Test that Axis camera entity is using the correct path with stream profike."""
     assert len(hass.states.async_entity_ids(CAMERA_DOMAIN)) == 1
 
@@ -70,7 +72,7 @@ async def test_camera_with_stream_profile(hass, setup_config_entry):
     )
 
 
-async def test_camera_disabled(hass, prepare_config_entry):
+async def test_camera_disabled(hass: HomeAssistant, prepare_config_entry) -> None:
     """Test that Axis camera platform is loaded properly but does not create camera entity."""
     with patch("axis.vapix.vapix.Params.image_format", new=None):
         await prepare_config_entry()

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -46,7 +46,9 @@ async def mock_config_entry_fixture(hass, config_entry):
         yield config_entry
 
 
-async def test_flow_manual_configuration(hass, setup_default_vapix_requests):
+async def test_flow_manual_configuration(
+    hass: HomeAssistant, setup_default_vapix_requests
+) -> None:
     """Test that config flow works."""
     MockConfigEntry(domain=AXIS_DOMAIN, source=SOURCE_IGNORE).add_to_hass(hass)
 
@@ -80,8 +82,8 @@ async def test_flow_manual_configuration(hass, setup_default_vapix_requests):
 
 
 async def test_manual_configuration_update_configuration(
-    hass, mock_config_entry, mock_vapix_requests
-):
+    hass: HomeAssistant, mock_config_entry, mock_vapix_requests
+) -> None:
     """Test that config flow fails on already configured device."""
     assert mock_config_entry.data[CONF_HOST] == "1.2.3.4"
 
@@ -162,8 +164,8 @@ async def test_flow_fails_cannot_connect(hass: HomeAssistant) -> None:
 
 
 async def test_flow_create_entry_multiple_existing_entries_of_same_model(
-    hass, setup_default_vapix_requests
-):
+    hass: HomeAssistant, setup_default_vapix_requests
+) -> None:
     """Test that create entry can generate a name with other entries."""
     entry = MockConfigEntry(
         domain=AXIS_DOMAIN,
@@ -208,8 +210,8 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
 
 
 async def test_reauth_flow_update_configuration(
-    hass, mock_config_entry, mock_vapix_requests
-):
+    hass: HomeAssistant, mock_config_entry, mock_vapix_requests
+) -> None:
     """Test that config flow fails on already configured device."""
     assert mock_config_entry.data[CONF_HOST] == "1.2.3.4"
     assert mock_config_entry.data[CONF_USERNAME] == "root"
@@ -308,8 +310,8 @@ async def test_reauth_flow_update_configuration(
     ],
 )
 async def test_discovery_flow(
-    hass, setup_default_vapix_requests, source: str, discovery_info: dict
-):
+    hass: HomeAssistant, setup_default_vapix_requests, source: str, discovery_info: dict
+) -> None:
     """Test the different discovery flows for new devices work."""
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, data=discovery_info, context={"source": source}
@@ -384,8 +386,8 @@ async def test_discovery_flow(
     ],
 )
 async def test_discovered_device_already_configured(
-    hass, mock_config_entry, source: str, discovery_info: dict
-):
+    hass: HomeAssistant, mock_config_entry, source: str, discovery_info: dict
+) -> None:
     """Test that discovery doesn't setup already configured devices."""
     assert mock_config_entry.data[CONF_HOST] == DEFAULT_HOST
 
@@ -439,13 +441,13 @@ async def test_discovered_device_already_configured(
     ],
 )
 async def test_discovery_flow_updated_configuration(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_vapix_requests,
     source: str,
     discovery_info: dict,
     expected_port: int,
-):
+) -> None:
     """Test that discovery flow update configuration with new parameters."""
     assert mock_config_entry.data == {
         CONF_HOST: DEFAULT_HOST,
@@ -512,8 +514,8 @@ async def test_discovery_flow_updated_configuration(
     ],
 )
 async def test_discovery_flow_ignore_non_axis_device(
-    hass, source: str, discovery_info: dict
-):
+    hass: HomeAssistant, source: str, discovery_info: dict
+) -> None:
     """Test that discovery flow ignores devices with non Axis OUI."""
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, data=discovery_info, context={"source": source}
@@ -561,8 +563,8 @@ async def test_discovery_flow_ignore_non_axis_device(
     ],
 )
 async def test_discovery_flow_ignore_link_local_address(
-    hass, source: str, discovery_info: dict
-):
+    hass: HomeAssistant, source: str, discovery_info: dict
+) -> None:
     """Test that discovery flow ignores devices with link local addresses."""
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN, data=discovery_info, context={"source": source}
@@ -572,7 +574,7 @@ async def test_discovery_flow_ignore_link_local_address(
     assert result["reason"] == "link_local_address"
 
 
-async def test_option_flow(hass, setup_config_entry):
+async def test_option_flow(hass: HomeAssistant, setup_config_entry) -> None:
     """Test config flow options."""
     assert CONF_STREAM_PROFILE not in setup_config_entry.options
     assert CONF_VIDEO_SOURCE not in setup_config_entry.options

--- a/tests/components/axis/test_diagnostics.py
+++ b/tests/components/axis/test_diagnostics.py
@@ -1,16 +1,19 @@
 """Test Axis diagnostics."""
-
 import pytest
 
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from .const import API_DISCOVERY_BASIC_DEVICE_INFO
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_BASIC_DEVICE_INFO])
-async def test_entry_diagnostics(hass, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, setup_config_entry
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, setup_config_entry

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -5,14 +5,15 @@ import pytest
 
 from homeassistant.components import axis
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 
 
-async def test_setup_entry(hass, setup_config_entry):
+async def test_setup_entry(hass: HomeAssistant, setup_config_entry) -> None:
     """Test successful setup of entry."""
     assert setup_config_entry.state == ConfigEntryState.LOADED
 
 
-async def test_setup_entry_fails(hass, config_entry):
+async def test_setup_entry_fails(hass: HomeAssistant, config_entry) -> None:
     """Test successful setup of entry."""
     mock_device = Mock()
     mock_device.async_setup = AsyncMock(return_value=False)
@@ -25,7 +26,7 @@ async def test_setup_entry_fails(hass, config_entry):
     assert config_entry.state == ConfigEntryState.SETUP_ERROR
 
 
-async def test_unload_entry(hass, setup_config_entry):
+async def test_unload_entry(hass: HomeAssistant, setup_config_entry) -> None:
     """Test successful unload of entry."""
     assert setup_config_entry.state == ConfigEntryState.LOADED
 
@@ -34,7 +35,7 @@ async def test_unload_entry(hass, setup_config_entry):
 
 
 @pytest.mark.parametrize("config_entry_version", [1])
-async def test_migrate_entry(hass, config_entry):
+async def test_migrate_entry(hass: HomeAssistant, config_entry) -> None:
     """Test successful migration of entry data."""
     assert config_entry.version == 1
 

--- a/tests/components/axis/test_light.py
+++ b/tests/components/axis/test_light.py
@@ -66,7 +66,7 @@ async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     assert AXIS_DOMAIN not in hass.data
 
 
-async def test_no_lights(hass, setup_config_entry):
+async def test_no_lights(hass: HomeAssistant, setup_config_entry) -> None:
     """Test that no light events in Axis results in no light entities."""
     assert not hass.states.async_entity_ids(LIGHT_DOMAIN)
 
@@ -74,8 +74,8 @@ async def test_no_lights(hass, setup_config_entry):
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_LIGHT_CONTROL])
 @pytest.mark.parametrize("light_control_items", [[]])
 async def test_no_light_entity_without_light_control_representation(
-    hass, setup_config_entry, mock_rtsp_event
-):
+    hass: HomeAssistant, setup_config_entry, mock_rtsp_event
+) -> None:
     """Verify no lights entities get created without light control representation."""
     mock_rtsp_event(
         topic="tns1:Device/tnsaxis:Light/Status",
@@ -90,7 +90,7 @@ async def test_no_light_entity_without_light_control_representation(
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_LIGHT_CONTROL])
-async def test_lights(hass, setup_config_entry, mock_rtsp_event):
+async def test_lights(hass: HomeAssistant, setup_config_entry, mock_rtsp_event) -> None:
     """Test that lights are loaded properly."""
     # Add light
     with patch(

--- a/tests/components/axis/test_switch.py
+++ b/tests/components/axis/test_switch.py
@@ -27,12 +27,14 @@ async def test_platform_manually_configured(hass: HomeAssistant) -> None:
     assert AXIS_DOMAIN not in hass.data
 
 
-async def test_no_switches(hass, setup_config_entry):
+async def test_no_switches(hass: HomeAssistant, setup_config_entry) -> None:
     """Test that no output events in Axis results in no switch entities."""
     assert not hass.states.async_entity_ids(SWITCH_DOMAIN)
 
 
-async def test_switches_with_port_cgi(hass, setup_config_entry, mock_rtsp_event):
+async def test_switches_with_port_cgi(
+    hass: HomeAssistant, setup_config_entry, mock_rtsp_event
+) -> None:
     """Test that switches are loaded properly using port.cgi."""
     device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
 
@@ -88,7 +90,9 @@ async def test_switches_with_port_cgi(hass, setup_config_entry, mock_rtsp_event)
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_PORT_MANAGEMENT])
-async def test_switches_with_port_management(hass, setup_config_entry, mock_rtsp_event):
+async def test_switches_with_port_management(
+    hass: HomeAssistant, setup_config_entry, mock_rtsp_event
+) -> None:
     """Test that switches are loaded properly using port management."""
     device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
 

--- a/tests/components/azure_event_hub/test_config_flow.py
+++ b/tests/components/azure_event_hub/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.azure_event_hub.const import (
     STEP_CONN_STRING,
     STEP_SAS,
 )
+from homeassistant.core import HomeAssistant
 
 from .const import (
     BASE_CONFIG_CS,
@@ -38,14 +39,14 @@ _LOGGER = logging.getLogger(__name__)
     ids=["connection_string", "sas"],
 )
 async def test_form(
-    hass,
+    hass: HomeAssistant,
     mock_setup_entry,
     mock_from_connection_string,
     step1_config,
     step_id,
     step2_config,
     data_config,
-):
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
@@ -69,7 +70,7 @@ async def test_form(
     mock_setup_entry.assert_called_once()
 
 
-async def test_import(hass, mock_setup_entry):
+async def test_import(hass: HomeAssistant, mock_setup_entry) -> None:
     """Test we get the form."""
 
     import_config = IMPORT_CONFIG.copy()
@@ -95,7 +96,7 @@ async def test_import(hass, mock_setup_entry):
     [config_entries.SOURCE_USER, config_entries.SOURCE_IMPORT],
     ids=["user", "import"],
 )
-async def test_single_instance(hass, source):
+async def test_single_instance(hass: HomeAssistant, source) -> None:
     """Test uniqueness of username."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -119,11 +120,11 @@ async def test_single_instance(hass, source):
     ids=["cannot_connect", "unknown"],
 )
 async def test_connection_error_sas(
-    hass,
+    hass: HomeAssistant,
     mock_get_eventhub_properties,
     side_effect,
     error_message,
-):
+) -> None:
     """Test we handle connection errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -148,11 +149,11 @@ async def test_connection_error_sas(
     ids=["cannot_connect", "unknown"],
 )
 async def test_connection_error_cs(
-    hass,
+    hass: HomeAssistant,
     mock_from_connection_string,
     side_effect,
     error_message,
-):
+) -> None:
     """Test we handle connection errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -172,7 +173,7 @@ async def test_connection_error_cs(
     assert result2["errors"] == {"base": error_message}
 
 
-async def test_options_flow(hass, entry):
+async def test_options_flow(hass: HomeAssistant, entry) -> None:
     """Test options flow."""
     result = await hass.config_entries.options.async_init(entry.entry_id)
 

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -59,7 +59,7 @@ async def test_filter_only_config(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_unload_entry(hass, entry, mock_create_batch):
+async def test_unload_entry(hass: HomeAssistant, entry, mock_create_batch) -> None:
     """Test being able to unload an entry.
 
     Queue should be empty, so adding events to the batch should not be called,
@@ -71,7 +71,9 @@ async def test_unload_entry(hass, entry, mock_create_batch):
     assert entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_failed_test_connection(hass, mock_get_eventhub_properties):
+async def test_failed_test_connection(
+    hass: HomeAssistant, mock_get_eventhub_properties
+) -> None:
     """Test being able to unload an entry."""
     entry = MockConfigEntry(
         domain=azure_event_hub.DOMAIN,
@@ -85,7 +87,9 @@ async def test_failed_test_connection(hass, mock_get_eventhub_properties):
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_send_batch_error(hass, entry_with_one_event, mock_send_batch):
+async def test_send_batch_error(
+    hass: HomeAssistant, entry_with_one_event, mock_send_batch
+) -> None:
     """Test a error in send_batch, including recovering at the next interval."""
     mock_send_batch.reset_mock()
     mock_send_batch.side_effect = [EventHubError("Test"), None]
@@ -105,7 +109,9 @@ async def test_send_batch_error(hass, entry_with_one_event, mock_send_batch):
     mock_send_batch.assert_called_once()
 
 
-async def test_late_event(hass, entry_with_one_event, mock_create_batch):
+async def test_late_event(
+    hass: HomeAssistant, entry_with_one_event, mock_create_batch
+) -> None:
     """Test the check on late events."""
     with patch(
         f"{AZURE_EVENT_HUB_PATH}.utcnow",
@@ -120,7 +126,9 @@ async def test_late_event(hass, entry_with_one_event, mock_create_batch):
         mock_create_batch.add.assert_not_called()
 
 
-async def test_full_batch(hass, entry_with_one_event, mock_create_batch):
+async def test_full_batch(
+    hass: HomeAssistant, entry_with_one_event, mock_create_batch
+) -> None:
     """Test the full batch behaviour."""
     mock_create_batch.add.side_effect = [ValueError, None]
     async_fire_time_changed(
@@ -199,7 +207,7 @@ async def test_full_batch(hass, entry_with_one_event, mock_create_batch):
     ],
     ids=["allowlist", "denylist", "filtered_allowlist", "filtered_denylist"],
 )
-async def test_filter(hass, entry, tests, mock_create_batch):
+async def test_filter(hass: HomeAssistant, entry, tests, mock_create_batch) -> None:
     """Test different filters.
 
     Filter_schema is also a fixture which is replaced by the filter_schema

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -142,7 +142,7 @@ async def test_removing_non_existing_backup(
 async def test_getting_backup_that_does_not_exist(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Test getting backup that does not exist."""
     manager = BackupManager(hass)
     manager.backups = {TEST_BACKUP.slug: TEST_BACKUP}

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -9,8 +9,8 @@ from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceCla
 from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -31,8 +31,11 @@ def calls(hass):
 
 
 async def test_get_conditions(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected conditions from a binary_sensor."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -74,19 +77,19 @@ async def test_get_conditions(
 @pytest.mark.parametrize(
     "hidden_by,entity_category",
     (
-        (RegistryEntryHider.INTEGRATION, None),
-        (RegistryEntryHider.USER, None),
+        (er.RegistryEntryHider.INTEGRATION, None),
+        (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
-    hidden_by,
-    entity_category,
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    hidden_by: er.RegistryEntryHider | None,
+    entity_category: EntityCategory | None,
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -119,7 +122,11 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_get_conditions_no_state(hass, device_registry, entity_registry):
+async def test_get_conditions_no_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a binary_sensor."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -157,7 +164,11 @@ async def test_get_conditions_no_state(hass, device_registry, entity_registry):
     assert conditions == expected_conditions
 
 
-async def test_get_condition_capabilities(hass, device_registry, entity_registry):
+async def test_get_condition_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a binary_sensor condition."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -183,7 +194,9 @@ async def test_get_condition_capabilities(hass, device_registry, entity_registry
         assert capabilities == expected_capabilities
 
 
-async def test_if_state(hass, calls, enable_custom_integrations):
+async def test_if_state(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -256,7 +269,9 @@ async def test_if_state(hass, calls, enable_custom_integrations):
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
-async def test_if_fires_on_for_condition(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_for_condition(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -8,8 +8,8 @@ from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceCla
 from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -31,8 +31,11 @@ def calls(hass):
 
 
 async def test_get_triggers(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected triggers from a binary_sensor."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -74,19 +77,19 @@ async def test_get_triggers(
 @pytest.mark.parametrize(
     "hidden_by,entity_category",
     (
-        (RegistryEntryHider.INTEGRATION, None),
-        (RegistryEntryHider.USER, None),
+        (er.RegistryEntryHider.INTEGRATION, None),
+        (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
-    hidden_by,
-    entity_category,
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    hidden_by: er.RegistryEntryHider | None,
+    entity_category: EntityCategory | None,
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -119,7 +122,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_no_state(hass, device_registry, entity_registry):
+async def test_get_triggers_no_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a binary_sensor."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -160,7 +167,11 @@ async def test_get_triggers_no_state(hass, device_registry, entity_registry):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a binary_sensor trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -186,7 +197,9 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for on and off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -271,8 +284,8 @@ async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations)
 
 
 async def test_if_fires_on_state_change_with_for(
-    hass, calls, enable_custom_integrations
-):
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -13,6 +13,7 @@ from homeassistant.components.blackbird.media_player import (
 )
 from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
 
 class AttrDict(dict):
@@ -204,7 +205,7 @@ def media_player_entity(hass, setup_blackbird):
     return media_player
 
 
-async def test_setup_platform(hass, setup_blackbird):
+async def test_setup_platform(hass: HomeAssistant, setup_blackbird) -> None:
     """Test setting up platform."""
     # One service must be registered
     assert hass.services.has_service(DOMAIN, SERVICE_SETALLZONES)
@@ -213,8 +214,8 @@ async def test_setup_platform(hass, setup_blackbird):
 
 
 async def test_setallzones_service_call_with_entity_id(
-    hass, media_player_entity, mock_blackbird
-):
+    hass: HomeAssistant, media_player_entity, mock_blackbird
+) -> None:
     """Test set all zone source service call with entity id."""
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.name == "Zone name"
@@ -236,8 +237,8 @@ async def test_setallzones_service_call_with_entity_id(
 
 
 async def test_setallzones_service_call_without_entity_id(
-    mock_blackbird, hass, media_player_entity
-):
+    mock_blackbird, hass: HomeAssistant, media_player_entity
+) -> None:
     """Test set all zone source service call without entity id."""
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.name == "Zone name"
@@ -255,7 +256,7 @@ async def test_setallzones_service_call_without_entity_id(
     assert media_player_entity.source == "three"
 
 
-async def test_update(hass, media_player_entity):
+async def test_update(hass: HomeAssistant, media_player_entity) -> None:
     """Test updating values from blackbird."""
     assert media_player_entity.state is None
     assert media_player_entity.source is None
@@ -266,12 +267,12 @@ async def test_update(hass, media_player_entity):
     assert media_player_entity.source == "one"
 
 
-async def test_name(media_player_entity):
+async def test_name(media_player_entity) -> None:
     """Test name property."""
     assert media_player_entity.name == "Zone name"
 
 
-async def test_state(hass, media_player_entity, mock_blackbird):
+async def test_state(hass: HomeAssistant, media_player_entity, mock_blackbird) -> None:
     """Test state property."""
     assert media_player_entity.state is None
 
@@ -283,7 +284,7 @@ async def test_state(hass, media_player_entity, mock_blackbird):
     assert media_player_entity.state == STATE_OFF
 
 
-async def test_supported_features(media_player_entity):
+async def test_supported_features(media_player_entity) -> None:
     """Test supported features property."""
     assert (
         MediaPlayerEntityFeature.TURN_ON
@@ -293,27 +294,29 @@ async def test_supported_features(media_player_entity):
     )
 
 
-async def test_source(hass, media_player_entity):
+async def test_source(hass: HomeAssistant, media_player_entity) -> None:
     """Test source property."""
     assert media_player_entity.source is None
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.source == "one"
 
 
-async def test_media_title(hass, media_player_entity):
+async def test_media_title(hass: HomeAssistant, media_player_entity) -> None:
     """Test media title property."""
     assert media_player_entity.media_title is None
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.media_title == "one"
 
 
-async def test_source_list(media_player_entity):
+async def test_source_list(media_player_entity) -> None:
     """Test source list property."""
     # Note, the list is sorted!
     assert media_player_entity.source_list == ["one", "two", "three"]
 
 
-async def test_select_source(hass, media_player_entity, mock_blackbird):
+async def test_select_source(
+    hass: HomeAssistant, media_player_entity, mock_blackbird
+) -> None:
     """Test source selection methods."""
     await hass.async_add_executor_job(media_player_entity.update)
 
@@ -331,7 +334,9 @@ async def test_select_source(hass, media_player_entity, mock_blackbird):
     assert media_player_entity.source == "two"
 
 
-async def test_turn_on(hass, media_player_entity, mock_blackbird):
+async def test_turn_on(
+    hass: HomeAssistant, media_player_entity, mock_blackbird
+) -> None:
     """Testing turning on the zone."""
     mock_blackbird.zones[3].power = False
     await hass.async_add_executor_job(media_player_entity.update)
@@ -343,7 +348,9 @@ async def test_turn_on(hass, media_player_entity, mock_blackbird):
     assert media_player_entity.state == STATE_ON
 
 
-async def test_turn_off(hass, media_player_entity, mock_blackbird):
+async def test_turn_off(
+    hass: HomeAssistant, media_player_entity, mock_blackbird
+) -> None:
     """Testing turning off the zone."""
     mock_blackbird.zones[3].power = True
     await hass.async_add_executor_job(media_player_entity.update)

--- a/tests/components/blebox/test_binary_sensor.py
+++ b/tests/components/blebox/test_binary_sensor.py
@@ -28,7 +28,7 @@ def airsensor_fixture() -> tuple[AsyncMock, str]:
     return feature, "binary_sensor.windrainsensor_0_rain"
 
 
-async def test_init(rainsensor: AsyncMock, hass: HomeAssistant):
+async def test_init(rainsensor: AsyncMock, hass: HomeAssistant) -> None:
     """Test binary_sensor initialisation."""
     _, entity_id = rainsensor
     entry = await async_setup_entity(hass, entity_id)

--- a/tests/components/blebox/test_button.py
+++ b/tests/components/blebox/test_button.py
@@ -6,6 +6,7 @@ import blebox_uniapi
 import pytest
 
 from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -39,7 +40,9 @@ def tv_lift_box_fixture(caplog):
     return (feature, "button.tvliftbox_open_or_stop")
 
 
-async def test_tvliftbox_init(tvliftbox, hass, caplog):
+async def test_tvliftbox_init(
+    tvliftbox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test tvLiftBox initialisation."""
     caplog.set_level(logging.ERROR)
 
@@ -53,7 +56,9 @@ async def test_tvliftbox_init(tvliftbox, hass, caplog):
 
 
 @pytest.mark.parametrize("input", query_icon_matching)
-async def test_get_icon(input, tvliftbox, hass, caplog):
+async def test_get_icon(
+    input, tvliftbox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if proper icon is returned."""
     caplog.set_level(logging.ERROR)
 

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
@@ -75,7 +76,7 @@ def thermobox_fixture():
     return (feature, "climate.thermobox_thermostat")
 
 
-async def test_init(saunabox, hass):
+async def test_init(saunabox, hass: HomeAssistant) -> None:
     """Test default state."""
 
     _, entity_id = saunabox
@@ -111,7 +112,7 @@ async def test_init(saunabox, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_update(saunabox, hass, config):
+async def test_update(saunabox, hass: HomeAssistant, config) -> None:
     """Test updating."""
 
     feature_mock, entity_id = saunabox
@@ -131,7 +132,7 @@ async def test_update(saunabox, hass, config):
     assert state.state == HVACMode.OFF
 
 
-async def test_on_when_below_desired(saunabox, hass):
+async def test_on_when_below_desired(saunabox, hass: HomeAssistant) -> None:
     """Test when temperature is below desired."""
 
     feature_mock, entity_id = saunabox
@@ -165,7 +166,7 @@ async def test_on_when_below_desired(saunabox, hass):
     assert state.state == HVACMode.HEAT
 
 
-async def test_on_when_above_desired(saunabox, hass):
+async def test_on_when_above_desired(saunabox, hass: HomeAssistant) -> None:
     """Test when temperature is below desired."""
 
     feature_mock, entity_id = saunabox
@@ -200,7 +201,7 @@ async def test_on_when_above_desired(saunabox, hass):
     assert state.state == HVACMode.HEAT
 
 
-async def test_off(saunabox, hass):
+async def test_off(saunabox, hass: HomeAssistant) -> None:
     """Test turning off."""
 
     feature_mock, entity_id = saunabox
@@ -235,7 +236,7 @@ async def test_off(saunabox, hass):
     assert state.state == HVACMode.OFF
 
 
-async def test_set_thermo(saunabox, hass):
+async def test_set_thermo(saunabox, hass: HomeAssistant) -> None:
     """Test setting thermostat."""
 
     feature_mock, entity_id = saunabox
@@ -269,7 +270,9 @@ async def test_set_thermo(saunabox, hass):
     assert state.state == HVACMode.HEAT
 
 
-async def test_update_failure(saunabox, hass, caplog):
+async def test_update_failure(
+    saunabox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that update failures are logged."""
 
     caplog.set_level(logging.ERROR)
@@ -281,7 +284,9 @@ async def test_update_failure(saunabox, hass, caplog):
     assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
 
 
-async def test_reding_hvac_actions(saunabox, hass, caplog):
+async def test_reding_hvac_actions(
+    saunabox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test hvac action for given device(mock) state."""
 
     caplog.set_level(logging.ERROR)
@@ -307,7 +312,9 @@ async def test_reding_hvac_actions(saunabox, hass, caplog):
     assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.OFF, HVACMode.HEAT]
 
 
-async def test_thermo_off(thermobox, hass, caplog):
+async def test_thermo_off(
+    thermobox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test hvac action off fir given device state."""
     caplog.set_level(logging.ERROR)
 

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -55,7 +55,9 @@ def flow_feature_mock_fixture():
     )
 
 
-async def test_flow_works(hass, valid_feature_mock, flow_feature_mock):
+async def test_flow_works(
+    hass: HomeAssistant, valid_feature_mock, flow_feature_mock
+) -> None:
     """Test that config flow works."""
 
     result = await hass.config_entries.flow.async_init(
@@ -87,7 +89,9 @@ def product_class_mock_fixture():
     return patcher
 
 
-async def test_flow_with_connection_failure(hass, product_class_mock):
+async def test_flow_with_connection_failure(
+    hass: HomeAssistant, product_class_mock
+) -> None:
     """Test that config flow works."""
     with product_class_mock as products_class:
         products_class.async_from_host = AsyncMock(
@@ -102,7 +106,7 @@ async def test_flow_with_connection_failure(hass, product_class_mock):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_flow_with_api_failure(hass, product_class_mock):
+async def test_flow_with_api_failure(hass: HomeAssistant, product_class_mock) -> None:
     """Test that config flow works."""
     with product_class_mock as products_class:
         products_class.async_from_host = AsyncMock(
@@ -117,7 +121,9 @@ async def test_flow_with_api_failure(hass, product_class_mock):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_flow_with_unknown_failure(hass, product_class_mock):
+async def test_flow_with_unknown_failure(
+    hass: HomeAssistant, product_class_mock
+) -> None:
     """Test that config flow works."""
     with product_class_mock as products_class:
         products_class.async_from_host = AsyncMock(side_effect=RuntimeError)
@@ -129,7 +135,9 @@ async def test_flow_with_unknown_failure(hass, product_class_mock):
         assert result["errors"] == {"base": "unknown"}
 
 
-async def test_flow_with_unsupported_version(hass, product_class_mock):
+async def test_flow_with_unsupported_version(
+    hass: HomeAssistant, product_class_mock
+) -> None:
     """Test that config flow works."""
     with product_class_mock as products_class:
         products_class.async_from_host = AsyncMock(
@@ -150,7 +158,7 @@ async def test_async_setup(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_already_configured(hass, valid_feature_mock):
+async def test_already_configured(hass: HomeAssistant, valid_feature_mock) -> None:
     """Test that same device cannot be added twice."""
 
     config = mock_config("172.2.3.4")
@@ -168,7 +176,7 @@ async def test_already_configured(hass, valid_feature_mock):
     assert result["reason"] == "address_already_configured"
 
 
-async def test_async_setup_entry(hass, valid_feature_mock):
+async def test_async_setup_entry(hass: HomeAssistant, valid_feature_mock) -> None:
     """Test async_setup_entry (for coverage)."""
 
     config = mock_config()
@@ -181,7 +189,7 @@ async def test_async_setup_entry(hass, valid_feature_mock):
     assert config.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_async_remove_entry(hass, valid_feature_mock):
+async def test_async_remove_entry(hass: HomeAssistant, valid_feature_mock) -> None:
     """Test async_setup_entry (for coverage)."""
 
     config = mock_config()

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
@@ -92,7 +93,7 @@ def gate_fixture():
     return (feature, "cover.gatecontroller_position")
 
 
-async def test_init_gatecontroller(gatecontroller, hass):
+async def test_init_gatecontroller(gatecontroller, hass: HomeAssistant) -> None:
     """Test gateController default state."""
 
     _, entity_id = gatecontroller
@@ -122,7 +123,7 @@ async def test_init_gatecontroller(gatecontroller, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_init_shutterbox(shutterbox, hass):
+async def test_init_shutterbox(shutterbox, hass: HomeAssistant) -> None:
     """Test gateBox default state."""
 
     _, entity_id = shutterbox
@@ -152,7 +153,7 @@ async def test_init_shutterbox(shutterbox, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_init_gatebox(gatebox, hass):
+async def test_init_gatebox(gatebox, hass: HomeAssistant) -> None:
     """Test cover default state."""
 
     _, entity_id = gatebox
@@ -185,7 +186,7 @@ async def test_init_gatebox(gatebox, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_open(feature, hass):
+async def test_open(feature, hass: HomeAssistant) -> None:
     """Test cover opening."""
 
     feature_mock, entity_id = feature
@@ -213,7 +214,7 @@ async def test_open(feature, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_close(feature, hass):
+async def test_close(feature, hass: HomeAssistant) -> None:
     """Test cover closing."""
 
     feature_mock, entity_id = feature
@@ -251,7 +252,7 @@ def opening_to_stop_feature_mock(feature_mock):
 
 
 @pytest.mark.parametrize("feature", FIXTURES_SUPPORTING_STOP, indirect=["feature"])
-async def test_stop(feature, hass):
+async def test_stop(feature, hass: HomeAssistant) -> None:
     """Test cover stopping."""
 
     feature_mock, entity_id = feature
@@ -268,7 +269,7 @@ async def test_stop(feature, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_update(feature, hass):
+async def test_update(feature, hass: HomeAssistant) -> None:
     """Test cover updating."""
 
     feature_mock, entity_id = feature
@@ -289,7 +290,7 @@ async def test_update(feature, hass):
 @pytest.mark.parametrize(
     "feature", ["gatecontroller", "shutterbox"], indirect=["feature"]
 )
-async def test_set_position(feature, hass):
+async def test_set_position(feature, hass: HomeAssistant) -> None:
     """Test cover position setting."""
 
     feature_mock, entity_id = feature
@@ -318,7 +319,7 @@ async def test_set_position(feature, hass):
     assert hass.states.get(entity_id).state == STATE_OPENING
 
 
-async def test_unknown_position(shutterbox, hass):
+async def test_unknown_position(shutterbox, hass: HomeAssistant) -> None:
     """Test cover position setting."""
 
     feature_mock, entity_id = shutterbox
@@ -336,7 +337,7 @@ async def test_unknown_position(shutterbox, hass):
     assert ATTR_CURRENT_POSITION not in state.attributes
 
 
-async def test_with_stop(gatebox, hass):
+async def test_with_stop(gatebox, hass: HomeAssistant) -> None:
     """Test stop capability is available."""
 
     feature_mock, entity_id = gatebox
@@ -350,7 +351,7 @@ async def test_with_stop(gatebox, hass):
     assert supported_features & CoverEntityFeature.STOP
 
 
-async def test_with_no_stop(gatebox, hass):
+async def test_with_no_stop(gatebox, hass: HomeAssistant) -> None:
     """Test stop capability is not available."""
 
     feature_mock, entity_id = gatebox
@@ -365,7 +366,9 @@ async def test_with_no_stop(gatebox, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_update_failure(feature, hass, caplog):
+async def test_update_failure(
+    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that update failures are logged."""
 
     caplog.set_level(logging.ERROR)
@@ -378,7 +381,7 @@ async def test_update_failure(feature, hass, caplog):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_opening_state(feature, hass):
+async def test_opening_state(feature, hass: HomeAssistant) -> None:
     """Test that entity properties work."""
 
     feature_mock, entity_id = feature
@@ -392,7 +395,7 @@ async def test_opening_state(feature, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_closing_state(feature, hass):
+async def test_closing_state(feature, hass: HomeAssistant) -> None:
     """Test that entity properties work."""
 
     feature_mock, entity_id = feature
@@ -406,7 +409,7 @@ async def test_closing_state(feature, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
-async def test_closed_state(feature, hass):
+async def test_closed_state(feature, hass: HomeAssistant) -> None:
     """Test that entity properties work."""
 
     feature_mock, entity_id = feature

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
@@ -49,7 +50,7 @@ def dimmer_fixture():
     return (feature, "light.dimmerbox_brightness")
 
 
-async def test_dimmer_init(dimmer, hass):
+async def test_dimmer_init(dimmer, hass: HomeAssistant) -> None:
     """Test cover default state."""
 
     _, entity_id = dimmer
@@ -75,7 +76,7 @@ async def test_dimmer_init(dimmer, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_dimmer_update(dimmer, hass):
+async def test_dimmer_update(dimmer, hass: HomeAssistant) -> None:
     """Test light updating."""
 
     feature_mock, entity_id = dimmer
@@ -91,7 +92,7 @@ async def test_dimmer_update(dimmer, hass):
     assert state.state == STATE_ON
 
 
-async def test_dimmer_on(dimmer, hass):
+async def test_dimmer_on(dimmer, hass: HomeAssistant) -> None:
     """Test light on."""
 
     feature_mock, entity_id = dimmer
@@ -126,7 +127,7 @@ async def test_dimmer_on(dimmer, hass):
     assert state.attributes[ATTR_BRIGHTNESS] == 254
 
 
-async def test_dimmer_on_with_brightness(dimmer, hass):
+async def test_dimmer_on_with_brightness(dimmer, hass: HomeAssistant) -> None:
     """Test light on with a brightness value."""
 
     feature_mock, entity_id = dimmer
@@ -167,7 +168,7 @@ async def test_dimmer_on_with_brightness(dimmer, hass):
     assert state.state == STATE_ON
 
 
-async def test_dimmer_off(dimmer, hass):
+async def test_dimmer_off(dimmer, hass: HomeAssistant) -> None:
     """Test light off."""
 
     feature_mock, entity_id = dimmer
@@ -222,7 +223,7 @@ def wlightboxs_fixture():
     return (feature, "light.wlightboxs_color")
 
 
-async def test_wlightbox_s_init(wlightbox_s, hass):
+async def test_wlightbox_s_init(wlightbox_s, hass: HomeAssistant) -> None:
     """Test cover default state."""
 
     _, entity_id = wlightbox_s
@@ -248,7 +249,7 @@ async def test_wlightbox_s_init(wlightbox_s, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_wlightbox_s_update(wlightbox_s, hass):
+async def test_wlightbox_s_update(wlightbox_s, hass: HomeAssistant) -> None:
     """Test light updating."""
 
     feature_mock, entity_id = wlightbox_s
@@ -266,7 +267,7 @@ async def test_wlightbox_s_update(wlightbox_s, hass):
     assert state.attributes[ATTR_BRIGHTNESS] == 0xAB
 
 
-async def test_wlightbox_s_on(wlightbox_s, hass):
+async def test_wlightbox_s_on(wlightbox_s, hass: HomeAssistant) -> None:
     """Test light on."""
 
     feature_mock, entity_id = wlightbox_s
@@ -325,7 +326,7 @@ def wlightbox_fixture():
     return (feature, "light.wlightbox_color")
 
 
-async def test_wlightbox_init(wlightbox, hass):
+async def test_wlightbox_init(wlightbox, hass: HomeAssistant) -> None:
     """Test cover default state."""
 
     _, entity_id = wlightbox
@@ -352,7 +353,7 @@ async def test_wlightbox_init(wlightbox, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_wlightbox_update(wlightbox, hass):
+async def test_wlightbox_update(wlightbox, hass: HomeAssistant) -> None:
     """Test light updating."""
 
     feature_mock, entity_id = wlightbox
@@ -370,7 +371,7 @@ async def test_wlightbox_update(wlightbox, hass):
     assert state.state == STATE_ON
 
 
-async def test_wlightbox_on_rgbw(wlightbox, hass):
+async def test_wlightbox_on_rgbw(wlightbox, hass: HomeAssistant) -> None:
     """Test light on."""
 
     feature_mock, entity_id = wlightbox
@@ -420,7 +421,7 @@ async def test_wlightbox_on_rgbw(wlightbox, hass):
     assert state.attributes[ATTR_RGBW_COLOR] == (0xC1, 0xD2, 0xF3, 0xC7)
 
 
-async def test_wlightbox_on_to_last_color(wlightbox, hass):
+async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> None:
     """Test light on."""
 
     feature_mock, entity_id = wlightbox
@@ -456,7 +457,7 @@ async def test_wlightbox_on_to_last_color(wlightbox, hass):
     assert state.state == STATE_ON
 
 
-async def test_wlightbox_off(wlightbox, hass):
+async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
     """Test light off."""
 
     feature_mock, entity_id = wlightbox
@@ -491,7 +492,9 @@ async def test_wlightbox_off(wlightbox, hass):
 
 
 @pytest.mark.parametrize("feature", ALL_LIGHT_FIXTURES, indirect=["feature"])
-async def test_update_failure(feature, hass, caplog):
+async def test_update_failure(
+    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that update failures are logged."""
 
     caplog.set_level(logging.ERROR)
@@ -504,7 +507,9 @@ async def test_update_failure(feature, hass, caplog):
 
 
 @pytest.mark.parametrize("feature", ALL_LIGHT_FIXTURES, indirect=["feature"])
-async def test_turn_on_failure(feature, hass, caplog):
+async def test_turn_on_failure(
+    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that turn_on failures are logged."""
 
     caplog.set_level(logging.ERROR)
@@ -527,7 +532,7 @@ async def test_turn_on_failure(feature, hass, caplog):
     )
 
 
-async def test_wlightbox_on_effect(wlightbox, hass):
+async def test_wlightbox_on_effect(wlightbox, hass: HomeAssistant) -> None:
     """Test light on."""
 
     feature_mock, entity_id = wlightbox

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
@@ -55,7 +56,7 @@ def tempsensor_fixture():
     return (feature, "sensor.tempsensor_0_temperature")
 
 
-async def test_init(tempsensor, hass):
+async def test_init(tempsensor, hass: HomeAssistant) -> None:
     """Test sensor default state."""
 
     _, entity_id = tempsensor
@@ -79,7 +80,7 @@ async def test_init(tempsensor, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_update(tempsensor, hass):
+async def test_update(tempsensor, hass: HomeAssistant) -> None:
     """Test sensor update."""
 
     feature_mock, entity_id = tempsensor
@@ -95,7 +96,9 @@ async def test_update(tempsensor, hass):
     assert state.state == "25.18"
 
 
-async def test_update_failure(tempsensor, hass, caplog):
+async def test_update_failure(
+    tempsensor, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that update failures are logged."""
 
     caplog.set_level(logging.ERROR)
@@ -107,7 +110,7 @@ async def test_update_failure(tempsensor, hass, caplog):
     assert f"Updating '{feature_mock.full_name}' failed: " in caplog.text
 
 
-async def test_airsensor_init(airsensor, hass):
+async def test_airsensor_init(airsensor, hass: HomeAssistant) -> None:
     """Test airSensor default state."""
 
     _, entity_id = airsensor
@@ -130,7 +133,7 @@ async def test_airsensor_init(airsensor, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_airsensor_update(airsensor, hass):
+async def test_airsensor_update(airsensor, hass: HomeAssistant) -> None:
     """Test air quality sensor state after update."""
 
     feature_mock, entity_id = airsensor

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import (
@@ -43,7 +44,7 @@ def switchbox_fixture():
     return (feature, "switch.switchbox_0_relay")
 
 
-async def test_switchbox_init(switchbox, hass, config):
+async def test_switchbox_init(switchbox, hass: HomeAssistant, config) -> None:
     """Test switch default state."""
 
     feature_mock, entity_id = switchbox
@@ -69,7 +70,7 @@ async def test_switchbox_init(switchbox, hass, config):
     assert device.sw_version == "1.23"
 
 
-async def test_switchbox_update_when_off(switchbox, hass):
+async def test_switchbox_update_when_off(switchbox, hass: HomeAssistant) -> None:
     """Test switch updating when off."""
 
     feature_mock, entity_id = switchbox
@@ -84,7 +85,7 @@ async def test_switchbox_update_when_off(switchbox, hass):
     assert state.state == STATE_OFF
 
 
-async def test_switchbox_update_when_on(switchbox, hass):
+async def test_switchbox_update_when_on(switchbox, hass: HomeAssistant) -> None:
     """Test switch updating when on."""
 
     feature_mock, entity_id = switchbox
@@ -99,7 +100,7 @@ async def test_switchbox_update_when_on(switchbox, hass):
     assert state.state == STATE_ON
 
 
-async def test_switchbox_on(switchbox, hass):
+async def test_switchbox_on(switchbox, hass: HomeAssistant) -> None:
     """Test turning switch on."""
 
     feature_mock, entity_id = switchbox
@@ -127,7 +128,7 @@ async def test_switchbox_on(switchbox, hass):
     assert state.state == STATE_ON
 
 
-async def test_switchbox_off(switchbox, hass):
+async def test_switchbox_off(switchbox, hass: HomeAssistant) -> None:
     """Test turning switch off."""
 
     feature_mock, entity_id = switchbox
@@ -188,7 +189,7 @@ def switchbox_d_fixture():
     return (features, ["switch.switchboxd_0_relay", "switch.switchboxd_1_relay"])
 
 
-async def test_switchbox_d_init(switchbox_d, hass):
+async def test_switchbox_d_init(switchbox_d, hass: HomeAssistant) -> None:
     """Test switch default state."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -232,7 +233,7 @@ async def test_switchbox_d_init(switchbox_d, hass):
     assert device.sw_version == "1.23"
 
 
-async def test_switchbox_d_update_when_off(switchbox_d, hass):
+async def test_switchbox_d_update_when_off(switchbox_d, hass: HomeAssistant) -> None:
     """Test switch updating when off."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -249,7 +250,9 @@ async def test_switchbox_d_update_when_off(switchbox_d, hass):
     assert hass.states.get(entity_ids[1]).state == STATE_OFF
 
 
-async def test_switchbox_d_update_when_second_off(switchbox_d, hass):
+async def test_switchbox_d_update_when_second_off(
+    switchbox_d, hass: HomeAssistant
+) -> None:
     """Test switch updating when off."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -266,7 +269,7 @@ async def test_switchbox_d_update_when_second_off(switchbox_d, hass):
     assert hass.states.get(entity_ids[1]).state == STATE_OFF
 
 
-async def test_switchbox_d_turn_first_on(switchbox_d, hass):
+async def test_switchbox_d_turn_first_on(switchbox_d, hass: HomeAssistant) -> None:
     """Test turning switch on."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -295,7 +298,7 @@ async def test_switchbox_d_turn_first_on(switchbox_d, hass):
     assert hass.states.get(entity_ids[1]).state == STATE_OFF
 
 
-async def test_switchbox_d_second_on(switchbox_d, hass):
+async def test_switchbox_d_second_on(switchbox_d, hass: HomeAssistant) -> None:
     """Test turning switch on."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -324,7 +327,7 @@ async def test_switchbox_d_second_on(switchbox_d, hass):
     assert hass.states.get(entity_ids[1]).state == STATE_ON
 
 
-async def test_switchbox_d_first_off(switchbox_d, hass):
+async def test_switchbox_d_first_off(switchbox_d, hass: HomeAssistant) -> None:
     """Test turning switch on."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -353,7 +356,7 @@ async def test_switchbox_d_first_off(switchbox_d, hass):
     assert hass.states.get(entity_ids[1]).state == STATE_ON
 
 
-async def test_switchbox_d_second_off(switchbox_d, hass):
+async def test_switchbox_d_second_off(switchbox_d, hass: HomeAssistant) -> None:
     """Test turning switch on."""
 
     feature_mocks, entity_ids = switchbox_d
@@ -385,7 +388,9 @@ ALL_SWITCH_FIXTURES = ["switchbox", "switchbox_d"]
 
 
 @pytest.mark.parametrize("feature", ALL_SWITCH_FIXTURES, indirect=["feature"])
-async def test_update_failure(feature, hass, caplog):
+async def test_update_failure(
+    feature, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that update failures are logged."""
 
     caplog.set_level(logging.ERROR)

--- a/tests/components/blueprint/test_default_blueprints.py
+++ b/tests/components/blueprint/test_default_blueprints.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("domain", DOMAINS)
-def test_default_blueprints(domain: str):
+def test_default_blueprints(domain: str) -> None:
     """Validate a folder of blueprints."""
     integration = importlib.import_module(f"homeassistant.components.{domain}")
     blueprint_folder = pathlib.Path(integration.__file__).parent / BLUEPRINT_FOLDER

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -120,7 +120,7 @@ def test_get_github_import_url() -> None:
     )
 
 
-def test_extract_blueprint_from_community_topic(community_post):
+def test_extract_blueprint_from_community_topic(community_post) -> None:
     """Test extracting blueprint."""
     imported_blueprint = importer._extract_blueprint_from_community_topic(
         "http://example.com", json.loads(community_post)
@@ -160,7 +160,9 @@ def test_extract_blueprint_from_community_topic_wrong_lang() -> None:
         )
 
 
-async def test_fetch_blueprint_from_community_url(hass, aioclient_mock, community_post):
+async def test_fetch_blueprint_from_community_url(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, community_post
+) -> None:
     """Test fetching blueprint from url."""
     aioclient_mock.get(
         "https://community.home-assistant.io/t/test-topic/123.json", text=community_post
@@ -189,7 +191,9 @@ async def test_fetch_blueprint_from_community_url(hass, aioclient_mock, communit
         "https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/motion_light.yaml",
     ),
 )
-async def test_fetch_blueprint_from_github_url(hass, aioclient_mock, url):
+async def test_fetch_blueprint_from_github_url(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, url: str
+) -> None:
     """Test fetching blueprint from url."""
     aioclient_mock.get(
         "https://raw.githubusercontent.com/balloob/home-assistant-config/main/blueprints/automation/motion_light.yaml",

--- a/tests/components/blueprint/test_models.py
+++ b/tests/components/blueprint/test_models.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.blueprint import errors, models
+from homeassistant.core import HomeAssistant
 from homeassistant.util.yaml import Input
 
 
@@ -76,7 +77,7 @@ def test_blueprint_model_init() -> None:
         )
 
 
-def test_blueprint_properties(blueprint_1):
+def test_blueprint_properties(blueprint_1) -> None:
     """Test properties."""
     assert blueprint_1.metadata == {
         "name": "Hello",
@@ -131,7 +132,7 @@ def test_blueprint_validate() -> None:
     ).validate() == ["Requires at least Home Assistant 100000.0.0"]
 
 
-def test_blueprint_inputs(blueprint_2):
+def test_blueprint_inputs(blueprint_2) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -151,7 +152,7 @@ def test_blueprint_inputs(blueprint_2):
     }
 
 
-def test_blueprint_inputs_validation(blueprint_1):
+def test_blueprint_inputs_validation(blueprint_1) -> None:
     """Test blueprint input validation."""
     inputs = models.BlueprintInputs(
         blueprint_1,
@@ -161,7 +162,7 @@ def test_blueprint_inputs_validation(blueprint_1):
         inputs.validate()
 
 
-def test_blueprint_inputs_default(blueprint_2):
+def test_blueprint_inputs_default(blueprint_2) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -176,7 +177,7 @@ def test_blueprint_inputs_default(blueprint_2):
     assert inputs.async_substitute() == {"example": 1, "example-default": "test"}
 
 
-def test_blueprint_inputs_override_default(blueprint_2):
+def test_blueprint_inputs_override_default(blueprint_2) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -199,7 +200,9 @@ def test_blueprint_inputs_override_default(blueprint_2):
     assert inputs.async_substitute() == {"example": 1, "example-default": "custom"}
 
 
-async def test_domain_blueprints_get_blueprint_errors(hass, domain_bps):
+async def test_domain_blueprints_get_blueprint_errors(
+    hass: HomeAssistant, domain_bps
+) -> None:
     """Test domain blueprints."""
     assert hass.data["blueprint"]["automation"] is domain_bps
 
@@ -214,7 +217,7 @@ async def test_domain_blueprints_get_blueprint_errors(hass, domain_bps):
         await domain_bps.async_get_blueprint("non-existing-path")
 
 
-async def test_domain_blueprints_caching(domain_bps):
+async def test_domain_blueprints_caching(domain_bps) -> None:
     """Test domain blueprints cache blueprints."""
     obj = object()
     with patch.object(domain_bps, "_load_blueprint", return_value=obj):
@@ -231,7 +234,7 @@ async def test_domain_blueprints_caching(domain_bps):
         assert await domain_bps.async_get_blueprint("something") is obj_2
 
 
-async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1):
+async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1) -> None:
     """Test DomainBlueprints.async_inputs_from_config."""
     with pytest.raises(errors.InvalidBlueprintInputs):
         await domain_bps.async_inputs_from_config({"not-referencing": "use_blueprint"})
@@ -251,7 +254,7 @@ async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1):
     assert inputs.inputs == {"test-input": None}
 
 
-async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1):
+async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1) -> None:
     """Test DomainBlueprints.async_add_blueprint."""
     with patch.object(domain_bps, "_create_file") as create_file_mock:
         # Should add extension when not present.
@@ -267,7 +270,7 @@ async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1):
         assert not mock_load.mock_calls
 
 
-async def test_inputs_from_config_nonexisting_blueprint(domain_bps):
+async def test_inputs_from_config_nonexisting_blueprint(domain_bps) -> None:
     """Test referring non-existing blueprint."""
     with pytest.raises(errors.FailedToLoad):
         await domain_bps.async_inputs_from_config(

--- a/tests/components/blueprint/test_schemas.py
+++ b/tests/components/blueprint/test_schemas.py
@@ -53,7 +53,7 @@ _LOGGER = logging.getLogger(__name__)
         },
     ),
 )
-def test_blueprint_schema(blueprint):
+def test_blueprint_schema(blueprint) -> None:
     """Test different schemas."""
     try:
         schemas.BLUEPRINT_SCHEMA(blueprint)
@@ -95,7 +95,7 @@ def test_blueprint_schema(blueprint):
         },
     ),
 )
-def test_blueprint_schema_invalid(blueprint):
+def test_blueprint_schema_invalid(blueprint) -> None:
     """Test different schemas."""
     with pytest.raises(vol.Invalid):
         schemas.BLUEPRINT_SCHEMA(blueprint)
@@ -109,6 +109,6 @@ def test_blueprint_schema_invalid(blueprint):
         {"path": "hello.yaml", "input": {"hello": None}},
     ),
 )
-def test_blueprint_instance_fields(bp_instance):
+def test_blueprint_instance_fields(bp_instance) -> None:
     """Test blueprint instance fields."""
     schemas.BLUEPRINT_INSTANCE_FIELDS({"use_blueprint": bp_instance})

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import parse_yaml
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
 
@@ -84,7 +85,11 @@ async def test_list_blueprints_non_existing_domain(
     assert blueprints == {}
 
 
-async def test_import_blueprint(hass, aioclient_mock, hass_ws_client):
+async def test_import_blueprint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test importing blueprints."""
     raw_data = Path(
         hass.config.path("blueprints/automation/test_event_service.yaml")
@@ -127,7 +132,11 @@ async def test_import_blueprint(hass, aioclient_mock, hass_ws_client):
     }
 
 
-async def test_save_blueprint(hass, aioclient_mock, hass_ws_client):
+async def test_save_blueprint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test saving blueprints."""
     raw_data = Path(
         hass.config.path("blueprints/automation/test_event_service.yaml")
@@ -177,7 +186,11 @@ async def test_save_blueprint(hass, aioclient_mock, hass_ws_client):
         assert len(parse_yaml(output_yaml)) > 1
 
 
-async def test_save_existing_file(hass, aioclient_mock, hass_ws_client):
+async def test_save_existing_file(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test saving blueprints."""
 
     client = await hass_ws_client(hass)
@@ -199,7 +212,11 @@ async def test_save_existing_file(hass, aioclient_mock, hass_ws_client):
     assert msg["error"] == {"code": "already_exists", "message": "File already exists"}
 
 
-async def test_save_file_error(hass, aioclient_mock, hass_ws_client):
+async def test_save_file_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test saving blueprints with OS error."""
     with patch("pathlib.Path.write_text", side_effect=OSError):
         client = await hass_ws_client(hass)
@@ -220,7 +237,11 @@ async def test_save_file_error(hass, aioclient_mock, hass_ws_client):
         assert not msg["success"]
 
 
-async def test_save_invalid_blueprint(hass, aioclient_mock, hass_ws_client):
+async def test_save_invalid_blueprint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test saving invalid blueprints."""
 
     client = await hass_ws_client(hass)
@@ -245,7 +266,11 @@ async def test_save_invalid_blueprint(hass, aioclient_mock, hass_ws_client):
     }
 
 
-async def test_delete_blueprint(hass, aioclient_mock, hass_ws_client):
+async def test_delete_blueprint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test deleting blueprints."""
 
     with patch("pathlib.Path.unlink", return_value=Mock()) as unlink_mock:
@@ -266,7 +291,11 @@ async def test_delete_blueprint(hass, aioclient_mock, hass_ws_client):
         assert msg["success"]
 
 
-async def test_delete_non_exist_file_blueprint(hass, aioclient_mock, hass_ws_client):
+async def test_delete_non_exist_file_blueprint(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test deleting non existing blueprints."""
 
     client = await hass_ws_client(hass)
@@ -303,8 +332,10 @@ async def test_delete_non_exist_file_blueprint(hass, aioclient_mock, hass_ws_cli
     ),
 )
 async def test_delete_blueprint_in_use_by_automation(
-    hass, aioclient_mock, hass_ws_client
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test deleting a blueprint which is in use."""
 
     with patch("pathlib.Path.unlink", return_value=Mock()) as unlink_mock:
@@ -346,7 +377,11 @@ async def test_delete_blueprint_in_use_by_automation(
         },
     ),
 )
-async def test_delete_blueprint_in_use_by_script(hass, aioclient_mock, hass_ws_client):
+async def test_delete_blueprint_in_use_by_script(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test deleting a blueprint which is in use."""
 
     with patch("pathlib.Path.unlink", return_value=Mock()) as unlink_mock:

--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -96,7 +96,11 @@ class MyCoordinator(ActiveBluetoothDataUpdateCoordinator[dict[str, Any]]):
         super()._async_handle_bluetooth_event(service_info, change)
 
 
-async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapters):
+async def test_basic_usage(
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -133,8 +137,10 @@ async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapte
 
 
 async def test_bleak_error_during_polling(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test bleak error during polling ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -184,8 +190,10 @@ async def test_bleak_error_during_polling(
 
 
 async def test_generic_exception_during_polling(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test generic exception during polling ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -235,8 +243,10 @@ async def test_generic_exception_during_polling(
 
 
 async def test_polling_debounce(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -279,8 +289,10 @@ async def test_polling_debounce(
 
 
 async def test_polling_debounce_with_custom_debouncer(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -324,8 +336,10 @@ async def test_polling_debounce_with_custom_debouncer(
 
 
 async def test_polling_rejecting_the_first_time(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test need_poll rejects the first time ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     attempt = 0

--- a/tests/components/bluetooth/test_active_update_processor.py
+++ b/tests/components/bluetooth/test_active_update_processor.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import MagicMock, call
 
 from bleak import BleakError
+import pytest
 
 from homeassistant.components.bluetooth import (
     DOMAIN,
@@ -48,8 +49,10 @@ GENERIC_BLUETOOTH_SERVICE_INFO_2 = BluetoothServiceInfo(
 
 
 async def test_basic_usage(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the ActiveBluetoothProcessorCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -95,8 +98,10 @@ async def test_basic_usage(
 
 
 async def test_poll_can_be_skipped(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test need_poll callback works and can skip a poll if its not needed."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -155,8 +160,11 @@ async def test_poll_can_be_skipped(
 
 
 async def test_bleak_error_and_recover(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters, caplog
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test bleak error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -217,8 +225,10 @@ async def test_bleak_error_and_recover(
 
 
 async def test_poll_failure_and_recover(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -274,8 +284,10 @@ async def test_poll_failure_and_recover(
 
 
 async def test_second_poll_needed(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """If a poll is queued, by the time it starts it may no longer be needed."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -323,8 +335,10 @@ async def test_second_poll_needed(
 
 
 async def test_rate_limit(
-    hass: HomeAssistant, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/bluetooth/test_advertisement_tracker.py
+++ b/tests/components/bluetooth/test_advertisement_tracker.py
@@ -1,10 +1,10 @@
 """Tests for the Bluetooth integration advertisement tracking."""
-
 from datetime import timedelta
 import time
 from unittest.mock import patch
 
 from bleak.backends.scanner import BLEDevice
+import pytest
 
 from homeassistant.components.bluetooth import (
     async_register_scanner,
@@ -18,7 +18,7 @@ from homeassistant.components.bluetooth.const import (
     SOURCE_LOCAL,
     UNAVAILABLE_TRACK_SECONDS,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import (
@@ -34,8 +34,11 @@ ONE_HOUR_SECONDS = 3600
 
 
 async def test_advertisment_interval_shorter_than_adapter_stack_timeout(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test we can determine the advertisement interval."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:12", "wohand")
@@ -78,8 +81,11 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout(
 
 
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a long advertisement interval."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:18", "wohand")
@@ -124,8 +130,11 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_connectab
 
 
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_change_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a long advertisement interval with an adapter change."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
@@ -179,8 +188,11 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
 
 
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_not_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a long advertisement interval that is not connectable not reaching the advertising interval."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
@@ -228,8 +240,11 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_not_conne
 
 
 async def test_advertisment_interval_shorter_than_adapter_stack_timeout_adapter_change_not_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a short advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:5C", "wohand")
@@ -293,8 +308,11 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout_adapter_
 
 
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_change_not_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a long advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
@@ -391,8 +409,11 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
 
 
 async def test_advertisment_interval_longer_increasing_than_adapter_stack_timeout_adapter_change_not_connectable(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test device with a increasing advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -1,6 +1,4 @@
 """Tests for the Bluetooth integration API."""
-
-
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 
 from homeassistant.components import bluetooth
@@ -11,11 +9,12 @@ from homeassistant.components.bluetooth import (
     async_scanner_by_source,
     async_scanner_devices_by_address,
 )
+from homeassistant.core import HomeAssistant
 
 from . import FakeScanner, MockBleakClient, _get_manager, generate_advertisement_data
 
 
-async def test_scanner_by_source(hass, enable_bluetooth):
+async def test_scanner_by_source(hass: HomeAssistant, enable_bluetooth: None) -> None:
     """Test we can get a scanner by source."""
 
     hci2_scanner = FakeScanner(hass, "hci2", "hci2")
@@ -26,7 +25,9 @@ async def test_scanner_by_source(hass, enable_bluetooth):
     assert async_scanner_by_source(hass, "hci2") is None
 
 
-async def test_async_scanner_devices_by_address_connectable(hass, enable_bluetooth):
+async def test_async_scanner_devices_by_address_connectable(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test getting scanner devices by address with connectable devices."""
     manager = _get_manager()
 
@@ -83,7 +84,9 @@ async def test_async_scanner_devices_by_address_connectable(hass, enable_bluetoo
     cancel()
 
 
-async def test_async_scanner_devices_by_address_non_connectable(hass, enable_bluetooth):
+async def test_async_scanner_devices_by_address_non_connectable(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test getting scanner devices by address with non-connectable devices."""
     manager = _get_manager()
     switchbot_device = BLEDevice(

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -22,7 +23,7 @@ from homeassistant.components.bluetooth.const import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     UNAVAILABLE_TRACK_SECONDS,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_loads
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -32,7 +33,7 @@ from . import MockBleakClient, _get_manager, generate_advertisement_data
 from tests.common import async_fire_time_changed, load_fixture
 
 
-async def test_remote_scanner(hass, enable_bluetooth):
+async def test_remote_scanner(hass: HomeAssistant, enable_bluetooth: None) -> None:
     """Test the remote scanner base class merges advertisement_data."""
     manager = _get_manager()
 
@@ -118,7 +119,9 @@ async def test_remote_scanner(hass, enable_bluetooth):
     unsetup()
 
 
-async def test_remote_scanner_expires_connectable(hass, enable_bluetooth):
+async def test_remote_scanner_expires_connectable(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test the remote scanner expires stale connectable data."""
     manager = _get_manager()
 
@@ -190,7 +193,9 @@ async def test_remote_scanner_expires_connectable(hass, enable_bluetooth):
     unsetup()
 
 
-async def test_remote_scanner_expires_non_connectable(hass, enable_bluetooth):
+async def test_remote_scanner_expires_non_connectable(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test the remote scanner expires stale non connectable data."""
     manager = _get_manager()
 
@@ -285,7 +290,9 @@ async def test_remote_scanner_expires_non_connectable(hass, enable_bluetooth):
     unsetup()
 
 
-async def test_base_scanner_connecting_behavior(hass, enable_bluetooth):
+async def test_base_scanner_connecting_behavior(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test that the default behavior is to mark the scanner as not scanning when connecting."""
     manager = _get_manager()
 
@@ -346,8 +353,8 @@ async def test_base_scanner_connecting_behavior(hass, enable_bluetooth):
 
 
 async def test_restore_history_remote_adapter(
-    hass, hass_storage, disable_new_discovery_flows
-):
+    hass: HomeAssistant, hass_storage, disable_new_discovery_flows
+) -> None:
     """Test we can restore history for a remote adapter."""
 
     data = hass_storage[storage.REMOTE_SCANNER_STORAGE_KEY] = json_loads(
@@ -407,8 +414,8 @@ async def test_restore_history_remote_adapter(
 
 
 async def test_device_with_ten_minute_advertising_interval(
-    hass, caplog, enable_bluetooth
-):
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, enable_bluetooth: None
+) -> None:
     """Test a device with a 10 minute advertising interval."""
     manager = _get_manager()
 

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -412,7 +412,9 @@ async def test_options_flow_enabled_linux(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_async_step_user_linux_adapter_is_ignored(hass, one_adapter):
+async def test_async_step_user_linux_adapter_is_ignored(
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test we give a hint that the adapter is ignored."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the bluetooth config flow."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from bluetooth_adapters import DEFAULT_ADDRESS, AdapterDetails
 
@@ -15,15 +15,16 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_options_flow_disabled_not_setup(
-    hass,
-    hass_ws_client,
-    mock_bleak_scanner_start,
-    mock_bluetooth_adapters,
-    macos_adapter,
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    macos_adapter: None,
+) -> None:
     """Test options are disabled if the integration has not been setup."""
     await async_setup_component(hass, "config", {})
     entry = MockConfigEntry(
@@ -44,7 +45,7 @@ async def test_options_flow_disabled_not_setup(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_async_step_user_macos(hass, macos_adapter):
+async def test_async_step_user_macos(hass: HomeAssistant, macos_adapter: None) -> None:
     """Test setting up manually with one adapter on MacOS."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -67,7 +68,9 @@ async def test_async_step_user_macos(hass, macos_adapter):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_async_step_user_linux_one_adapter(hass, one_adapter):
+async def test_async_step_user_linux_one_adapter(
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test setting up manually with one adapter on Linux."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -90,7 +93,9 @@ async def test_async_step_user_linux_one_adapter(hass, one_adapter):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_async_step_user_linux_two_adapters(hass, two_adapters):
+async def test_async_step_user_linux_two_adapters(
+    hass: HomeAssistant, two_adapters: None
+) -> None:
     """Test setting up manually with two adapters on Linux."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -113,7 +118,9 @@ async def test_async_step_user_linux_two_adapters(hass, two_adapters):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_async_step_user_only_allows_one(hass, macos_adapter):
+async def test_async_step_user_only_allows_one(
+    hass: HomeAssistant, macos_adapter: None
+) -> None:
     """Test setting up manually with an existing entry."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=DEFAULT_ADDRESS)
     entry.add_to_hass(hass)
@@ -158,8 +165,8 @@ async def test_async_step_integration_discovery(hass: HomeAssistant) -> None:
 
 
 async def test_async_step_integration_discovery_during_onboarding_one_adapter(
-    hass, one_adapter
-):
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test setting up from integration discovery during onboarding."""
     details = AdapterDetails(
         address="00:00:00:00:00:01",
@@ -189,8 +196,8 @@ async def test_async_step_integration_discovery_during_onboarding_one_adapter(
 
 
 async def test_async_step_integration_discovery_during_onboarding_two_adapters(
-    hass, two_adapters
-):
+    hass: HomeAssistant, two_adapters: None
+) -> None:
     """Test setting up from integration discovery during onboarding."""
     details1 = AdapterDetails(
         address="00:00:00:00:00:01",
@@ -235,7 +242,9 @@ async def test_async_step_integration_discovery_during_onboarding_two_adapters(
     assert len(mock_onboarding.mock_calls) == 2
 
 
-async def test_async_step_integration_discovery_during_onboarding(hass, macos_adapter):
+async def test_async_step_integration_discovery_during_onboarding(
+    hass: HomeAssistant, macos_adapter: None
+) -> None:
     """Test setting up from integration discovery during onboarding."""
     details = AdapterDetails(
         address=DEFAULT_ADDRESS,
@@ -287,8 +296,11 @@ async def test_async_step_integration_discovery_already_exists(
 
 
 async def test_options_flow_linux(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters, one_adapter
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    one_adapter: None,
+) -> None:
     """Test options on Linux."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -338,12 +350,12 @@ async def test_options_flow_linux(
 
 
 async def test_options_flow_disabled_macos(
-    hass,
-    hass_ws_client,
-    mock_bleak_scanner_start,
-    mock_bluetooth_adapters,
-    macos_adapter,
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    macos_adapter: None,
+) -> None:
     """Test options are disabled on MacOS."""
     await async_setup_component(hass, "config", {})
     entry = MockConfigEntry(
@@ -368,8 +380,12 @@ async def test_options_flow_disabled_macos(
 
 
 async def test_options_flow_enabled_linux(
-    hass, hass_ws_client, mock_bleak_scanner_start, mock_bluetooth_adapters, one_adapter
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    one_adapter: None,
+) -> None:
     """Test options are enabled on Linux."""
     await async_setup_component(hass, "config", {})
     entry = MockConfigEntry(

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -1,13 +1,12 @@
 """Test bluetooth diagnostics."""
-
-
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import DEFAULT_ADDRESS
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import BaseHaRemoteScanner, HaBluetoothConnector
+from homeassistant.core import HomeAssistant
 
 from . import (
     MockBleakClient,
@@ -18,11 +17,16 @@ from . import (
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 async def test_diagnostics(
-    hass, hass_client, mock_bleak_scanner_start, enable_bluetooth, two_adapters
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    two_adapters: None,
+) -> None:
     """Test we can setup and unsetup bluetooth with multiple adapters."""
     # Normally we do not want to patch our classes, but since bleak will import
     # a different scanner based on the operating system, we need to patch here
@@ -241,8 +245,12 @@ async def test_diagnostics(
 
 
 async def test_diagnostics_macos(
-    hass, hass_client, mock_bleak_scanner_start, mock_bluetooth_adapters, macos_adapter
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    macos_adapter,
+) -> None:
     """Test diagnostics for macos."""
     # Normally we do not want to patch our classes, but since bleak will import
     # a different scanner based on the operating system, we need to patch here
@@ -413,13 +421,13 @@ async def test_diagnostics_macos(
 
 
 async def test_diagnostics_remote_adapter(
-    hass,
-    hass_client,
-    mock_bleak_scanner_start,
-    mock_bluetooth_adapters,
-    enable_bluetooth,
-    one_adapter,
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+    enable_bluetooth: None,
+    one_adapter: None,
+) -> None:
     """Test diagnostics for remote adapter."""
     manager = _get_manager()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -56,7 +56,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_setup_and_stop(hass, mock_bleak_scanner_start, enable_bluetooth):
+async def test_setup_and_stop(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test we and setup and stop the scanner."""
     mock_bt = [
         {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
@@ -75,7 +77,9 @@ async def test_setup_and_stop(hass, mock_bleak_scanner_start, enable_bluetooth):
     assert len(mock_bleak_scanner_start.mock_calls) == 1
 
 
-async def test_setup_and_stop_passive(hass, mock_bleak_scanner_start, one_adapter):
+async def test_setup_and_stop_passive(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+) -> None:
     """Test we and setup and stop the scanner the passive scanner."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
@@ -123,8 +127,10 @@ async def test_setup_and_stop_passive(hass, mock_bleak_scanner_start, one_adapte
 
 
 async def test_setup_and_stop_old_bluez(
-    hass, mock_bleak_scanner_start, one_adapter_old_bluez
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    one_adapter_old_bluez: None,
+) -> None:
     """Test we and setup and stop the scanner the passive scanner with older bluez."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN,
@@ -170,7 +176,9 @@ async def test_setup_and_stop_old_bluez(
     }
 
 
-async def test_setup_and_stop_no_bluetooth(hass, caplog, macos_adapter):
+async def test_setup_and_stop_no_bluetooth(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we fail gracefully when bluetooth is not available."""
     mock_bt = [
         {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
@@ -191,7 +199,9 @@ async def test_setup_and_stop_no_bluetooth(hass, caplog, macos_adapter):
     assert "Failed to initialize Bluetooth" in caplog.text
 
 
-async def test_setup_and_stop_broken_bluetooth(hass, caplog, macos_adapter):
+async def test_setup_and_stop_broken_bluetooth(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we fail gracefully when bluetooth/dbus is broken."""
     mock_bt = []
     with patch(
@@ -210,7 +220,9 @@ async def test_setup_and_stop_broken_bluetooth(hass, caplog, macos_adapter):
     assert len(bluetooth.async_discovered_service_info(hass)) == 0
 
 
-async def test_setup_and_stop_broken_bluetooth_hanging(hass, caplog, macos_adapter):
+async def test_setup_and_stop_broken_bluetooth_hanging(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we fail gracefully when bluetooth/dbus is hanging."""
     mock_bt = []
 
@@ -232,7 +244,9 @@ async def test_setup_and_stop_broken_bluetooth_hanging(hass, caplog, macos_adapt
     assert "Timed out starting Bluetooth" in caplog.text
 
 
-async def test_setup_and_retry_adapter_not_yet_available(hass, caplog, macos_adapter):
+async def test_setup_and_retry_adapter_not_yet_available(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we retry if the adapter is not yet available."""
     mock_bt = []
     with patch(
@@ -265,7 +279,9 @@ async def test_setup_and_retry_adapter_not_yet_available(hass, caplog, macos_ada
         await hass.async_block_till_done()
 
 
-async def test_no_race_during_manual_reload_in_retry_state(hass, caplog, macos_adapter):
+async def test_no_race_during_manual_reload_in_retry_state(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we can successfully reload when the entry is in a retry state."""
     mock_bt = []
     with patch(
@@ -300,8 +316,8 @@ async def test_no_race_during_manual_reload_in_retry_state(hass, caplog, macos_a
 
 
 async def test_calling_async_discovered_devices_no_bluetooth(
-    hass, caplog, macos_adapter
-):
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
     """Test we fail gracefully when asking for discovered devices and there is no blueooth."""
     mock_bt = []
     with patch(
@@ -322,8 +338,8 @@ async def test_calling_async_discovered_devices_no_bluetooth(
 
 
 async def test_discovery_match_by_service_uuid(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test bluetooth discovery match by service_uuid."""
     mock_bt = [
         {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
@@ -365,8 +381,8 @@ def _domains_from_mock_config_flow(mock_config_flow: Mock) -> list[str]:
 
 
 async def test_discovery_match_by_service_uuid_connectable(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by service_uuid and the ble device is connectable."""
     mock_bt = [
         {
@@ -412,8 +428,8 @@ async def test_discovery_match_by_service_uuid_connectable(
 
 
 async def test_discovery_match_by_service_uuid_not_connectable(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by service_uuid and the ble device is not connectable."""
     mock_bt = [
         {
@@ -457,8 +473,8 @@ async def test_discovery_match_by_service_uuid_not_connectable(
 
 
 async def test_discovery_match_by_name_connectable_false(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by name and the integration will take non-connectable devices."""
     mock_bt = [
         {
@@ -529,8 +545,8 @@ async def test_discovery_match_by_name_connectable_false(
 
 
 async def test_discovery_match_by_local_name(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by local_name."""
     mock_bt = [{"domain": "switchbot", "local_name": "wohand"}]
     with patch(
@@ -567,8 +583,8 @@ async def test_discovery_match_by_local_name(
 
 
 async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by manufacturer_id and manufacturer_data_start."""
     mock_bt = [
         {
@@ -643,8 +659,8 @@ async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
 
 
 async def test_discovery_match_by_service_data_uuid_then_others(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by service_data_uuid and then other fields."""
     mock_bt = [
         {
@@ -797,8 +813,8 @@ async def test_discovery_match_by_service_data_uuid_then_others(
 
 
 async def test_discovery_match_by_service_data_uuid_when_format_changes(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery match by service_data_uuid when format changes."""
     mock_bt = [
         {
@@ -880,8 +896,8 @@ async def test_discovery_match_by_service_data_uuid_when_format_changes(
 
 
 async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test bluetooth discovery matches twice for service_uuid and then manufacturer_id."""
     mock_bt = [
         {
@@ -943,7 +959,9 @@ async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
         assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_rediscovery(hass, mock_bleak_scanner_start, enable_bluetooth):
+async def test_rediscovery(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test bluetooth discovery can be re-enabled for a given domain."""
     mock_bt = [
         {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
@@ -985,8 +1003,8 @@ async def test_rediscovery(hass, mock_bleak_scanner_start, enable_bluetooth):
 
 
 async def test_async_discovered_device_api(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test the async_discovered_device API."""
     mock_bt = []
     with patch(
@@ -1078,7 +1096,9 @@ async def test_async_discovered_device_api(
             assert bluetooth.async_address_present(hass, "44:44:33:11:23:45") is True
 
 
-async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetooth):
+async def test_register_callbacks(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback."""
     mock_bt = []
     callbacks = []
@@ -1154,8 +1174,11 @@ async def test_register_callbacks(hass, mock_bleak_scanner_start, enable_bluetoo
 
 
 async def test_register_callbacks_raises_exception(
-    hass, mock_bleak_scanner_start, enable_bluetooth, caplog
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test registering a callback that raises ValueError."""
     mock_bt = []
     callbacks = []
@@ -1212,8 +1235,8 @@ async def test_register_callbacks_raises_exception(
 
 
 async def test_register_callback_by_address(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by address."""
     mock_bt = []
     callbacks = []
@@ -1303,8 +1326,8 @@ async def test_register_callback_by_address(
 
 
 async def test_register_callback_by_address_connectable_only(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by address connectable only."""
     mock_bt = []
     connectable_callbacks = []
@@ -1382,8 +1405,8 @@ async def test_register_callback_by_address_connectable_only(
 
 
 async def test_register_callback_by_manufacturer_id(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by manufacturer_id."""
     mock_bt = []
     callbacks = []
@@ -1437,8 +1460,8 @@ async def test_register_callback_by_manufacturer_id(
 
 
 async def test_register_callback_by_connectable(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by connectable."""
     mock_bt = []
     callbacks = []
@@ -1492,8 +1515,8 @@ async def test_register_callback_by_connectable(
 
 
 async def test_not_filtering_wanted_apple_devices(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test filtering noisy apple devices."""
     mock_bt = []
     callbacks = []
@@ -1552,8 +1575,8 @@ async def test_not_filtering_wanted_apple_devices(
 
 
 async def test_filtering_noisy_apple_devices(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test filtering noisy apple devices."""
     mock_bt = []
     callbacks = []
@@ -1602,8 +1625,8 @@ async def test_filtering_noisy_apple_devices(
 
 
 async def test_register_callback_by_address_connectable_manufacturer_id(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by address, manufacturer_id, and connectable."""
     mock_bt = []
     callbacks = []
@@ -1656,8 +1679,8 @@ async def test_register_callback_by_address_connectable_manufacturer_id(
 
 
 async def test_register_callback_by_manufacturer_id_and_address(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by manufacturer_id and address."""
     mock_bt = []
     callbacks = []
@@ -1721,8 +1744,8 @@ async def test_register_callback_by_manufacturer_id_and_address(
 
 
 async def test_register_callback_by_service_uuid_and_address(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by service_uuid and address."""
     mock_bt = []
     callbacks = []
@@ -1790,8 +1813,8 @@ async def test_register_callback_by_service_uuid_and_address(
 
 
 async def test_register_callback_by_service_data_uuid_and_address(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by service_data_uuid and address."""
     mock_bt = []
     callbacks = []
@@ -1859,8 +1882,8 @@ async def test_register_callback_by_service_data_uuid_and_address(
 
 
 async def test_register_callback_by_local_name(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by local_name."""
     mock_bt = []
     callbacks = []
@@ -1922,8 +1945,11 @@ async def test_register_callback_by_local_name(
 
 
 async def test_register_callback_by_local_name_overly_broad(
-    hass, mock_bleak_scanner_start, enable_bluetooth, caplog
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test registering a callback by local_name that is too broad."""
     mock_bt = []
 
@@ -1955,8 +1981,8 @@ async def test_register_callback_by_local_name_overly_broad(
 
 
 async def test_register_callback_by_service_data_uuid(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by service_data_uuid."""
     mock_bt = []
     callbacks = []
@@ -2010,8 +2036,8 @@ async def test_register_callback_by_service_data_uuid(
 
 
 async def test_register_callback_survives_reload(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test registering a callback by address survives bluetooth being reloaded."""
     mock_bt = []
     callbacks = []
@@ -2073,8 +2099,8 @@ async def test_register_callback_survives_reload(
 
 
 async def test_process_advertisements_bail_on_good_advertisement(
-    hass: HomeAssistant, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test as soon as we see a 'good' advertisement we return it."""
     done = asyncio.Future()
 
@@ -2112,8 +2138,8 @@ async def test_process_advertisements_bail_on_good_advertisement(
 
 
 async def test_process_advertisements_ignore_bad_advertisement(
-    hass: HomeAssistant, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Check that we ignore bad advertisements."""
     done = asyncio.Event()
     return_value = asyncio.Event()
@@ -2166,8 +2192,8 @@ async def test_process_advertisements_ignore_bad_advertisement(
 
 
 async def test_process_advertisements_timeout(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test we timeout if no advertisements at all."""
 
     def _callback(service_info: BluetoothServiceInfo) -> bool:
@@ -2180,8 +2206,8 @@ async def test_process_advertisements_timeout(
 
 
 async def test_wrapped_instance_with_filter(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test consumers can use the wrapped instance with a filter as if it was normal BleakScanner."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2252,8 +2278,8 @@ async def test_wrapped_instance_with_filter(
 
 
 async def test_wrapped_instance_with_service_uuids(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test consumers can use the wrapped instance with a service_uuids list as if it was normal BleakScanner."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2308,8 +2334,8 @@ async def test_wrapped_instance_with_service_uuids(
 
 
 async def test_wrapped_instance_with_broken_callbacks(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test broken callbacks do not cause the scanner to fail."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2352,8 +2378,8 @@ async def test_wrapped_instance_with_broken_callbacks(
 
 
 async def test_wrapped_instance_changes_uuids(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test consumers can use the wrapped instance can change the uuids later."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2407,8 +2433,8 @@ async def test_wrapped_instance_changes_uuids(
 
 
 async def test_wrapped_instance_changes_filters(
-    hass, mock_bleak_scanner_start, enable_bluetooth
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+) -> None:
     """Test consumers can use the wrapped instance can change the filter later."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2463,8 +2489,11 @@ async def test_wrapped_instance_changes_filters(
 
 
 async def test_wrapped_instance_unsupported_filter(
-    hass, mock_bleak_scanner_start, caplog, enable_bluetooth
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+) -> None:
     """Test we want when their filter is ineffective."""
     with patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=[]
@@ -2486,8 +2515,8 @@ async def test_wrapped_instance_unsupported_filter(
 
 
 async def test_async_ble_device_from_address(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test the async_ble_device_from_address api."""
     mock_bt = []
     with patch(
@@ -2529,8 +2558,8 @@ async def test_async_ble_device_from_address(
 
 
 async def test_can_unsetup_bluetooth_single_adapter_macos(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test we can setup and unsetup bluetooth."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={}, unique_id=DEFAULT_ADDRESS)
     entry.add_to_hass(hass)
@@ -2544,8 +2573,11 @@ async def test_can_unsetup_bluetooth_single_adapter_macos(
 
 
 async def test_can_unsetup_bluetooth_single_adapter_linux(
-    hass, mock_bleak_scanner_start, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    one_adapter: None,
+) -> None:
     """Test we can setup and unsetup bluetooth."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
@@ -2561,8 +2593,11 @@ async def test_can_unsetup_bluetooth_single_adapter_linux(
 
 
 async def test_can_unsetup_bluetooth_multiple_adapters(
-    hass, mock_bleak_scanner_start, enable_bluetooth, two_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    two_adapters: None,
+) -> None:
     """Test we can setup and unsetup bluetooth with multiple adapters."""
     entry1 = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
@@ -2584,8 +2619,11 @@ async def test_can_unsetup_bluetooth_multiple_adapters(
 
 
 async def test_three_adapters_one_missing(
-    hass, mock_bleak_scanner_start, enable_bluetooth, two_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    enable_bluetooth: None,
+    two_adapters: None,
+) -> None:
     """Test three adapters but one is missing results in a retry on setup."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:03"
@@ -2596,7 +2634,9 @@ async def test_three_adapters_one_missing(
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_auto_detect_bluetooth_adapters_linux(hass, one_adapter):
+async def test_auto_detect_bluetooth_adapters_linux(
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test we auto detect bluetooth adapters on linux."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
@@ -2604,7 +2644,9 @@ async def test_auto_detect_bluetooth_adapters_linux(hass, one_adapter):
     assert len(hass.config_entries.flow.async_progress(bluetooth.DOMAIN)) == 1
 
 
-async def test_auto_detect_bluetooth_adapters_linux_multiple(hass, two_adapters):
+async def test_auto_detect_bluetooth_adapters_linux_multiple(
+    hass: HomeAssistant, two_adapters: None
+) -> None:
     """Test we auto detect bluetooth adapters on linux with multiple adapters."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
@@ -2649,13 +2691,17 @@ async def test_no_auto_detect_bluetooth_adapters_windows(hass: HomeAssistant) ->
     assert len(hass.config_entries.flow.async_progress(bluetooth.DOMAIN)) == 0
 
 
-async def test_getting_the_scanner_returns_the_wrapped_instance(hass, enable_bluetooth):
+async def test_getting_the_scanner_returns_the_wrapped_instance(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test getting the scanner returns the wrapped instance."""
     scanner = bluetooth.async_get_scanner(hass)
     assert isinstance(scanner, HaBleakScannerWrapper)
 
 
-async def test_scanner_count_connectable(hass, enable_bluetooth):
+async def test_scanner_count_connectable(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test getting the connectable scanner count."""
     scanner = FakeScanner(hass, "any", "any")
     cancel = bluetooth.async_register_scanner(hass, scanner, False)
@@ -2663,7 +2709,7 @@ async def test_scanner_count_connectable(hass, enable_bluetooth):
     cancel()
 
 
-async def test_scanner_count(hass, enable_bluetooth):
+async def test_scanner_count(hass: HomeAssistant, enable_bluetooth: None) -> None:
     """Test getting the connectable and non-connectable scanner count."""
     scanner = FakeScanner(hass, "any", "any")
     cancel = bluetooth.async_register_scanner(hass, scanner, False)
@@ -2672,8 +2718,8 @@ async def test_scanner_count(hass, enable_bluetooth):
 
 
 async def test_migrate_single_entry_macos(
-    hass, mock_bleak_scanner_start, macos_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+) -> None:
     """Test we can migrate a single entry on MacOS."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={})
     entry.add_to_hass(hass)
@@ -2682,7 +2728,9 @@ async def test_migrate_single_entry_macos(
     assert entry.unique_id == DEFAULT_ADDRESS
 
 
-async def test_migrate_single_entry_linux(hass, mock_bleak_scanner_start, one_adapter):
+async def test_migrate_single_entry_linux(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+) -> None:
     """Test we can migrate a single entry on Linux."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={})
     entry.add_to_hass(hass)
@@ -2691,7 +2739,9 @@ async def test_migrate_single_entry_linux(hass, mock_bleak_scanner_start, one_ad
     assert entry.unique_id == "00:00:00:00:00:01"
 
 
-async def test_discover_new_usb_adapters(hass, mock_bleak_scanner_start, one_adapter):
+async def test_discover_new_usb_adapters(
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+) -> None:
     """Test we can discover new usb adapters."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
@@ -2746,8 +2796,8 @@ async def test_discover_new_usb_adapters(hass, mock_bleak_scanner_start, one_ada
 
 
 async def test_discover_new_usb_adapters_with_firmware_fallback_delay(
-    hass, mock_bleak_scanner_start, one_adapter
-):
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+) -> None:
     """Test we can discover new usb adapters with a firmware fallback delay."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
@@ -2819,8 +2869,11 @@ async def test_discover_new_usb_adapters_with_firmware_fallback_delay(
 
 
 async def test_issue_outdated_haos(
-    hass, mock_bleak_scanner_start, one_adapter, operating_system_85
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    one_adapter: None,
+    operating_system_85: None,
+) -> None:
     """Test we create an issue on outdated haos."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
@@ -2836,8 +2889,11 @@ async def test_issue_outdated_haos(
 
 
 async def test_issue_outdated_haos_no_adapters(
-    hass, mock_bleak_scanner_start, no_adapters, operating_system_85
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    no_adapters: None,
+    operating_system_85: None,
+) -> None:
     """Test we do not create an issue on outdated haos if there are no adapters."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
@@ -2850,8 +2906,11 @@ async def test_issue_outdated_haos_no_adapters(
 
 
 async def test_haos_9_or_later(
-    hass, mock_bleak_scanner_start, one_adapter, operating_system_90
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    one_adapter: None,
+    operating_system_90: None,
+) -> None:
     """Test we do not create issues for haos 9.x or later."""
     entry = MockConfigEntry(
         domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -296,7 +296,7 @@ async def test_switching_adapters_based_on_stale(
 
 
 async def test_restore_history_from_dbus(
-    hass: HomeAssistant, one_adapte: None, disable_new_discovery_flows
+    hass: HomeAssistant, one_adapter: None, disable_new_discovery_flows
 ) -> None:
     """Test we can restore history from dbus."""
     address = "AA:BB:CC:CC:CC:FF"

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1,5 +1,6 @@
 """Tests for the Bluetooth integration manager."""
 
+from collections.abc import Generator
 from datetime import timedelta
 import time
 from unittest.mock import patch
@@ -45,7 +46,7 @@ from tests.common import async_fire_time_changed, load_fixture
 
 
 @pytest.fixture
-def register_hci0_scanner(hass: HomeAssistant) -> None:
+def register_hci0_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
     """Register an hci0 scanner."""
     hci0_scanner = FakeScanner(hass, "hci0", "hci0")
     cancel = bluetooth.async_register_scanner(hass, hci0_scanner, True)
@@ -54,7 +55,7 @@ def register_hci0_scanner(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def register_hci1_scanner(hass: HomeAssistant) -> None:
+def register_hci1_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
     """Register an hci1 scanner."""
     hci1_scanner = FakeScanner(hass, "hci1", "hci1")
     cancel = bluetooth.async_register_scanner(hass, hci1_scanner, True)
@@ -63,8 +64,11 @@ def register_hci1_scanner(hass: HomeAssistant) -> None:
 
 
 async def test_advertisements_do_not_switch_adapters_for_no_reason(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test we only switch adapters when needed."""
 
     address = "44:44:33:11:23:12"
@@ -111,8 +115,11 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
 
 
 async def test_switching_adapters_based_on_rssi(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test switching adapters based on rssi."""
 
     address = "44:44:33:11:23:45"
@@ -167,8 +174,11 @@ async def test_switching_adapters_based_on_rssi(
 
 
 async def test_switching_adapters_based_on_zero_rssi(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test switching adapters based on zero rssi."""
 
     address = "44:44:33:11:23:45"
@@ -223,8 +233,11 @@ async def test_switching_adapters_based_on_zero_rssi(
 
 
 async def test_switching_adapters_based_on_stale(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test switching adapters based on the previous advertisement being stale."""
 
     address = "44:44:33:11:23:41"
@@ -283,8 +296,8 @@ async def test_switching_adapters_based_on_stale(
 
 
 async def test_restore_history_from_dbus(
-    hass, one_adapter, disable_new_discovery_flows
-):
+    hass: HomeAssistant, one_adapte: None, disable_new_discovery_flows
+) -> None:
     """Test we can restore history from dbus."""
     address = "AA:BB:CC:CC:CC:FF"
 
@@ -306,8 +319,8 @@ async def test_restore_history_from_dbus(
 
 
 async def test_restore_history_from_dbus_and_remote_adapters(
-    hass, one_adapter, hass_storage, disable_new_discovery_flows
-):
+    hass: HomeAssistant, one_adapter: None, hass_storage, disable_new_discovery_flows
+) -> None:
     """Test we can restore history from dbus along with remote adapters."""
     address = "AA:BB:CC:CC:CC:FF"
 
@@ -343,8 +356,8 @@ async def test_restore_history_from_dbus_and_remote_adapters(
 
 
 async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
-    hass, one_adapter, hass_storage, disable_new_discovery_flows
-):
+    hass: HomeAssistant, one_adapter: None, hass_storage, disable_new_discovery_flows
+) -> None:
     """Test we can restore history from dbus when the remote adapters data is corrupted."""
     address = "AA:BB:CC:CC:CC:FF"
 
@@ -378,8 +391,11 @@ async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
 
 
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test switching adapters based on rssi from connectable to non connectable."""
 
     address = "44:44:33:11:23:45"
@@ -461,8 +477,11 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
 
 
 async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_connectable(
-    hass, enable_bluetooth, register_hci0_scanner, register_hci1_scanner
-):
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+    register_hci0_scanner: None,
+    register_hci1_scanner: None,
+) -> None:
     """Test we can still get a connectable BLEDevice when the best path is non-connectable.
 
     In this case the the device is closer to a non-connectable scanner, but the
@@ -509,8 +528,8 @@ async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_
 
 
 async def test_switching_adapters_when_one_goes_away(
-    hass, enable_bluetooth, register_hci0_scanner
-):
+    hass: HomeAssistant, enable_bluetooth: None, register_hci0_scanner: None
+) -> None:
     """Test switching adapters when one goes away."""
     cancel_hci2 = bluetooth.async_register_scanner(
         hass, FakeScanner(hass, "hci2", "hci2"), True
@@ -560,8 +579,8 @@ async def test_switching_adapters_when_one_goes_away(
 
 
 async def test_switching_adapters_when_one_stop_scanning(
-    hass, enable_bluetooth, register_hci0_scanner
-):
+    hass: HomeAssistant, enable_bluetooth: None, register_hci0_scanner: None
+) -> None:
     """Test switching adapters when stops scanning."""
     hci2_scanner = FakeScanner(hass, "hci2", "hci2")
     cancel_hci2 = bluetooth.async_register_scanner(hass, hci2_scanner, True)
@@ -612,8 +631,8 @@ async def test_switching_adapters_when_one_stop_scanning(
 
 
 async def test_goes_unavailable_connectable_only_and_recovers(
-    hass, mock_bluetooth_adapters
-):
+    hass: HomeAssistant, mock_bluetooth_adapters: None
+) -> None:
     """Test all connectable scanners go unavailable, and than recover when there is a non-connectable scanner."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -18,6 +18,7 @@ from homeassistant.components.bluetooth.wrappers import (
     HaBleakClientWrapper,
     HaBleakScannerWrapper,
 )
+from homeassistant.core import HomeAssistant
 
 from . import (
     MockBleakClient,
@@ -28,7 +29,9 @@ from . import (
 )
 
 
-async def test_wrapped_bleak_scanner(hass, enable_bluetooth):
+async def test_wrapped_bleak_scanner(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test wrapped bleak scanner dispatches calls as expected."""
     scanner = HaBleakScannerWrapper()
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
@@ -40,7 +43,9 @@ async def test_wrapped_bleak_scanner(hass, enable_bluetooth):
     assert await scanner.discover() == [switchbot_device]
 
 
-async def test_wrapped_bleak_client_raises_device_missing(hass, enable_bluetooth):
+async def test_wrapped_bleak_client_raises_device_missing(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test wrapped bleak client dispatches calls as expected."""
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
     client = HaBleakClientWrapper(switchbot_device)
@@ -53,8 +58,8 @@ async def test_wrapped_bleak_client_raises_device_missing(hass, enable_bluetooth
 
 
 async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
-    hass, enable_bluetooth
-):
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test wrapped bleak client can set a disconnected callback before connected."""
     switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
     client = HaBleakClientWrapper(switchbot_device)
@@ -62,8 +67,8 @@ async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
 
 
 async def test_wrapped_bleak_client_local_adapter_only(
-    hass, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test wrapped bleak client with only a local adapter."""
     manager = _get_manager()
 
@@ -123,8 +128,8 @@ async def test_wrapped_bleak_client_local_adapter_only(
 
 
 async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
-    hass, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test wrapped bleak client can set a disconnected callback after connected."""
     manager = _get_manager()
 
@@ -210,8 +215,8 @@ async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
 
 
 async def test_ble_device_with_proxy_client_out_of_connections_no_scanners(
-    hass, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test we switch to the next available proxy when one runs out of connections with no scanners."""
     manager = _get_manager()
 
@@ -247,8 +252,8 @@ async def test_ble_device_with_proxy_client_out_of_connections_no_scanners(
 
 
 async def test_ble_device_with_proxy_client_out_of_connections(
-    hass, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test handling all scanners are out of connection slots."""
     manager = _get_manager()
 
@@ -311,7 +316,9 @@ async def test_ble_device_with_proxy_client_out_of_connections(
     cancel()
 
 
-async def test_ble_device_with_proxy_clear_cache(hass, enable_bluetooth, one_adapter):
+async def test_ble_device_with_proxy_clear_cache(
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test we can clear cache on the proxy."""
     manager = _get_manager()
 
@@ -372,8 +379,8 @@ async def test_ble_device_with_proxy_clear_cache(hass, enable_bluetooth, one_ada
 
 
 async def test_ble_device_with_proxy_client_out_of_connections_uses_best_available(
-    hass, enable_bluetooth, one_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+) -> None:
     """Test we switch to the next available proxy when one runs out of connections."""
     manager = _get_manager()
 
@@ -481,8 +488,8 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
 
 
 async def test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos(
-    hass, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant, enable_bluetooth: None, macos_adapter: None
+) -> None:
     """Test we switch to the next available proxy when one runs out of connections on MacOS."""
     manager = _get_manager()
 

--- a/tests/components/bluetooth/test_passive_update_coordinator.py
+++ b/tests/components/bluetooth/test_passive_update_coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
     PassiveBluetoothDataUpdateCoordinator,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -59,7 +60,11 @@ class MyCoordinator(PassiveBluetoothDataUpdateCoordinator):
         super()._async_handle_bluetooth_event(service_info, change)
 
 
-async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapters):
+async def test_basic_usage(
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the PassiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     coordinator = MyCoordinator(
@@ -88,8 +93,10 @@ async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapte
 
 
 async def test_context_compatiblity_with_data_update_coordinator(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test contexts can be passed for compatibility with DataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     coordinator = MyCoordinator(
@@ -124,8 +131,10 @@ async def test_context_compatiblity_with_data_update_coordinator(
 
 
 async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test that the coordinator goes unavailable when the bluetooth stack no longer sees the device."""
     start_monotonic = time.monotonic()
     with patch(
@@ -181,8 +190,10 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
 
 
 async def test_passive_bluetooth_coordinator_entity(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test integration of PassiveBluetoothDataUpdateCoordinator with PassiveBluetoothCoordinatorEntity."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     coordinator = MyCoordinator(

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -30,7 +30,7 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import CoreState, callback
+from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -99,7 +99,11 @@ GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 )
 
 
-async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapters):
+async def test_basic_usage(
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test basic usage of the PassiveBluetoothProcessorCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -198,8 +202,10 @@ async def test_basic_usage(hass, mock_bleak_scanner_start, mock_bluetooth_adapte
 
 
 async def test_unavailable_after_no_data(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test that the coordinator is unavailable after no data for a while."""
     start_monotonic = time.monotonic()
 
@@ -306,8 +312,10 @@ async def test_unavailable_after_no_data(
 
 
 async def test_no_updates_once_stopping(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test updates are ignored once hass is stopping."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -361,8 +369,11 @@ async def test_no_updates_once_stopping(
 
 
 async def test_exception_from_update_method(
-    hass, caplog, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test we handle exceptions from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -426,8 +437,10 @@ async def test_exception_from_update_method(
 
 
 async def test_bad_data_from_update_method(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test we handle bad data from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -780,8 +793,10 @@ GOVEE_B5178_PRIMARY_AND_REMOTE_PASSIVE_BLUETOOTH_DATA_UPDATE = (
 
 
 async def test_integration_with_entity(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test integration of PassiveBluetoothProcessorCoordinator with PassiveBluetoothCoordinatorEntity."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -912,8 +927,10 @@ NO_DEVICES_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 
 
 async def test_integration_with_entity_without_a_device(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test integration with PassiveBluetoothCoordinatorEntity with no device."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -975,8 +992,10 @@ async def test_integration_with_entity_without_a_device(
 
 
 async def test_passive_bluetooth_entity_with_entity_platform(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test with a mock entity platform."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -1074,8 +1093,10 @@ BINARY_SENSOR_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 
 
 async def test_integration_multiple_entity_platforms(
-    hass, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test integration of PassiveBluetoothProcessorCoordinator with multiple platforms."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -1165,8 +1186,11 @@ async def test_integration_multiple_entity_platforms(
 
 
 async def test_exception_from_coordinator_update_method(
-    hass, caplog, mock_bleak_scanner_start, mock_bluetooth_adapters
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_bleak_scanner_start: MagicMock,
+    mock_bluetooth_adapters: None,
+) -> None:
     """Test we handle exceptions from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -17,6 +17,7 @@ from homeassistant.components.bluetooth.const import (
 from homeassistant.components.bluetooth.scanner import NEED_RESET_ERRORS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import _get_manager, async_setup_with_one_adapter, generate_advertisement_data
@@ -25,8 +26,11 @@ from tests.common import async_fire_time_changed
 
 
 async def test_config_entry_can_be_reloaded_when_stop_raises(
-    hass, caplog, enable_bluetooth, macos_adapter
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_bluetooth: None,
+    macos_adapter: None,
+) -> None:
     """Test we can reload if stopping the scanner raises."""
     entry = hass.config_entries.async_entries(bluetooth.DOMAIN)[0]
     assert entry.state == ConfigEntryState.LOADED
@@ -42,7 +46,9 @@ async def test_config_entry_can_be_reloaded_when_stop_raises(
     assert "Error stopping scanner" in caplog.text
 
 
-async def test_dbus_socket_missing_in_container(hass, caplog, one_adapter):
+async def test_dbus_socket_missing_in_container(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
     """Test we handle dbus being missing in the container."""
 
     with patch(
@@ -62,7 +68,9 @@ async def test_dbus_socket_missing_in_container(hass, caplog, one_adapter):
     assert "docker" in caplog.text
 
 
-async def test_dbus_socket_missing(hass, caplog, one_adapter):
+async def test_dbus_socket_missing(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
     """Test we handle dbus being missing."""
 
     with patch(
@@ -82,7 +90,9 @@ async def test_dbus_socket_missing(hass, caplog, one_adapter):
     assert "docker" not in caplog.text
 
 
-async def test_dbus_broken_pipe_in_container(hass, caplog, one_adapter):
+async def test_dbus_broken_pipe_in_container(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
     """Test we handle dbus broken pipe in the container."""
 
     with patch(
@@ -103,7 +113,9 @@ async def test_dbus_broken_pipe_in_container(hass, caplog, one_adapter):
     assert "container" in caplog.text
 
 
-async def test_dbus_broken_pipe(hass, caplog, one_adapter):
+async def test_dbus_broken_pipe(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
     """Test we handle dbus broken pipe."""
 
     with patch(
@@ -124,7 +136,9 @@ async def test_dbus_broken_pipe(hass, caplog, one_adapter):
     assert "container" not in caplog.text
 
 
-async def test_invalid_dbus_message(hass, caplog, one_adapter):
+async def test_invalid_dbus_message(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
     """Test we handle invalid dbus message."""
 
     with patch(
@@ -142,7 +156,9 @@ async def test_invalid_dbus_message(hass, caplog, one_adapter):
 
 
 @pytest.mark.parametrize("error", NEED_RESET_ERRORS)
-async def test_adapter_needs_reset_at_start(hass, caplog, one_adapter, error):
+async def test_adapter_needs_reset_at_start(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None, error: str
+) -> None:
     """Test we cycle the adapter when it needs a restart."""
 
     with patch(
@@ -162,7 +178,9 @@ async def test_adapter_needs_reset_at_start(hass, caplog, one_adapter, error):
     await hass.async_block_till_done()
 
 
-async def test_recovery_from_dbus_restart(hass, one_adapter):
+async def test_recovery_from_dbus_restart(
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test we can recover when DBus gets restarted out from under us."""
 
     called_start = 0
@@ -245,7 +263,7 @@ async def test_recovery_from_dbus_restart(hass, one_adapter):
     assert called_start == 2
 
 
-async def test_adapter_recovery(hass, one_adapter):
+async def test_adapter_recovery(hass: HomeAssistant, one_adapter: None) -> None:
     """Test we can recover when the adapter stops responding."""
 
     called_start = 0
@@ -328,7 +346,9 @@ async def test_adapter_recovery(hass, one_adapter):
     assert called_start == 2
 
 
-async def test_adapter_scanner_fails_to_start_first_time(hass, one_adapter):
+async def test_adapter_scanner_fails_to_start_first_time(
+    hass: HomeAssistant, one_adapter: None
+) -> None:
     """Test we can recover when the adapter stops responding and the first recovery fails."""
 
     called_start = 0
@@ -432,8 +452,8 @@ async def test_adapter_scanner_fails_to_start_first_time(hass, one_adapter):
 
 
 async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
-    hass, one_adapter, caplog
-):
+    hass: HomeAssistant, one_adapter: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we can recover the adapter at startup and we wait for Dbus to init."""
 
     called_start = 0
@@ -490,7 +510,9 @@ async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
     assert "Waiting for adapter to initialize" in caplog.text
 
 
-async def test_restart_takes_longer_than_watchdog_time(hass, one_adapter, caplog):
+async def test_restart_takes_longer_than_watchdog_time(
+    hass: HomeAssistant, one_adapter: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we do not try to recover the adapter again if the restart is still in progress."""
 
     release_start_event = asyncio.Event()

--- a/tests/components/bluetooth/test_usage.py
+++ b/tests/components/bluetooth/test_usage.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import bleak
 from bleak.backends.device import BLEDevice
 import bleak_retry_connector
+import pytest
 
 from homeassistant.components.bluetooth.usage import (
     install_multiple_bleak_catcher,
@@ -38,7 +39,9 @@ async def test_multiple_bleak_scanner_instances(hass: HomeAssistant) -> None:
     assert not isinstance(instance, HaBleakScannerWrapper)
 
 
-async def test_wrapping_bleak_client(hass, enable_bluetooth):
+async def test_wrapping_bleak_client(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test we wrap BleakClient."""
     install_multiple_bleak_catcher()
 
@@ -53,7 +56,9 @@ async def test_wrapping_bleak_client(hass, enable_bluetooth):
     assert not isinstance(instance, HaBleakClientWrapper)
 
 
-async def test_bleak_client_reports_with_address(hass, enable_bluetooth, caplog):
+async def test_bleak_client_reports_with_address(
+    hass: HomeAssistant, enable_bluetooth: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we report when we pass an address to BleakClient."""
     install_multiple_bleak_catcher()
 
@@ -79,8 +84,8 @@ async def test_bleak_client_reports_with_address(hass, enable_bluetooth, caplog)
 
 
 async def test_bleak_retry_connector_client_reports_with_address(
-    hass, enable_bluetooth, caplog
-):
+    hass: HomeAssistant, enable_bluetooth: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we report when we pass an address to BleakClientWithServiceCache."""
     install_multiple_bleak_catcher()
 

--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -193,8 +193,12 @@ def _generate_scanners_with_fake_devices(hass):
 
 
 async def test_test_switch_adapters_when_out_of_slots(
-    hass, two_adapters, enable_bluetooth, install_bleak_catcher, mock_platform_client
-):
+    hass: HomeAssistant,
+    two_adapters: None,
+    enable_bluetooth: None,
+    install_bleak_catcher,
+    mock_platform_client,
+) -> None:
     """Ensure we try another scanner when one runs out of slots."""
     manager = _get_manager()
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices(
@@ -246,12 +250,12 @@ async def test_test_switch_adapters_when_out_of_slots(
 
 
 async def test_release_slot_on_connect_failure(
-    hass,
-    two_adapters,
-    enable_bluetooth,
+    hass: HomeAssistant,
+    two_adapters: None,
+    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client_that_fails_to_connect,
-):
+) -> None:
     """Ensure the slot gets released on connection failure."""
     manager = _get_manager()
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices(
@@ -274,12 +278,12 @@ async def test_release_slot_on_connect_failure(
 
 
 async def test_release_slot_on_connect_exception(
-    hass,
-    two_adapters,
-    enable_bluetooth,
+    hass: HomeAssistant,
+    two_adapters: None,
+    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client_that_raises_on_connect,
-):
+) -> None:
     """Ensure the slot gets released on connection exception."""
     manager = _get_manager()
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices(
@@ -303,11 +307,11 @@ async def test_release_slot_on_connect_exception(
 
 
 async def test_we_switch_adapters_on_failure(
-    hass,
-    two_adapters,
-    enable_bluetooth,
+    hass: HomeAssistant,
+    two_adapters: None,
+    enable_bluetooth: None,
     install_bleak_catcher,
-):
+) -> None:
     """Ensure we try the next best adapter after a failure."""
     hci0_device_advs, cancel_hci0, cancel_hci1 = _generate_scanners_with_fake_devices(
         hass

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -1,5 +1,4 @@
 """Test Bluetooth LE device tracker."""
-
 import asyncio
 from datetime import timedelta
 from unittest.mock import patch
@@ -18,7 +17,9 @@ from homeassistant.components.device_tracker import (
     CONF_TRACK_NEW,
     DOMAIN,
 )
+from homeassistant.components.device_tracker.legacy import Device
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, slugify
 
@@ -65,8 +66,8 @@ class MockBleakClientBattery5(MockBleakClient):
 
 
 async def test_preserve_new_tracked_device_name(
-    hass, mock_bluetooth, mock_device_tracker_conf
-):
+    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+) -> None:
     """Test preserving tracked device name across new seens."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -133,8 +134,8 @@ async def test_preserve_new_tracked_device_name(
 
 
 async def test_tracking_battery_times_out(
-    hass, mock_bluetooth, mock_device_tracker_conf
-):
+    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+) -> None:
     """Test tracking the battery times out."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -199,7 +200,9 @@ async def test_tracking_battery_times_out(
     assert "battery" not in state.attributes
 
 
-async def test_tracking_battery_fails(hass, mock_bluetooth, mock_device_tracker_conf):
+async def test_tracking_battery_fails(
+    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+) -> None:
     """Test tracking the battery fails."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -265,8 +268,8 @@ async def test_tracking_battery_fails(hass, mock_bluetooth, mock_device_tracker_
 
 
 async def test_tracking_battery_successful(
-    hass, mock_bluetooth, mock_device_tracker_conf
-):
+    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+) -> None:
     """Test tracking the battery gets a value."""
 
     address = "DE:AD:BE:EF:13:37"

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -1,5 +1,4 @@
 """Test BMW diagnostics."""
-
 import datetime
 import json
 import os
@@ -18,10 +17,13 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 
 @freeze_time(datetime.datetime(2022, 7, 10, 11))
-async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture):
+async def test_config_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
+) -> None:
     """Test config entry diagnostics."""
 
     # Make sure that local timezone for test is UTC
@@ -42,7 +44,9 @@ async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, bmw_fi
 
 
 @freeze_time(datetime.datetime(2022, 7, 10, 11))
-async def test_device_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture):
+async def test_device_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
+) -> None:
     """Test device diagnostics."""
 
     # Make sure that local timezone for test is UTC
@@ -70,8 +74,8 @@ async def test_device_diagnostics(hass: HomeAssistant, hass_client, bmw_fixture)
 
 @freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_device_diagnostics_vehicle_not_found(
-    hass: HomeAssistant, hass_client, bmw_fixture
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
+) -> None:
     """Test device diagnostics when the vehicle cannot be found."""
 
     # Make sure that local timezone for test is UTC

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -1,11 +1,10 @@
 """Tests for the Bond button device."""
-
 from bond_async import Action, DeviceType
 
-from homeassistant import core
 from homeassistant.components.bond.button import STEP_SIZE
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -58,7 +57,7 @@ def light(name: str):
     }
 
 
-async def test_entity_registry(hass: core.HomeAssistant):
+async def test_entity_registry(hass: HomeAssistant) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -79,7 +78,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id_startdimmer"
 
 
-async def test_mutually_exclusive_actions(hass: core.HomeAssistant):
+async def test_mutually_exclusive_actions(hass: HomeAssistant) -> None:
     """Tests we do not create the button when there is a mutually exclusive action."""
     await setup_platform(
         hass,
@@ -91,7 +90,7 @@ async def test_mutually_exclusive_actions(hass: core.HomeAssistant):
     assert not hass.states.async_all("button")
 
 
-async def test_stop_not_created_no_other_buttons(hass: core.HomeAssistant):
+async def test_stop_not_created_no_other_buttons(hass: HomeAssistant) -> None:
     """Tests we do not create the stop button when there are no other buttons."""
     await setup_platform(
         hass,
@@ -103,7 +102,7 @@ async def test_stop_not_created_no_other_buttons(hass: core.HomeAssistant):
     assert not hass.states.async_all("button")
 
 
-async def test_press_button_with_argument(hass: core.HomeAssistant):
+async def test_press_button_with_argument(hass: HomeAssistant) -> None:
     """Tests we can press a button with an argument."""
     await setup_platform(
         hass,
@@ -142,7 +141,7 @@ async def test_press_button_with_argument(hass: core.HomeAssistant):
     )
 
 
-async def test_press_button(hass: core.HomeAssistant):
+async def test_press_button(hass: HomeAssistant) -> None:
     """Tests we can press a button."""
     await setup_platform(
         hass,

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -8,11 +8,12 @@ from unittest.mock import MagicMock, Mock, patch
 
 from aiohttp import ClientConnectionError, ClientResponseError
 
-from homeassistant import config_entries, core
+from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from .common import (
     patch_bond_bridge,
@@ -27,7 +28,7 @@ from .common import (
 from tests.common import MockConfigEntry
 
 
-async def test_user_form(hass: core.HomeAssistant):
+async def test_user_form(hass: HomeAssistant) -> None:
     """Test we get the user initiated form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -56,7 +57,7 @@ async def test_user_form(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_with_non_bridge(hass: core.HomeAssistant):
+async def test_user_form_with_non_bridge(hass: HomeAssistant) -> None:
     """Test setup a smart by bond fan."""
 
     result = await hass.config_entries.flow.async_init(
@@ -91,7 +92,7 @@ async def test_user_form_with_non_bridge(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_invalid_auth(hass: core.HomeAssistant):
+async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -111,7 +112,7 @@ async def test_user_form_invalid_auth(hass: core.HomeAssistant):
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_form_cannot_connect(hass: core.HomeAssistant):
+async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -129,7 +130,7 @@ async def test_user_form_cannot_connect(hass: core.HomeAssistant):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_form_old_firmware(hass: core.HomeAssistant):
+async def test_user_form_old_firmware(hass: HomeAssistant) -> None:
     """Test we handle unsupported old firmware."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -147,7 +148,7 @@ async def test_user_form_old_firmware(hass: core.HomeAssistant):
     assert result2["errors"] == {"base": "old_firmware"}
 
 
-async def test_user_form_unexpected_client_error(hass: core.HomeAssistant):
+async def test_user_form_unexpected_client_error(hass: HomeAssistant) -> None:
     """Test we handle unexpected client error gracefully."""
     await _help_test_form_unexpected_error(
         hass,
@@ -157,7 +158,7 @@ async def test_user_form_unexpected_client_error(hass: core.HomeAssistant):
     )
 
 
-async def test_user_form_unexpected_error(hass: core.HomeAssistant):
+async def test_user_form_unexpected_error(hass: HomeAssistant) -> None:
     """Test we handle unexpected error gracefully."""
     await _help_test_form_unexpected_error(
         hass,
@@ -167,7 +168,7 @@ async def test_user_form_unexpected_error(hass: core.HomeAssistant):
     )
 
 
-async def test_user_form_one_entry_per_device_allowed(hass: core.HomeAssistant):
+async def test_user_form_one_entry_per_device_allowed(hass: HomeAssistant) -> None:
     """Test that only one entry allowed per unique ID reported by Bond hub device."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -194,7 +195,7 @@ async def test_user_form_one_entry_per_device_allowed(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_zeroconf_form(hass: core.HomeAssistant):
+async def test_zeroconf_form(hass: HomeAssistant) -> None:
     """Test we get the discovery form."""
 
     with patch_bond_version(), patch_bond_token():
@@ -232,7 +233,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
+async def test_zeroconf_form_token_unavailable(hass: HomeAssistant) -> None:
     """Test we get the discovery form and we handle the token being unavailable."""
 
     with patch_bond_version(), patch_bond_token():
@@ -269,7 +270,7 @@ async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_form_token_times_out(hass: core.HomeAssistant):
+async def test_zeroconf_form_token_times_out(hass: HomeAssistant) -> None:
     """Test we get the discovery form and we handle the token request timeout."""
 
     with patch_bond_version(), patch_bond_token(side_effect=asyncio.TimeoutError):
@@ -306,7 +307,7 @@ async def test_zeroconf_form_token_times_out(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
+async def test_zeroconf_form_with_token_available(hass: HomeAssistant) -> None:
     """Test we get the discovery form when we can get the token."""
 
     with patch_bond_version(return_value={"bondid": "ZXXX12345"}), patch_bond_token(
@@ -348,8 +349,8 @@ async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
 
 
 async def test_zeroconf_form_with_token_available_name_unavailable(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test we get the discovery form when we can get the token but the name is unavailable."""
 
     with patch_bond_version(
@@ -388,7 +389,7 @@ async def test_zeroconf_form_with_token_available_name_unavailable(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_already_configured(hass: core.HomeAssistant):
+async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery when already configured."""
 
     entry = MockConfigEntry(
@@ -420,7 +421,7 @@ async def test_zeroconf_already_configured(hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_in_setup_retry_state(hass: core.HomeAssistant):
+async def test_zeroconf_in_setup_retry_state(hass: HomeAssistant) -> None:
     """Test we retry right away on zeroconf discovery."""
 
     entry = MockConfigEntry(
@@ -459,7 +460,7 @@ async def test_zeroconf_in_setup_retry_state(hass: core.HomeAssistant):
     assert entry.state is ConfigEntryState.LOADED
 
 
-async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistant):
+async def test_zeroconf_already_configured_refresh_token(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf when already configured and the token is out of date."""
     entry2 = MockConfigEntry(
         domain=DOMAIN,
@@ -508,8 +509,8 @@ async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistan
 
 
 async def test_zeroconf_already_configured_no_reload_same_host(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test starting a flow from zeroconf when already configured does not reload if the host is the same."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -541,7 +542,7 @@ async def test_zeroconf_already_configured_no_reload_same_host(
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_zeroconf_form_unexpected_error(hass: core.HomeAssistant):
+async def test_zeroconf_form_unexpected_error(hass: HomeAssistant) -> None:
     """Test we handle unexpected error gracefully."""
     await _help_test_form_unexpected_error(
         hass,
@@ -561,13 +562,13 @@ async def test_zeroconf_form_unexpected_error(hass: core.HomeAssistant):
 
 
 async def _help_test_form_unexpected_error(
-    hass: core.HomeAssistant,
+    hass: HomeAssistant,
     *,
     source: str,
-    initial_input: dict[str, Any] = None,
+    initial_input: dict[str, Any] | None = None,
     user_input: dict[str, Any],
     error: Exception,
-):
+) -> None:
     """Test we handle unexpected error gracefully."""
     with patch_bond_token():
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 from bond_async import Action, DeviceType
 
-from homeassistant import core
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -22,6 +21,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
@@ -72,7 +72,7 @@ def tilt_shades(name: str):
     }
 
 
-async def test_entity_registry(hass: core.HomeAssistant):
+async def test_entity_registry(hass: HomeAssistant) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -87,7 +87,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_open_cover(hass: core.HomeAssistant):
+async def test_open_cover(hass: HomeAssistant) -> None:
     """Tests that open cover command delegates to API."""
     await setup_platform(
         hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
@@ -105,7 +105,7 @@ async def test_open_cover(hass: core.HomeAssistant):
     mock_open.assert_called_once_with("test-device-id", Action.open())
 
 
-async def test_close_cover(hass: core.HomeAssistant):
+async def test_close_cover(hass: HomeAssistant) -> None:
     """Tests that close cover command delegates to API."""
     await setup_platform(
         hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
@@ -123,7 +123,7 @@ async def test_close_cover(hass: core.HomeAssistant):
     mock_close.assert_called_once_with("test-device-id", Action.close())
 
 
-async def test_stop_cover(hass: core.HomeAssistant):
+async def test_stop_cover(hass: HomeAssistant) -> None:
     """Tests that stop cover command delegates to API."""
     await setup_platform(
         hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
@@ -141,7 +141,7 @@ async def test_stop_cover(hass: core.HomeAssistant):
     mock_hold.assert_called_once_with("test-device-id", Action.hold())
 
 
-async def test_tilt_open_cover(hass: core.HomeAssistant):
+async def test_tilt_open_cover(hass: HomeAssistant) -> None:
     """Tests that tilt open cover command delegates to API."""
     await setup_platform(
         hass, COVER_DOMAIN, tilt_only_shades("name-1"), bond_device_id="test-device-id"
@@ -160,7 +160,7 @@ async def test_tilt_open_cover(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == STATE_UNKNOWN
 
 
-async def test_tilt_close_cover(hass: core.HomeAssistant):
+async def test_tilt_close_cover(hass: HomeAssistant) -> None:
     """Tests that tilt close cover command delegates to API."""
     await setup_platform(
         hass, COVER_DOMAIN, tilt_only_shades("name-1"), bond_device_id="test-device-id"
@@ -179,7 +179,7 @@ async def test_tilt_close_cover(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == STATE_UNKNOWN
 
 
-async def test_tilt_stop_cover(hass: core.HomeAssistant):
+async def test_tilt_stop_cover(hass: HomeAssistant) -> None:
     """Tests that tilt stop cover command delegates to API."""
     await setup_platform(
         hass,
@@ -202,7 +202,7 @@ async def test_tilt_stop_cover(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == STATE_UNKNOWN
 
 
-async def test_tilt_and_open(hass: core.HomeAssistant):
+async def test_tilt_and_open(hass: HomeAssistant) -> None:
     """Tests that supports both tilt and open."""
     await setup_platform(
         hass,
@@ -225,7 +225,7 @@ async def test_tilt_and_open(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == STATE_CLOSED
 
 
-async def test_update_reports_open_cover(hass: core.HomeAssistant):
+async def test_update_reports_open_cover(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports cover is open."""
     await setup_platform(hass, COVER_DOMAIN, shades("name-1"))
 
@@ -236,7 +236,7 @@ async def test_update_reports_open_cover(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == "open"
 
 
-async def test_update_reports_closed_cover(hass: core.HomeAssistant):
+async def test_update_reports_closed_cover(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports cover is closed."""
     await setup_platform(hass, COVER_DOMAIN, shades("name-1"))
 
@@ -247,14 +247,14 @@ async def test_update_reports_closed_cover(hass: core.HomeAssistant):
     assert hass.states.get("cover.name_1").state == "closed"
 
 
-async def test_cover_available(hass: core.HomeAssistant):
+async def test_cover_available(hass: HomeAssistant) -> None:
     """Tests that available state is updated based on API errors."""
     await help_test_entity_available(
         hass, COVER_DOMAIN, shades("name-1"), "cover.name_1"
     )
 
 
-async def test_set_position_cover(hass: core.HomeAssistant):
+async def test_set_position_cover(hass: HomeAssistant) -> None:
     """Tests that set position cover command delegates to API."""
     await setup_platform(
         hass,

--- a/tests/components/bond/test_entity.py
+++ b/tests/components/bond/test_entity.py
@@ -6,11 +6,10 @@ from unittest.mock import patch
 from bond_async import BPUPSubscriptions, DeviceType
 from bond_async.bpup import BPUP_ALIVE_TIMEOUT
 
-from homeassistant import core
 from homeassistant.components import fan
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.util import utcnow
 
 from .common import patch_bond_device_state, setup_platform
@@ -27,7 +26,7 @@ def ceiling_fan(name: str):
     }
 
 
-async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssistant):
+async def test_bpup_goes_offline_and_recovers_same_entity(hass: HomeAssistant) -> None:
     """Test that push updates fail and we fallback to polling and then bpup recovers.
 
     The BPUP recovery is triggered by an update for the entity and
@@ -111,8 +110,8 @@ async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssista
 
 
 async def test_bpup_goes_offline_and_recovers_different_entity(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test that push updates fail and we fallback to polling and then bpup recovers.
 
     The BPUP recovery is triggered by an update for a different entity which
@@ -173,7 +172,7 @@ async def test_bpup_goes_offline_and_recovers_different_entity(
     assert state.attributes[fan.ATTR_PERCENTAGE] == 33
 
 
-async def test_polling_fails_and_recovers(hass: core.HomeAssistant):
+async def test_polling_fails_and_recovers(hass: HomeAssistant) -> None:
     """Test that polling fails and we recover."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -194,7 +193,7 @@ async def test_polling_fails_and_recovers(hass: core.HomeAssistant):
     assert state.attributes[fan.ATTR_PERCENTAGE] == 33
 
 
-async def test_polling_stops_at_the_stop_event(hass: core.HomeAssistant):
+async def test_polling_stops_at_the_stop_event(hass: HomeAssistant) -> None:
     """Test that polling stops at the stop event."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -27,6 +27,7 @@ from homeassistant.components.fan import (
     SERVICE_SET_PRESET_MODE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -74,7 +75,7 @@ async def turn_fan_on(
     await hass.async_block_till_done()
 
 
-async def test_entity_registry(hass: core.HomeAssistant):
+async def test_entity_registry(hass: HomeAssistant) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -93,7 +94,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
     assert device.configuration_url == "http://some host"
 
 
-async def test_non_standard_speed_list(hass: core.HomeAssistant):
+async def test_non_standard_speed_list(hass: HomeAssistant) -> None:
     """Tests that the device is registered with custom speed list if number of supported speeds differs form 3."""
     await setup_platform(
         hass,
@@ -123,7 +124,7 @@ async def test_non_standard_speed_list(hass: core.HomeAssistant):
         )
 
 
-async def test_fan_speed_with_no_max_speed(hass: core.HomeAssistant):
+async def test_fan_speed_with_no_max_speed(hass: HomeAssistant) -> None:
     """Tests that fans without max speed (increase/decrease controls) map speed to HA standard."""
     await setup_platform(
         hass,
@@ -137,7 +138,7 @@ async def test_fan_speed_with_no_max_speed(hass: core.HomeAssistant):
     assert hass.states.get("fan.name_1").attributes["percentage"] == 100
 
 
-async def test_turn_on_fan_with_speed(hass: core.HomeAssistant):
+async def test_turn_on_fan_with_speed(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to set speed API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -149,7 +150,7 @@ async def test_turn_on_fan_with_speed(hass: core.HomeAssistant):
     mock_set_speed.assert_called_with("test-device-id", Action.set_speed(1))
 
 
-async def test_turn_on_fan_with_percentage_3_speeds(hass: core.HomeAssistant):
+async def test_turn_on_fan_with_percentage_3_speeds(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to set speed API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -173,7 +174,7 @@ async def test_turn_on_fan_with_percentage_3_speeds(hass: core.HomeAssistant):
     mock_set_speed.assert_called_with("test-device-id", Action.set_speed(3))
 
 
-async def test_turn_on_fan_with_percentage_6_speeds(hass: core.HomeAssistant):
+async def test_turn_on_fan_with_percentage_6_speeds(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to set speed API."""
     await setup_platform(
         hass,
@@ -201,7 +202,7 @@ async def test_turn_on_fan_with_percentage_6_speeds(hass: core.HomeAssistant):
     mock_set_speed.assert_called_with("test-device-id", Action.set_speed(6))
 
 
-async def test_turn_on_fan_preset_mode(hass: core.HomeAssistant):
+async def test_turn_on_fan_preset_mode(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to breeze on API."""
     await setup_platform(
         hass,
@@ -233,7 +234,7 @@ async def test_turn_on_fan_preset_mode(hass: core.HomeAssistant):
     mock_set_preset_mode.assert_called_with("test-device-id", Action(Action.BREEZE_ON))
 
 
-async def test_turn_on_fan_preset_mode_not_supported(hass: core.HomeAssistant):
+async def test_turn_on_fan_preset_mode_not_supported(hass: HomeAssistant) -> None:
     """Tests calling breeze mode on a fan that does not support it raises."""
     await setup_platform(
         hass,
@@ -258,7 +259,7 @@ async def test_turn_on_fan_preset_mode_not_supported(hass: core.HomeAssistant):
         )
 
 
-async def test_turn_on_fan_with_off_with_breeze(hass: core.HomeAssistant):
+async def test_turn_on_fan_with_off_with_breeze(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to turn off API."""
     await setup_platform(
         hass,
@@ -281,7 +282,7 @@ async def test_turn_on_fan_with_off_with_breeze(hass: core.HomeAssistant):
     ]
 
 
-async def test_turn_on_fan_without_speed(hass: core.HomeAssistant):
+async def test_turn_on_fan_without_speed(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to turn on API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -293,7 +294,7 @@ async def test_turn_on_fan_without_speed(hass: core.HomeAssistant):
     mock_turn_on.assert_called_with("test-device-id", Action.turn_on())
 
 
-async def test_turn_on_fan_with_off_percentage(hass: core.HomeAssistant):
+async def test_turn_on_fan_with_off_percentage(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to turn off API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -305,7 +306,7 @@ async def test_turn_on_fan_with_off_percentage(hass: core.HomeAssistant):
     mock_turn_off.assert_called_with("test-device-id", Action.turn_off())
 
 
-async def test_set_speed_off(hass: core.HomeAssistant):
+async def test_set_speed_off(hass: HomeAssistant) -> None:
     """Tests that set_speed(off) command delegates to turn off API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -323,7 +324,7 @@ async def test_set_speed_off(hass: core.HomeAssistant):
     mock_turn_off.assert_called_with("test-device-id", Action.turn_off())
 
 
-async def test_turn_off_fan(hass: core.HomeAssistant):
+async def test_turn_off_fan(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -341,7 +342,7 @@ async def test_turn_off_fan(hass: core.HomeAssistant):
     mock_turn_off.assert_called_once_with("test-device-id", Action.turn_off())
 
 
-async def test_set_speed_belief_speed_zero(hass: core.HomeAssistant):
+async def test_set_speed_belief_speed_zero(hass: HomeAssistant) -> None:
     """Tests that set power belief service delegates to API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -361,7 +362,7 @@ async def test_set_speed_belief_speed_zero(hass: core.HomeAssistant):
     )
 
 
-async def test_set_speed_belief_speed_api_error(hass: core.HomeAssistant):
+async def test_set_speed_belief_speed_api_error(hass: HomeAssistant) -> None:
     """Tests that set power belief service delegates to API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -379,7 +380,7 @@ async def test_set_speed_belief_speed_api_error(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
 
-async def test_set_speed_belief_speed_100(hass: core.HomeAssistant):
+async def test_set_speed_belief_speed_100(hass: HomeAssistant) -> None:
     """Tests that set power belief service delegates to API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -398,7 +399,7 @@ async def test_set_speed_belief_speed_100(hass: core.HomeAssistant):
     mock_action.assert_called_with("test-device-id", Action.set_speed_belief(3))
 
 
-async def test_update_reports_fan_on(hass: core.HomeAssistant):
+async def test_update_reports_fan_on(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports fan power is on."""
     await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
 
@@ -409,7 +410,7 @@ async def test_update_reports_fan_on(hass: core.HomeAssistant):
     assert hass.states.get("fan.name_1").state == "on"
 
 
-async def test_update_reports_fan_off(hass: core.HomeAssistant):
+async def test_update_reports_fan_off(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports fan power is off."""
     await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
 
@@ -420,7 +421,7 @@ async def test_update_reports_fan_off(hass: core.HomeAssistant):
     assert hass.states.get("fan.name_1").state == "off"
 
 
-async def test_update_reports_direction_forward(hass: core.HomeAssistant):
+async def test_update_reports_direction_forward(hass: HomeAssistant) -> None:
     """Tests that update command sets correct direction when Bond API reports fan direction is forward."""
     await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
 
@@ -431,7 +432,7 @@ async def test_update_reports_direction_forward(hass: core.HomeAssistant):
     assert hass.states.get("fan.name_1").attributes[ATTR_DIRECTION] == DIRECTION_FORWARD
 
 
-async def test_update_reports_direction_reverse(hass: core.HomeAssistant):
+async def test_update_reports_direction_reverse(hass: HomeAssistant) -> None:
     """Tests that update command sets correct direction when Bond API reports fan direction is reverse."""
     await setup_platform(hass, FAN_DOMAIN, ceiling_fan("name-1"))
 
@@ -442,7 +443,7 @@ async def test_update_reports_direction_reverse(hass: core.HomeAssistant):
     assert hass.states.get("fan.name_1").attributes[ATTR_DIRECTION] == DIRECTION_REVERSE
 
 
-async def test_set_fan_direction(hass: core.HomeAssistant):
+async def test_set_fan_direction(hass: HomeAssistant) -> None:
     """Tests that set direction command delegates to API."""
     await setup_platform(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -462,7 +463,7 @@ async def test_set_fan_direction(hass: core.HomeAssistant):
     )
 
 
-async def test_fan_available(hass: core.HomeAssistant):
+async def test_fan_available(hass: HomeAssistant) -> None:
     """Tests that available state is updated based on API errors."""
     await help_test_entity_available(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), "fan.name_1"

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
-async def test_async_setup_no_domain_config(hass: HomeAssistant):
+async def test_async_setup_no_domain_config(hass: HomeAssistant) -> None:
     """Test setup without configuration is noop."""
     result = await async_setup_component(hass, DOMAIN, {})
 
@@ -50,7 +50,9 @@ async def test_async_setup_no_domain_config(hass: HomeAssistant):
         OSError,
     ],
 )
-async def test_async_setup_raises_entry_not_ready(hass: HomeAssistant, exc: Exception):
+async def test_async_setup_raises_entry_not_ready(
+    hass: HomeAssistant, exc: Exception
+) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -63,7 +65,7 @@ async def test_async_setup_raises_entry_not_ready(hass: HomeAssistant, exc: Exce
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_async_setup_raises_fails_if_auth_fails(hass: HomeAssistant):
+async def test_async_setup_raises_fails_if_auth_fails(hass: HomeAssistant) -> None:
     """Test that setup fails if auth fails during setup."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -78,7 +80,9 @@ async def test_async_setup_raises_fails_if_auth_fails(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAssistant):
+async def test_async_setup_entry_sets_up_hub_and_supported_domains(
+    hass: HomeAssistant,
+) -> None:
     """Test that configuring entry sets up cover domain."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -124,7 +128,7 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
     assert len(mock_switch_async_setup_entry.mock_calls) == 1
 
 
-async def test_unload_config_entry(hass: HomeAssistant):
+async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test that configuration entry supports unloading."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -149,7 +153,7 @@ async def test_unload_config_entry(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_old_identifiers_are_removed(hass: HomeAssistant):
+async def test_old_identifiers_are_removed(hass: HomeAssistant) -> None:
     """Test we remove the old non-unique identifiers."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -198,7 +202,7 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant):
     assert device_registry.async_get_device(identifiers={new_identifiers}) is not None
 
 
-async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant):
+async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant) -> None:
     """Test we can setup a smart by bond device and get the suggested area."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -241,7 +245,7 @@ async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant):
     assert device.suggested_area == "Den"
 
 
-async def test_bridge_device_suggested_area(hass: HomeAssistant):
+async def test_bridge_device_suggested_area(hass: HomeAssistant) -> None:
     """Test we can setup a bridge bond device and get the suggested area."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from bond_async import Action, DeviceType
 import pytest
 
-from homeassistant import core
 from homeassistant.components.bond.const import (
     ATTR_POWER_STATE,
     DOMAIN,
@@ -30,6 +29,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -153,7 +153,7 @@ def light_brightness_increase_decrease_only(name: str):
     }
 
 
-async def test_fan_entity_registry(hass: core.HomeAssistant):
+async def test_fan_entity_registry(hass: HomeAssistant) -> None:
     """Tests that fan with light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -168,7 +168,7 @@ async def test_fan_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_fan_up_light_entity_registry(hass: core.HomeAssistant):
+async def test_fan_up_light_entity_registry(hass: HomeAssistant) -> None:
     """Tests that fan with up light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -183,7 +183,7 @@ async def test_fan_up_light_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id_up_light"
 
 
-async def test_fan_down_light_entity_registry(hass: core.HomeAssistant):
+async def test_fan_down_light_entity_registry(hass: HomeAssistant) -> None:
     """Tests that fan with down light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -198,7 +198,7 @@ async def test_fan_down_light_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id_down_light"
 
 
-async def test_fireplace_entity_registry(hass: core.HomeAssistant):
+async def test_fireplace_entity_registry(hass: HomeAssistant) -> None:
     """Tests that flame fireplace devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -213,7 +213,7 @@ async def test_fireplace_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_fireplace_with_light_entity_registry(hass: core.HomeAssistant):
+async def test_fireplace_with_light_entity_registry(hass: HomeAssistant) -> None:
     """Tests that flame+light devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -230,7 +230,7 @@ async def test_fireplace_with_light_entity_registry(hass: core.HomeAssistant):
     assert entity_light.unique_id == "test-hub-id_test-device-id_light"
 
 
-async def test_light_entity_registry(hass: core.HomeAssistant):
+async def test_light_entity_registry(hass: HomeAssistant) -> None:
     """Tests lights are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -245,7 +245,7 @@ async def test_light_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_sbb_trust_state(hass: core.HomeAssistant):
+async def test_sbb_trust_state(hass: HomeAssistant) -> None:
     """Assumed state should be False if device is a Smart by Bond."""
     version = {
         "model": "MR123A",
@@ -259,7 +259,7 @@ async def test_sbb_trust_state(hass: core.HomeAssistant):
     assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
 
 
-async def test_trust_state_not_specified(hass: core.HomeAssistant):
+async def test_trust_state_not_specified(hass: HomeAssistant) -> None:
     """Assumed state should be True if Trust State is not specified."""
     await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))
 
@@ -267,7 +267,7 @@ async def test_trust_state_not_specified(hass: core.HomeAssistant):
     assert device.attributes.get(ATTR_ASSUMED_STATE) is True
 
 
-async def test_trust_state(hass: core.HomeAssistant):
+async def test_trust_state(hass: HomeAssistant) -> None:
     """Assumed state should be True if Trust State is False."""
     await setup_platform(
         hass, LIGHT_DOMAIN, ceiling_fan("name-1"), props={"trust_state": False}
@@ -277,7 +277,7 @@ async def test_trust_state(hass: core.HomeAssistant):
     assert device.attributes.get(ATTR_ASSUMED_STATE) is True
 
 
-async def test_no_trust_state(hass: core.HomeAssistant):
+async def test_no_trust_state(hass: HomeAssistant) -> None:
     """Assumed state should be False if Trust State is True."""
     await setup_platform(
         hass, LIGHT_DOMAIN, ceiling_fan("name-1"), props={"trust_state": True}
@@ -286,7 +286,7 @@ async def test_no_trust_state(hass: core.HomeAssistant):
     assert device.attributes.get(ATTR_ASSUMED_STATE) is not True
 
 
-async def test_light_set_brightness_belief_full(hass: core.HomeAssistant):
+async def test_light_set_brightness_belief_full(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -309,7 +309,7 @@ async def test_light_set_brightness_belief_full(hass: core.HomeAssistant):
     )
 
 
-async def test_light_set_brightness_belief_api_error(hass: core.HomeAssistant):
+async def test_light_set_brightness_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief throws HomeAssistantError in the event of an api error."""
     await setup_platform(
         hass,
@@ -330,7 +330,7 @@ async def test_light_set_brightness_belief_api_error(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
 
-async def test_fp_light_set_brightness_belief_full(hass: core.HomeAssistant):
+async def test_fp_light_set_brightness_belief_full(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -353,7 +353,7 @@ async def test_fp_light_set_brightness_belief_full(hass: core.HomeAssistant):
     )
 
 
-async def test_fp_light_set_brightness_belief_api_error(hass: core.HomeAssistant):
+async def test_fp_light_set_brightness_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief throws HomeAssistantError in the event of an api error."""
     await setup_platform(
         hass,
@@ -375,8 +375,8 @@ async def test_fp_light_set_brightness_belief_api_error(hass: core.HomeAssistant
 
 
 async def test_light_set_brightness_belief_brightness_not_supported(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Tests that the set brightness belief function of a light that doesn't support setting brightness returns an error."""
     await setup_platform(
         hass,
@@ -395,7 +395,7 @@ async def test_light_set_brightness_belief_brightness_not_supported(
         await hass.async_block_till_done()
 
 
-async def test_light_set_brightness_belief_zero(hass: core.HomeAssistant):
+async def test_light_set_brightness_belief_zero(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -418,7 +418,7 @@ async def test_light_set_brightness_belief_zero(hass: core.HomeAssistant):
     )
 
 
-async def test_fp_light_set_brightness_belief_zero(hass: core.HomeAssistant):
+async def test_fp_light_set_brightness_belief_zero(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -441,7 +441,7 @@ async def test_fp_light_set_brightness_belief_zero(hass: core.HomeAssistant):
     )
 
 
-async def test_light_set_power_belief(hass: core.HomeAssistant):
+async def test_light_set_power_belief(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -464,7 +464,7 @@ async def test_light_set_power_belief(hass: core.HomeAssistant):
     )
 
 
-async def test_light_set_power_belief_api_error(hass: core.HomeAssistant):
+async def test_light_set_power_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light throws HomeAssistantError in the event of an api error."""
     await setup_platform(
         hass,
@@ -485,7 +485,7 @@ async def test_light_set_power_belief_api_error(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
 
-async def test_fp_light_set_power_belief(hass: core.HomeAssistant):
+async def test_fp_light_set_power_belief(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light delegates to API."""
     await setup_platform(
         hass,
@@ -508,7 +508,7 @@ async def test_fp_light_set_power_belief(hass: core.HomeAssistant):
     )
 
 
-async def test_fp_light_set_power_belief_api_error(hass: core.HomeAssistant):
+async def test_fp_light_set_power_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set brightness belief function of a light throws HomeAssistantError in the event of an api error."""
     await setup_platform(
         hass,
@@ -530,8 +530,8 @@ async def test_fp_light_set_power_belief_api_error(hass: core.HomeAssistant):
 
 
 async def test_fp_light_set_brightness_belief_brightness_not_supported(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Tests that the set brightness belief function of a fireplace light that doesn't support setting brightness returns an error."""
     await setup_platform(
         hass,
@@ -550,7 +550,7 @@ async def test_fp_light_set_brightness_belief_brightness_not_supported(
         await hass.async_block_till_done()
 
 
-async def test_light_start_increasing_brightness(hass: core.HomeAssistant):
+async def test_light_start_increasing_brightness(hass: HomeAssistant) -> None:
     """Tests a light that can only increase or decrease brightness delegates to API can start increasing brightness."""
     await setup_platform(
         hass,
@@ -574,8 +574,8 @@ async def test_light_start_increasing_brightness(hass: core.HomeAssistant):
 
 
 async def test_light_start_increasing_brightness_missing_service(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Tests a light does not have start increasing brightness throws."""
     await setup_platform(
         hass, LIGHT_DOMAIN, light("name-1"), bond_device_id="test-device-id"
@@ -591,7 +591,7 @@ async def test_light_start_increasing_brightness_missing_service(
         await hass.async_block_till_done()
 
 
-async def test_light_start_decreasing_brightness(hass: core.HomeAssistant):
+async def test_light_start_decreasing_brightness(hass: HomeAssistant) -> None:
     """Tests a light that can only increase or decrease brightness delegates to API can start decreasing brightness."""
     await setup_platform(
         hass,
@@ -615,8 +615,8 @@ async def test_light_start_decreasing_brightness(hass: core.HomeAssistant):
 
 
 async def test_light_start_decreasing_brightness_missing_service(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Tests a light does not have start decreasing brightness throws."""
     await setup_platform(
         hass,
@@ -635,7 +635,7 @@ async def test_light_start_decreasing_brightness_missing_service(
         await hass.async_block_till_done()
 
 
-async def test_light_stop(hass: core.HomeAssistant):
+async def test_light_stop(hass: HomeAssistant) -> None:
     """Tests a light that can only increase or decrease brightness delegates to API can stop."""
     await setup_platform(
         hass,
@@ -657,8 +657,8 @@ async def test_light_stop(hass: core.HomeAssistant):
 
 
 async def test_light_stop_missing_service(
-    hass: core.HomeAssistant,
-):
+    hass: HomeAssistant,
+) -> None:
     """Tests a light does not have stop throws."""
     await setup_platform(
         hass,
@@ -677,7 +677,7 @@ async def test_light_stop_missing_service(
         await hass.async_block_till_done()
 
 
-async def test_turn_on_light(hass: core.HomeAssistant):
+async def test_turn_on_light(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to API."""
     await setup_platform(
         hass, LIGHT_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -695,7 +695,7 @@ async def test_turn_on_light(hass: core.HomeAssistant):
     mock_turn_light_on.assert_called_once_with("test-device-id", Action.turn_light_on())
 
 
-async def test_turn_off_light(hass: core.HomeAssistant):
+async def test_turn_off_light(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to API."""
     await setup_platform(
         hass, LIGHT_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
@@ -715,7 +715,7 @@ async def test_turn_off_light(hass: core.HomeAssistant):
     )
 
 
-async def test_brightness_support(hass: core.HomeAssistant):
+async def test_brightness_support(hass: HomeAssistant) -> None:
     """Tests that a dimmable light should support the brightness feature."""
     await setup_platform(
         hass,
@@ -741,7 +741,7 @@ async def test_brightness_support(hass: core.HomeAssistant):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_brightness_not_supported(hass: core.HomeAssistant):
+async def test_brightness_not_supported(hass: HomeAssistant) -> None:
     """Tests that a non-dimmable light should not support the brightness feature."""
     await setup_platform(
         hass,
@@ -767,7 +767,7 @@ async def test_brightness_not_supported(hass: core.HomeAssistant):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_turn_on_light_with_brightness(hass: core.HomeAssistant):
+async def test_turn_on_light_with_brightness(hass: HomeAssistant) -> None:
     """Tests that turn on command, on a dimmable light, delegates to API and parses brightness."""
     await setup_platform(
         hass,
@@ -790,7 +790,7 @@ async def test_turn_on_light_with_brightness(hass: core.HomeAssistant):
     )
 
 
-async def test_turn_on_up_light(hass: core.HomeAssistant):
+async def test_turn_on_up_light(hass: HomeAssistant) -> None:
     """Tests that turn on command, on an up light, delegates to API."""
     await setup_platform(
         hass,
@@ -813,7 +813,7 @@ async def test_turn_on_up_light(hass: core.HomeAssistant):
     )
 
 
-async def test_turn_off_up_light(hass: core.HomeAssistant):
+async def test_turn_off_up_light(hass: HomeAssistant) -> None:
     """Tests that turn off command, on an up light, delegates to API."""
     await setup_platform(
         hass,
@@ -836,7 +836,7 @@ async def test_turn_off_up_light(hass: core.HomeAssistant):
     )
 
 
-async def test_turn_on_down_light(hass: core.HomeAssistant):
+async def test_turn_on_down_light(hass: HomeAssistant) -> None:
     """Tests that turn on command, on a down light, delegates to API."""
     await setup_platform(
         hass,
@@ -859,7 +859,7 @@ async def test_turn_on_down_light(hass: core.HomeAssistant):
     )
 
 
-async def test_turn_off_down_light(hass: core.HomeAssistant):
+async def test_turn_off_down_light(hass: HomeAssistant) -> None:
     """Tests that turn off command, on a down light, delegates to API."""
     await setup_platform(
         hass,
@@ -882,7 +882,7 @@ async def test_turn_off_down_light(hass: core.HomeAssistant):
     )
 
 
-async def test_update_reports_light_is_on(hass: core.HomeAssistant):
+async def test_update_reports_light_is_on(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))
 
@@ -893,7 +893,7 @@ async def test_update_reports_light_is_on(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1").state == "on"
 
 
-async def test_update_reports_light_is_off(hass: core.HomeAssistant):
+async def test_update_reports_light_is_off(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the light is off."""
     await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))
 
@@ -904,7 +904,7 @@ async def test_update_reports_light_is_off(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1").state == "off"
 
 
-async def test_update_reports_up_light_is_on(hass: core.HomeAssistant):
+async def test_update_reports_up_light_is_on(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the up light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, up_light_ceiling_fan("name-1"))
 
@@ -915,7 +915,7 @@ async def test_update_reports_up_light_is_on(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1_up_light").state == "on"
 
 
-async def test_update_reports_up_light_is_off(hass: core.HomeAssistant):
+async def test_update_reports_up_light_is_off(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the up light is off."""
     await setup_platform(hass, LIGHT_DOMAIN, up_light_ceiling_fan("name-1"))
 
@@ -926,7 +926,7 @@ async def test_update_reports_up_light_is_off(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1_up_light").state == "off"
 
 
-async def test_update_reports_down_light_is_on(hass: core.HomeAssistant):
+async def test_update_reports_down_light_is_on(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the down light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, down_light_ceiling_fan("name-1"))
 
@@ -937,7 +937,7 @@ async def test_update_reports_down_light_is_on(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1_down_light").state == "on"
 
 
-async def test_update_reports_down_light_is_off(hass: core.HomeAssistant):
+async def test_update_reports_down_light_is_off(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the down light is off."""
     await setup_platform(hass, LIGHT_DOMAIN, down_light_ceiling_fan("name-1"))
 
@@ -948,7 +948,7 @@ async def test_update_reports_down_light_is_off(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1_down_light").state == "off"
 
 
-async def test_turn_on_fireplace_with_brightness(hass: core.HomeAssistant):
+async def test_turn_on_fireplace_with_brightness(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to set flame API."""
     await setup_platform(
         hass, LIGHT_DOMAIN, fireplace("name-1"), bond_device_id="test-device-id"
@@ -966,7 +966,7 @@ async def test_turn_on_fireplace_with_brightness(hass: core.HomeAssistant):
     mock_set_flame.assert_called_once_with("test-device-id", Action.set_flame(50))
 
 
-async def test_turn_on_fireplace_without_brightness(hass: core.HomeAssistant):
+async def test_turn_on_fireplace_without_brightness(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to turn on API."""
     await setup_platform(
         hass, LIGHT_DOMAIN, fireplace("name-1"), bond_device_id="test-device-id"
@@ -984,7 +984,7 @@ async def test_turn_on_fireplace_without_brightness(hass: core.HomeAssistant):
     mock_turn_on.assert_called_once_with("test-device-id", Action.turn_on())
 
 
-async def test_turn_off_fireplace(hass: core.HomeAssistant):
+async def test_turn_off_fireplace(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to API."""
     await setup_platform(
         hass, LIGHT_DOMAIN, fireplace("name-1"), bond_device_id="test-device-id"
@@ -1002,7 +1002,7 @@ async def test_turn_off_fireplace(hass: core.HomeAssistant):
     mock_turn_off.assert_called_once_with("test-device-id", Action.turn_off())
 
 
-async def test_flame_converted_to_brightness(hass: core.HomeAssistant):
+async def test_flame_converted_to_brightness(hass: HomeAssistant) -> None:
     """Tests that reported flame level (0..100) converted to HA brightness (0...255)."""
     await setup_platform(hass, LIGHT_DOMAIN, fireplace("name-1"))
 
@@ -1013,14 +1013,14 @@ async def test_flame_converted_to_brightness(hass: core.HomeAssistant):
     assert hass.states.get("light.name_1").attributes[ATTR_BRIGHTNESS] == 128
 
 
-async def test_light_available(hass: core.HomeAssistant):
+async def test_light_available(hass: HomeAssistant) -> None:
     """Tests that available state is updated based on API errors."""
     await help_test_entity_available(
         hass, LIGHT_DOMAIN, ceiling_fan("name-1"), "light.name_1"
     )
 
 
-async def test_parse_brightness(hass: core.HomeAssistant):
+async def test_parse_brightness(hass: HomeAssistant) -> None:
     """Tests that reported brightness level (0..100) converted to HA brightness (0...255)."""
     await setup_platform(hass, LIGHT_DOMAIN, dimmable_ceiling_fan("name-1"))
 

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from bond_async import Action, DeviceType
 import pytest
 
-from homeassistant import core
 from homeassistant.components.bond.const import (
     ATTR_POWER_STATE,
     DOMAIN as BOND_DOMAIN,
@@ -12,6 +11,7 @@ from homeassistant.components.bond.const import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -33,7 +33,7 @@ def generic_device(name: str):
     return {"name": name, "type": DeviceType.GENERIC_DEVICE}
 
 
-async def test_entity_registry(hass: core.HomeAssistant):
+async def test_entity_registry(hass: HomeAssistant) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(
         hass,
@@ -48,7 +48,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
     assert entity.unique_id == "test-hub-id_test-device-id"
 
 
-async def test_turn_on_switch(hass: core.HomeAssistant):
+async def test_turn_on_switch(hass: HomeAssistant) -> None:
     """Tests that turn on command delegates to API."""
     await setup_platform(
         hass, SWITCH_DOMAIN, generic_device("name-1"), bond_device_id="test-device-id"
@@ -66,7 +66,7 @@ async def test_turn_on_switch(hass: core.HomeAssistant):
     mock_turn_on.assert_called_once_with("test-device-id", Action.turn_on())
 
 
-async def test_turn_off_switch(hass: core.HomeAssistant):
+async def test_turn_off_switch(hass: HomeAssistant) -> None:
     """Tests that turn off command delegates to API."""
     await setup_platform(
         hass, SWITCH_DOMAIN, generic_device("name-1"), bond_device_id="test-device-id"
@@ -84,7 +84,7 @@ async def test_turn_off_switch(hass: core.HomeAssistant):
     mock_turn_off.assert_called_once_with("test-device-id", Action.turn_off())
 
 
-async def test_switch_set_power_belief(hass: core.HomeAssistant):
+async def test_switch_set_power_belief(hass: HomeAssistant) -> None:
     """Tests that the set power belief service delegates to API."""
     await setup_platform(
         hass, SWITCH_DOMAIN, generic_device("name-1"), bond_device_id="test-device-id"
@@ -104,7 +104,7 @@ async def test_switch_set_power_belief(hass: core.HomeAssistant):
     )
 
 
-async def test_switch_set_power_belief_api_error(hass: core.HomeAssistant):
+async def test_switch_set_power_belief_api_error(hass: HomeAssistant) -> None:
     """Tests that the set power belief service throws HomeAssistantError in the event of an api error."""
     await setup_platform(
         hass, SWITCH_DOMAIN, generic_device("name-1"), bond_device_id="test-device-id"
@@ -122,7 +122,7 @@ async def test_switch_set_power_belief_api_error(hass: core.HomeAssistant):
         await hass.async_block_till_done()
 
 
-async def test_update_reports_switch_is_on(hass: core.HomeAssistant):
+async def test_update_reports_switch_is_on(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the device is on."""
     await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
 
@@ -133,7 +133,7 @@ async def test_update_reports_switch_is_on(hass: core.HomeAssistant):
     assert hass.states.get("switch.name_1").state == "on"
 
 
-async def test_update_reports_switch_is_off(hass: core.HomeAssistant):
+async def test_update_reports_switch_is_off(hass: HomeAssistant) -> None:
     """Tests that update command sets correct state when Bond API reports the device is off."""
     await setup_platform(hass, SWITCH_DOMAIN, generic_device("name-1"))
 
@@ -144,7 +144,7 @@ async def test_update_reports_switch_is_off(hass: core.HomeAssistant):
     assert hass.states.get("switch.name_1").state == "off"
 
 
-async def test_switch_available(hass: core.HomeAssistant):
+async def test_switch_available(hass: HomeAssistant) -> None:
     """Tests that available state is updated based on API errors."""
     await help_test_entity_available(
         hass, SWITCH_DOMAIN, generic_device("name-1"), "switch.name_1"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
