### PR TITLE
Add climate Tuya Power command instead of switch

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -280,7 +280,12 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        commands = [{"code": DPCode.SWITCH, "value": hvac_mode != HVACMode.OFF}]
+        if DPCode.SWITCH in self.device.function:
+            commands = [{"code": DPCode.SWITCH, "value": hvac_mode != HVACMode.OFF}]
+        elif DPCode.POWER_SWITCH in self.device.function:
+            commands = [
+                {"code": DPCode.POWER_SWITCH, "value": hvac_mode != HVACMode.OFF}
+            ]
         if hvac_mode in self._hvac_to_tuya:
             commands.append(
                 {"code": DPCode.MODE, "value": self._hvac_to_tuya[hvac_mode]}
@@ -416,11 +421,15 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         """Return hvac mode."""
         # If the switch off, hvac mode is off as well. Unless the switch
         # the switch is on or doesn't exists of course...
-        if not self.device.status.get(DPCode.SWITCH, True):
+        dp_name = DPCode.SWITCH
+        if DPCode.POWER_SWITCH in self.device.function:
+            dp_name = DPCode.POWER_SWITCH
+
+        if not self.device.status.get(dp_name, True):
             return HVACMode.OFF
 
         if DPCode.MODE not in self.device.function:
-            if self.device.status.get(DPCode.SWITCH, False):
+            if self.device.status.get(dp_name, False):
                 return self.entity_description.switch_only_hvac_mode
             return HVACMode.OFF
 
@@ -430,7 +439,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             return TUYA_HVAC_TO_HA[mode]
 
         # If the switch is on, and the mode does not match any hvac mode.
-        if self.device.status.get(DPCode.SWITCH, False):
+        if self.device.status.get(dp_name, False):
             return self.entity_description.switch_only_hvac_mode
 
         return HVACMode.OFF
@@ -474,7 +483,11 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     def turn_on(self) -> None:
         """Turn the device on, retaining current HVAC (if supported)."""
         if DPCode.SWITCH in self.device.function:
-            self._send_command([{"code": DPCode.SWITCH, "value": True}])
+            self._send_command([{"code": DPCode.POWER, "value": True}])
+            return
+
+        if DPCode.POWER_SWITCH in self.device.function:
+            self._send_command([{"code": DPCode.POWER_SWITCH, "value": True}])
             return
 
         # Fake turn on
@@ -487,7 +500,11 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     def turn_off(self) -> None:
         """Turn the device on, retaining current HVAC (if supported)."""
         if DPCode.SWITCH in self.device.function:
-            self._send_command([{"code": DPCode.SWITCH, "value": False}])
+            self._send_command([{"code": DPCode.POWER, "value": False}])
+            return
+
+        if DPCode.POWER_SWITCH in self.device.function:
+            self._send_command([{"code": DPCode.POWER_SWITCH, "value": False}])
             return
 
         # Fake turn off

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -286,6 +286,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             commands = [
                 {"code": DPCode.POWER_SWITCH, "value": hvac_mode != HVACMode.OFF}
             ]
+
         if hvac_mode in self._hvac_to_tuya:
             commands.append(
                 {"code": DPCode.MODE, "value": self._hvac_to_tuya[hvac_mode]}

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -254,6 +254,8 @@ class DPCode(StrEnum):
     PM25_STATE = "pm25_state"
     PM25_VALUE = "pm25_value"
     POWDER_SET = "powder_set"  # Powder
+    # JMC
+    POWER_SWITCH = "Power"
     POWER = "power"
     POWER_GO = "power_go"
     PRESENCE_STATE = "presence_state"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR aims to add a Power command capability to some Tuya climate device (Airton device for example) instead of the existing switch command. This command is used to turn on or off the climate device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78815
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
