### PR TITLE
Improve Google Calendar config flow error message when API disabled

### DIFF
--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from gcal_sync.api import GoogleCalendarService
-from gcal_sync.exceptions import ApiException
+from gcal_sync.exceptions import ApiException, ApiForbiddenException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -146,6 +146,12 @@ class OAuth2FlowHandler(
         )
         try:
             primary_calendar = await calendar_service.async_get_calendar("primary")
+        except ApiForbiddenException as err:
+            _LOGGER.error(
+                "Error reading primary calendar, make sure Google Calendar API is enabled: %s",
+                err,
+            )
+            return self.async_abort(reason="api_disabled")
         except ApiException as err:
             _LOGGER.error("Error reading primary calendar: %s", err)
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -21,7 +21,8 @@
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "code_expired": "Authentication code expired or credential setup is invalid, please try again.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]"
+      "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]",
+      "api_disabled": "You must enable the Google Calendar API in the Google Cloud Console"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import datetime
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 from aiohttp.client_exceptions import ClientError
@@ -95,10 +96,17 @@ async def primary_calendar_error() -> ClientError | None:
     return None
 
 
+@pytest.fixture
+async def primary_calendar_status() -> HTTPStatus | None:
+    """Fixture for tests to inject an error during calendar lookup."""
+    return HTTPStatus.OK
+
+
 @pytest.fixture(autouse=True)
 async def primary_calendar(
     mock_calendar_get: Callable[[...], None],
     primary_calendar_error: ClientError | None,
+    primary_calendar_status: HTTPStatus | None,
     primary_calendar_email: str,
 ) -> None:
     """Fixture to return the primary calendar."""
@@ -106,6 +114,7 @@ async def primary_calendar(
         "primary",
         {"id": primary_calendar_email, "summary": "Personal", "accessRole": "owner"},
         exc=primary_calendar_error,
+        status=primary_calendar_status,
     )
 
 
@@ -515,11 +524,19 @@ async def test_reauth_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
-@pytest.mark.parametrize("primary_calendar_error", [ClientError()])
+@pytest.mark.parametrize(
+    "primary_calendar_error,primary_calendar_status,reason",
+    [
+        (ClientError(), None, "cannot_connect"),
+        (None, HTTPStatus.FORBIDDEN, "api_disabled"),
+        (None, HTTPStatus.SERVICE_UNAVAILABLE, "cannot_connect"),
+    ],
+)
 async def test_calendar_lookup_failure(
     hass: HomeAssistant,
     mock_code_flow: Mock,
     mock_exchange: Mock,
+    reason: str,
 ) -> None:
     """Test successful config flow and title fetch fails gracefully."""
     await async_import_client_credential(
@@ -544,7 +561,7 @@ async def test_calendar_lookup_failure(
         )
 
     assert result.get("type") == "abort"
-    assert result.get("reason") == "cannot_connect"
+    assert result.get("reason") == reason
 
 
 async def test_options_flow_triggers_reauth(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a friendlier error message when the google calendar API is disabled, since this is a common step users get stuck on.

Improve config flow error:
<img width="513" alt="Screen Shot 2023-02-11 at 8 37 14 AM" src="https://user-images.githubusercontent.com/6026418/218269974-c33822b4-4583-426c-9fc6-82616f2f30dc.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82176
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
