### PR TITLE
Fix goodwe text(enum) sensors device class

### DIFF
--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -84,7 +84,7 @@ class GoodweSensorEntityDescription(SensorEntityDescription):
     ] = lambda entity: entity.coordinator.last_update_success
 
 
-_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+_DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
     "A": GoodweSensorEntityDescription(
         key="A",
         device_class=SensorDeviceClass.CURRENT,

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -19,16 +19,13 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
-    POWER_VOLT_AMPERE_REACTIVE,
     EntityCategory,
-    UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
     UnitOfTemperature,
-    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
@@ -87,7 +84,7 @@ class GoodweSensorEntityDescription(SensorEntityDescription):
     ] = lambda entity: entity.coordinator.last_update_success
 
 
-_DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
+_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "A": GoodweSensorEntityDescription(
         key="A",
         device_class=SensorDeviceClass.CURRENT,
@@ -114,18 +111,6 @@ _DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
         value=lambda prev, val: prev if not val else val,
         available=lambda entity: entity.coordinator.data is not None,
     ),
-    "VA": GoodweSensorEntityDescription(
-        key="VA",
-        device_class=SensorDeviceClass.APPARENT_POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
-    ),
-    "var": GoodweSensorEntityDescription(
-        key="var",
-        device_class=SensorDeviceClass.REACTIVE_POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
-    ),
     "C": GoodweSensorEntityDescription(
         key="C",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -137,12 +122,6 @@ _DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
-    ),
-    "h": GoodweSensorEntityDescription(
-        key="h",
-        device_class=SensorDeviceClass.DURATION,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTime.HOURS,
     ),
     "%": GoodweSensorEntityDescription(
         key="%",
@@ -199,14 +178,14 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
         self._attr_entity_category = (
             EntityCategory.DIAGNOSTIC if sensor.id_ not in _MAIN_SENSORS else None
         )
-        self.entity_description = _DESCRIPTIONS.get(sensor.unit, DIAG_SENSOR)
-        if not self.entity_description.native_unit_of_measurement:
-            self._attr_native_unit_of_measurement = sensor.unit
-        if self.entity_description == DIAG_SENSOR and (
-            "Enum" in type(sensor).__name__ or sensor.id_ == "timestamp"
-        ):
-            self.entity_description = ENUM_SENSOR
-            self._attr_native_unit_of_measurement = None
+        try:
+            self.entity_description = _DESCRIPTIONS[sensor.unit]
+        except KeyError:
+            if "Enum" in type(sensor).__name__ or sensor.id_ == "timestamp":
+                self.entity_description = ENUM_SENSOR
+            else:
+                self.entity_description = DIAG_SENSOR
+                self._attr_native_unit_of_measurement = sensor.unit
         self._attr_icon = _ICONS.get(sensor.kind)
         # Set the inverter SoC as main device battery sensor
         if sensor.id_ == BATTERY_SOC:

--- a/homeassistant/components/goodwe/sensor.py
+++ b/homeassistant/components/goodwe/sensor.py
@@ -133,9 +133,8 @@ DIAG_SENSOR = GoodweSensorEntityDescription(
     key="_",
     state_class=SensorStateClass.MEASUREMENT,
 )
-ENUM_SENSOR = GoodweSensorEntityDescription(
-    key="enum",
-    device_class=SensorDeviceClass.ENUM,
+TEXT_SENSOR = GoodweSensorEntityDescription(
+    key="text",
 )
 
 
@@ -182,7 +181,7 @@ class InverterSensor(CoordinatorEntity, SensorEntity):
             self.entity_description = _DESCRIPTIONS[sensor.unit]
         except KeyError:
             if "Enum" in type(sensor).__name__ or sensor.id_ == "timestamp":
-                self.entity_description = ENUM_SENSOR
+                self.entity_description = TEXT_SENSOR
             else:
                 self.entity_description = DIAG_SENSOR
                 self._attr_native_unit_of_measurement = sensor.unit


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Several inverter diagnostic sensors reporting string values were improperly declared
as measurements with empty strings as their units.
(These started to emit warnings to long since 2023.2.0)
Their device_class and native_units declarations were fixed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87477
- This PR is related to issue: #81601
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
