### PR TITLE
Ensure recorder still shuts down if the final commit fails

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1213,13 +1213,18 @@ class Recorder(threading.Thread):
         """End the recorder session."""
         if self.event_session is None:
             return
-        try:
+        if self.run_history.active:
             self.run_history.end(self.event_session)
+        try:
             self._commit_event_session_or_retry()
-            self.event_session.close()
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.exception("Error saving the event session during shutdown: %s", err)
-
+        try:
+            self.event_session.close()
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Error closing the event session during shutdown: %s", err
+            )
         self.run_history.clear()
 
     def _shutdown(self) -> None:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -989,8 +989,10 @@ class Recorder(threading.Thread):
 
     def _handle_sqlite_corruption(self) -> None:
         """Handle the sqlite3 database being corrupt."""
-        self._close_event_session()
-        self._close_connection()
+        try:
+            self._close_event_session()
+        finally:
+            self._close_connection()
         move_away_broken_database(dburl_to_path(self.db_url))
         self.run_history.reset()
         self._setup_recorder()
@@ -1219,17 +1221,15 @@ class Recorder(threading.Thread):
             self._commit_event_session_or_retry()
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.exception("Error saving the event session during shutdown: %s", err)
-        try:
-            self.event_session.close()
-        except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.exception(
-                "Error closing the event session during shutdown: %s", err
-            )
+
+        self.event_session.close()
         self.run_history.clear()
 
     def _shutdown(self) -> None:
         """Save end time for current run."""
         self.hass.add_job(self._async_stop_listeners)
         self._stop_executor()
-        self._end_session()
-        self._close_connection()
+        try:
+            self._end_session()
+        finally:
+            self._close_connection()

--- a/homeassistant/components/recorder/run_history.py
+++ b/homeassistant/components/recorder/run_history.py
@@ -72,6 +72,11 @@ class RunHistory:
             start=self.recording_start, created=dt_util.utcnow()
         )
 
+    @property
+    def active(self) -> bool:
+        """Return if a run is active."""
+        return self._current_run_info is not None
+
     def get(self, start: datetime) -> RecorderRuns | None:
         """Return the recorder run that started before or at start.
 
@@ -142,6 +147,5 @@ class RunHistory:
 
         Must run in the recorder thread.
         """
-        assert self._current_run_info is not None
-        assert self._current_run_info.end is not None
-        self._current_run_info = None
+        if self._current_run_info:
+            self._current_run_info = None

--- a/tests/components/recorder/test_run_history.py
+++ b/tests/components/recorder/test_run_history.py
@@ -69,10 +69,14 @@ async def test_run_history_while_recorder_is_not_yet_started(
         instance = await async_setup_recorder_instance(hass)
     run_history = instance.run_history
     assert run_history.current.start == run_history.recording_start
-    with instance.get_session() as session:
-        # Ideally we would run run_history.start in the recorder thread
-        # but since we mocked it out above, we run it directly here
-        # via the database executor to avoid blocking the event loop.
-        await instance.async_add_executor_job(run_history.start, session)
+
+    def _start_run_history():
+        with instance.get_session() as session:
+            run_history.start(session)
+
+    # Ideally we would run run_history.start in the recorder thread
+    # but since we mocked it out above, we run it directly here
+    # via the database executor to avoid blocking the event loop.
+    await instance.async_add_executor_job(_start_run_history)
     assert run_history.current.start == run_history.recording_start
     assert run_history.current.created >= run_history.recording_start

--- a/tests/components/recorder/test_run_history.py
+++ b/tests/components/recorder/test_run_history.py
@@ -1,11 +1,15 @@
 """Test run history."""
 
 from datetime import timedelta
+from unittest.mock import patch
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder.db_schema import RecorderRuns
 from homeassistant.components.recorder.models import process_timestamp
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
+
+from tests.common import SetupRecorderInstanceT
 
 
 async def test_run_history(recorder_mock, hass):
@@ -47,9 +51,22 @@ async def test_run_history(recorder_mock, hass):
     )
 
 
-async def test_run_history_during_schema_migration(recorder_mock, hass):
-    """Test the run history during schema migration."""
-    instance = recorder.get_instance(hass)
+async def test_run_history_while_recorder_is_not_yet_started(
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+    hass: HomeAssistant,
+    recorder_db_url: str,
+) -> None:
+    """Test the run history while recorder is not yet started.
+
+    This usually happens during schema migration because
+    we do not start right away.
+    """
+    # Prevent the run history from starting to ensure
+    # we can test run_history.current.start returns the expected value
+    with patch(
+        "homeassistant.components.recorder.run_history.RunHistory.start",
+    ):
+        instance = await async_setup_recorder_instance(hass)
     run_history = instance.run_history
     assert run_history.current.start == run_history.recording_start
     with instance.get_session() as session:

--- a/tests/components/recorder/test_run_history.py
+++ b/tests/components/recorder/test_run_history.py
@@ -70,6 +70,9 @@ async def test_run_history_while_recorder_is_not_yet_started(
     run_history = instance.run_history
     assert run_history.current.start == run_history.recording_start
     with instance.get_session() as session:
-        run_history.start(session)
+        # Ideally we would run run_history.start in the recorder thread
+        # but since we mocked it out above, we run it directly here
+        # via the database executor to avoid blocking the event loop.
+        await instance.async_add_executor_job(run_history.start, session)
     assert run_history.current.start == run_history.recording_start
     assert run_history.current.created >= run_history.recording_start


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the final commit in `_end_session` raised, we would never close the event session which would leave the connection open leading to an unclean shutdown.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
