### PR TITLE
Cache try_parse_enum

### DIFF
--- a/homeassistant/util/enum.py
+++ b/homeassistant/util/enum.py
@@ -1,13 +1,24 @@
 """Helpers for working with enums."""
+from collections.abc import Callable
 import contextlib
 from enum import Enum
-from functools import lru_cache
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+
+# https://github.com/python/mypy/issues/5107
+if TYPE_CHECKING:
+    _P = ParamSpec("_P")
+    _T = TypeVar("_T")
+
+    def lru_cache(maxsize: int | None) -> Callable[..., Callable[_P, _T]]:
+        """Stub for lru_cache."""
+
+else:
+    from functools import lru_cache
 
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(1024)
 def try_parse_enum(cls: type[_EnumT], value: Any) -> _EnumT | None:
     """Try to parse the value into an Enum.
 

--- a/homeassistant/util/enum.py
+++ b/homeassistant/util/enum.py
@@ -7,7 +7,7 @@ from typing import Any, TypeVar
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
 
-@lru_cache(maxsize=1042)
+@lru_cache(maxsize=1024)
 def try_parse_enum(cls: type[_EnumT], value: Any) -> _EnumT | None:
     """Try to parse the value into an Enum.
 

--- a/homeassistant/util/enum.py
+++ b/homeassistant/util/enum.py
@@ -4,8 +4,6 @@ import contextlib
 from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeVar
 
-_EnumT = TypeVar("_EnumT", bound=Enum)
-
 # https://github.com/python/mypy/issues/5107
 if TYPE_CHECKING:
     _LruCacheT = TypeVar("_LruCacheT", bound=Callable)
@@ -15,6 +13,8 @@ if TYPE_CHECKING:
 
 else:
     from functools import lru_cache
+
+_EnumT = TypeVar("_EnumT", bound=Enum)
 
 
 @lru_cache

--- a/homeassistant/util/enum.py
+++ b/homeassistant/util/enum.py
@@ -1,11 +1,13 @@
 """Helpers for working with enums."""
 import contextlib
 from enum import Enum
+from functools import lru_cache
 from typing import Any, TypeVar
 
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
 
+@lru_cache(maxsize=1042)
 def try_parse_enum(cls: type[_EnumT], value: Any) -> _EnumT | None:
     """Try to parse the value into an Enum.
 

--- a/homeassistant/util/enum.py
+++ b/homeassistant/util/enum.py
@@ -2,23 +2,22 @@
 from collections.abc import Callable
 import contextlib
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
+
+_EnumT = TypeVar("_EnumT", bound=Enum)
 
 # https://github.com/python/mypy/issues/5107
 if TYPE_CHECKING:
-    _P = ParamSpec("_P")
-    _T = TypeVar("_T")
+    _LruCacheT = TypeVar("_LruCacheT", bound=Callable)
 
-    def lru_cache(maxsize: int | None) -> Callable[..., Callable[_P, _T]]:
+    def lru_cache(func: _LruCacheT) -> _LruCacheT:
         """Stub for lru_cache."""
 
 else:
     from functools import lru_cache
 
-_EnumT = TypeVar("_EnumT", bound=Enum)
 
-
-@lru_cache(1024)
+@lru_cache
 def try_parse_enum(cls: type[_EnumT], value: Any) -> _EnumT | None:
     """Try to parse the value into an Enum.
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This function is the majority of the execution time of `list_statistic_ids` which has to be called to figure out which ids we want to fetch so any latency here has a knock on effect for fetching stats. Since it gets called with the same arguments over and over and the result will never change.

<img width="959" alt="Screenshot_2023-02-11_at_4_34_09_PM" src="https://user-images.githubusercontent.com/663432/218283932-ec48eda6-812b-4435-8785-5a458e1618cb.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
