### PR TITLE
Add type hints to integration tests (part 5)

### DIFF
--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -18,6 +18,7 @@ from homeassistant.components.denonavr.media_player import (
     SERVICE_UPDATE_AUDYSSEY,
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MODEL
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -84,7 +85,7 @@ async def setup_denonavr(hass):
     assert state.name == TEST_NAME
 
 
-async def test_get_command(hass, client):
+async def test_get_command(hass: HomeAssistant, client) -> None:
     """Test generic command functionality."""
     await setup_denonavr(hass)
 
@@ -98,7 +99,7 @@ async def test_get_command(hass, client):
     client.async_get_command.assert_awaited_with("test_command")
 
 
-async def test_dynamic_eq(hass, client):
+async def test_dynamic_eq(hass: HomeAssistant, client) -> None:
     """Test that dynamic eq method works."""
     await setup_denonavr(hass)
 
@@ -119,7 +120,7 @@ async def test_dynamic_eq(hass, client):
     client.async_dynamic_eq_off.assert_called_once()
 
 
-async def test_update_audyssey(hass, client):
+async def test_update_audyssey(hass: HomeAssistant, client) -> None:
     """Test that dynamic eq method works."""
     await setup_denonavr(hass)
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.components.device_automation import (
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
@@ -94,8 +94,12 @@ def fake_integration(hass):
 
 
 async def test_websocket_get_actions(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected actions through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -145,8 +149,12 @@ async def test_websocket_get_actions(
 
 
 async def test_websocket_get_conditions(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected conditions through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -195,8 +203,12 @@ async def test_websocket_get_conditions(
 
 
 async def test_websocket_get_triggers(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected triggers through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -253,8 +265,12 @@ async def test_websocket_get_triggers(
 
 
 async def test_websocket_get_action_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected action capabilities through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -317,8 +333,11 @@ async def test_websocket_get_action_capabilities(
 
 
 async def test_websocket_get_action_capabilities_unknown_domain(
-    hass, hass_ws_client, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get no action capabilities for a non existing domain."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -340,8 +359,12 @@ async def test_websocket_get_action_capabilities_unknown_domain(
 
 
 async def test_websocket_get_action_capabilities_no_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no action capabilities for a domain which has none.
 
     The tests tests a domain which has a device action platform, but no
@@ -367,8 +390,12 @@ async def test_websocket_get_action_capabilities_no_capabilities(
 
 
 async def test_websocket_get_action_capabilities_bad_action(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no action capabilities when there is an error."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -397,8 +424,12 @@ async def test_websocket_get_action_capabilities_bad_action(
 
 
 async def test_websocket_get_condition_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected condition capabilities through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -461,8 +492,11 @@ async def test_websocket_get_condition_capabilities(
 
 
 async def test_websocket_get_condition_capabilities_unknown_domain(
-    hass, hass_ws_client, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get no condition capabilities for a non existing domain."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -484,8 +518,12 @@ async def test_websocket_get_condition_capabilities_unknown_domain(
 
 
 async def test_websocket_get_condition_capabilities_no_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no condition capabilities for a domain which has none.
 
     The tests tests a domain which has a device condition platform, but no
@@ -515,8 +553,12 @@ async def test_websocket_get_condition_capabilities_no_capabilities(
 
 
 async def test_websocket_get_condition_capabilities_bad_condition(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no condition capabilities when there is an error."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -549,8 +591,10 @@ async def test_websocket_get_condition_capabilities_bad_condition(
 
 
 async def test_async_get_device_automations_single_device_trigger(
-    hass, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get can fetch the triggers for a device id."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -570,8 +614,10 @@ async def test_async_get_device_automations_single_device_trigger(
 
 
 async def test_async_get_device_automations_all_devices_trigger(
-    hass, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get can fetch all the triggers when no device id is passed."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -591,8 +637,10 @@ async def test_async_get_device_automations_all_devices_trigger(
 
 
 async def test_async_get_device_automations_all_devices_condition(
-    hass, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get can fetch all the conditions when no device id is passed."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -612,8 +660,10 @@ async def test_async_get_device_automations_all_devices_condition(
 
 
 async def test_async_get_device_automations_all_devices_action(
-    hass, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get can fetch all the actions when no device id is passed."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -633,8 +683,11 @@ async def test_async_get_device_automations_all_devices_action(
 
 
 async def test_async_get_device_automations_all_devices_action_exception_throw(
-    hass, device_registry, entity_registry, caplog
-):
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we get can fetch all the actions when no device id is passed and can handle one throwing an exception."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -659,8 +712,12 @@ async def test_async_get_device_automations_all_devices_action_exception_throw(
 
 
 async def test_websocket_get_trigger_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get the expected trigger capabilities through websocket."""
     await async_setup_component(hass, "device_automation", {})
     config_entry = MockConfigEntry(domain="test", data={})
@@ -723,8 +780,11 @@ async def test_websocket_get_trigger_capabilities(
 
 
 async def test_websocket_get_trigger_capabilities_unknown_domain(
-    hass, hass_ws_client, device_registry, entity_registry
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get no trigger capabilities for a non existing domain."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -746,8 +806,12 @@ async def test_websocket_get_trigger_capabilities_unknown_domain(
 
 
 async def test_websocket_get_trigger_capabilities_no_capabilities(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no trigger capabilities for a domain which has none.
 
     The tests tests a domain which has a device trigger platform, but no
@@ -777,8 +841,12 @@ async def test_websocket_get_trigger_capabilities_no_capabilities(
 
 
 async def test_websocket_get_trigger_capabilities_bad_trigger(
-    hass, hass_ws_client, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test we get no trigger capabilities when there is an error."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
@@ -833,7 +901,9 @@ async def test_automation_with_non_existing_integration(
     assert "Integration 'beer' not found" in caplog.text
 
 
-async def test_automation_with_device_action(hass, caplog, fake_integration):
+async def test_automation_with_device_action(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, fake_integration
+) -> None:
     """Test automation with a device action."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -866,8 +936,11 @@ async def test_automation_with_device_action(hass, caplog, fake_integration):
 
 
 async def test_automation_with_dynamically_validated_action(
-    hass, caplog, device_registry, fake_integration
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    fake_integration,
+) -> None:
     """Test device automation with an action which is dynamically validated."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -919,7 +992,9 @@ async def test_automation_with_integration_without_device_action(
     )
 
 
-async def test_automation_with_device_condition(hass, caplog, fake_integration):
+async def test_automation_with_device_condition(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, fake_integration
+) -> None:
     """Test automation with a device condition."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -949,8 +1024,11 @@ async def test_automation_with_device_condition(hass, caplog, fake_integration):
 
 
 async def test_automation_with_dynamically_validated_condition(
-    hass, caplog, device_registry, fake_integration
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    fake_integration,
+) -> None:
     """Test device automation with a condition which is dynamically validated."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -1013,7 +1091,9 @@ async def test_automation_with_integration_without_device_condition(
     )
 
 
-async def test_automation_with_device_trigger(hass, caplog, fake_integration):
+async def test_automation_with_device_trigger(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, fake_integration
+) -> None:
     """Test automation with a device trigger."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -1042,8 +1122,12 @@ async def test_automation_with_device_trigger(hass, caplog, fake_integration):
 
 
 async def test_automation_with_dynamically_validated_trigger(
-    hass, caplog, device_registry, entity_registry, fake_integration
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fake_integration,
+) -> None:
     """Test device automation with a trigger which is dynamically validated."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -1192,7 +1276,9 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_automation_with_sub_condition(hass, calls, enable_custom_integrations):
+async def test_automation_with_sub_condition(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test automation with device condition under and/or conditions."""
     DOMAIN = "light"
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -1360,7 +1446,9 @@ async def test_websocket_device_not_found(
     assert msg["error"] == {"code": "not_found", "message": "Device not found"}
 
 
-async def test_automation_with_unknown_device(hass, caplog, fake_integration):
+async def test_automation_with_unknown_device(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, fake_integration
+) -> None:
     """Test device automation with a trigger with an unknown device."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -1391,8 +1479,11 @@ async def test_automation_with_unknown_device(hass, caplog, fake_integration):
 
 
 async def test_automation_with_device_wrong_domain(
-    hass, caplog, device_registry, fake_integration
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    fake_integration,
+) -> None:
     """Test device automation where the device doesn't have the right config entry."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})
@@ -1428,8 +1519,11 @@ async def test_automation_with_device_wrong_domain(
 
 
 async def test_automation_with_device_component_not_loaded(
-    hass, caplog, device_registry, fake_integration
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    device_registry: dr.DeviceRegistry,
+    fake_integration,
+) -> None:
     """Test device automation where the device's config entry is not loaded."""
 
     module_cache = hass.data.setdefault(loader.DATA_COMPONENTS, {})

--- a/tests/components/device_automation/test_toggle_entity.py
+++ b/tests/components/device_automation/test_toggle_entity.py
@@ -5,6 +5,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -18,7 +19,9 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off triggers firing.
 
     This is a sanity test for the toggle entity device automation helper, this is
@@ -137,8 +140,8 @@ async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations)
 
 @pytest.mark.parametrize("trigger", ["turned_off", "changed_states"])
 async def test_if_fires_on_state_change_with_for(
-    hass, calls, enable_custom_integrations, trigger
-):
+    hass: HomeAssistant, calls, enable_custom_integrations: None, trigger
+) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, "test.switch")
 

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -73,7 +73,7 @@ def scanner(hass, enable_custom_integrations):
     return scanner
 
 
-async def test_lights_on_when_sun_sets(hass, scanner):
+async def test_lights_on_when_sun_sets(hass: HomeAssistant, scanner) -> None:
     """Test lights go on when there is someone home and the sun sets."""
     test_time = datetime(2017, 4, 5, 1, 2, 3, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.utcnow", return_value=test_time):
@@ -99,7 +99,9 @@ async def test_lights_on_when_sun_sets(hass, scanner):
     )
 
 
-async def test_lights_turn_off_when_everyone_leaves(hass, enable_custom_integrations):
+async def test_lights_turn_off_when_everyone_leaves(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test lights turn off when everyone leaves the house."""
     assert await async_setup_component(
         hass, "light", {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -126,7 +128,9 @@ async def test_lights_turn_off_when_everyone_leaves(hass, enable_custom_integrat
     )
 
 
-async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
+async def test_lights_turn_on_when_coming_home_after_sun_set(
+    hass: HomeAssistant, scanner
+) -> None:
     """Test lights turn on when coming home after sun set."""
     test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.utcnow", return_value=test_time):
@@ -148,7 +152,9 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
     )
 
 
-async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanner):
+async def test_lights_turn_on_when_coming_home_after_sun_set_person(
+    hass: HomeAssistant, scanner
+) -> None:
     """Test lights turn on when coming home after sun set."""
     device_1 = f"{DOMAIN}.device_1"
     device_2 = f"{DOMAIN}.device_2"

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -24,7 +24,9 @@ def test_tracker_entity() -> None:
     assert not instance.force_update
 
 
-async def test_cleanup_legacy(hass, enable_custom_integrations):
+async def test_cleanup_legacy(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test we clean up devices created by old device tracker."""
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -5,7 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.const import STATE_HOME, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +25,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a device_tracker."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -62,12 +67,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -100,7 +105,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("device_tracker.entity", STATE_HOME)
 

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -7,7 +7,12 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_tracker import DOMAIN, device_trigger
 import homeassistant.components.zone as zone
 from homeassistant.const import EntityCategory
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -51,7 +56,11 @@ def setup_zone(hass):
     )
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a device_tracker."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -89,12 +98,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -127,7 +136,7 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_if_fires_on_zone_change(hass, calls):
+async def test_if_fires_on_zone_change(hass: HomeAssistant, calls) -> None:
     """Test for enter and leave triggers firing."""
     hass.states.async_set(
         "device_tracker.entity",
@@ -217,7 +226,11 @@ async def test_if_fires_on_zone_change(hass, calls):
     )
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a device_tracker trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -14,12 +14,15 @@ from homeassistant.components.device_tracker.const import (
     SourceType,
 )
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
 
-async def test_scanner_entity_device_tracker(hass, enable_custom_integrations):
+async def test_scanner_entity_device_tracker(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test ScannerEntity based device tracker."""
     # Make device tied to other integration so device tracker entities get enabled
     dr.async_get(hass).async_get_or_create(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -95,7 +95,9 @@ async def test_reading_broken_yaml_config(hass: HomeAssistant) -> None:
         assert res[0].dev_id == "my_device"
 
 
-async def test_reading_yaml_config(hass, yaml_devices, enable_custom_integrations):
+async def test_reading_yaml_config(
+    hass: HomeAssistant, yaml_devices, enable_custom_integrations: None
+) -> None:
     """Test the rendering of the YAML configuration."""
     dev_id = "test"
     device = legacy.Device(
@@ -125,7 +127,7 @@ async def test_reading_yaml_config(hass, yaml_devices, enable_custom_integration
 
 
 @patch("homeassistant.components.device_tracker.const.LOGGER.warning")
-async def test_duplicate_mac_dev_id(mock_warning, hass):
+async def test_duplicate_mac_dev_id(mock_warning, hass: HomeAssistant) -> None:
     """Test adding duplicate MACs or device IDs to DeviceTracker."""
     devices = [
         legacy.Device(
@@ -162,7 +164,9 @@ async def test_duplicate_mac_dev_id(mock_warning, hass):
     assert "Duplicate device IDs" in args[0], "Duplicate device IDs warning expected"
 
 
-async def test_setup_without_yaml_file(hass, yaml_devices, enable_custom_integrations):
+async def test_setup_without_yaml_file(
+    hass: HomeAssistant, yaml_devices, enable_custom_integrations: None
+) -> None:
     """Test with no YAML file."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
@@ -210,7 +214,9 @@ async def test_gravatar_and_picture(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.device_tracker.legacy.DeviceTracker.see")
 @patch("homeassistant.components.demo.device_tracker.setup_scanner", autospec=True)
-async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
+async def test_discover_platform(
+    mock_demo_setup_scanner, mock_see, hass: HomeAssistant
+) -> None:
     """Test discovery of device_tracker demo platform."""
     with patch("homeassistant.components.device_tracker.legacy.update_config"):
         await discovery.async_load_platform(
@@ -227,7 +233,11 @@ async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
     )
 
 
-async def test_update_stale(hass, mock_device_tracker_conf, enable_custom_integrations):
+async def test_update_stale(
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test stalled update."""
 
     scanner = getattr(hass.components, "test.device_tracker").SCANNER
@@ -269,8 +279,10 @@ async def test_update_stale(hass, mock_device_tracker_conf, enable_custom_integr
 
 
 async def test_entity_attributes(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test the entity attributes."""
     devices = mock_device_tracker_conf
     dev_id = "test_entity"
@@ -302,7 +314,9 @@ async def test_entity_attributes(
 
 
 @patch("homeassistant.components.device_tracker.legacy.DeviceTracker.async_see")
-async def test_see_service(mock_see, hass, enable_custom_integrations):
+async def test_see_service(
+    mock_see, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the see service with a unicode dev_id and NO MAC."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
@@ -330,8 +344,10 @@ async def test_see_service(mock_see, hass, enable_custom_integrations):
 
 
 async def test_see_service_guard_config_entry(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test the guard if the device is registered in the entity registry."""
     mock_entry = Mock()
     dev_id = "test"
@@ -348,8 +364,10 @@ async def test_see_service_guard_config_entry(
 
 
 async def test_new_device_event_fired(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test that the device tracker will fire an event."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
@@ -380,8 +398,10 @@ async def test_new_device_event_fired(
 
 
 async def test_duplicate_yaml_keys(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test that the device tracker will not generate invalid YAML."""
     devices = mock_device_tracker_conf
     with assert_setup_component(1, device_tracker.DOMAIN):
@@ -397,8 +417,10 @@ async def test_duplicate_yaml_keys(
 
 
 async def test_invalid_dev_id(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test that the device tracker will not allow invalid dev ids."""
     devices = mock_device_tracker_conf
     with assert_setup_component(1, device_tracker.DOMAIN):
@@ -410,7 +432,9 @@ async def test_invalid_dev_id(
     assert not devices
 
 
-async def test_see_state(hass, yaml_devices, enable_custom_integrations):
+async def test_see_state(
+    hass: HomeAssistant, yaml_devices, enable_custom_integrations: None
+) -> None:
     """Test device tracker see records state correctly."""
     assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
 
@@ -447,8 +471,10 @@ async def test_see_state(hass, yaml_devices, enable_custom_integrations):
 
 
 async def test_see_passive_zone_state(
-    hass, mock_device_tracker_conf, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    mock_device_tracker_conf: list[legacy.Device],
+    enable_custom_integrations: None,
+) -> None:
     """Test that the device tracker sets gps for passive trackers."""
     now = dt_util.utcnow()
 
@@ -519,7 +545,9 @@ async def test_see_passive_zone_state(
 
 
 @patch("homeassistant.components.device_tracker.const.LOGGER.warning")
-async def test_see_failures(mock_warning, hass, mock_device_tracker_conf):
+async def test_see_failures(
+    mock_warning, hass: HomeAssistant, mock_device_tracker_conf: list[legacy.Device]
+) -> None:
     """Test that the device tracker see failures."""
     devices = mock_device_tracker_conf
     tracker = legacy.DeviceTracker(hass, timedelta(seconds=60), 0, {}, [])
@@ -578,8 +606,10 @@ async def test_bad_platform(hass: HomeAssistant) -> None:
 
 
 async def test_adding_unknown_device_to_config(
-    mock_device_tracker_conf, hass, enable_custom_integrations
-):
+    mock_device_tracker_conf: list[legacy.Device],
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
     """Test the adding of unknown devices to configuration file."""
     scanner = getattr(hass.components, "test.device_tracker").SCANNER
     scanner.reset()
@@ -597,7 +627,9 @@ async def test_adding_unknown_device_to_config(
     assert device.track
 
 
-async def test_picture_and_icon_on_see_discovery(mock_device_tracker_conf, hass):
+async def test_picture_and_icon_on_see_discovery(
+    mock_device_tracker_conf: list[legacy.Device], hass: HomeAssistant
+) -> None:
     """Test that picture and icon are set in initial see."""
     tracker = legacy.DeviceTracker(hass, timedelta(seconds=60), False, {}, [])
     await tracker.async_see(dev_id=11, picture="pic_url", icon="mdi:icon")
@@ -607,7 +639,9 @@ async def test_picture_and_icon_on_see_discovery(mock_device_tracker_conf, hass)
     assert mock_device_tracker_conf[0].entity_picture == "pic_url"
 
 
-async def test_backward_compatibility_for_track_new(mock_device_tracker_conf, hass):
+async def test_backward_compatibility_for_track_new(
+    mock_device_tracker_conf: list[legacy.Device], hass: HomeAssistant
+) -> None:
     """Test backward compatibility for track new."""
     tracker = legacy.DeviceTracker(
         hass, timedelta(seconds=60), False, {device_tracker.CONF_TRACK_NEW: True}, []
@@ -618,7 +652,9 @@ async def test_backward_compatibility_for_track_new(mock_device_tracker_conf, ha
     assert mock_device_tracker_conf[0].track is False
 
 
-async def test_old_style_track_new_is_skipped(mock_device_tracker_conf, hass):
+async def test_old_style_track_new_is_skipped(
+    mock_device_tracker_conf: list[legacy.Device], hass: HomeAssistant
+) -> None:
     """Test old style config is skipped."""
     tracker = legacy.DeviceTracker(
         hass, timedelta(seconds=60), None, {device_tracker.CONF_TRACK_NEW: False}, []

--- a/tests/components/devolo_home_control/test_binary_sensor.py
+++ b/tests/components/devolo_home_control/test_binary_sensor.py
@@ -24,7 +24,7 @@ from .mocks import (
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_binary_sensor(hass: HomeAssistant):
+async def test_binary_sensor(hass: HomeAssistant) -> None:
     """Test setup and state change of a binary sensor device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockBinarySensor()
@@ -63,7 +63,7 @@ async def test_binary_sensor(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_remote_control(hass: HomeAssistant):
+async def test_remote_control(hass: HomeAssistant) -> None:
     """Test setup and state change of a remote control device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockRemoteControl()
@@ -98,7 +98,7 @@ async def test_remote_control(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_disabled(hass: HomeAssistant):
+async def test_disabled(hass: HomeAssistant) -> None:
     """Test setup of a disabled device."""
     entry = configure_integration(hass)
     with patch(
@@ -112,7 +112,7 @@ async def test_disabled(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockBinarySensor()

--- a/tests/components/devolo_home_control/test_climate.py
+++ b/tests/components/devolo_home_control/test_climate.py
@@ -19,7 +19,7 @@ from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockClimate
 
 
-async def test_climate(hass: HomeAssistant):
+async def test_climate(hass: HomeAssistant) -> None:
     """Test setup and state change of a climate device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockClimate()
@@ -67,7 +67,7 @@ async def test_climate(hass: HomeAssistant):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_UNAVAILABLE
 
 
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockClimate()

--- a/tests/components/devolo_home_control/test_cover.py
+++ b/tests/components/devolo_home_control/test_cover.py
@@ -18,7 +18,7 @@ from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockCover
 
 
-async def test_cover(hass: HomeAssistant):
+async def test_cover(hass: HomeAssistant) -> None:
     """Test setup and state change of a cover device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockCover()
@@ -85,7 +85,7 @@ async def test_cover(hass: HomeAssistant):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_UNAVAILABLE
 
 
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockCover()

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -17,7 +17,7 @@ from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockBinarySensor
 
 
-async def test_setup_entry(hass: HomeAssistant, mock_zeroconf):
+async def test_setup_entry(hass: HomeAssistant, mock_zeroconf: None) -> None:
     """Test setup entry."""
     entry = configure_integration(hass)
     with patch("homeassistant.components.devolo_home_control.HomeControl"):
@@ -26,7 +26,7 @@ async def test_setup_entry(hass: HomeAssistant, mock_zeroconf):
 
 
 @pytest.mark.parametrize("credentials_valid", [False])
-async def test_setup_entry_credentials_invalid(hass: HomeAssistant):
+async def test_setup_entry_credentials_invalid(hass: HomeAssistant) -> None:
     """Test setup entry fails if credentials are invalid."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -34,14 +34,14 @@ async def test_setup_entry_credentials_invalid(hass: HomeAssistant):
 
 
 @pytest.mark.parametrize("maintenance", [True])
-async def test_setup_entry_maintenance(hass: HomeAssistant):
+async def test_setup_entry_maintenance(hass: HomeAssistant) -> None:
     """Test setup entry fails if mydevolo is in maintenance mode."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_gateway_offline(hass: HomeAssistant, mock_zeroconf):
+async def test_setup_gateway_offline(hass: HomeAssistant, mock_zeroconf: None) -> None:
     """Test setup entry fails on gateway offline."""
     entry = configure_integration(hass)
     with patch(
@@ -52,7 +52,7 @@ async def test_setup_gateway_offline(hass: HomeAssistant, mock_zeroconf):
         assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload entry."""
     entry = configure_integration(hass)
     with patch("homeassistant.components.devolo_home_control.HomeControl"):

--- a/tests/components/devolo_home_control/test_light.py
+++ b/tests/components/devolo_home_control/test_light.py
@@ -23,7 +23,7 @@ from . import configure_integration
 from .mocks import BinarySwitchPropertyMock, HomeControlMock, HomeControlMockLight
 
 
-async def test_light_without_binary_sensor(hass: HomeAssistant):
+async def test_light_without_binary_sensor(hass: HomeAssistant) -> None:
     """Test setup and state change of a light device that does not have an additional binary sensor."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockLight()
@@ -96,7 +96,7 @@ async def test_light_without_binary_sensor(hass: HomeAssistant):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_UNAVAILABLE
 
 
-async def test_light_with_binary_sensor(hass: HomeAssistant):
+async def test_light_with_binary_sensor(hass: HomeAssistant) -> None:
     """Test setup and state change of a light device that has an additional binary sensor."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockLight()
@@ -147,7 +147,7 @@ async def test_light_with_binary_sensor(hass: HomeAssistant):
         set_value.assert_called_once_with(False)
 
 
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockLight()

--- a/tests/components/devolo_home_control/test_sensor.py
+++ b/tests/components/devolo_home_control/test_sensor.py
@@ -21,7 +21,7 @@ from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockConsumption, HomeControlMockSensor
 
 
-async def test_temperature_sensor(hass: HomeAssistant):
+async def test_temperature_sensor(hass: HomeAssistant) -> None:
     """Test setup of a temperature sensor device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSensor()
@@ -43,7 +43,7 @@ async def test_temperature_sensor(hass: HomeAssistant):
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
 
 
-async def test_battery_sensor(hass: HomeAssistant):
+async def test_battery_sensor(hass: HomeAssistant) -> None:
     """Test setup and state change of a battery sensor device."""
     entry = configure_integration(hass)
     er = entity_registry.async_get(hass)
@@ -73,7 +73,7 @@ async def test_battery_sensor(hass: HomeAssistant):
     assert hass.states.get(f"{DOMAIN}.test_battery_level").state == "10"
 
 
-async def test_consumption_sensor(hass: HomeAssistant):
+async def test_consumption_sensor(hass: HomeAssistant) -> None:
     """Test setup and state change of a consumption sensor device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockConsumption()
@@ -118,7 +118,7 @@ async def test_consumption_sensor(hass: HomeAssistant):
     )
 
 
-async def test_voltage_sensor(hass: HomeAssistant):
+async def test_voltage_sensor(hass: HomeAssistant) -> None:
     """Test disabled setup of a voltage sensor device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockConsumption()
@@ -133,7 +133,7 @@ async def test_voltage_sensor(hass: HomeAssistant):
     assert state is None
 
 
-async def test_sensor_change(hass: HomeAssistant):
+async def test_sensor_change(hass: HomeAssistant) -> None:
     """Test state change of a sensor device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSensor()
@@ -157,7 +157,7 @@ async def test_sensor_change(hass: HomeAssistant):
     assert hass.states.get(f"{DOMAIN}.test_temperature").state == STATE_UNAVAILABLE
 
 
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSensor()

--- a/tests/components/devolo_home_control/test_siren.py
+++ b/tests/components/devolo_home_control/test_siren.py
@@ -17,7 +17,7 @@ from .mocks import HomeControlMock, HomeControlMockSiren
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_siren(hass: HomeAssistant):
+async def test_siren(hass: HomeAssistant) -> None:
     """Test setup and state change of a siren device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSiren()
@@ -47,7 +47,7 @@ async def test_siren(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_siren_switching(hass: HomeAssistant):
+async def test_siren_switching(hass: HomeAssistant) -> None:
     """Test setup and state change via switching of a siren device."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSiren()
@@ -98,7 +98,7 @@ async def test_siren_switching(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_siren_change_default_tone(hass: HomeAssistant):
+async def test_siren_change_default_tone(hass: HomeAssistant) -> None:
     """Test changing the default tone on message."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSiren()
@@ -127,7 +127,7 @@ async def test_siren_change_default_tone(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_remove_from_hass(hass: HomeAssistant):
+async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)
     test_gateway = HomeControlMockSiren()

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -28,7 +28,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_binary_sensor_setup(hass: HomeAssistant):
+async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     """Test default setup of the binary sensor component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -41,7 +41,9 @@ async def test_binary_sensor_setup(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_update_attached_to_router(hass: HomeAssistant, mock_device: MockDevice):
+async def test_update_attached_to_router(
+    hass: HomeAssistant, mock_device: MockDevice
+) -> None:
     """Test state change of a attached_to_router binary sensor device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -65,7 +65,7 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]):
     "exception_type, expected_error",
     [[DeviceNotFound, "cannot_connect"], [Exception, "unknown"]],
 )
-async def test_form_error(hass: HomeAssistant, exception_type, expected_error):
+async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -> None:
     """Test we handle errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -86,7 +86,7 @@ async def test_form_error(hass: HomeAssistant, exception_type, expected_error):
     assert result2["errors"] == {CONF_BASE: expected_error}
 
 
-async def test_zeroconf(hass: HomeAssistant):
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test that the zeroconf form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -126,7 +126,7 @@ async def test_zeroconf(hass: HomeAssistant):
     }
 
 
-async def test_abort_zeroconf_wrong_device(hass: HomeAssistant):
+async def test_abort_zeroconf_wrong_device(hass: HomeAssistant) -> None:
     """Test we abort zeroconf for wrong devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -138,7 +138,7 @@ async def test_abort_zeroconf_wrong_device(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("info")
-async def test_abort_if_configued(hass: HomeAssistant):
+async def test_abort_if_configued(hass: HomeAssistant) -> None:
     """Test we abort config flow if already configured."""
     serial_number = DISCOVERY_INFO.properties["SN"]
     entry = MockConfigEntry(
@@ -173,7 +173,7 @@ async def test_abort_if_configued(hass: HomeAssistant):
 
 @pytest.mark.usefixtures("mock_device")
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_form_reauth(hass: HomeAssistant):
+async def test_form_reauth(hass: HomeAssistant) -> None:
     """Test that the reauth confirmation form is served."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -212,7 +212,7 @@ async def test_form_reauth(hass: HomeAssistant):
 
 @pytest.mark.usefixtures("mock_device")
 @pytest.mark.usefixtures("mock_zeroconf")
-async def test_validate_input(hass: HomeAssistant):
+async def test_validate_input(hass: HomeAssistant) -> None:
     """Test input validation."""
     with patch(
         "homeassistant.components.devolo_home_network.config_flow.Device",

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -30,7 +30,7 @@ STATION = CONNECTED_STATIONS[0]
 SERIAL = DISCOVERY_INFO.properties["SN"]
 
 
-async def test_device_tracker(hass: HomeAssistant, mock_device: MockDevice):
+async def test_device_tracker(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test device tracker states."""
     state_key = (
         f"{PLATFORM}.{DOMAIN}_{SERIAL}_{STATION.mac_address.lower().replace(':', '_')}"
@@ -82,7 +82,7 @@ async def test_device_tracker(hass: HomeAssistant, mock_device: MockDevice):
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_restoring_clients(hass: HomeAssistant, mock_device: MockDevice):
+async def test_restoring_clients(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test restoring existing device_tracker entities."""
     state_key = (
         f"{PLATFORM}.{DOMAIN}_{SERIAL}_{STATION.mac_address.lower().replace(':', '_')}"

--- a/tests/components/devolo_home_network/test_diagnostics.py
+++ b/tests/components/devolo_home_network/test_diagnostics.py
@@ -19,7 +19,7 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-):
+) -> None:
     """Test config entry diagnostics."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_setup_entry(hass: HomeAssistant):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup entry."""
     entry = configure_integration(hass)
     with patch(
@@ -29,7 +29,7 @@ async def test_setup_entry(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_setup_without_password(hass: HomeAssistant):
+async def test_setup_without_password(hass: HomeAssistant) -> None:
     """Test setup entry without a device password set like used before HA Core 2022.06."""
     config = {
         CONF_IP_ADDRESS: IP,
@@ -44,7 +44,7 @@ async def test_setup_without_password(hass: HomeAssistant):
         assert entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_device_not_found(hass: HomeAssistant):
+async def test_setup_device_not_found(hass: HomeAssistant) -> None:
     """Test setup entry."""
     entry = configure_integration(hass)
     with patch(
@@ -56,7 +56,7 @@ async def test_setup_device_not_found(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload entry."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -65,7 +65,7 @@ async def test_unload_entry(hass: HomeAssistant):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_hass_stop(hass: HomeAssistant, mock_device: MockDevice):
+async def test_hass_stop(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test homeassistant stop event."""
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -21,7 +21,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_sensor_setup(hass: HomeAssistant):
+async def test_sensor_setup(hass: HomeAssistant) -> None:
     """Test default setup of the sensor component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -37,7 +37,7 @@ async def test_sensor_setup(hass: HomeAssistant):
 
 async def test_update_connected_wifi_clients(
     hass: HomeAssistant, mock_device: MockDevice
-):
+) -> None:
     """Test state change of a connected_wifi_clients sensor device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -79,7 +79,7 @@ async def test_update_connected_wifi_clients(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_neighboring_wifi_networks(
     hass: HomeAssistant, mock_device: MockDevice
-):
+) -> None:
     """Test state change of a neighboring_wifi_networks sensor device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -123,7 +123,7 @@ async def test_update_neighboring_wifi_networks(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_connected_plc_devices(
     hass: HomeAssistant, mock_device: MockDevice
-):
+) -> None:
     """Test state change of a connected_plc_devices sensor device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -32,7 +32,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_switch_setup(hass: HomeAssistant):
+async def test_switch_setup(hass: HomeAssistant) -> None:
     """Test default setup of the switch component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -47,7 +47,7 @@ async def test_switch_setup(hass: HomeAssistant):
 
 async def test_update_guest_wifi_status_auth_failed(
     hass: HomeAssistant, mock_device: MockDevice
-):
+) -> None:
     """Test getting the wifi_status with wrong password triggers the reauth flow."""
     entry = configure_integration(hass)
     mock_device.device.async_get_wifi_guest_access.side_effect = DevicePasswordProtected
@@ -70,7 +70,9 @@ async def test_update_guest_wifi_status_auth_failed(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_update_enable_guest_wifi(hass: HomeAssistant, mock_device: MockDevice):
+async def test_update_enable_guest_wifi(
+    hass: HomeAssistant, mock_device: MockDevice
+) -> None:
     """Test state change of a enable_guest_wifi switch device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -155,7 +157,7 @@ async def test_update_enable_guest_wifi(hass: HomeAssistant, mock_device: MockDe
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_update_enable_leds(hass: HomeAssistant, mock_device: MockDevice):
+async def test_update_enable_leds(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test state change of a enable_leds switch device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -250,7 +252,7 @@ async def test_device_failure(
     name: str,
     get_method: str,
     update_interval: timedelta,
-):
+) -> None:
     """Test device failure."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
@@ -281,7 +283,7 @@ async def test_device_failure(
 )
 async def test_auth_failed(
     hass: HomeAssistant, mock_device: MockDevice, name: str, set_method: str
-):
+) -> None:
     """Test setting unautherized triggers the reauth flow."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -796,8 +796,8 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_router(
 
 
 async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missing(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test matching based on hostname and macaddress after start but missing hostname."""
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dialogflow, intent_script
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 SESSION_ID = "a9b84cec-46b6-484e-8f31-f65dba03ae6d"
@@ -163,7 +163,7 @@ async def test_v2_data() -> None:
     assert dialogflow.get_api_version(Data.v2) == 2
 
 
-async def test_intent_action_incomplete_v1(fixture):
+async def test_intent_action_incomplete_v1(fixture) -> None:
     """Test when action is not completed."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -176,7 +176,7 @@ async def test_intent_action_incomplete_v1(fixture):
     assert await response.text() == ""
 
 
-async def test_intent_action_incomplete_v2(fixture):
+async def test_intent_action_incomplete_v2(fixture) -> None:
     """Test when action is not completed."""
     mock_client, webhook_id = fixture
     data = Data.v2
@@ -189,7 +189,7 @@ async def test_intent_action_incomplete_v2(fixture):
     assert await response.text() == ""
 
 
-async def test_intent_slot_filling_v1(fixture):
+async def test_intent_slot_filling_v1(fixture) -> None:
     """Test when Dialogflow asks for slot-filling return none."""
     mock_client, webhook_id = fixture
 
@@ -231,7 +231,7 @@ async def test_intent_slot_filling_v1(fixture):
     assert await response.text() == ""
 
 
-async def test_intent_request_with_parameters_v1(fixture):
+async def test_intent_request_with_parameters_v1(fixture) -> None:
     """Test a request with parameters."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -243,7 +243,7 @@ async def test_intent_request_with_parameters_v1(fixture):
     assert text == "You told us your sign is virgo."
 
 
-async def test_intent_request_with_parameters_v2(fixture):
+async def test_intent_request_with_parameters_v2(fixture) -> None:
     """Test a request with parameters."""
     mock_client, webhook_id = fixture
     data = Data.v2
@@ -255,7 +255,7 @@ async def test_intent_request_with_parameters_v2(fixture):
     assert text == "You told us your sign is virgo."
 
 
-async def test_intent_request_with_parameters_but_empty_v1(fixture):
+async def test_intent_request_with_parameters_but_empty_v1(fixture) -> None:
     """Test a request with parameters but empty value."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -268,7 +268,7 @@ async def test_intent_request_with_parameters_but_empty_v1(fixture):
     assert text == "You told us your sign is ."
 
 
-async def test_intent_request_with_parameters_but_empty_v2(fixture):
+async def test_intent_request_with_parameters_but_empty_v2(fixture) -> None:
     """Test a request with parameters but empty value."""
     mock_client, webhook_id = fixture
     data = Data.v2
@@ -281,7 +281,7 @@ async def test_intent_request_with_parameters_but_empty_v2(fixture):
     assert text == "You told us your sign is ."
 
 
-async def test_intent_request_without_slots_v1(hass, fixture):
+async def test_intent_request_without_slots_v1(hass: HomeAssistant, fixture) -> None:
     """Test a request without slots."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -311,7 +311,7 @@ async def test_intent_request_without_slots_v1(hass, fixture):
     assert text == "You are both home, you silly"
 
 
-async def test_intent_request_without_slots_v2(hass, fixture):
+async def test_intent_request_without_slots_v2(hass: HomeAssistant, fixture) -> None:
     """Test a request without slots."""
     mock_client, webhook_id = fixture
     data = Data.v2
@@ -341,7 +341,7 @@ async def test_intent_request_without_slots_v2(hass, fixture):
     assert text == "You are both home, you silly"
 
 
-async def test_intent_request_calling_service_v1(fixture, calls):
+async def test_intent_request_calling_service_v1(fixture, calls) -> None:
     """Test a request for calling a service.
 
     If this request is done async the test could finish before the action
@@ -363,7 +363,7 @@ async def test_intent_request_calling_service_v1(fixture, calls):
     assert call.data.get("hello") == "virgo"
 
 
-async def test_intent_request_calling_service_v2(fixture, calls):
+async def test_intent_request_calling_service_v2(fixture, calls) -> None:
     """Test a request for calling a service.
 
     If this request is done async the test could finish before the action
@@ -385,7 +385,7 @@ async def test_intent_request_calling_service_v2(fixture, calls):
     assert call.data.get("hello") == "virgo"
 
 
-async def test_intent_with_no_action_v1(fixture):
+async def test_intent_with_no_action_v1(fixture) -> None:
     """Test an intent with no defined action."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -399,7 +399,7 @@ async def test_intent_with_no_action_v1(fixture):
     assert text == "You have not defined an action in your Dialogflow intent."
 
 
-async def test_intent_with_no_action_v2(fixture):
+async def test_intent_with_no_action_v2(fixture) -> None:
     """Test an intent with no defined action."""
     mock_client, webhook_id = fixture
     data = Data.v2
@@ -413,7 +413,7 @@ async def test_intent_with_no_action_v2(fixture):
     assert text == "You have not defined an action in your Dialogflow intent."
 
 
-async def test_intent_with_unknown_action_v1(fixture):
+async def test_intent_with_unknown_action_v1(fixture) -> None:
     """Test an intent with an action not defined in the conf."""
     mock_client, webhook_id = fixture
     data = Data.v1
@@ -426,7 +426,7 @@ async def test_intent_with_unknown_action_v1(fixture):
     assert text == "This intent is not yet configured within Home Assistant."
 
 
-async def test_intent_with_unknown_action_v2(fixture):
+async def test_intent_with_unknown_action_v2(fixture) -> None:
     """Test an intent with an action not defined in the conf."""
     mock_client, webhook_id = fixture
     data = Data.v2

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -306,7 +306,7 @@ async def test_attributes_paused(
     hass: HomeAssistant,
     mock_now: dt_util.dt.datetime,
     aioclient_mock: AiohttpClientMocker,
-):
+) -> None:
     """Test attributes while paused."""
     await setup_integration(hass, aioclient_mock)
 

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -71,6 +71,7 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 # Auto-use the domain_data_mock fixture for every test in this module
 pytestmark = pytest.mark.usefixtures("domain_data_mock")
@@ -1001,7 +1002,10 @@ async def test_shuffle_repeat_modes(
 
 
 async def test_browse_media(
-    hass: HomeAssistant, hass_ws_client, dmr_device_mock: Mock, mock_entity_id: str
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    dmr_device_mock: Mock,
+    mock_entity_id: str,
 ) -> None:
     """Test the async_browse_media method."""
     # Based on cast's test_entity_browse_media
@@ -1106,7 +1110,7 @@ async def test_browse_media(
 
 async def test_browse_media_unfiltered(
     hass: HomeAssistant,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     config_entry_mock: MockConfigEntry,
     dmr_device_mock: Mock,
     mock_entity_id: str,

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -227,7 +227,9 @@ async def test_form_zeroconf_correct_oui(hass: HomeAssistant) -> None:
         None,
     ],
 )
-async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_effect):
+async def test_form_zeroconf_correct_oui_wrong_device(
+    hass: HomeAssistant, doorbell_state_side_effect
+) -> None:
     """Test we can setup from zeroconf with the correct OUI source but not a doorstation."""
     doorbirdapi = _get_mock_doorbirdapi_return_values(
         ready=[True], info={"WIFI_MAC_ADDR": "macaddr"}

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -28,7 +28,9 @@ def com_port():
     return port
 
 
-async def test_setup_network(hass, dsmr_connection_send_validate_fixture):
+async def test_setup_network(
+    hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -71,10 +73,10 @@ async def test_setup_network(hass, dsmr_connection_send_validate_fixture):
 
 
 async def test_setup_network_rfxtrx(
-    hass,
+    hass: HomeAssistant,
     dsmr_connection_send_validate_fixture,
     rfxtrx_dsmr_connection_send_validate_fixture,
-):
+) -> None:
     """Test we can setup network."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
@@ -122,7 +124,9 @@ async def test_setup_network_rfxtrx(
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-async def test_setup_serial(com_mock, hass, dsmr_connection_send_validate_fixture):
+async def test_setup_serial(
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -164,10 +168,10 @@ async def test_setup_serial(com_mock, hass, dsmr_connection_send_validate_fixtur
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_rfxtrx(
     com_mock,
-    hass,
+    hass: HomeAssistant,
     dsmr_connection_send_validate_fixture,
     rfxtrx_dsmr_connection_send_validate_fixture,
-):
+) -> None:
     """Test we can setup serial."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
@@ -212,7 +216,9 @@ async def test_setup_serial_rfxtrx(
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-async def test_setup_5L(com_mock, hass, dsmr_connection_send_validate_fixture):
+async def test_setup_5L(
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -254,7 +260,9 @@ async def test_setup_5L(com_mock, hass, dsmr_connection_send_validate_fixture):
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-async def test_setup_5S(com_mock, hass, dsmr_connection_send_validate_fixture):
+async def test_setup_5S(
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -295,7 +303,9 @@ async def test_setup_5S(com_mock, hass, dsmr_connection_send_validate_fixture):
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
+async def test_setup_Q3D(
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -338,8 +348,8 @@ async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_manual(
-    com_mock, hass, dsmr_connection_send_validate_fixture
-):
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test we can setup serial with manual entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -385,7 +395,9 @@ async def test_setup_serial_manual(
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-async def test_setup_serial_fail(com_mock, hass, dsmr_connection_send_validate_fixture):
+async def test_setup_serial_fail(
+    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+) -> None:
     """Test failed serial connection."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
@@ -431,10 +443,10 @@ async def test_setup_serial_fail(com_mock, hass, dsmr_connection_send_validate_f
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_timeout(
     com_mock,
-    hass,
+    hass: HomeAssistant,
     dsmr_connection_send_validate_fixture,
     rfxtrx_dsmr_connection_send_validate_fixture,
-):
+) -> None:
     """Test failed serial connection."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
     (
@@ -487,10 +499,10 @@ async def test_setup_serial_timeout(
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_wrong_telegram(
     com_mock,
-    hass,
+    hass: HomeAssistant,
     dsmr_connection_send_validate_fixture,
     rfxtrx_dsmr_connection_send_validate_fixture,
-):
+) -> None:
     """Test failed telegram data."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
     (

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -4,7 +4,6 @@ Tests setup of the DSMR component and ensure incoming telegrams cause
 Entity to be updated with new values.
 
 """
-
 import asyncio
 import datetime
 from decimal import Decimal
@@ -28,12 +27,13 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfVolume,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, patch
 
 
-async def test_default_setup(hass, dsmr_connection_fixture):
+async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test the default setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -137,7 +137,7 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     )
 
 
-async def test_setup_only_energy(hass, dsmr_connection_fixture):
+async def test_setup_only_energy(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test the default setup."""
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -166,7 +166,7 @@ async def test_setup_only_energy(hass, dsmr_connection_fixture):
     assert not entry
 
 
-async def test_v4_meter(hass, dsmr_connection_fixture):
+async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if v4 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -242,7 +242,7 @@ async def test_v4_meter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_v5_meter(hass, dsmr_connection_fixture):
+async def test_v5_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -314,7 +314,7 @@ async def test_v5_meter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_luxembourg_meter(hass, dsmr_connection_fixture):
+async def test_luxembourg_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -403,7 +403,7 @@ async def test_luxembourg_meter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_belgian_meter(hass, dsmr_connection_fixture):
+async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -475,7 +475,7 @@ async def test_belgian_meter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_belgian_meter_low(hass, dsmr_connection_fixture):
+async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -523,7 +523,7 @@ async def test_belgian_meter_low(hass, dsmr_connection_fixture):
     assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
 
 
-async def test_swedish_meter(hass, dsmr_connection_fixture):
+async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -596,7 +596,7 @@ async def test_swedish_meter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_easymeter(hass, dsmr_connection_fixture):
+async def test_easymeter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """Test if Q3D meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -672,7 +672,7 @@ async def test_easymeter(hass, dsmr_connection_fixture):
     )
 
 
-async def test_tcp(hass, dsmr_connection_fixture):
+async def test_tcp(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """If proper config provided TCP connection should be made."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -700,7 +700,7 @@ async def test_tcp(hass, dsmr_connection_fixture):
     assert connection_factory.call_args_list[0][0][1] == "1234"
 
 
-async def test_rfxtrx_tcp(hass, rfxtrx_dsmr_connection_fixture):
+async def test_rfxtrx_tcp(hass: HomeAssistant, rfxtrx_dsmr_connection_fixture) -> None:
     """If proper config provided RFXtrx TCP connection should be made."""
     (connection_factory, transport, protocol) = rfxtrx_dsmr_connection_fixture
 
@@ -728,7 +728,9 @@ async def test_rfxtrx_tcp(hass, rfxtrx_dsmr_connection_fixture):
     assert connection_factory.call_args_list[0][0][1] == "1234"
 
 
-async def test_connection_errors_retry(hass, dsmr_connection_fixture):
+async def test_connection_errors_retry(
+    hass: HomeAssistant, dsmr_connection_fixture
+) -> None:
     """Connection should be retried on error during setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -765,7 +767,7 @@ async def test_connection_errors_retry(hass, dsmr_connection_fixture):
         assert first_fail_connection_factory.call_count >= 2, "connecting not retried"
 
 
-async def test_reconnect(hass, dsmr_connection_fixture):
+async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     """If transport disconnects, the connection should be retried."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -822,7 +824,9 @@ async def test_reconnect(hass, dsmr_connection_fixture):
     assert mock_entry.state == config_entries.ConfigEntryState.NOT_LOADED
 
 
-async def test_gas_meter_providing_energy_reading(hass, dsmr_connection_fixture):
+async def test_gas_meter_providing_energy_reading(
+    hass: HomeAssistant, dsmr_connection_fixture
+) -> None:
     """Test that gas providing energy readings use the correct device class."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 

--- a/tests/components/dsmr_reader/test_config_flow.py
+++ b/tests/components/dsmr_reader/test_config_flow.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-async def test_import_step(hass: HomeAssistant):
+async def test_import_step(hass: HomeAssistant) -> None:
     """Test the import step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -22,7 +22,7 @@ async def test_import_step(hass: HomeAssistant):
     assert second_result["reason"] == "single_instance_allowed"
 
 
-async def test_user_step(hass: HomeAssistant):
+async def test_user_step(hass: HomeAssistant) -> None:
     """Test the user step call."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -100,7 +100,9 @@ async def test_setup_backoff(
         assert aioclient_mock.call_count == idx + 1
 
 
-async def test_service_set_txt(hass, aioclient_mock, setup_duckdns):
+async def test_service_set_txt(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, setup_duckdns
+) -> None:
     """Test set txt service call."""
     # Empty the fixture mock requests
     aioclient_mock.clear_requests()
@@ -116,7 +118,9 @@ async def test_service_set_txt(hass, aioclient_mock, setup_duckdns):
     assert aioclient_mock.call_count == 1
 
 
-async def test_service_clear_txt(hass, aioclient_mock, setup_duckdns):
+async def test_service_clear_txt(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, setup_duckdns
+) -> None:
     """Test clear txt service call."""
     # Empty the fixture mock requests
     aioclient_mock.clear_requests()

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -18,7 +18,9 @@ from tests.common import MockConfigEntry
         (True, False, "create_entry", config_entries.ConfigEntryState.SETUP_RETRY, ""),
     ],
 )
-async def test_flow(hass, first_con, second_con, exp_type, exp_result, exp_reason):
+async def test_flow(
+    hass: HomeAssistant, first_con, second_con, exp_type, exp_result, exp_reason
+) -> None:
     """Run a flow with or without errors and return result."""
     host = "1.2.3.4"
     with patch(

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
@@ -53,7 +53,7 @@ def mock_device():
     return mock_dev
 
 
-async def test_cover_setup(hass, mock_device):
+async def test_cover_setup(hass: HomeAssistant, mock_device) -> None:
     """Test a successful setup."""
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("cover.name")
@@ -92,7 +92,7 @@ async def test_cover_setup(hass, mock_device):
     )
 
 
-async def test_cover_without_tilt(hass, mock_device):
+async def test_cover_without_tilt(hass: HomeAssistant, mock_device) -> None:
     """Test a cover with no tilt."""
     mock_device.has_tilt = False
     await create_entity_from_device(hass, mock_device)
@@ -117,7 +117,7 @@ async def check_cover_position(
     assert entity_state.state == expected
 
 
-async def test_cover_positions(hass, mock_device):
+async def test_cover_positions(hass: HomeAssistant, mock_device) -> None:
     """Test that the state updates in the various positions."""
     update_func = await create_entity_from_device(hass, mock_device)
     await check_cover_position(
@@ -134,7 +134,7 @@ async def test_cover_positions(hass, mock_device):
     )
 
 
-async def test_cover_restore_state(hass, mock_device):
+async def test_cover_restore_state(hass: HomeAssistant, mock_device) -> None:
     """Test restore from cache."""
     mock_restore_cache(
         hass,
@@ -146,7 +146,7 @@ async def test_cover_restore_state(hass, mock_device):
     assert entity_state.state == STATE_OPEN
 
 
-async def test_cover_restore_state_bad_cache(hass, mock_device):
+async def test_cover_restore_state_bad_cache(hass: HomeAssistant, mock_device) -> None:
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,

--- a/tests/components/dynalite/test_light.py
+++ b/tests/components/dynalite/test_light.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .common import (
     ATTR_METHOD,
@@ -49,7 +49,7 @@ def mock_device():
     return mock_dev
 
 
-async def test_light_setup(hass, mock_device):
+async def test_light_setup(hass: HomeAssistant, mock_device) -> None:
     """Test a successful setup."""
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("light.name")
@@ -68,7 +68,7 @@ async def test_light_setup(hass, mock_device):
     )
 
 
-async def test_unload_config_entry(hass, mock_device):
+async def test_unload_config_entry(hass: HomeAssistant, mock_device) -> None:
     """Test when a config entry is unloaded from HA."""
     await create_entity_from_device(hass, mock_device)
     assert hass.states.get("light.name")
@@ -78,7 +78,7 @@ async def test_unload_config_entry(hass, mock_device):
     assert hass.states.get("light.name").state == STATE_UNAVAILABLE
 
 
-async def test_remove_config_entry(hass, mock_device):
+async def test_remove_config_entry(hass: HomeAssistant, mock_device) -> None:
     """Test when a config entry is removed from HA."""
     await create_entity_from_device(hass, mock_device)
     assert hass.states.get("light.name")
@@ -88,7 +88,7 @@ async def test_remove_config_entry(hass, mock_device):
     assert not hass.states.get("light.name")
 
 
-async def test_light_restore_state(hass, mock_device):
+async def test_light_restore_state(hass: HomeAssistant, mock_device) -> None:
     """Test restore from cache."""
     mock_restore_cache(
         hass,
@@ -102,7 +102,7 @@ async def test_light_restore_state(hass, mock_device):
     assert entity_state.attributes[ATTR_COLOR_MODE] == ColorMode.BRIGHTNESS
 
 
-async def test_light_restore_state_bad_cache(hass, mock_device):
+async def test_light_restore_state_bad_cache(hass: HomeAssistant, mock_device) -> None:
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,

--- a/tests/components/dynalite/test_switch.py
+++ b/tests/components/dynalite/test_switch.py
@@ -1,12 +1,11 @@
 """Test Dynalite switch."""
-
 from unittest.mock import Mock
 
 from dynalite_devices_lib.switch import DynalitePresetSwitchDevice
 import pytest
 
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .common import (
     ATTR_METHOD,
@@ -32,7 +31,7 @@ def mock_device():
     return mock_dev
 
 
-async def test_switch_setup(hass, mock_device):
+async def test_switch_setup(hass: HomeAssistant, mock_device) -> None:
     """Test a successful setup."""
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("switch.name")
@@ -50,7 +49,9 @@ async def test_switch_setup(hass, mock_device):
 
 
 @pytest.mark.parametrize("saved_state, level", [(STATE_ON, 1), (STATE_OFF, 0)])
-async def test_switch_restore_state(hass, mock_device, saved_state, level):
+async def test_switch_restore_state(
+    hass: HomeAssistant, mock_device, saved_state, level
+) -> None:
     """Test restore from cache."""
     mock_restore_cache(
         hass,

--- a/tests/components/eafm/test_config_flow.py
+++ b/tests/components/eafm/test_config_flow.py
@@ -6,9 +6,12 @@ from voluptuous.error import MultipleInvalid
 
 from homeassistant import config_entries
 from homeassistant.components.eafm import const
+from homeassistant.core import HomeAssistant
 
 
-async def test_flow_no_discovered_stations(hass, mock_get_stations):
+async def test_flow_no_discovered_stations(
+    hass: HomeAssistant, mock_get_stations
+) -> None:
     """Test config flow discovers no station."""
     mock_get_stations.return_value = []
     result = await hass.config_entries.flow.async_init(
@@ -18,7 +21,7 @@ async def test_flow_no_discovered_stations(hass, mock_get_stations):
     assert result["reason"] == "no_stations"
 
 
-async def test_flow_invalid_station(hass, mock_get_stations):
+async def test_flow_invalid_station(hass: HomeAssistant, mock_get_stations) -> None:
     """Test config flow errors on invalid station."""
     mock_get_stations.return_value = [
         {"label": "My station", "stationReference": "L12345"}
@@ -35,7 +38,9 @@ async def test_flow_invalid_station(hass, mock_get_stations):
         )
 
 
-async def test_flow_works(hass, mock_get_stations, mock_get_station):
+async def test_flow_works(
+    hass: HomeAssistant, mock_get_stations, mock_get_station
+) -> None:
     """Test config flow discovers no station."""
     mock_get_stations.return_value = [
         {"label": "My station", "stationReference": "L12345"}

--- a/tests/components/eafm/test_sensor.py
+++ b/tests/components/eafm/test_sensor.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -53,7 +54,7 @@ async def async_setup_test_fixture(hass, mock_get_station, initial_value):
     return entry, poll
 
 
-async def test_reading_measures_not_list(hass, mock_get_station):
+async def test_reading_measures_not_list(hass: HomeAssistant, mock_get_station) -> None:
     """Test that a measure can be a dict not a list.
 
     E.g. https://environment.data.gov.uk/flood-monitoring/id/stations/751110
@@ -78,7 +79,7 @@ async def test_reading_measures_not_list(hass, mock_get_station):
     assert state.state == "5"
 
 
-async def test_reading_no_unit(hass, mock_get_station):
+async def test_reading_no_unit(hass: HomeAssistant, mock_get_station) -> None:
     """Test that a sensor functions even if its unit is not known.
 
     E.g. https://environment.data.gov.uk/flood-monitoring/id/stations/L0410
@@ -105,7 +106,9 @@ async def test_reading_no_unit(hass, mock_get_station):
     assert state.state == "5"
 
 
-async def test_ignore_invalid_latest_reading(hass, mock_get_station):
+async def test_ignore_invalid_latest_reading(
+    hass: HomeAssistant, mock_get_station
+) -> None:
     """Test that a sensor functions even if its unit is not known.
 
     E.g. https://environment.data.gov.uk/flood-monitoring/id/stations/L0410
@@ -144,7 +147,9 @@ async def test_ignore_invalid_latest_reading(hass, mock_get_station):
 
 
 @pytest.mark.parametrize("exception", CONNECTION_EXCEPTIONS)
-async def test_reading_unavailable(hass, mock_get_station, exception):
+async def test_reading_unavailable(
+    hass: HomeAssistant, mock_get_station, exception
+) -> None:
     """Test that a sensor is marked as unavailable if there is a connection error."""
     _, poll = await async_setup_test_fixture(
         hass,
@@ -174,7 +179,9 @@ async def test_reading_unavailable(hass, mock_get_station, exception):
 
 
 @pytest.mark.parametrize("exception", CONNECTION_EXCEPTIONS)
-async def test_recover_from_failure(hass, mock_get_station, exception):
+async def test_recover_from_failure(
+    hass: HomeAssistant, mock_get_station, exception
+) -> None:
     """Test that a sensor recovers from failures."""
     _, poll = await async_setup_test_fixture(
         hass,
@@ -223,7 +230,7 @@ async def test_recover_from_failure(hass, mock_get_station, exception):
     assert state.state == "56"
 
 
-async def test_reading_is_sampled(hass, mock_get_station):
+async def test_reading_is_sampled(hass: HomeAssistant, mock_get_station) -> None:
     """Test that a sensor is added and polled."""
     await async_setup_test_fixture(
         hass,
@@ -250,7 +257,9 @@ async def test_reading_is_sampled(hass, mock_get_station):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "m"
 
 
-async def test_multiple_readings_are_sampled(hass, mock_get_station):
+async def test_multiple_readings_are_sampled(
+    hass: HomeAssistant, mock_get_station
+) -> None:
     """Test that multiple sensors are added and polled."""
     await async_setup_test_fixture(
         hass,
@@ -291,7 +300,7 @@ async def test_multiple_readings_are_sampled(hass, mock_get_station):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "m"
 
 
-async def test_ignore_no_latest_reading(hass, mock_get_station):
+async def test_ignore_no_latest_reading(hass: HomeAssistant, mock_get_station) -> None:
     """Test that a measure is ignored if it has no latest reading."""
     await async_setup_test_fixture(
         hass,
@@ -330,7 +339,9 @@ async def test_ignore_no_latest_reading(hass, mock_get_station):
     assert state is None
 
 
-async def test_mark_existing_as_unavailable_if_no_latest(hass, mock_get_station):
+async def test_mark_existing_as_unavailable_if_no_latest(
+    hass: HomeAssistant, mock_get_station
+) -> None:
     """Test that a measure is marked as unavailable if it has no latest reading."""
     _, poll = await async_setup_test_fixture(
         hass,
@@ -396,7 +407,7 @@ async def test_mark_existing_as_unavailable_if_no_latest(hass, mock_get_station)
     assert state.state == "5"
 
 
-async def test_unload_entry(hass, mock_get_station):
+async def test_unload_entry(hass: HomeAssistant, mock_get_station) -> None:
     """Test being able to unload an entry."""
     entry, _ = await async_setup_test_fixture(
         hass,

--- a/tests/components/easyenergy/test_diagnostics.py
+++ b/tests/components/easyenergy/test_diagnostics.py
@@ -1,7 +1,6 @@
 """Tests for the diagnostics data provided by the easyEnergy integration."""
 from unittest.mock import MagicMock
 
-from aiohttp import ClientSession
 from easyenergy import EasyEnergyNoDataError
 import pytest
 
@@ -12,12 +11,13 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.freeze_time("2023-01-19 15:00:00")
 async def test_diagnostics(
     hass: HomeAssistant,
-    hass_client: ClientSession,
+    hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test diagnostics."""
@@ -57,7 +57,7 @@ async def test_diagnostics(
 @pytest.mark.freeze_time("2023-01-19 15:00:00")
 async def test_diagnostics_no_gas_today(
     hass: HomeAssistant,
-    hass_client: ClientSession,
+    hass_client: ClientSessionGenerator,
     mock_easyenergy: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -71,33 +71,33 @@ def thermostat_fixture(data):
     return ecobee.Thermostat(data, 1, thermostat)
 
 
-async def test_name(thermostat):
+async def test_name(thermostat) -> None:
     """Test name property."""
     assert thermostat.name == "Ecobee"
 
 
-async def test_current_temperature(ecobee_fixture, thermostat):
+async def test_current_temperature(ecobee_fixture, thermostat) -> None:
     """Test current temperature."""
     assert thermostat.current_temperature == 30
     ecobee_fixture["runtime"]["actualTemperature"] = HTTPStatus.NOT_FOUND
     assert thermostat.current_temperature == 40.4
 
 
-async def test_target_temperature_low(ecobee_fixture, thermostat):
+async def test_target_temperature_low(ecobee_fixture, thermostat) -> None:
     """Test target low temperature."""
     assert thermostat.target_temperature_low == 40
     ecobee_fixture["runtime"]["desiredHeat"] = 502
     assert thermostat.target_temperature_low == 50.2
 
 
-async def test_target_temperature_high(ecobee_fixture, thermostat):
+async def test_target_temperature_high(ecobee_fixture, thermostat) -> None:
     """Test target high temperature."""
     assert thermostat.target_temperature_high == 20
     ecobee_fixture["runtime"]["desiredCool"] = 679
     assert thermostat.target_temperature_high == 67.9
 
 
-async def test_target_temperature(ecobee_fixture, thermostat):
+async def test_target_temperature(ecobee_fixture, thermostat) -> None:
     """Test target temperature."""
     assert thermostat.target_temperature is None
     ecobee_fixture["settings"]["hvacMode"] = "heat"
@@ -110,14 +110,14 @@ async def test_target_temperature(ecobee_fixture, thermostat):
     assert thermostat.target_temperature is None
 
 
-async def test_desired_fan_mode(ecobee_fixture, thermostat):
+async def test_desired_fan_mode(ecobee_fixture, thermostat) -> None:
     """Test desired fan mode property."""
     assert thermostat.fan_mode == "on"
     ecobee_fixture["runtime"]["desiredFanMode"] = "auto"
     assert thermostat.fan_mode == "auto"
 
 
-async def test_fan(ecobee_fixture, thermostat):
+async def test_fan(ecobee_fixture, thermostat) -> None:
     """Test fan property."""
     assert thermostat.fan == const.STATE_ON
     ecobee_fixture["equipmentStatus"] = ""
@@ -126,7 +126,7 @@ async def test_fan(ecobee_fixture, thermostat):
     assert thermostat.fan == STATE_OFF
 
 
-async def test_hvac_mode(ecobee_fixture, thermostat):
+async def test_hvac_mode(ecobee_fixture, thermostat) -> None:
     """Test current operation property."""
     assert thermostat.hvac_mode == "heat_cool"
     ecobee_fixture["settings"]["hvacMode"] = "heat"
@@ -139,19 +139,19 @@ async def test_hvac_mode(ecobee_fixture, thermostat):
     assert thermostat.hvac_mode == "off"
 
 
-async def test_hvac_modes(thermostat):
+async def test_hvac_modes(thermostat) -> None:
     """Test operation list property."""
     assert ["heat_cool", "heat", "cool", "off"] == thermostat.hvac_modes
 
 
-async def test_hvac_mode2(ecobee_fixture, thermostat):
+async def test_hvac_mode2(ecobee_fixture, thermostat) -> None:
     """Test operation mode property."""
     assert thermostat.hvac_mode == "heat_cool"
     ecobee_fixture["settings"]["hvacMode"] = "heat"
     assert thermostat.hvac_mode == "heat"
 
 
-async def test_extra_state_attributes(ecobee_fixture, thermostat):
+async def test_extra_state_attributes(ecobee_fixture, thermostat) -> None:
     """Test device state attributes property."""
     ecobee_fixture["equipmentStatus"] = "heatPump2"
     assert {
@@ -201,14 +201,14 @@ async def test_extra_state_attributes(ecobee_fixture, thermostat):
     } == thermostat.extra_state_attributes
 
 
-async def test_is_aux_heat_on(ecobee_fixture, thermostat):
+async def test_is_aux_heat_on(ecobee_fixture, thermostat) -> None:
     """Test aux heat property."""
     assert not thermostat.is_aux_heat
     ecobee_fixture["equipmentStatus"] = "fan, auxHeat"
     assert thermostat.is_aux_heat
 
 
-async def test_set_temperature(ecobee_fixture, thermostat, data):
+async def test_set_temperature(ecobee_fixture, thermostat, data) -> None:
     """Test set temperature."""
     # Auto -> Auto
     data.reset_mock()
@@ -247,7 +247,7 @@ async def test_set_temperature(ecobee_fixture, thermostat, data):
     assert not data.ecobee.set_hold_temp.called
 
 
-async def test_set_hvac_mode(thermostat, data):
+async def test_set_hvac_mode(thermostat, data) -> None:
     """Test operation mode setter."""
     data.reset_mock()
     thermostat.set_hvac_mode("heat_cool")
@@ -257,7 +257,7 @@ async def test_set_hvac_mode(thermostat, data):
     data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "heat")])
 
 
-async def test_set_fan_min_on_time(thermostat, data):
+async def test_set_fan_min_on_time(thermostat, data) -> None:
     """Test fan min on time setter."""
     data.reset_mock()
     thermostat.set_fan_min_on_time(15)
@@ -267,7 +267,7 @@ async def test_set_fan_min_on_time(thermostat, data):
     data.ecobee.set_fan_min_on_time.assert_has_calls([mock.call(1, 20)])
 
 
-async def test_resume_program(thermostat, data):
+async def test_resume_program(thermostat, data) -> None:
     """Test resume program."""
     # False
     data.reset_mock()
@@ -289,7 +289,7 @@ async def test_resume_program(thermostat, data):
     data.ecobee.resume_program.assert_has_calls([mock.call(1, "true")])
 
 
-async def test_hold_preference(ecobee_fixture, thermostat):
+async def test_hold_preference(ecobee_fixture, thermostat) -> None:
     """Test hold preference."""
     ecobee_fixture["settings"]["holdAction"] = "indefinite"
     assert thermostat.hold_preference() == "indefinite"
@@ -304,7 +304,7 @@ async def test_hold_preference(ecobee_fixture, thermostat):
         assert thermostat.hold_preference() == "nextTransition"
 
 
-def test_hold_hours(ecobee_fixture, thermostat):
+def test_hold_hours(ecobee_fixture, thermostat) -> None:
     """Test hold hours preference."""
     ecobee_fixture["settings"]["holdAction"] = "useEndTime2hour"
     assert thermostat.hold_hours() == 2
@@ -319,7 +319,7 @@ def test_hold_hours(ecobee_fixture, thermostat):
         assert thermostat.hold_hours() is None
 
 
-async def test_set_fan_mode_on(thermostat, data):
+async def test_set_fan_mode_on(thermostat, data) -> None:
     """Test set fan mode to on."""
     data.reset_mock()
     thermostat.set_fan_mode("on")
@@ -328,7 +328,7 @@ async def test_set_fan_mode_on(thermostat, data):
     )
 
 
-async def test_set_fan_mode_auto(thermostat, data):
+async def test_set_fan_mode_auto(thermostat, data) -> None:
     """Test set fan mode to auto."""
     data.reset_mock()
     thermostat.set_fan_mode("auto")

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -135,8 +135,8 @@ async def test_import_flow_triggered_but_no_ecobee_conf(hass: HomeAssistant) -> 
 
 
 async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_valid_tokens(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test expected result if import flow triggers and ecobee.conf exists with valid tokens."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
@@ -186,8 +186,8 @@ async def test_import_flow_triggered_with_ecobee_conf_and_invalid_data(
 
 
 async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_stale_tokens(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test expected result if import flow triggers and ecobee.conf exists with stale tokens."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass

--- a/tests/components/ecobee/test_number.py
+++ b/tests/components/ecobee/test_number.py
@@ -38,7 +38,7 @@ async def test_ventilator_min_on_away_attributes(hass: HomeAssistant) -> None:
     assert state.attributes.get("unit_of_measurement") == UnitOfTime.MINUTES
 
 
-async def test_set_min_time_home(hass: HomeAssistant):
+async def test_set_min_time_home(hass: HomeAssistant) -> None:
     """Test the number can set min time home."""
     target_value = 40
     with patch(

--- a/tests/components/efergy/test_config_flow.py
+++ b/tests/components/efergy/test_config_flow.py
@@ -16,7 +16,7 @@ def _patch_setup():
     return patch("homeassistant.components.efergy.async_setup_entry")
 
 
-async def test_flow_user(hass: HomeAssistant):
+async def test_flow_user(hass: HomeAssistant) -> None:
     """Test user initialized flow."""
     with _patch_efergy(), _patch_setup():
         result = await hass.config_entries.flow.async_init(
@@ -36,7 +36,7 @@ async def test_flow_user(hass: HomeAssistant):
         assert result["result"].unique_id == HID
 
 
-async def test_flow_user_cannot_connect(hass: HomeAssistant):
+async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
     """Test user initialized flow with unreachable service."""
     with _patch_efergy_status() as efergymock:
         efergymock.side_effect = exceptions.ConnectError
@@ -48,7 +48,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant):
         assert result["errors"]["base"] == "cannot_connect"
 
 
-async def test_flow_user_invalid_auth(hass: HomeAssistant):
+async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
     """Test user initialized flow with invalid authentication."""
     with _patch_efergy_status() as efergymock:
         efergymock.side_effect = exceptions.InvalidAuth
@@ -60,7 +60,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant):
         assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_flow_user_unknown(hass: HomeAssistant):
+async def test_flow_user_unknown(hass: HomeAssistant) -> None:
     """Test user initialized flow with unknown error."""
     with _patch_efergy_status() as efergymock:
         efergymock.side_effect = Exception
@@ -72,7 +72,7 @@ async def test_flow_user_unknown(hass: HomeAssistant):
         assert result["errors"]["base"] == "unknown"
 
 
-async def test_flow_reauth(hass: HomeAssistant):
+async def test_flow_reauth(hass: HomeAssistant) -> None:
     """Test reauth step."""
     entry = create_entry(hass)
     with _patch_efergy(), _patch_setup():

--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -12,7 +12,7 @@ from . import _patch_efergy_status, create_entry, init_integration, setup_platfo
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test unload."""
     entry = await init_integration(hass, aioclient_mock)
     assert entry.state == ConfigEntryState.LOADED
@@ -24,7 +24,7 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_not_ready(hass: HomeAssistant):
+async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = create_entry(hass)
     with _patch_efergy_status() as efergymock:
@@ -35,7 +35,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant):
         assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_auth_failed(hass: HomeAssistant):
+async def test_async_setup_entry_auth_failed(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryAuthFailed when authentication fails."""
     entry = create_entry(hass)
     with _patch_efergy_status() as efergymock:
@@ -46,7 +46,9 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant):
         assert not hass.data.get(DOMAIN)
 
 
-async def test_device_info(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_device_info(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test device info."""
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
     device_registry = dr.async_get(hass)

--- a/tests/components/efergy/test_sensor.py
+++ b/tests/components/efergy/test_sensor.py
@@ -28,7 +28,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 async def test_sensor_readings(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test for successfully setting up the Efergy platform."""
     for description in SENSOR_TYPES:
         description.entity_registry_enabled_default = True
@@ -99,7 +99,7 @@ async def test_sensor_readings(
 
 async def test_multi_sensor_readings(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test for multiple sensors in one household."""
     for description in SENSOR_TYPES:
         description.entity_registry_enabled_default = True
@@ -123,7 +123,7 @@ async def test_multi_sensor_readings(
 
 async def test_failed_update_and_reconnection(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test failed update and reconnection."""
     await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
     assert hass.states.get("sensor.power_usage").state == "1580"

--- a/tests/components/eight_sleep/test_config_flow.py
+++ b/tests/components/eight_sleep/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_form(hass: HomeAssistant) -> None:
     }
 
 
-async def test_form_invalid_auth(hass, token_error) -> None:
+async def test_form_invalid_auth(hass: HomeAssistant, token_error) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -68,7 +68,7 @@ async def test_import(hass: HomeAssistant) -> None:
     }
 
 
-async def test_import_invalid_auth(hass, token_error) -> None:
+async def test_import_invalid_auth(hass: HomeAssistant, token_error) -> None:
     """Test we handle invalid auth on import."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -396,8 +396,8 @@ async def test_form_user_with_secure_elk_with_discovery_pick_manual(
 
 
 async def test_form_user_with_secure_elk_with_discovery_pick_manual_direct_discovery(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test we can setup a secure elk with discovery but user picks manual and directed discovery succeeds."""
 
     with _patch_discovery():
@@ -983,8 +983,8 @@ async def test_form_import_existing(hass: HomeAssistant) -> None:
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already_configured(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort if the host is already configured but the mac does not match."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1013,8 +1013,8 @@ async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we add a missing unique id to the config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -264,7 +264,7 @@ async def hue_client(hass_hue, hass_client_no_auth):
     return await hass_client_no_auth()
 
 
-async def test_discover_lights(hass, hue_client):
+async def test_discover_lights(hass: HomeAssistant, hue_client) -> None:
     """Test the discovery of lights."""
     result = await hue_client.get("/api/username/lights")
 
@@ -322,7 +322,7 @@ async def test_discover_lights(hass, hue_client):
     assert device["state"][HUE_API_STATE_ON] is False
 
 
-async def test_light_without_brightness_supported(hass_hue, hue_client):
+async def test_light_without_brightness_supported(hass_hue, hue_client) -> None:
     """Test that light without brightness is supported."""
     light_without_brightness_json = await perform_get_light_state(
         hue_client, "light.no_brightness", HTTPStatus.OK
@@ -361,7 +361,7 @@ async def test_lights_all_dimmable(
     )
 
 
-async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client):
+async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client) -> None:
     """Test that light without brightness can be turned off."""
     hass_hue.states.async_set("light.no_brightness", "on", {})
     turn_off_calls = []
@@ -396,7 +396,7 @@ async def test_light_without_brightness_can_be_turned_off(hass_hue, hue_client):
     assert "light.no_brightness" in call.data[ATTR_ENTITY_ID]
 
 
-async def test_light_without_brightness_can_be_turned_on(hass_hue, hue_client):
+async def test_light_without_brightness_can_be_turned_on(hass_hue, hue_client) -> None:
     """Test that light without brightness can be turned on."""
     hass_hue.states.async_set("light.no_brightness", "off", {})
 
@@ -446,7 +446,7 @@ async def test_light_without_brightness_can_be_turned_on(hass_hue, hue_client):
         (const.STATE_UNKNOWN, True),
     ],
 )
-async def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
+async def test_reachable_for_state(hass_hue, hue_client, state, is_reachable) -> None:
     """Test that an entity is reported as unreachable if in unavailable state."""
     entity_id = "light.ceiling_lights"
 
@@ -457,7 +457,7 @@ async def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
     assert state_json["state"]["reachable"] == is_reachable, state_json
 
 
-async def test_discover_full_state(hue_client):
+async def test_discover_full_state(hue_client) -> None:
     """Test the discovery of full state."""
     result = await hue_client.get(f"/api/{HUE_API_USERNAME}")
 
@@ -508,7 +508,7 @@ async def test_discover_full_state(hue_client):
     assert config_json["linkbutton"] is True
 
 
-async def test_discover_config(hue_client):
+async def test_discover_config(hue_client) -> None:
     """Test the discovery of configuration."""
     result = await hue_client.get(f"/api/{HUE_API_USERNAME}/config")
 
@@ -566,7 +566,7 @@ async def test_discover_config(hue_client):
     assert "error" not in config_json
 
 
-async def test_get_light_state(hass_hue, hue_client):
+async def test_get_light_state(hass_hue, hue_client) -> None:
     """Test the getting of light state."""
     # Turn ceiling lights on and set to 127 brightness, and set light color
     await hass_hue.services.async_call(
@@ -627,7 +627,7 @@ async def test_get_light_state(hass_hue, hue_client):
     )
 
 
-async def test_put_light_state(hass, hass_hue, hue_client):
+async def test_put_light_state(hass: HomeAssistant, hass_hue, hue_client) -> None:
     """Test the setting of light states."""
     await perform_put_test_on_ceiling_lights(hass_hue, hue_client)
 
@@ -796,7 +796,9 @@ async def test_put_light_state(hass, hass_hue, hue_client):
     assert call_turn_on[0].data[light.ATTR_TRANSITION] == 6
 
 
-async def test_put_light_state_script(hass, hass_hue, hue_client):
+async def test_put_light_state_script(
+    hass: HomeAssistant, hass_hue, hue_client
+) -> None:
     """Test the setting of script variables."""
     # Turn the kitchen light off first
     await hass_hue.services.async_call(
@@ -828,7 +830,7 @@ async def test_put_light_state_script(hass, hass_hue, hue_client):
     )
 
 
-async def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
+async def test_put_light_state_climate_set_temperature(hass_hue, hue_client) -> None:
     """Test setting climate temperature."""
     brightness = 19
     temperature = round(brightness / 254 * 100)
@@ -853,7 +855,7 @@ async def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
     assert ecobee_result.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_put_light_state_humidifier_set_humidity(hass_hue, hue_client):
+async def test_put_light_state_humidifier_set_humidity(hass_hue, hue_client) -> None:
     """Test setting humidifier target humidity."""
     # Turn the humidifier off first
     await hass_hue.services.async_call(
@@ -886,7 +888,7 @@ async def test_put_light_state_humidifier_set_humidity(hass_hue, hue_client):
     assert hygrostat_result.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_put_light_state_media_player(hass_hue, hue_client):
+async def test_put_light_state_media_player(hass_hue, hue_client) -> None:
     """Test turning on media player and setting volume."""
     # Turn the music player off first
     await hass_hue.services.async_call(
@@ -914,7 +916,7 @@ async def test_put_light_state_media_player(hass_hue, hue_client):
     assert walkman.attributes[media_player.ATTR_MEDIA_VOLUME_LEVEL] == level
 
 
-async def test_open_cover_without_position(hass_hue, hue_client):
+async def test_open_cover_without_position(hass_hue, hue_client) -> None:
     """Test opening cover ."""
     cover_id = "cover.living_room_window"
     # Close cover first
@@ -977,7 +979,7 @@ async def test_open_cover_without_position(hass_hue, hue_client):
     assert cover_test_2.attributes.get("current_position") == 0
 
 
-async def test_set_position_cover(hass_hue, hue_client):
+async def test_set_position_cover(hass_hue, hue_client) -> None:
     """Test setting position cover ."""
     cover_id = "cover.living_room_window"
     cover_number = ENTITY_NUMBERS_BY_ID[cover_id]
@@ -1028,7 +1030,7 @@ async def test_set_position_cover(hass_hue, hue_client):
     assert cover_test_2.attributes.get("current_position") == level
 
 
-async def test_put_light_state_fan(hass_hue, hue_client):
+async def test_put_light_state_fan(hass_hue, hue_client) -> None:
     """Test turning on fan and setting speed."""
     # Turn the fan off first
     await hass_hue.services.async_call(
@@ -1117,7 +1119,7 @@ async def test_put_light_state_fan(hass_hue, hue_client):
 
 
 # pylint: disable=invalid-name
-async def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
+async def test_put_with_form_urlencoded_content_type(hass_hue, hue_client) -> None:
     """Test the form with urlencoded content."""
     entity_number = ENTITY_NUMBERS_BY_ID["light.ceiling_lights"]
     # Needed for Alexa
@@ -1136,7 +1138,7 @@ async def test_put_with_form_urlencoded_content_type(hass_hue, hue_client):
     assert result.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_entity_not_found(hue_client):
+async def test_entity_not_found(hue_client) -> None:
     """Test for entity which are not found."""
     result = await hue_client.get("/api/username/lights/98")
 
@@ -1147,7 +1149,7 @@ async def test_entity_not_found(hue_client):
     assert result.status == HTTPStatus.NOT_FOUND
 
 
-async def test_allowed_methods(hue_client):
+async def test_allowed_methods(hue_client) -> None:
     """Test the allowed methods."""
     result = await hue_client.get(
         "/api/username/lights/ENTITY_NUMBERS_BY_ID[light.ceiling_lights]/state"
@@ -1166,7 +1168,7 @@ async def test_allowed_methods(hue_client):
     assert result.status == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-async def test_proper_put_state_request(hue_client):
+async def test_proper_put_state_request(hue_client) -> None:
     """Test the request to set the state."""
     # Test proper on value parsing
     result = await hue_client.put(
@@ -1189,7 +1191,7 @@ async def test_proper_put_state_request(hue_client):
     assert result.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_get_empty_groups_state(hue_client):
+async def test_get_empty_groups_state(hue_client) -> None:
     """Test the request to get groups endpoint."""
     # Test proper on value parsing
     result = await hue_client.get("/api/username/groups")
@@ -1305,7 +1307,7 @@ async def perform_put_light_state(
     return result
 
 
-async def test_external_ip_blocked(hue_client):
+async def test_external_ip_blocked(hue_client) -> None:
     """Test external IP blocked."""
     getUrls = [
         "/api/username/groups",
@@ -1333,7 +1335,7 @@ async def test_external_ip_blocked(hue_client):
             assert result.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_unauthorized_user_blocked(hue_client):
+async def test_unauthorized_user_blocked(hue_client) -> None:
     """Test unauthorized_user blocked."""
     getUrls = [
         "/api/wronguser",
@@ -1346,7 +1348,9 @@ async def test_unauthorized_user_blocked(hue_client):
         assert result_json[0]["error"]["description"] == "unauthorized user"
 
 
-async def test_put_then_get_cached_properly(hass, hass_hue, hue_client):
+async def test_put_then_get_cached_properly(
+    hass: HomeAssistant, hass_hue, hue_client
+) -> None:
     """Test the setting of light states and an immediate readback reads the same values."""
 
     # Turn the bedroom light on first
@@ -1469,7 +1473,9 @@ async def test_put_then_get_cached_properly(hass, hass_hue, hue_client):
         assert ceiling_json["state"][HUE_API_STATE_BRI] == 127
 
 
-async def test_put_than_get_when_service_call_fails(hass, hass_hue, hue_client):
+async def test_put_than_get_when_service_call_fails(
+    hass: HomeAssistant, hass_hue, hue_client
+) -> None:
     """Test putting and getting the light state when the service call fails."""
 
     # Turn the bedroom light off first
@@ -1519,14 +1525,14 @@ async def test_put_than_get_when_service_call_fails(hass, hass_hue, hue_client):
     assert ceiling_json["state"][HUE_API_STATE_ON] is False
 
 
-async def test_get_invalid_entity(hass, hass_hue, hue_client):
+async def test_get_invalid_entity(hass: HomeAssistant, hass_hue, hue_client) -> None:
     """Test the setting of light states and an immediate readback reads the same values."""
 
     # Check that we get an error with an invalid entity number.
     await perform_get_light_state_by_number(hue_client, 999, HTTPStatus.NOT_FOUND)
 
 
-async def test_put_light_state_scene(hass, hass_hue, hue_client):
+async def test_put_light_state_scene(hass: HomeAssistant, hass_hue, hue_client) -> None:
     """Test the setting of scene variables."""
     # Turn the kitchen lights off first
     await hass_hue.services.async_call(
@@ -1568,7 +1574,7 @@ async def test_put_light_state_scene(hass, hass_hue, hue_client):
     assert hass_hue.states.get("light.kitchen_lights").state == STATE_OFF
 
 
-async def test_only_change_contrast(hass, hass_hue, hue_client):
+async def test_only_change_contrast(hass: HomeAssistant, hass_hue, hue_client) -> None:
     """Test when only changing the contrast of a light state."""
 
     # Turn the kitchen lights off first
@@ -1597,7 +1603,9 @@ async def test_only_change_contrast(hass, hass_hue, hue_client):
     assert ceiling_lights.attributes[light.ATTR_BRIGHTNESS] == 255
 
 
-async def test_only_change_hue_or_saturation(hass, hass_hue, hue_client):
+async def test_only_change_hue_or_saturation(
+    hass: HomeAssistant, hass_hue, hue_client
+) -> None:
     """Test setting either the hue or the saturation but not both."""
 
     # TODO: The handling of this appears wrong, as setting only one will set the other to 0.
@@ -1634,7 +1642,9 @@ async def test_only_change_hue_or_saturation(hass, hass_hue, hue_client):
     ] == (0, 3)
 
 
-async def test_specificly_exposed_entities(hass, base_setup, hass_client_no_auth):
+async def test_specificly_exposed_entities(
+    hass: HomeAssistant, base_setup, hass_client_no_auth: ClientSessionGenerator
+) -> None:
     """Test specific entities with expose by default off."""
     conf = {
         emulated_hue.CONF_LISTEN_PORT: BRIDGE_SERVER_PORT,

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -17,7 +17,9 @@ from homeassistant.util import utcnow
 from tests.common import async_fire_time_changed
 
 
-async def test_config_google_home_entity_id_to_number(hass, hass_storage):
+async def test_config_google_home_entity_id_to_number(
+    hass: HomeAssistant, hass_storage
+) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {
@@ -48,7 +50,9 @@ async def test_config_google_home_entity_id_to_number(hass, hass_storage):
     assert entity_id == "light.test2"
 
 
-async def test_config_google_home_entity_id_to_number_altered(hass, hass_storage):
+async def test_config_google_home_entity_id_to_number_altered(
+    hass: HomeAssistant, hass_storage
+) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {
@@ -79,7 +83,9 @@ async def test_config_google_home_entity_id_to_number_altered(hass, hass_storage
     assert entity_id == "light.test2"
 
 
-async def test_config_google_home_entity_id_to_number_empty(hass, hass_storage):
+async def test_config_google_home_entity_id_to_number_empty(
+    hass: HomeAssistant, hass_storage
+) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {"version": DATA_VERSION, "key": DATA_KEY, "data": {}}

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -12,6 +12,7 @@ from homeassistant import setup
 from homeassistant.components import emulated_hue
 from homeassistant.components.emulated_hue import upnp
 from homeassistant.const import CONTENT_TYPE_JSON
+from homeassistant.core import HomeAssistant
 
 from tests.common import get_test_instance_port
 
@@ -149,7 +150,7 @@ MX:3
     assert mock_transport.sends == []
 
 
-async def test_description_xml(hass, hue_client):
+async def test_description_xml(hass: HomeAssistant, hue_client) -> None:
     """Test the description."""
     await setup_hue(hass)
     client = await hue_client()
@@ -166,7 +167,7 @@ async def test_description_xml(hass, hue_client):
         pytest.fail("description.xml is not valid XML!")
 
 
-async def test_create_username(hass, hue_client):
+async def test_create_username(hass: HomeAssistant, hue_client) -> None:
     """Test the creation of an username."""
     await setup_hue(hass)
     client = await hue_client()
@@ -184,7 +185,7 @@ async def test_create_username(hass, hue_client):
     assert "username" in success_json["success"]
 
 
-async def test_unauthorized_view(hass, hue_client):
+async def test_unauthorized_view(hass: HomeAssistant, hue_client) -> None:
     """Test unauthorized view."""
     await setup_hue(hass)
     client = await hue_client()
@@ -210,7 +211,7 @@ async def test_unauthorized_view(hass, hue_client):
     assert "1" in error_json["type"]
 
 
-async def test_valid_username_request(hass, hue_client):
+async def test_valid_username_request(hass: HomeAssistant, hue_client) -> None:
     """Test request with a valid username."""
     await setup_hue(hass)
     client = await hue_client()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
