### PR TITLE
Add type hints to integration tests (part 4)

### DIFF
--- a/tests/components/comfoconnect/test_sensor.py
+++ b/tests/components/comfoconnect/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.sensor import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
@@ -50,7 +51,7 @@ async def setup_sensor(hass, mock_bridge_discover, mock_comfoconnect_command):
         await hass.async_block_till_done()
 
 
-async def test_sensors(hass, setup_sensor):
+async def test_sensors(hass: HomeAssistant, setup_sensor) -> None:
     """Test the sensors."""
     state = hass.states.get("sensor.comfoairq_inside_humidity")
     assert state is not None

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -3,6 +3,8 @@ import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components.config import area_registry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
 
 from tests.common import ANY
 
@@ -14,7 +16,9 @@ def client(hass, hass_ws_client):
     return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
-async def test_list_areas(hass, client, area_registry):
+async def test_list_areas(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test list entries."""
     area1 = area_registry.async_create("mock 1")
     area2 = area_registry.async_create(
@@ -40,7 +44,9 @@ async def test_list_areas(hass, client, area_registry):
     ]
 
 
-async def test_create_area(hass, client, area_registry):
+async def test_create_area(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test create entry."""
     # Create area with only mandatory parameters
     await client.send_json(
@@ -79,7 +85,9 @@ async def test_create_area(hass, client, area_registry):
     assert len(area_registry.areas) == 2
 
 
-async def test_create_area_with_name_already_in_use(hass, client, area_registry):
+async def test_create_area_with_name_already_in_use(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test create entry that should fail."""
     area_registry.async_create("mock")
 
@@ -95,7 +103,9 @@ async def test_create_area_with_name_already_in_use(hass, client, area_registry)
     assert len(area_registry.areas) == 1
 
 
-async def test_delete_area(hass, client, area_registry):
+async def test_delete_area(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test delete entry."""
     area = area_registry.async_create("mock")
 
@@ -109,7 +119,9 @@ async def test_delete_area(hass, client, area_registry):
     assert not area_registry.areas
 
 
-async def test_delete_non_existing_area(hass, client, area_registry):
+async def test_delete_non_existing_area(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test delete entry that should fail."""
     area_registry.async_create("mock")
 
@@ -125,7 +137,9 @@ async def test_delete_non_existing_area(hass, client, area_registry):
     assert len(area_registry.areas) == 1
 
 
-async def test_update_area(hass, client, area_registry):
+async def test_update_area(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test update entry."""
     area = area_registry.async_create("mock 1")
 
@@ -171,7 +185,9 @@ async def test_update_area(hass, client, area_registry):
     assert len(area_registry.areas) == 1
 
 
-async def test_update_area_with_same_name(hass, client, area_registry):
+async def test_update_area_with_same_name(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test update entry."""
     area = area_registry.async_create("mock 1")
 
@@ -191,7 +207,9 @@ async def test_update_area_with_same_name(hass, client, area_registry):
     assert len(area_registry.areas) == 1
 
 
-async def test_update_area_with_name_already_in_use(hass, client, area_registry):
+async def test_update_area_with_name_already_in_use(
+    hass: HomeAssistant, client, area_registry: ar.AreaRegistry
+) -> None:
     """Test update entry."""
     area = area_registry.async_create("mock 1")
     area_registry.async_create("mock 2")

--- a/tests/components/config/test_auth.py
+++ b/tests/components/config/test_auth.py
@@ -15,7 +15,11 @@ def setup_config(hass, aiohttp_client):
     hass.loop.run_until_complete(auth_config.async_setup(hass))
 
 
-async def test_list_requires_admin(hass, hass_ws_client, hass_read_only_access_token):
+async def test_list_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test get users requires auth."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
@@ -26,7 +30,9 @@ async def test_list_requires_admin(hass, hass_ws_client, hass_read_only_access_t
     assert result["error"]["code"] == "unauthorized"
 
 
-async def test_list(hass, hass_ws_client, hass_admin_user):
+async def test_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test get users."""
     group = MockGroup().add_to_hass(hass)
 
@@ -108,7 +114,11 @@ async def test_list(hass, hass_ws_client, hass_admin_user):
     }
 
 
-async def test_delete_requires_admin(hass, hass_ws_client, hass_read_only_access_token):
+async def test_delete_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test delete command requires an admin."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
@@ -121,7 +131,9 @@ async def test_delete_requires_admin(hass, hass_ws_client, hass_read_only_access
     assert result["error"]["code"] == "unauthorized"
 
 
-async def test_delete_unable_self_account(hass, hass_ws_client, hass_access_token):
+async def test_delete_unable_self_account(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
+) -> None:
     """Test we cannot delete our own account."""
     client = await hass_ws_client(hass, hass_access_token)
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
@@ -135,7 +147,9 @@ async def test_delete_unable_self_account(hass, hass_ws_client, hass_access_toke
     assert result["error"]["code"] == "no_delete_self"
 
 
-async def test_delete_unknown_user(hass, hass_ws_client, hass_access_token):
+async def test_delete_unknown_user(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
+) -> None:
     """Test we cannot delete an unknown user."""
     client = await hass_ws_client(hass, hass_access_token)
 
@@ -148,7 +162,9 @@ async def test_delete_unknown_user(hass, hass_ws_client, hass_access_token):
     assert result["error"]["code"] == "not_found"
 
 
-async def test_delete(hass, hass_ws_client, hass_access_token):
+async def test_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
+) -> None:
     """Test delete command works."""
     client = await hass_ws_client(hass, hass_access_token)
     test_user = MockUser(id="efg").add_to_hass(hass)
@@ -164,7 +180,9 @@ async def test_delete(hass, hass_ws_client, hass_access_token):
     assert len(await hass.auth.async_get_users()) == cur_users - 1
 
 
-async def test_create(hass, hass_ws_client, hass_access_token):
+async def test_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
+) -> None:
     """Test create command works."""
     client = await hass_ws_client(hass, hass_access_token)
 
@@ -186,7 +204,9 @@ async def test_create(hass, hass_ws_client, hass_access_token):
     assert not user.system_generated
 
 
-async def test_create_user_group(hass, hass_ws_client, hass_access_token):
+async def test_create_user_group(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_access_token: str
+) -> None:
     """Test create user with a group."""
     client = await hass_ws_client(hass, hass_access_token)
 
@@ -215,7 +235,11 @@ async def test_create_user_group(hass, hass_ws_client, hass_access_token):
     assert not user.system_generated
 
 
-async def test_create_requires_admin(hass, hass_ws_client, hass_read_only_access_token):
+async def test_create_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test create command requires an admin."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
@@ -253,7 +277,11 @@ async def test_update(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -
     assert data_user["group_ids"] == ["system-read-only"]
 
 
-async def test_update_requires_admin(hass, hass_ws_client, hass_read_only_access_token):
+async def test_update_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test update command requires an admin."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 

--- a/tests/components/config/test_auth_provider_homeassistant.py
+++ b/tests/components/config/test_auth_provider_homeassistant.py
@@ -70,7 +70,9 @@ async def test_create_auth_user_already_credentials() -> None:
     # assert False
 
 
-async def test_create_auth_unknown_user(hass_ws_client, hass):
+async def test_create_auth_unknown_user(
+    hass_ws_client: WebSocketGenerator, hass: HomeAssistant
+) -> None:
     """Test create pointing at unknown user."""
     client = await hass_ws_client(hass)
 
@@ -91,8 +93,10 @@ async def test_create_auth_unknown_user(hass_ws_client, hass):
 
 
 async def test_create_auth_requires_admin(
-    hass, hass_ws_client, hass_read_only_access_token
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test create requires admin to call API."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
@@ -111,7 +115,9 @@ async def test_create_auth_requires_admin(
     assert result["error"]["code"] == "unauthorized"
 
 
-async def test_create_auth(hass, hass_ws_client, hass_storage):
+async def test_create_auth(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test create auth command works."""
     client = await hass_ws_client(hass)
     user = MockUser().add_to_hass(hass)
@@ -140,7 +146,9 @@ async def test_create_auth(hass, hass_ws_client, hass_storage):
     assert entry["username"] == "test-user2"
 
 
-async def test_create_auth_duplicate_username(hass, hass_ws_client, hass_storage):
+async def test_create_auth_duplicate_username(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test we can't create auth with a duplicate username."""
     client = await hass_ws_client(hass)
     user = MockUser().add_to_hass(hass)
@@ -165,7 +173,9 @@ async def test_create_auth_duplicate_username(hass, hass_ws_client, hass_storage
     assert result["error"]["code"] == "username_exists"
 
 
-async def test_delete_removes_just_auth(hass_ws_client, hass, hass_storage):
+async def test_delete_removes_just_auth(
+    hass_ws_client: WebSocketGenerator, hass: HomeAssistant, hass_storage
+) -> None:
     """Test deleting an auth without being connected to a user."""
     client = await hass_ws_client(hass)
 
@@ -187,7 +197,9 @@ async def test_delete_removes_just_auth(hass_ws_client, hass, hass_storage):
     assert len(hass_storage[prov_ha.STORAGE_KEY]["data"]["users"]) == 0
 
 
-async def test_delete_removes_credential(hass, hass_ws_client, hass_storage):
+async def test_delete_removes_credential(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test deleting auth that is connected to a user."""
     client = await hass_ws_client(hass)
 
@@ -216,7 +228,11 @@ async def test_delete_removes_credential(hass, hass_ws_client, hass_storage):
     assert len(hass_storage[prov_ha.STORAGE_KEY]["data"]["users"]) == 0
 
 
-async def test_delete_requires_admin(hass, hass_ws_client, hass_read_only_access_token):
+async def test_delete_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test delete requires admin."""
     client = await hass_ws_client(hass, hass_read_only_access_token)
 
@@ -252,7 +268,9 @@ async def test_delete_unknown_auth(
     assert result["error"]["code"] == "auth_not_found"
 
 
-async def test_change_password(hass, hass_ws_client, auth_provider):
+async def test_change_password(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, auth_provider
+) -> None:
     """Test that change password succeeds with valid password."""
     client = await hass_ws_client(hass)
     await client.send_json(
@@ -270,8 +288,11 @@ async def test_change_password(hass, hass_ws_client, auth_provider):
 
 
 async def test_change_password_wrong_pw(
-    hass, hass_ws_client, hass_admin_user, auth_provider
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+    auth_provider,
+) -> None:
     """Test that change password fails with invalid password."""
 
     client = await hass_ws_client(hass)
@@ -291,7 +312,9 @@ async def test_change_password_wrong_pw(
         await auth_provider.async_validate_login("test-user", "new-pass")
 
 
-async def test_change_password_no_creds(hass, hass_ws_client, hass_admin_user):
+async def test_change_password_no_creds(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test that change password fails with no credentials."""
     hass_admin_user.credentials.clear()
     client = await hass_ws_client(hass)
@@ -310,7 +333,9 @@ async def test_change_password_no_creds(hass, hass_ws_client, hass_admin_user):
     assert result["error"]["code"] == "credentials_not_found"
 
 
-async def test_admin_change_password_not_owner(hass, hass_ws_client, auth_provider):
+async def test_admin_change_password_not_owner(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, auth_provider
+) -> None:
     """Test that change password fails when not owner."""
     client = await hass_ws_client(hass)
 
@@ -331,7 +356,9 @@ async def test_admin_change_password_not_owner(hass, hass_ws_client, auth_provid
     await auth_provider.async_validate_login("test-user", "test-pass")
 
 
-async def test_admin_change_password_no_user(hass, hass_ws_client, owner_access_token):
+async def test_admin_change_password_no_user(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, owner_access_token
+) -> None:
     """Test that change password fails with unknown user."""
     client = await hass_ws_client(hass, owner_access_token)
 
@@ -350,8 +377,11 @@ async def test_admin_change_password_no_user(hass, hass_ws_client, owner_access_
 
 
 async def test_admin_change_password_no_cred(
-    hass, hass_ws_client, owner_access_token, hass_admin_user
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    owner_access_token,
+    hass_admin_user: MockUser,
+) -> None:
     """Test that change password fails with unknown credential."""
 
     hass_admin_user.credentials.clear()
@@ -372,12 +402,12 @@ async def test_admin_change_password_no_cred(
 
 
 async def test_admin_change_password(
-    hass,
-    hass_ws_client,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
     owner_access_token,
     auth_provider,
-    hass_admin_user,
-):
+    hass_admin_user: MockUser,
+) -> None:
     """Test that owners can change any password."""
     client = await hass_ws_client(hass, owner_access_token)
 

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -25,8 +26,11 @@ async def setup_automation(
 
 @pytest.mark.parametrize("automation_config", ({},))
 async def test_get_automation_config(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+) -> None:
     """Test getting automation config."""
     with patch.object(config, "SECTIONS", ["automation"]):
         await async_setup_component(hass, "config", {})
@@ -45,8 +49,11 @@ async def test_get_automation_config(
 
 @pytest.mark.parametrize("automation_config", ({},))
 async def test_update_automation_config(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+) -> None:
     """Test updating automation config."""
     with patch.object(config, "SECTIONS", ["automation"]):
         await async_setup_component(hass, "config", {})
@@ -78,8 +85,12 @@ async def test_update_automation_config(
 
 @pytest.mark.parametrize("automation_config", ({},))
 async def test_update_automation_config_with_error(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation, caplog
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test updating automation config with errors."""
     with patch.object(config, "SECTIONS", ["automation"]):
         await async_setup_component(hass, "config", {})
@@ -108,8 +119,11 @@ async def test_update_automation_config_with_error(
 
 @pytest.mark.parametrize("automation_config", ({},))
 async def test_update_remove_key_automation_config(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+) -> None:
     """Test updating automation config while removing a key."""
     with patch.object(config, "SECTIONS", ["automation"]):
         await async_setup_component(hass, "config", {})
@@ -141,8 +155,11 @@ async def test_update_remove_key_automation_config(
 
 @pytest.mark.parametrize("automation_config", ({},))
 async def test_bad_formatted_automations(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+) -> None:
     """Test that we handle automations without ID."""
     with patch.object(config, "SECTIONS", ["automation"]):
         await async_setup_component(hass, "config", {})
@@ -197,8 +214,11 @@ async def test_bad_formatted_automations(
     ),
 )
 async def test_delete_automation(
-    hass: HomeAssistant, hass_client, hass_config_store, setup_automation
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_automation,
+) -> None:
     """Test deleting an automation."""
     ent_reg = er.async_get(hass)
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -18,6 +18,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import (
     MockConfigEntry,
     MockModule,
+    MockUser,
     mock_entity_platform,
     mock_integration,
 )
@@ -45,7 +46,7 @@ async def client(hass, hass_client):
     return await hass_client()
 
 
-async def test_get_entries(hass, client, clear_handlers):
+async def test_get_entries(hass: HomeAssistant, client, clear_handlers) -> None:
     """Test get entries."""
     mock_integration(hass, MockModule("comp1"))
     mock_integration(
@@ -213,7 +214,7 @@ async def test_get_entries(hass, client, clear_handlers):
     assert data[0]["domain"] == "comp5"
 
 
-async def test_remove_entry(hass, client):
+async def test_remove_entry(hass: HomeAssistant, client) -> None:
     """Test removing an entry via the API."""
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.LOADED)
     entry.add_to_hass(hass)
@@ -224,7 +225,7 @@ async def test_remove_entry(hass, client):
     assert len(hass.config_entries.async_entries()) == 0
 
 
-async def test_reload_entry(hass, client):
+async def test_reload_entry(hass: HomeAssistant, client) -> None:
     """Test reloading an entry via the API."""
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.LOADED)
     entry.add_to_hass(hass)
@@ -237,13 +238,15 @@ async def test_reload_entry(hass, client):
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_reload_invalid_entry(hass, client):
+async def test_reload_invalid_entry(hass: HomeAssistant, client) -> None:
     """Test reloading an invalid entry via the API."""
     resp = await client.post("/api/config/config_entries/entry/invalid/reload")
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_remove_entry_unauth(hass, client, hass_admin_user):
+async def test_remove_entry_unauth(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test removing an entry via the API."""
     hass_admin_user.groups = []
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.LOADED)
@@ -253,7 +256,9 @@ async def test_remove_entry_unauth(hass, client, hass_admin_user):
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_reload_entry_unauth(hass, client, hass_admin_user):
+async def test_reload_entry_unauth(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test reloading an entry via the API."""
     hass_admin_user.groups = []
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.LOADED)
@@ -265,7 +270,9 @@ async def test_reload_entry_unauth(hass, client, hass_admin_user):
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_reload_entry_in_failed_state(hass, client, hass_admin_user):
+async def test_reload_entry_in_failed_state(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test reloading an entry via the API that has already failed to unload."""
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.FAILED_UNLOAD)
     entry.add_to_hass(hass)
@@ -276,7 +283,9 @@ async def test_reload_entry_in_failed_state(hass, client, hass_admin_user):
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_reload_entry_in_setup_retry(hass, client, hass_admin_user):
+async def test_reload_entry_in_setup_retry(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test reloading an entry via the API that is in setup retry."""
     mock_setup_entry = AsyncMock(return_value=True)
     mock_unload_entry = AsyncMock(return_value=True)
@@ -315,7 +324,9 @@ async def test_reload_entry_in_setup_retry(hass, client, hass_admin_user):
         ("helper", {"world"}),
     ),
 )
-async def test_available_flows(hass, client, type_filter, result):
+async def test_available_flows(
+    hass: HomeAssistant, client, type_filter, result
+) -> None:
     """Test querying the available flows."""
     with patch.object(
         config_flows,
@@ -336,7 +347,7 @@ async def test_available_flows(hass, client, type_filter, result):
 ############################
 
 
-async def test_initialize_flow(hass, client):
+async def test_initialize_flow(hass: HomeAssistant, client) -> None:
     """Test we can initialize a flow."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -384,7 +395,7 @@ async def test_initialize_flow(hass, client):
     }
 
 
-async def test_initialize_flow_unmet_dependency(hass, client):
+async def test_initialize_flow_unmet_dependency(hass: HomeAssistant, client) -> None:
     """Test unmet dependencies are listed."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -413,7 +424,9 @@ async def test_initialize_flow_unmet_dependency(hass, client):
     assert data == "Failed dependencies dependency_1"
 
 
-async def test_initialize_flow_unauth(hass, client, hass_admin_user):
+async def test_initialize_flow_unauth(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test we can initialize a flow."""
     hass_admin_user.groups = []
 
@@ -438,7 +451,7 @@ async def test_initialize_flow_unauth(hass, client, hass_admin_user):
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_abort(hass, client):
+async def test_abort(hass: HomeAssistant, client) -> None:
     """Test a flow that aborts."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -462,7 +475,9 @@ async def test_abort(hass, client):
     }
 
 
-async def test_create_account(hass, client, enable_custom_integrations):
+async def test_create_account(
+    hass: HomeAssistant, client, enable_custom_integrations: None
+) -> None:
     """Test a flow that creates an account."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -515,7 +530,9 @@ async def test_create_account(hass, client, enable_custom_integrations):
     }
 
 
-async def test_two_step_flow(hass, client, enable_custom_integrations):
+async def test_two_step_flow(
+    hass: HomeAssistant, client, enable_custom_integrations: None
+) -> None:
     """Test we can finish a two step flow."""
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
@@ -589,7 +606,9 @@ async def test_two_step_flow(hass, client, enable_custom_integrations):
         }
 
 
-async def test_continue_flow_unauth(hass, client, hass_admin_user):
+async def test_continue_flow_unauth(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test we can't finish a two step flow."""
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
@@ -671,7 +690,9 @@ async def test_get_progress_index(
     ]
 
 
-async def test_get_progress_index_unauth(hass, hass_ws_client, hass_admin_user):
+async def test_get_progress_index_unauth(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test we can't get flows that are in progress."""
     assert await async_setup_component(hass, "config", {})
     hass_admin_user.groups = []
@@ -684,7 +705,7 @@ async def test_get_progress_index_unauth(hass, hass_ws_client, hass_admin_user):
     assert response["error"]["code"] == "unauthorized"
 
 
-async def test_get_progress_flow(hass, client):
+async def test_get_progress_flow(hass: HomeAssistant, client) -> None:
     """Test we can query the API for same result as we get from init a flow."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -718,7 +739,9 @@ async def test_get_progress_flow(hass, client):
     assert data == data2
 
 
-async def test_get_progress_flow_unauth(hass, client, hass_admin_user):
+async def test_get_progress_flow_unauth(
+    hass: HomeAssistant, client, hass_admin_user: MockUser
+) -> None:
     """Test we can can't query the API for result of flow."""
     mock_entity_platform(hass, "config_flow.test", None)
 
@@ -751,7 +774,7 @@ async def test_get_progress_flow_unauth(hass, client, hass_admin_user):
     assert resp2.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_options_flow(hass, client):
+async def test_options_flow(hass: HomeAssistant, client) -> None:
     """Test we can change options."""
 
     class TestFlow(core_ce.ConfigFlow):
@@ -796,7 +819,7 @@ async def test_options_flow(hass, client):
     }
 
 
-async def test_two_step_options_flow(hass, client):
+async def test_two_step_options_flow(hass: HomeAssistant, client) -> None:
     """Test we can finish a two step options flow."""
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
@@ -861,7 +884,7 @@ async def test_two_step_options_flow(hass, client):
         }
 
 
-async def test_options_flow_with_invalid_data(hass, client):
+async def test_options_flow_with_invalid_data(hass: HomeAssistant, client) -> None:
     """Test an options flow with invalid_data."""
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
@@ -1182,7 +1205,9 @@ async def test_ignore_flow_nonexisting(
     assert response["error"]["code"] == "not_found"
 
 
-async def test_get_entries_ws(hass, hass_ws_client, clear_handlers):
+async def test_get_entries_ws(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, clear_handlers
+) -> None:
     """Test get entries with the websocket api."""
     assert await async_setup_component(hass, "config", {})
     mock_integration(hass, MockModule("comp1"))
@@ -1543,7 +1568,9 @@ async def test_get_entries_ws(hass, hass_ws_client, clear_handlers):
     assert response["success"] is False
 
 
-async def test_subscribe_entries_ws(hass, hass_ws_client, clear_handlers):
+async def test_subscribe_entries_ws(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, clear_handlers
+) -> None:
     """Test subscribe entries with the websocket api."""
     assert await async_setup_component(hass, "config", {})
     mock_integration(hass, MockModule("comp1"))
@@ -1709,7 +1736,9 @@ async def test_subscribe_entries_ws(hass, hass_ws_client, clear_handlers):
     ]
 
 
-async def test_subscribe_entries_ws_filtered(hass, hass_ws_client, clear_handlers):
+async def test_subscribe_entries_ws_filtered(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, clear_handlers
+) -> None:
     """Test subscribe entries with the websocket api with a type filter."""
     assert await async_setup_component(hass, "config", {})
     mock_integration(hass, MockModule("comp1"))

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -16,7 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util, location
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from tests.typing import ClientSessionGenerator
+from tests.common import MockUser
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
@@ -59,7 +60,7 @@ async def test_validate_config_ok(
     assert result["errors"] == "beer"
 
 
-async def test_websocket_core_update(hass, client):
+async def test_websocket_core_update(hass: HomeAssistant, client) -> None:
     """Test core config update websocket command."""
     assert hass.config.latitude != 60
     assert hass.config.longitude != 50
@@ -130,7 +131,9 @@ async def test_websocket_core_update(hass, client):
         mock_update_sensor_units.assert_called_once()
 
 
-async def test_websocket_core_update_not_admin(hass, hass_ws_client, hass_admin_user):
+async def test_websocket_core_update_not_admin(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test core config fails for non admin."""
     hass_admin_user.groups = []
     with patch.object(config, "SECTIONS", ["core"]):
@@ -147,7 +150,7 @@ async def test_websocket_core_update_not_admin(hass, hass_ws_client, hass_admin_
     assert msg["error"]["code"] == "unauthorized"
 
 
-async def test_websocket_bad_core_update(hass, client):
+async def test_websocket_bad_core_update(hass: HomeAssistant, client) -> None:
     """Test core config update fails with bad parameters."""
     await client.send_json({"id": 7, "type": "config/core/update", "latituude": 23})
 
@@ -159,7 +162,7 @@ async def test_websocket_bad_core_update(hass, client):
     assert msg["error"]["code"] == "invalid_format"
 
 
-async def test_detect_config(hass, client):
+async def test_detect_config(hass: HomeAssistant, client) -> None:
     """Test detect config."""
     with patch(
         "homeassistant.util.location.async_detect_location_info",
@@ -173,7 +176,7 @@ async def test_detect_config(hass, client):
     assert msg["result"] == {}
 
 
-async def test_detect_config_fail(hass, client):
+async def test_detect_config_fail(hass: HomeAssistant, client) -> None:
     """Test detect config."""
     with patch(
         "homeassistant.util.location.async_detect_location_info",

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -18,7 +18,9 @@ def client(hass, hass_ws_client):
     return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
-async def test_list_devices(hass, client, device_registry):
+async def test_list_devices(
+    hass: HomeAssistant, client, device_registry: dr.DeviceRegistry
+) -> None:
     """Test list entries."""
     device1 = device_registry.async_get_or_create(
         config_entry_id="1234",
@@ -121,7 +123,13 @@ async def test_list_devices(hass, client, device_registry):
         ["name_by_user", None],
     ],
 )
-async def test_update_device(hass, client, device_registry, payload_key, payload_value):
+async def test_update_device(
+    hass: HomeAssistant,
+    client,
+    device_registry: dr.DeviceRegistry,
+    payload_key,
+    payload_value,
+) -> None:
     """Test update entry."""
     device = device_registry.async_get_or_create(
         config_entry_id="1234",

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -4,6 +4,8 @@ from pytest_unordered import unordered
 
 from homeassistant.components.config import entity_registry
 from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryDisabler
 from homeassistant.helpers.entity_registry import (
     RegistryEntry,
@@ -35,7 +37,7 @@ def device_registry(hass):
     return mock_device_registry(hass)
 
 
-async def test_list_entities(hass, client):
+async def test_list_entities(hass: HomeAssistant, client) -> None:
     """Test list entries."""
     mock_registry(
         hass,
@@ -142,7 +144,7 @@ async def test_list_entities(hass, client):
     ]
 
 
-async def test_get_entity(hass, client):
+async def test_get_entity(hass: HomeAssistant, client) -> None:
     """Test get entry."""
     mock_registry(
         hass,
@@ -224,7 +226,7 @@ async def test_get_entity(hass, client):
     }
 
 
-async def test_get_entities(hass, client):
+async def test_get_entities(hass: HomeAssistant, client) -> None:
     """Test get entry."""
     mock_registry(
         hass,
@@ -307,7 +309,7 @@ async def test_get_entities(hass, client):
     }
 
 
-async def test_update_entity(hass, client):
+async def test_update_entity(hass: HomeAssistant, client) -> None:
     """Test updating entity."""
     registry = mock_registry(
         hass,
@@ -490,7 +492,7 @@ async def test_update_entity(hass, client):
     }
 
 
-async def test_update_entity_require_restart(hass, client):
+async def test_update_entity_require_restart(hass: HomeAssistant, client) -> None:
     """Test updating entity."""
     entity_id = "test_domain.test_platform_1234"
     config_entry = MockConfigEntry(domain="test_platform")
@@ -543,7 +545,9 @@ async def test_update_entity_require_restart(hass, client):
     }
 
 
-async def test_enable_entity_disabled_device(hass, client, device_registry):
+async def test_enable_entity_disabled_device(
+    hass: HomeAssistant, client, device_registry: dr.DeviceRegistry
+) -> None:
     """Test enabling entity of disabled device."""
     entity_id = "test_domain.test_platform_1234"
     config_entry = MockConfigEntry(domain="test_platform")
@@ -590,7 +594,7 @@ async def test_enable_entity_disabled_device(hass, client, device_registry):
     assert not msg["success"]
 
 
-async def test_update_entity_no_changes(hass, client):
+async def test_update_entity_no_changes(hass: HomeAssistant, client) -> None:
     """Test update entity with no changes."""
     mock_registry(
         hass,
@@ -653,7 +657,7 @@ async def test_update_entity_no_changes(hass, client):
     assert state.name == "name of entity"
 
 
-async def test_get_nonexisting_entity(client):
+async def test_get_nonexisting_entity(client) -> None:
     """Test get entry with nonexisting entity."""
     await client.send_json(
         {
@@ -667,7 +671,7 @@ async def test_get_nonexisting_entity(client):
     assert not msg["success"]
 
 
-async def test_update_nonexisting_entity(client):
+async def test_update_nonexisting_entity(client) -> None:
     """Test update a nonexisting entity."""
     await client.send_json(
         {
@@ -682,7 +686,7 @@ async def test_update_nonexisting_entity(client):
     assert not msg["success"]
 
 
-async def test_update_entity_id(hass, client):
+async def test_update_entity_id(hass: HomeAssistant, client) -> None:
     """Test update entity id."""
     mock_registry(
         hass,
@@ -742,7 +746,7 @@ async def test_update_entity_id(hass, client):
     assert hass.states.get("test_domain.planet") is not None
 
 
-async def test_update_existing_entity_id(hass, client):
+async def test_update_existing_entity_id(hass: HomeAssistant, client) -> None:
     """Test update entity id to an already registered entity id."""
     mock_registry(
         hass,
@@ -779,7 +783,7 @@ async def test_update_existing_entity_id(hass, client):
     assert not msg["success"]
 
 
-async def test_update_invalid_entity_id(hass, client):
+async def test_update_invalid_entity_id(hass: HomeAssistant, client) -> None:
     """Test update entity id to an invalid entity id."""
     mock_registry(
         hass,
@@ -810,7 +814,7 @@ async def test_update_invalid_entity_id(hass, client):
     assert not msg["success"]
 
 
-async def test_remove_entity(hass, client):
+async def test_remove_entity(hass: HomeAssistant, client) -> None:
     """Test removing entity."""
     registry = mock_registry(
         hass,
@@ -839,7 +843,7 @@ async def test_remove_entity(hass, client):
     assert len(registry.entities) == 0
 
 
-async def test_remove_non_existing_entity(hass, client):
+async def test_remove_non_existing_entity(hass: HomeAssistant, client) -> None:
     """Test removing non existing entity."""
     mock_registry(hass, {})
 

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -1,8 +1,9 @@
 """Test config init."""
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_config_setup(hass, event_loop):
+async def test_config_setup(hass: HomeAssistant, event_loop) -> None:
     """Test it sets up hassbian."""
     await async_setup_component(hass, "config", {})
     assert "config" in hass.config.components

--- a/tests/components/config/test_scene.py
+++ b/tests/components/config/test_scene.py
@@ -7,7 +7,10 @@ import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -17,7 +20,12 @@ async def setup_scene(hass, scene_config):
 
 
 @pytest.mark.parametrize("scene_config", ({},))
-async def test_create_scene(hass, hass_client, hass_config_store, setup_scene):
+async def test_create_scene(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_scene,
+) -> None:
     """Test creating a scene."""
     with patch.object(config, "SECTIONS", ["scene"]):
         await async_setup_component(hass, "config", {})
@@ -59,7 +67,12 @@ async def test_create_scene(hass, hass_client, hass_config_store, setup_scene):
 
 
 @pytest.mark.parametrize("scene_config", ({},))
-async def test_update_scene(hass, hass_client, hass_config_store, setup_scene):
+async def test_update_scene(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_scene,
+) -> None:
     """Test updating a scene."""
     with patch.object(config, "SECTIONS", ["scene"]):
         await async_setup_component(hass, "config", {})
@@ -102,7 +115,12 @@ async def test_update_scene(hass, hass_client, hass_config_store, setup_scene):
 
 
 @pytest.mark.parametrize("scene_config", ({},))
-async def test_bad_formatted_scene(hass, hass_client, hass_config_store, setup_scene):
+async def test_bad_formatted_scene(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_scene,
+) -> None:
     """Test that we handle scene without ID."""
     with patch.object(config, "SECTIONS", ["scene"]):
         await async_setup_component(hass, "config", {})
@@ -163,7 +181,12 @@ async def test_bad_formatted_scene(hass, hass_client, hass_config_store, setup_s
         ],
     ),
 )
-async def test_delete_scene(hass, hass_client, hass_config_store, setup_scene):
+async def test_delete_scene(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    setup_scene,
+) -> None:
     """Test deleting a scene."""
     ent_reg = er.async_get(hass)
 

--- a/tests/components/config/test_script.py
+++ b/tests/components/config/test_script.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +21,9 @@ async def setup_script(hass, script_config, stub_blueprint_populate):  # noqa: F
 
 
 @pytest.mark.parametrize("script_config", ({},))
-async def test_get_script_config(hass: HomeAssistant, hass_client, hass_config_store):
+async def test_get_script_config(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
+) -> None:
     """Test getting script config."""
     with patch.object(config, "SECTIONS", ["script"]):
         await async_setup_component(hass, "config", {})
@@ -42,8 +45,8 @@ async def test_get_script_config(hass: HomeAssistant, hass_client, hass_config_s
 
 @pytest.mark.parametrize("script_config", ({},))
 async def test_update_script_config(
-    hass: HomeAssistant, hass_client, hass_config_store
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
+) -> None:
     """Test updating script config."""
     with patch.object(config, "SECTIONS", ["script"]):
         await async_setup_component(hass, "config", {})
@@ -73,8 +76,11 @@ async def test_update_script_config(
 
 @pytest.mark.parametrize("script_config", ({},))
 async def test_update_script_config_with_error(
-    hass: HomeAssistant, hass_client, hass_config_store, caplog
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_config_store,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test updating script config with errors."""
     with patch.object(config, "SECTIONS", ["script"]):
         await async_setup_component(hass, "config", {})
@@ -103,8 +109,8 @@ async def test_update_script_config_with_error(
 
 @pytest.mark.parametrize("script_config", ({},))
 async def test_update_remove_key_script_config(
-    hass: HomeAssistant, hass_client, hass_config_store
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
+) -> None:
     """Test updating script config while removing a key."""
     with patch.object(config, "SECTIONS", ["script"]):
         await async_setup_component(hass, "config", {})
@@ -141,7 +147,9 @@ async def test_update_remove_key_script_config(
         },
     ),
 )
-async def test_delete_script(hass: HomeAssistant, hass_client, hass_config_store):
+async def test_delete_script(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
+) -> None:
     """Test deleting a script."""
     with patch.object(config, "SECTIONS", ["script"]):
         await async_setup_component(hass, "config", {})

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -2,7 +2,7 @@
 import pytest
 
 from homeassistant.components import conversation
-from homeassistant.core import DOMAIN as HASS_DOMAIN, Context
+from homeassistant.core import DOMAIN as HASS_DOMAIN, Context, HomeAssistant
 from homeassistant.helpers import entity, entity_registry, intent
 from homeassistant.setup import async_setup_component
 
@@ -26,7 +26,9 @@ async def init_components(hass):
         {"entity_category": entity.EntityCategory.DIAGNOSTIC},
     ],
 )
-async def test_hidden_entities_skipped(hass, init_components, er_kwargs):
+async def test_hidden_entities_skipped(
+    hass: HomeAssistant, init_components, er_kwargs
+) -> None:
     """Test we skip hidden entities."""
 
     er = entity_registry.async_get(hass)

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -17,7 +17,8 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_mock_service
+from tests.common import MockConfigEntry, MockUser, async_mock_service
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 AGENT_ID_OPTIONS = [None, conversation.AgentManager.HOME_ASSISTANT_AGENT]
 
@@ -45,8 +46,12 @@ async def init_components(hass):
 
 @pytest.mark.parametrize("agent_id", AGENT_ID_OPTIONS)
 async def test_http_processing_intent(
-    hass, init_components, hass_client, hass_admin_user, agent_id
-):
+    hass: HomeAssistant,
+    init_components,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    agent_id,
+) -> None:
     """Test processing intent via HTTP API."""
     # Add an alias
     entities = entity_registry.async_get(hass)
@@ -87,8 +92,12 @@ async def test_http_processing_intent(
 
 
 async def test_http_processing_intent_target_ha_agent(
-    hass, init_components, hass_client, hass_admin_user, mock_agent
-):
+    hass: HomeAssistant,
+    init_components,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    mock_agent,
+) -> None:
     """Test processing intent can be processed via HTTP API with picking agent."""
     # Add an alias
     entities = entity_registry.async_get(hass)
@@ -129,8 +138,11 @@ async def test_http_processing_intent_target_ha_agent(
 
 
 async def test_http_processing_intent_entity_added(
-    hass, init_components, hass_client, hass_admin_user
-):
+    hass: HomeAssistant,
+    init_components,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+) -> None:
     """Test processing intent via HTTP API with entities added later.
 
     We want to ensure that adding an entity later busts the cache
@@ -267,7 +279,9 @@ async def test_http_processing_intent_entity_added(
 
 @pytest.mark.parametrize("agent_id", AGENT_ID_OPTIONS)
 @pytest.mark.parametrize("sentence", ("turn on kitchen", "turn kitchen on"))
-async def test_turn_on_intent(hass, init_components, sentence, agent_id):
+async def test_turn_on_intent(
+    hass: HomeAssistant, init_components, sentence, agent_id
+) -> None:
     """Test calling the turn on intent."""
     hass.states.async_set("light.kitchen", "off")
     calls = async_mock_service(hass, HASS_DOMAIN, "turn_on")
@@ -286,7 +300,7 @@ async def test_turn_on_intent(hass, init_components, sentence, agent_id):
 
 
 @pytest.mark.parametrize("sentence", ("turn off kitchen", "turn kitchen off"))
-async def test_turn_off_intent(hass, init_components, sentence):
+async def test_turn_off_intent(hass: HomeAssistant, init_components, sentence) -> None:
     """Test calling the turn on intent."""
     hass.states.async_set("light.kitchen", "on")
     calls = async_mock_service(hass, HASS_DOMAIN, "turn_off")
@@ -303,7 +317,9 @@ async def test_turn_off_intent(hass, init_components, sentence):
     assert call.data == {"entity_id": "light.kitchen"}
 
 
-async def test_http_api_no_match(hass, init_components, hass_client):
+async def test_http_api_no_match(
+    hass: HomeAssistant, init_components, hass_client: ClientSessionGenerator
+) -> None:
     """Test the HTTP conversation API with an intent match failure."""
     client = await hass_client()
 
@@ -330,7 +346,9 @@ async def test_http_api_no_match(hass, init_components, hass_client):
     }
 
 
-async def test_http_api_handle_failure(hass, init_components, hass_client):
+async def test_http_api_handle_failure(
+    hass: HomeAssistant, init_components, hass_client: ClientSessionGenerator
+) -> None:
     """Test the HTTP conversation API with an error during handling."""
     client = await hass_client()
 
@@ -367,7 +385,9 @@ async def test_http_api_handle_failure(hass, init_components, hass_client):
     }
 
 
-async def test_http_api_unexpected_failure(hass, init_components, hass_client):
+async def test_http_api_unexpected_failure(
+    hass: HomeAssistant, init_components, hass_client: ClientSessionGenerator
+) -> None:
     """Test the HTTP conversation API with an unexpected error during handling."""
     client = await hass_client()
 
@@ -404,7 +424,9 @@ async def test_http_api_unexpected_failure(hass, init_components, hass_client):
     }
 
 
-async def test_http_api_wrong_data(hass, init_components, hass_client):
+async def test_http_api_wrong_data(
+    hass: HomeAssistant, init_components, hass_client: ClientSessionGenerator
+) -> None:
     """Test the HTTP conversation API."""
     client = await hass_client()
 
@@ -416,7 +438,13 @@ async def test_http_api_wrong_data(hass, init_components, hass_client):
 
 
 @pytest.mark.parametrize("agent_id", (None, "mock-entry"))
-async def test_custom_agent(hass, hass_client, hass_admin_user, mock_agent, agent_id):
+async def test_custom_agent(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    mock_agent,
+    agent_id,
+) -> None:
     """Test a custom conversation agent."""
     assert await async_setup_component(hass, "conversation", {})
 
@@ -488,7 +516,9 @@ async def test_custom_agent(hass, hass_client, hass_admin_user, mock_agent, agen
         },
     ],
 )
-async def test_ws_api(hass, hass_ws_client, payload):
+async def test_ws_api(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, payload
+) -> None:
     """Test the Websocket conversation API."""
     assert await async_setup_component(hass, "conversation", {})
     client = await hass_ws_client(hass)
@@ -516,7 +546,9 @@ async def test_ws_api(hass, hass_ws_client, payload):
 
 
 @pytest.mark.parametrize("agent_id", AGENT_ID_OPTIONS)
-async def test_ws_prepare(hass, hass_ws_client, agent_id):
+async def test_ws_prepare(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, agent_id
+) -> None:
     """Test the Websocket prepare conversation API."""
     assert await async_setup_component(hass, "conversation", {})
     agent = await conversation._get_agent_manager(hass).async_get_agent()
@@ -544,7 +576,9 @@ async def test_ws_prepare(hass, hass_ws_client, agent_id):
     assert agent._lang_intents.get(hass.config.language)
 
 
-async def test_custom_sentences(hass, hass_client, hass_admin_user):
+async def test_custom_sentences(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_admin_user: MockUser
+) -> None:
     """Test custom sentences with a custom intent."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
@@ -584,7 +618,9 @@ async def test_custom_sentences(hass, hass_client, hass_admin_user):
         }
 
 
-async def test_custom_sentences_config(hass, hass_client, hass_admin_user):
+async def test_custom_sentences_config(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_admin_user: MockUser
+) -> None:
     """Test custom sentences with a custom intent in config."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(
@@ -667,7 +703,7 @@ async def test_prepare_fail(hass: HomeAssistant) -> None:
     assert not agent._lang_intents.get("not-a-language")
 
 
-async def test_language_region(hass, init_components):
+async def test_language_region(hass: HomeAssistant, init_components) -> None:
     """Test calling the turn on intent."""
     hass.states.async_set("light.kitchen", "off")
     calls = async_mock_service(hass, HASS_DOMAIN, "turn_on")
@@ -716,7 +752,7 @@ async def test_reload_on_new_component(hass: HomeAssistant) -> None:
     assert {"light"} == (lang_intents.loaded_components - loaded_components)
 
 
-async def test_non_default_response(hass, init_components):
+async def test_non_default_response(hass: HomeAssistant, init_components) -> None:
     """Test intent response that is not the default."""
     hass.states.async_set("cover.front_door", "closed")
     async_mock_service(hass, "cover", SERVICE_OPEN_COVER)
@@ -735,7 +771,7 @@ async def test_non_default_response(hass, init_components):
     assert result.response.speech["plain"]["speech"] == "Opened front door"
 
 
-async def test_turn_on_area(hass, init_components):
+async def test_turn_on_area(hass: HomeAssistant, init_components) -> None:
     """Test turning on an area."""
     er = entity_registry.async_get(hass)
     dr = device_registry.async_get(hass)
@@ -801,7 +837,7 @@ async def test_turn_on_area(hass, init_components):
     assert call.data == {"entity_id": "light.stove"}
 
 
-async def test_light_area_same_name(hass, init_components):
+async def test_light_area_same_name(hass: HomeAssistant, init_components) -> None:
     """Test turning on a light with the same name as an area."""
     entities = entity_registry.async_get(hass)
     devices = device_registry.async_get(hass)
@@ -857,7 +893,9 @@ async def test_agent_id_validator_invalid_agent(hass: HomeAssistant) -> None:
     conversation.agent_id_validator(conversation.AgentManager.HOME_ASSISTANT_AGENT)
 
 
-async def test_get_agent_list(hass, init_components, mock_agent, hass_ws_client):
+async def test_get_agent_list(
+    hass: HomeAssistant, init_components, mock_agent, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test getting agent info."""
     client = await hass_ws_client(hass)
 

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -25,7 +25,8 @@ from homeassistant.setup import async_setup_component
 
 from .common import async_decrement, async_increment, async_reset
 
-from tests.common import mock_restore_cache
+from tests.common import MockUser, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -266,7 +267,7 @@ async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> Non
     assert int(state.state) == 0
 
 
-async def test_counter_context(hass, hass_admin_user):
+async def test_counter_context(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test that counter context works."""
     assert await async_setup_component(hass, "counter", {"counter": {"test": {}}})
 
@@ -287,7 +288,7 @@ async def test_counter_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_counter_min(hass, hass_admin_user):
+async def test_counter_min(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test that min works."""
     assert await async_setup_component(
         hass, "counter", {"counter": {"test": {"minimum": "0", "initial": "0"}}}
@@ -322,7 +323,7 @@ async def test_counter_min(hass, hass_admin_user):
     assert state2.state == "1"
 
 
-async def test_counter_max(hass, hass_admin_user):
+async def test_counter_max(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test that max works."""
     assert await async_setup_component(
         hass, "counter", {"counter": {"test": {"maximum": "0", "initial": "0"}}}
@@ -357,7 +358,7 @@ async def test_counter_max(hass, hass_admin_user):
     assert state2.state == "-1"
 
 
-async def test_configure(hass, hass_admin_user):
+async def test_configure(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test that setting values through configure works."""
     assert await async_setup_component(
         hass, "counter", {"counter": {"test": {"maximum": "10", "initial": "10"}}}
@@ -492,7 +493,7 @@ async def test_configure(hass, hass_admin_user):
     assert state.attributes.get("initial") == 6
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -501,7 +502,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={
@@ -527,7 +528,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert state.attributes[ATTR_EDITABLE] is False
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(
         config={
@@ -559,7 +562,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -584,7 +589,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update_min_max(hass, hass_ws_client, storage_setup):
+async def test_update_min_max(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating min/max updates the state."""
 
     settings = {
@@ -670,7 +677,9 @@ async def test_update_min_max(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_STEP] == 6
 
 
-async def test_create(hass, hass_ws_client, storage_setup):
+async def test_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test creating counter using WS."""
 
     items = []

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -5,7 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.cover import DOMAIN, CoverEntityFeature
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -41,14 +42,14 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
     ],
 )
 async def test_get_actions(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_action_types,
-):
+) -> None:
     """Test we get the expected actions from a cover."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -96,12 +97,12 @@ async def test_get_actions(
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -136,8 +137,11 @@ async def test_get_actions_hidden_auxiliary(
 
 
 async def test_get_action_capabilities(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover action."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init(empty=True)
@@ -183,8 +187,11 @@ async def test_get_action_capabilities(
 
 
 async def test_get_action_capabilities_set_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover action."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -231,8 +238,11 @@ async def test_get_action_capabilities_set_pos(
 
 
 async def test_get_action_capabilities_set_tilt_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover action."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -278,7 +288,7 @@ async def test_get_action_capabilities_set_tilt_pos(
             assert capabilities == {"extra_fields": []}
 
 
-async def test_action(hass, enable_custom_integrations):
+async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test for cover actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -344,7 +354,9 @@ async def test_action(hass, enable_custom_integrations):
     assert len(stop_calls) == 1
 
 
-async def test_action_tilt(hass, enable_custom_integrations):
+async def test_action_tilt(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test for cover tilt actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -397,7 +409,9 @@ async def test_action_tilt(hass, enable_custom_integrations):
     assert len(close_calls) == 1
 
 
-async def test_action_set_position(hass, enable_custom_integrations):
+async def test_action_set_position(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test for cover set position actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -13,7 +13,8 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -69,14 +70,14 @@ def calls(hass):
     ],
 )
 async def test_get_conditions(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_condition_types,
-):
+) -> None:
     """Test we get the expected conditions from a cover."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -125,12 +126,12 @@ async def test_get_conditions(
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -165,8 +166,11 @@ async def test_get_conditions_hidden_auxiliary(
 
 
 async def test_get_condition_capabilities(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover condition."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -196,8 +200,11 @@ async def test_get_condition_capabilities(
 
 
 async def test_get_condition_capabilities_set_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover condition."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -250,8 +257,11 @@ async def test_get_condition_capabilities_set_pos(
 
 
 async def test_get_condition_capabilities_set_tilt_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover condition."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -303,7 +313,7 @@ async def test_get_condition_capabilities_set_tilt_pos(
             assert capabilities == {"extra_fields": []}
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("cover.entity", STATE_OPEN)
 
@@ -431,7 +441,12 @@ async def test_if_state(hass, calls):
     assert calls[3].data["some"] == "is_closing - event - test_event4"
 
 
-async def test_if_position(hass, calls, caplog, enable_custom_integrations):
+async def test_if_position(
+    hass: HomeAssistant,
+    calls,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
     """Test for position conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -576,7 +591,12 @@ async def test_if_position(hass, calls, caplog, enable_custom_integrations):
         assert record.levelname in ("DEBUG", "INFO")
 
 
-async def test_if_tilt_position(hass, calls, caplog, enable_custom_integrations):
+async def test_if_tilt_position(
+    hass: HomeAssistant,
+    calls,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
     """Test for tilt position conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -14,7 +14,8 @@ from homeassistant.const import (
     STATE_OPENING,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -68,14 +69,14 @@ def calls(hass):
     ],
 )
 async def test_get_triggers(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_trigger_types,
-):
+) -> None:
     """Test we get the expected triggers from a cover."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -126,12 +127,12 @@ async def test_get_triggers(
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -166,8 +167,11 @@ async def test_get_triggers_hidden_auxiliary(
 
 
 async def test_get_trigger_capabilities(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover trigger."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -201,8 +205,11 @@ async def test_get_trigger_capabilities(
 
 
 async def test_get_trigger_capabilities_set_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover trigger."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -263,8 +270,11 @@ async def test_get_trigger_capabilities_set_pos(
 
 
 async def test_get_trigger_capabilities_set_tilt_pos(
-    hass, device_registry, entity_registry, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test we get the expected capabilities from a cover trigger."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -324,7 +334,7 @@ async def test_get_trigger_capabilities_set_tilt_pos(
             }
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test for state triggers firing."""
     hass.states.async_set("cover.entity", STATE_CLOSED)
 
@@ -458,7 +468,7 @@ async def test_if_fires_on_state_change(hass, calls):
     ] == "closing - device - {} - opening - closing - None".format("cover.entity")
 
 
-async def test_if_fires_on_state_change_with_for(hass, calls):
+async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for triggers firing with delay."""
     entity_id = "cover.entity"
     hass.states.async_set(entity_id, STATE_CLOSED)
@@ -513,7 +523,9 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
     )
 
 
-async def test_if_fires_on_position(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_position(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for position triggers."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
@@ -652,7 +664,9 @@ async def test_if_fires_on_position(hass, calls, enable_custom_integrations):
     )
 
 
-async def test_if_fires_on_tilt_position(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_tilt_position(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for tilt position triggers."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -9,10 +9,11 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_services(hass, enable_custom_integrations):
+async def test_services(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test the provided services."""
     platform = getattr(hass.components, "test.cover")
 

--- a/tests/components/cpuspeed/test_diagnostics.py
+++ b/tests/components/cpuspeed/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     info = {
         "hz_actual": (3200000001, 0),

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -176,7 +176,9 @@ async def start_options_flow(
     return await hass.config_entries.options.async_init(entry_id)
 
 
-async def test_no_user_input(crownstone_setup: MockFixture, hass: HomeAssistant):
+async def test_no_user_input(
+    crownstone_setup: MockFixture, hass: HomeAssistant
+) -> None:
     """Test the flow done in the correct way."""
     # test if a form is returned if no input is provided
     result = await hass.config_entries.flow.async_init(
@@ -188,7 +190,9 @@ async def test_no_user_input(crownstone_setup: MockFixture, hass: HomeAssistant)
     assert crownstone_setup.call_count == 0
 
 
-async def test_abort_if_configured(crownstone_setup: MockFixture, hass: HomeAssistant):
+async def test_abort_if_configured(
+    crownstone_setup: MockFixture, hass: HomeAssistant
+) -> None:
     """Test flow with correct login input and abort if sphere already configured."""
     # create mock entry conf
     configured_entry_data = create_mocked_entry_data_conf(
@@ -218,7 +222,7 @@ async def test_abort_if_configured(crownstone_setup: MockFixture, hass: HomeAssi
 
 async def test_authentication_errors(
     crownstone_setup: MockFixture, hass: HomeAssistant
-):
+) -> None:
     """Test flow with wrong auth errors."""
     cloud = get_mocked_crownstone_cloud()
     # side effect: auth error login failed
@@ -243,7 +247,9 @@ async def test_authentication_errors(
     assert crownstone_setup.call_count == 0
 
 
-async def test_unknown_error(crownstone_setup: MockFixture, hass: HomeAssistant):
+async def test_unknown_error(
+    crownstone_setup: MockFixture, hass: HomeAssistant
+) -> None:
     """Test flow with unknown error."""
     cloud = get_mocked_crownstone_cloud()
     # side effect: unknown error
@@ -258,7 +264,7 @@ async def test_unknown_error(crownstone_setup: MockFixture, hass: HomeAssistant)
 
 async def test_successful_login_no_usb(
     crownstone_setup: MockFixture, hass: HomeAssistant
-):
+) -> None:
     """Test a successful login without configuring a USB."""
     entry_data_without_usb = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -289,7 +295,7 @@ async def test_successful_login_with_usb(
     pyserial_comports_none_types: MockFixture,
     usb_path: MockFixture,
     hass: HomeAssistant,
-):
+) -> None:
     """Test flow with correct login and usb configuration."""
     entry_data_with_usb = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -341,7 +347,7 @@ async def test_successful_login_with_usb(
 
 async def test_successful_login_with_manual_usb_path(
     crownstone_setup: MockFixture, pyserial_comports: MockFixture, hass: HomeAssistant
-):
+) -> None:
     """Test flow with correct login and usb configuration."""
     entry_data_with_manual_usb = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -385,7 +391,7 @@ async def test_successful_login_with_manual_usb_path(
 
 async def test_options_flow_setup_usb(
     pyserial_comports: MockFixture, usb_path: MockFixture, hass: HomeAssistant
-):
+) -> None:
     """Test options flow init."""
     configured_entry_data = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -462,7 +468,7 @@ async def test_options_flow_setup_usb(
     )
 
 
-async def test_options_flow_remove_usb(hass: HomeAssistant):
+async def test_options_flow_remove_usb(hass: HomeAssistant) -> None:
     """Test selecting to set up an USB dongle."""
     configured_entry_data = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -515,7 +521,7 @@ async def test_options_flow_remove_usb(hass: HomeAssistant):
 
 async def test_options_flow_manual_usb_path(
     pyserial_comports: MockFixture, hass: HomeAssistant
-):
+) -> None:
     """Test flow with correct login and usb configuration."""
     configured_entry_data = create_mocked_entry_data_conf(
         email="example@homeassistant.com",
@@ -574,7 +580,7 @@ async def test_options_flow_manual_usb_path(
     )
 
 
-async def test_options_flow_change_usb_sphere(hass: HomeAssistant):
+async def test_options_flow_change_usb_sphere(hass: HomeAssistant) -> None:
     """Test changing the usb sphere in the options."""
     configured_entry_data = create_mocked_entry_data_conf(
         email="example@homeassistant.com",

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -43,7 +43,7 @@ def mock_daikin_discovery():
         yield Discovery
 
 
-async def test_user(hass, mock_daikin):
+async def test_user(hass: HomeAssistant, mock_daikin) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         "daikin",
@@ -64,7 +64,7 @@ async def test_user(hass, mock_daikin):
     assert result["data"][KEY_MAC] == MAC
 
 
-async def test_abort_if_already_setup(hass, mock_daikin):
+async def test_abort_if_already_setup(hass: HomeAssistant, mock_daikin) -> None:
     """Test we abort if Daikin is already setup."""
     MockConfigEntry(domain="daikin", unique_id=MAC).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
@@ -87,7 +87,7 @@ async def test_abort_if_already_setup(hass, mock_daikin):
         (Exception, "unknown"),
     ],
 )
-async def test_device_abort(hass, mock_daikin, s_effect, reason):
+async def test_device_abort(hass: HomeAssistant, mock_daikin, s_effect, reason) -> None:
     """Test device abort."""
     mock_daikin.factory.side_effect = s_effect
 
@@ -132,8 +132,8 @@ async def test_api_password_abort(hass: HomeAssistant) -> None:
     ],
 )
 async def test_discovery_zeroconf(
-    hass, mock_daikin, mock_daikin_discovery, source, data, unique_id
-):
+    hass: HomeAssistant, mock_daikin, mock_daikin_discovery, source, data, unique_id
+) -> None:
     """Test discovery/zeroconf step."""
     result = await hass.config_entries.flow.async_init(
         "daikin",

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -42,7 +42,9 @@ async def test_no_sensors(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
+async def test_alarm_control_panel(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of alarm control panel entities."""
     data = {
         "alarmsystems": {

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -479,8 +479,12 @@ TEST_DATA = [
 
 @pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
 async def test_binary_sensors(
-    hass, aioclient_mock, mock_deconz_websocket, sensor_data, expected
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_deconz_websocket,
+    sensor_data,
+    expected,
+) -> None:
     """Test successful creation of binary sensor entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
@@ -636,7 +640,9 @@ async def test_allow_clip_sensor(
     assert hass.states.get("binary_sensor.clip_flag_boot_time").state == STATE_ON
 
 
-async def test_add_new_binary_sensor(hass, aioclient_mock, mock_deconz_websocket):
+async def test_add_new_binary_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that adding a new binary sensor works."""
     event_added_sensor = {
         "t": "event",
@@ -664,8 +670,8 @@ async def test_add_new_binary_sensor(hass, aioclient_mock, mock_deconz_websocket
 
 
 async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that adding a new binary sensor is not allowed."""
     sensor = {
         "name": "Presence sensor",
@@ -713,8 +719,8 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
 
 
 async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that adding a new binary sensor is not allowed."""
     sensor = {
         "name": "Presence sensor",

--- a/tests/components/deconz/test_button.py
+++ b/tests/components/deconz/test_button.py
@@ -100,7 +100,9 @@ TEST_DATA = [
 
 
 @pytest.mark.parametrize("raw_data, expected", TEST_DATA)
-async def test_button(hass, aioclient_mock, raw_data, expected):
+async def test_button(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
+) -> None:
     """Test successful creation of button entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -59,7 +59,9 @@ async def test_no_sensors(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_simple_climate_device(hass, aioclient_mock, mock_deconz_websocket):
+async def test_simple_climate_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of climate entities.
 
     This is a simple water heater that only supports setting temperature and on and off.
@@ -186,8 +188,8 @@ async def test_simple_climate_device(hass, aioclient_mock, mock_deconz_websocket
 
 
 async def test_climate_device_without_cooling_support(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of sensor entities."""
     data = {
         "sensors": {
@@ -364,8 +366,8 @@ async def test_climate_device_without_cooling_support(
 
 
 async def test_climate_device_with_cooling_support(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of sensor entities."""
     data = {
         "sensors": {
@@ -468,8 +470,8 @@ async def test_climate_device_with_cooling_support(
 
 
 async def test_climate_device_with_fan_support(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of sensor entities."""
     data = {
         "sensors": {
@@ -609,7 +611,9 @@ async def test_climate_device_with_fan_support(
         )
 
 
-async def test_climate_device_with_preset(hass, aioclient_mock, mock_deconz_websocket):
+async def test_climate_device_with_preset(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of sensor entities."""
     data = {
         "sensors": {
@@ -795,7 +799,9 @@ async def test_clip_climate_device(
     )
 
 
-async def test_verify_state_update(hass, aioclient_mock, mock_deconz_websocket):
+async def test_verify_state_update(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that state update properly."""
     data = {
         "sensors": {
@@ -840,7 +846,9 @@ async def test_verify_state_update(hass, aioclient_mock, mock_deconz_websocket):
     )
 
 
-async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocket):
+async def test_add_new_climate_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that adding a new climate device works."""
     event_added_sensor = {
         "t": "event",
@@ -902,7 +910,9 @@ async def test_not_allow_clip_thermostat(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_no_mode_no_state(hass, aioclient_mock, mock_deconz_websocket):
+async def test_no_mode_no_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that a climate device without mode and state works."""
     data = {
         "sensors": {
@@ -943,7 +953,9 @@ async def test_no_mode_no_state(hass, aioclient_mock, mock_deconz_websocket):
     mock_deconz_put_request(aioclient_mock, config_entry.data, "/sensors/0/config")
 
 
-async def test_boost_mode(hass, aioclient_mock, mock_deconz_websocket):
+async def test_boost_mode(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that a climate device with boost mode and different state works."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -365,7 +365,9 @@ async def test_manual_configuration_timeout_get_bridge(
         (pydeconz.errors.RequestError, "no_key"),
     ],
 )
-async def test_link_step_fails(hass, aioclient_mock, raised_error, error_string):
+async def test_link_step_fails(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raised_error, error_string
+) -> None:
     """Test config flow should abort if no API key was possible to retrieve."""
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
@@ -534,8 +536,8 @@ async def test_ssdp_discovery_dont_update_configuration(
 
 
 async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
-    hass, aioclient_mock
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test to ensure the SSDP discovery does not update an Hass.io entry."""
     config_entry = await setup_deconz_integration(
         hass, aioclient_mock, source=SOURCE_HASSIO

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -41,7 +41,9 @@ async def test_no_covers(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_cover(hass, aioclient_mock, mock_deconz_websocket):
+async def test_cover(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported cover entities are created."""
     data = {
         "lights": {

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -33,7 +33,9 @@ from tests.common import async_capture_events
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
+async def test_deconz_events(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of deconz events."""
     data = {
         "sensors": {
@@ -209,7 +211,9 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
+async def test_deconz_alarm_events(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of deconz alarm events."""
     data = {
         "alarmsystems": {
@@ -419,7 +423,9 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_presence_events(hass, aioclient_mock, mock_deconz_websocket):
+async def test_deconz_presence_events(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of deconz presence events."""
     data = {
         "sensors": {
@@ -521,8 +527,8 @@ async def test_deconz_presence_events(hass, aioclient_mock, mock_deconz_websocke
 
 
 async def test_deconz_relative_rotary_events(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test successful creation of deconz relative rotary events."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -283,8 +283,11 @@ async def test_get_triggers_manage_unsupported_remotes(
 
 
 async def test_functional_device_trigger(
-    hass, aioclient_mock, mock_deconz_websocket, automation_calls
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_deconz_websocket,
+    automation_calls,
+) -> None:
     """Test proper matching and attachment of device trigger automation."""
 
     data = {

--- a/tests/components/deconz/test_diagnostics.py
+++ b/tests/components/deconz/test_diagnostics.py
@@ -1,19 +1,24 @@
 """Test deCONZ diagnostics."""
-
 from pydeconz.websocket import State
 
 from homeassistant.components.deconz.const import CONF_MASTER_GATEWAY
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import HOST, PORT, setup_deconz_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def test_entry_diagnostics(
-    hass, hass_client, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_deconz_websocket,
+) -> None:
     """Test config entry diagnostics."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
 

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -31,7 +31,9 @@ async def test_no_fans(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_fans(hass, aioclient_mock, mock_deconz_websocket):
+async def test_fans(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported fan entities are created."""
     data = {
         "lights": {
@@ -240,7 +242,9 @@ async def test_fans(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_fans_legacy_speed_modes(hass, aioclient_mock, mock_deconz_websocket):
+async def test_fans_legacy_speed_modes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported fan entities are created.
 
     Legacy fan support.

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -211,8 +211,8 @@ async def test_gateway_device_configuration_url_when_addon(
 
 
 async def test_connection_status_signalling(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Make sure that connection status triggers a dispatcher send."""
     data = {
         "sensors": {
@@ -301,7 +301,9 @@ async def test_get_deconz_session(hass: HomeAssistant) -> None:
         (pydeconz.Unauthorized, AuthenticationRequired),
     ],
 )
-async def test_get_deconz_session_fails(hass, side_effect, raised_exception):
+async def test_get_deconz_session_fails(
+    hass: HomeAssistant, side_effect, raised_exception
+) -> None:
     """Failed call."""
     with patch(
         "pydeconz.DeconzSession.refresh_state",

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -293,7 +293,9 @@ async def test_no_lights_or_groups(
         ),
     ],
 )
-async def test_lights(hass, aioclient_mock, input, expected):
+async def test_lights(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+) -> None:
     """Test that different light entities are created with expected values."""
     data = {"lights": {"0": input}}
     with patch.dict(DECONZ_WEB_REQUEST, data):
@@ -317,7 +319,9 @@ async def test_lights(hass, aioclient_mock, input, expected):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_light_state_change(hass, aioclient_mock, mock_deconz_websocket):
+async def test_light_state_change(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Verify light can change state on websocket event."""
     data = {
         "lights": {
@@ -505,7 +509,9 @@ async def test_light_state_change(hass, aioclient_mock, mock_deconz_websocket):
         ),
     ],
 )
-async def test_light_service_calls(hass, aioclient_mock, input, expected):
+async def test_light_service_calls(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+) -> None:
     """Verify light can change state on websocket event."""
     data = {
         "lights": {
@@ -769,7 +775,9 @@ async def test_configuration_tool(
         ),
     ],
 )
-async def test_groups(hass, aioclient_mock, input, expected):
+async def test_groups(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+) -> None:
     """Test that different group entities are created with expected values."""
     data = {
         "groups": {
@@ -907,7 +915,9 @@ async def test_groups(hass, aioclient_mock, input, expected):
         ),
     ],
 )
-async def test_group_service_calls(hass, aioclient_mock, input, expected):
+async def test_group_service_calls(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+) -> None:
     """Verify expected group web request from different service calls."""
     data = {
         "groups": {
@@ -1065,8 +1075,8 @@ async def test_disable_light_groups(
 
 
 async def test_non_color_light_reports_color(
-    hass, aioclient_mock, mock_deconz_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Verify hs_color does not crash when a group gets updated with a bad color value.
 
     After calling a scene color temp light of certain manufacturers

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -31,7 +31,9 @@ async def test_no_locks(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_lock_from_light(hass, aioclient_mock, mock_deconz_websocket):
+async def test_lock_from_light(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported lock entities based on lights are created."""
     data = {
         "lights": {
@@ -104,7 +106,9 @@ async def test_lock_from_light(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_lock_from_sensor(hass, aioclient_mock, mock_deconz_websocket):
+async def test_lock_from_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported lock entities based on sensors are created."""
     data = {
         "sensors": {

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -109,8 +109,12 @@ TEST_DATA = [
 
 @pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
 async def test_number_entities(
-    hass, aioclient_mock, mock_deconz_websocket, sensor_data, expected
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_deconz_websocket,
+    sensor_data,
+    expected,
+) -> None:
     """Test successful creation of number entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -56,7 +56,9 @@ TEST_DATA = [
 
 
 @pytest.mark.parametrize("raw_data, expected", TEST_DATA)
-async def test_scenes(hass, aioclient_mock, raw_data, expected):
+async def test_scenes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
+) -> None:
     """Test successful creation of scene entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
@@ -108,7 +110,9 @@ async def test_scenes(hass, aioclient_mock, raw_data, expected):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_only_new_scenes_are_created(hass, aioclient_mock, mock_deconz_websocket):
+async def test_only_new_scenes_are_created(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that scenes works."""
     data = {
         "groups": {

--- a/tests/components/deconz/test_select.py
+++ b/tests/components/deconz/test_select.py
@@ -167,7 +167,9 @@ TEST_DATA = [
 
 
 @pytest.mark.parametrize("raw_data, expected", TEST_DATA)
-async def test_select(hass, aioclient_mock, raw_data, expected):
+async def test_select(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
+) -> None:
     """Test successful creation of button entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -621,8 +621,12 @@ TEST_DATA = [
 
 @pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
 async def test_sensors(
-    hass, aioclient_mock, mock_deconz_websocket, sensor_data, expected
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_deconz_websocket,
+    sensor_data,
+    expected,
+) -> None:
     """Test successful creation of sensor entities."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
@@ -787,7 +791,9 @@ async def test_allow_clip_sensors(
     assert hass.states.get("sensor.clip_flur").state == "0"
 
 
-async def test_add_new_sensor(hass, aioclient_mock, mock_deconz_websocket):
+async def test_add_new_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that adding a new sensor works."""
     event_added_sensor = {
         "t": "event",
@@ -825,8 +831,11 @@ BAD_SENSOR_DATA = [
 
 @pytest.mark.parametrize("sensor_type, sensor_property", BAD_SENSOR_DATA)
 async def test_dont_add_sensor_if_state_is_none(
-    hass, aioclient_mock, sensor_type, sensor_property
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    sensor_type,
+    sensor_property,
+) -> None:
     """Test sensor with scaled data is not created if state is None."""
     data = {
         "sensors": {
@@ -878,7 +887,9 @@ async def test_air_quality_sensor_without_ppb(
     assert len(hass.states.async_all()) == 1
 
 
-async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
+async def test_add_battery_later(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that a battery sensor can be created later on.
 
     Without an initial battery state a battery sensor
@@ -935,7 +946,9 @@ async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
 
 
 @pytest.mark.parametrize("model_id", ["0x8030", "0x8031", "0x8034", "0x8035"])
-async def test_special_danfoss_battery_creation(hass, aioclient_mock, model_id):
+async def test_special_danfoss_battery_creation(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, model_id
+) -> None:
     """Test the special Danfoss battery creation works.
 
     Normally there should only be one battery sensor per device from deCONZ.

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -52,8 +52,11 @@ async def test_service_setup_and_unload(
 @patch("homeassistant.core.ServiceRegistry.async_remove")
 @patch("homeassistant.core.ServiceRegistry.async_register")
 async def test_service_setup_and_unload_not_called_if_multiple_integrations_detected(
-    register_service_mock, remove_service_mock, hass, aioclient_mock
-):
+    register_service_mock,
+    remove_service_mock,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Make sure that services are only setup and removed once."""
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     register_service_mock.reset_mock()

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -1,5 +1,4 @@
 """deCONZ switch platform tests."""
-
 from unittest.mock import patch
 
 from homeassistant.components.siren import ATTR_DURATION, DOMAIN as SIREN_DOMAIN
@@ -11,6 +10,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_gateway import (
     DECONZ_WEB_REQUEST,
@@ -18,8 +18,12 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_sirens(hass, aioclient_mock, mock_deconz_websocket):
+
+async def test_sirens(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that siren entities are created."""
     data = {
         "lights": {

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -29,7 +29,9 @@ async def test_no_switches(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_power_plugs(hass, aioclient_mock, mock_deconz_websocket):
+async def test_power_plugs(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
     """Test that all supported switch entities are created."""
     data = {
         "lights": {

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import recorder as recorder_helper
 from homeassistant.setup import async_setup_component
 
@@ -25,7 +26,9 @@ def recorder_url_mock():
         yield
 
 
-async def test_setup(hass, mock_zeroconf, mock_get_source_ip, mock_bluetooth):
+async def test_setup(
+    hass: HomeAssistant, mock_zeroconf: None, mock_get_source_ip, mock_bluetooth: None
+) -> None:
     """Test setup."""
     recorder_helper.async_initialize_recorder(hass)
     assert await async_setup_component(hass, "default_config", {"foo": "bar"})

--- a/tests/components/deluge/test_config_flow.py
+++ b/tests/components/deluge/test_config_flow.py
@@ -49,7 +49,7 @@ def deluge_setup_fixture():
         yield
 
 
-async def test_flow_user(hass: HomeAssistant, api):
+async def test_flow_user(hass: HomeAssistant, api) -> None:
     """Test user initialized flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -61,7 +61,7 @@ async def test_flow_user(hass: HomeAssistant, api):
     assert result["data"] == CONF_DATA
 
 
-async def test_flow_user_already_configured(hass: HomeAssistant, api):
+async def test_flow_user_already_configured(hass: HomeAssistant, api) -> None:
     """Test user initialized flow with duplicate server."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -78,7 +78,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant, api):
     assert result["reason"] == "already_configured"
 
 
-async def test_flow_user_cannot_connect(hass: HomeAssistant, conn_error):
+async def test_flow_user_cannot_connect(hass: HomeAssistant, conn_error) -> None:
     """Test user initialized flow with unreachable server."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
@@ -88,7 +88,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant, conn_error):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_flow_user_unknown_error(hass: HomeAssistant, unknown_error):
+async def test_flow_user_unknown_error(hass: HomeAssistant, unknown_error) -> None:
     """Test user initialized flow with unreachable server."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
@@ -98,7 +98,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant, unknown_error):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_flow_reauth(hass: HomeAssistant, api):
+async def test_flow_reauth(hass: HomeAssistant, api) -> None:
     """Test reauth step."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/demo/test_cover.py
+++ b/tests/components/demo/test_cover.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -45,7 +46,7 @@ async def setup_comp(hass):
         await hass.async_block_till_done()
 
 
-async def test_supported_features(hass, setup_comp):
+async def test_supported_features(hass: HomeAssistant, setup_comp) -> None:
     """Test cover supported features."""
     state = hass.states.get("cover.garage_door")
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 3
@@ -57,7 +58,7 @@ async def test_supported_features(hass, setup_comp):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 255
 
 
-async def test_close_cover(hass, setup_comp):
+async def test_close_cover(hass: HomeAssistant, setup_comp) -> None:
     """Test closing the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.state == STATE_OPEN
@@ -78,7 +79,7 @@ async def test_close_cover(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
 
-async def test_open_cover(hass, setup_comp):
+async def test_open_cover(hass: HomeAssistant, setup_comp) -> None:
     """Test opening the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.state == STATE_OPEN
@@ -98,7 +99,7 @@ async def test_open_cover(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_toggle_cover(hass, setup_comp):
+async def test_toggle_cover(hass: HomeAssistant, setup_comp) -> None:
     """Test toggling the cover."""
     # Start open
     await hass.services.async_call(
@@ -138,7 +139,7 @@ async def test_toggle_cover(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_set_cover_position(hass, setup_comp):
+async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
     """Test moving the cover to a specific position."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -157,7 +158,7 @@ async def test_set_cover_position(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
 
 
-async def test_stop_cover(hass, setup_comp):
+async def test_stop_cover(hass: HomeAssistant, setup_comp) -> None:
     """Test stopping the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -176,7 +177,7 @@ async def test_stop_cover(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_POSITION] == 80
 
 
-async def test_close_cover_tilt(hass, setup_comp):
+async def test_close_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     """Test closing the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -192,7 +193,7 @@ async def test_close_cover_tilt(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
 
-async def test_open_cover_tilt(hass, setup_comp):
+async def test_open_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     """Test opening the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -208,7 +209,7 @@ async def test_open_cover_tilt(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
 
-async def test_toggle_cover_tilt(hass, setup_comp):
+async def test_toggle_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     """Test toggling the cover tilt."""
     # Start open
     await hass.services.async_call(
@@ -245,7 +246,7 @@ async def test_toggle_cover_tilt(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
 
-async def test_set_cover_tilt_position(hass, setup_comp):
+async def test_set_cover_tilt_position(hass: HomeAssistant, setup_comp) -> None:
     """Test moving the cover til to a specific position."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -264,7 +265,7 @@ async def test_set_cover_tilt_position(hass, setup_comp):
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 90
 
 
-async def test_stop_cover_tilt(hass, setup_comp):
+async def test_stop_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     """Test stopping the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 FULL_FAN_ENTITY_IDS = ["fan.living_room_fan", "fan.percentage_full_fan"]
@@ -38,7 +39,7 @@ async def setup_comp(hass):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_turn_on(hass, fan_entity_id):
+async def test_turn_on(hass: HomeAssistant, fan_entity_id) -> None:
     """Test turning on the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -51,7 +52,9 @@ async def test_turn_on(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FULL_FAN_ENTITY_IDS)
-async def test_turn_on_with_speed_and_percentage(hass, fan_entity_id):
+async def test_turn_on_with_speed_and_percentage(
+    hass: HomeAssistant, fan_entity_id
+) -> None:
     """Test turning on the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -127,7 +130,9 @@ async def test_turn_on_with_speed_and_percentage(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODE_ONLY)
-async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
+async def test_turn_on_with_preset_mode_only(
+    hass: HomeAssistant, fan_entity_id
+) -> None:
     """Test turning on the device with a preset_mode and no speed setting."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -179,7 +184,9 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODES)
-async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
+async def test_turn_on_with_preset_mode_and_speed(
+    hass: HomeAssistant, fan_entity_id
+) -> None:
     """Test turning on the device with a preset_mode and speed."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -246,7 +253,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_turn_off(hass, fan_entity_id):
+async def test_turn_off(hass: HomeAssistant, fan_entity_id) -> None:
     """Test turning off the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -265,7 +272,7 @@ async def test_turn_off(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_turn_off_without_entity_id(hass, fan_entity_id):
+async def test_turn_off_without_entity_id(hass: HomeAssistant, fan_entity_id) -> None:
     """Test turning off all fans."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -284,7 +291,7 @@ async def test_turn_off_without_entity_id(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FULL_FAN_ENTITY_IDS)
-async def test_set_direction(hass, fan_entity_id):
+async def test_set_direction(hass: HomeAssistant, fan_entity_id) -> None:
     """Test setting the direction of the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -300,7 +307,7 @@ async def test_set_direction(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODES)
-async def test_set_preset_mode(hass, fan_entity_id):
+async def test_set_preset_mode(hass: HomeAssistant, fan_entity_id) -> None:
     """Test setting the preset mode of the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -318,7 +325,7 @@ async def test_set_preset_mode(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_set_preset_mode_invalid(hass, fan_entity_id):
+async def test_set_preset_mode_invalid(hass: HomeAssistant, fan_entity_id) -> None:
     """Test setting a invalid preset mode for the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -343,7 +350,7 @@ async def test_set_preset_mode_invalid(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", FULL_FAN_ENTITY_IDS)
-async def test_set_percentage(hass, fan_entity_id):
+async def test_set_percentage(hass: HomeAssistant, fan_entity_id) -> None:
     """Test setting the percentage speed of the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -359,7 +366,7 @@ async def test_set_percentage(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_increase_decrease_speed(hass, fan_entity_id):
+async def test_increase_decrease_speed(hass: HomeAssistant, fan_entity_id) -> None:
     """Test increasing and decreasing the percentage speed of the device."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -439,7 +446,9 @@ async def test_increase_decrease_speed(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", PERCENTAGE_MODEL_FANS)
-async def test_increase_decrease_speed_with_percentage_step(hass, fan_entity_id):
+async def test_increase_decrease_speed_with_percentage_step(
+    hass: HomeAssistant, fan_entity_id
+) -> None:
     """Test increasing speed with a percentage step."""
     await hass.services.async_call(
         fan.DOMAIN,
@@ -470,7 +479,7 @@ async def test_increase_decrease_speed_with_percentage_step(hass, fan_entity_id)
 
 
 @pytest.mark.parametrize("fan_entity_id", FULL_FAN_ENTITY_IDS)
-async def test_oscillate(hass, fan_entity_id):
+async def test_oscillate(hass: HomeAssistant, fan_entity_id) -> None:
     """Test oscillating the fan."""
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
@@ -496,7 +505,7 @@ async def test_oscillate(hass, fan_entity_id):
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
-async def test_is_on(hass, fan_entity_id):
+async def test_is_on(hass: HomeAssistant, fan_entity_id) -> None:
     """Test is on service call."""
     assert not fan.is_on(hass, fan_entity_id)
 

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.demo import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 
@@ -22,7 +23,7 @@ def mock_device_tracker_update_config():
         yield
 
 
-async def test_setting_up_demo(mock_history, hass):
+async def test_setting_up_demo(mock_history, hass: HomeAssistant) -> None:
     """Test if we can set up the demo and dump it to JSON."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -380,7 +380,7 @@ async def test_play_media(hass: HomeAssistant) -> None:
     assert state.attributes.get(mp.ATTR_MEDIA_CONTENT_ID) == "some_id"
 
 
-async def test_seek(hass, mock_media_seek):
+async def test_seek(hass: HomeAssistant, mock_media_seek) -> None:
     """Test seek."""
     assert await async_setup_component(
         hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -55,7 +55,9 @@ async def setup_notify(hass):
     await hass.async_block_till_done()
 
 
-async def test_no_notify_service(hass, mock_demo_notify, caplog):
+async def test_no_notify_service(
+    hass: HomeAssistant, mock_demo_notify, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test missing platform notify service instance."""
     caplog.set_level(logging.ERROR)
     mock_demo_notify.return_value = None
@@ -65,7 +67,7 @@ async def test_no_notify_service(hass, mock_demo_notify, caplog):
     assert "Failed to initialize notification service demo" in caplog.text
 
 
-async def test_discover_notify(hass, mock_demo_notify):
+async def test_discover_notify(hass: HomeAssistant, mock_demo_notify) -> None:
     """Test discovery of notify demo platform."""
     assert notify.DOMAIN not in hass.config.components
     mock_demo_notify.return_value = None
@@ -82,7 +84,7 @@ async def test_discover_notify(hass, mock_demo_notify):
     )
 
 
-async def test_sending_none_message(hass, events):
+async def test_sending_none_message(hass: HomeAssistant, events) -> None:
     """Test send with None as message."""
     await setup_notify(hass)
     with pytest.raises(vol.Invalid):
@@ -93,7 +95,7 @@ async def test_sending_none_message(hass, events):
     assert len(events) == 0
 
 
-async def test_sending_templated_message(hass, events):
+async def test_sending_templated_message(hass: HomeAssistant, events) -> None:
     """Send a templated message."""
     await setup_notify(hass)
     hass.states.async_set("sensor.temperature", 10)
@@ -108,7 +110,7 @@ async def test_sending_templated_message(hass, events):
     assert last_event.data[notify.ATTR_MESSAGE] == "10"
 
 
-async def test_method_forwards_correct_data(hass, events):
+async def test_method_forwards_correct_data(hass: HomeAssistant, events) -> None:
     """Test that all data from the service gets forwarded to service."""
     await setup_notify(hass)
     data = {
@@ -127,7 +129,9 @@ async def test_method_forwards_correct_data(hass, events):
     } == data
 
 
-async def test_calling_notify_from_script_loaded_from_yaml_without_title(hass, events):
+async def test_calling_notify_from_script_loaded_from_yaml_without_title(
+    hass: HomeAssistant, events
+) -> None:
     """Test if we can call a notify from a script."""
     await setup_notify(hass)
     step = {
@@ -149,7 +153,9 @@ async def test_calling_notify_from_script_loaded_from_yaml_without_title(hass, e
     } == events[0].data
 
 
-async def test_calling_notify_from_script_loaded_from_yaml_with_title(hass, events):
+async def test_calling_notify_from_script_loaded_from_yaml_with_title(
+    hass: HomeAssistant, events
+) -> None:
     """Test if we can call a notify from a script."""
     await setup_notify(hass)
     step = {
@@ -180,7 +186,9 @@ async def test_targets_are_services(hass: HomeAssistant) -> None:
     assert hass.services.has_service("notify", service) is not None
 
 
-async def test_messages_to_targets_route(hass, calls, record_calls):
+async def test_messages_to_targets_route(
+    hass: HomeAssistant, calls, record_calls
+) -> None:
     """Test message routing to specific target services."""
     await setup_notify(hass)
     hass.bus.async_listen_once("notify", record_calls)

--- a/tests/components/demo/test_sensor.py
+++ b/tests/components/demo/test_sensor.py
@@ -6,13 +6,14 @@ import pytest
 from homeassistant import core as ha
 from homeassistant.components.demo import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache_with_extra_data
 
 
 @pytest.mark.parametrize("entity_id, delta", (("sensor.total_energy_kwh", 0.5),))
-async def test_energy_sensor(hass: ha.HomeAssistant, entity_id, delta, freezer):
+async def test_energy_sensor(hass: HomeAssistant, entity_id, delta, freezer) -> None:
     """Test energy sensors increase periodically."""
     assert await async_setup_component(
         hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: {"platform": DOMAIN}}
@@ -31,7 +32,7 @@ async def test_energy_sensor(hass: ha.HomeAssistant, entity_id, delta, freezer):
 
 
 @pytest.mark.parametrize("entity_id, delta", (("sensor.total_energy_kwh", 0.5),))
-async def test_restore_state(hass: ha.HomeAssistant, entity_id, delta, freezer):
+async def test_restore_state(hass: HomeAssistant, entity_id, delta, freezer) -> None:
     """Test energy sensors restore state."""
     fake_state = ha.State(
         entity_id,

--- a/tests/components/demo/test_stt.py
+++ b/tests/components/demo/test_stt.py
@@ -6,6 +6,8 @@ import pytest
 from homeassistant.components import stt
 from homeassistant.setup import async_setup_component
 
+from tests.typing import ClientSessionGenerator
+
 
 @pytest.fixture(autouse=True)
 async def setup_comp(hass):
@@ -14,7 +16,7 @@ async def setup_comp(hass):
     await hass.async_block_till_done()
 
 
-async def test_demo_settings(hass_client):
+async def test_demo_settings(hass_client: ClientSessionGenerator) -> None:
     """Test retrieve settings from demo provider."""
     client = await hass_client()
 
@@ -32,7 +34,7 @@ async def test_demo_settings(hass_client):
     }
 
 
-async def test_demo_speech_no_metadata(hass_client):
+async def test_demo_speech_no_metadata(hass_client: ClientSessionGenerator) -> None:
     """Test retrieve settings from demo provider."""
     client = await hass_client()
 
@@ -40,7 +42,7 @@ async def test_demo_speech_no_metadata(hass_client):
     assert response.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_demo_speech_wrong_metadata(hass_client):
+async def test_demo_speech_wrong_metadata(hass_client: ClientSessionGenerator) -> None:
     """Test retrieve settings from demo provider."""
     client = await hass_client()
 
@@ -57,7 +59,7 @@ async def test_demo_speech_wrong_metadata(hass_client):
     assert response.status == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
 
-async def test_demo_speech(hass_client):
+async def test_demo_speech(hass_client: ClientSessionGenerator) -> None:
     """Test retrieve settings from demo provider."""
     client = await hass_client()
 

--- a/tests/components/demo/test_switch.py
+++ b/tests/components/demo/test_switch.py
@@ -8,6 +8,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 SWITCH_ENTITY_IDS = ["switch.decorative_lights", "switch.ac"]
@@ -23,7 +24,7 @@ async def setup_comp(hass):
 
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
-async def test_turn_on(hass, switch_entity_id):
+async def test_turn_on(hass: HomeAssistant, switch_entity_id) -> None:
     """Test switch turn on method."""
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -47,7 +48,7 @@ async def test_turn_on(hass, switch_entity_id):
 
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
-async def test_turn_off(hass, switch_entity_id):
+async def test_turn_off(hass: HomeAssistant, switch_entity_id) -> None:
     """Test switch turn off method."""
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -71,7 +72,9 @@ async def test_turn_off(hass, switch_entity_id):
 
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
-async def test_turn_off_without_entity_id(hass, switch_entity_id):
+async def test_turn_off_without_entity_id(
+    hass: HomeAssistant, switch_entity_id
+) -> None:
     """Test switch turn off all switches."""
     await hass.services.async_call(
         SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "all"}, blocking=True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
