### PR TITLE
Allow resetting MQTT climate attributes and ignore empty values

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -646,7 +646,16 @@ class MqttClimate(MqttEntity, ClimateEntity):
         ) -> None:
             """Handle climate attributes coming via MQTT."""
             payload = render_template(msg, template_name)
-
+            if not payload:
+                _LOGGER.debug(
+                    "Invalid empty payload for attribute %s, ignoring update",
+                    attr,
+                )
+                return
+            if payload == PAYLOAD_NONE:
+                setattr(self, attr, None)
+                get_mqtt_data(self.hass).state_write_requests.write_state_request(self)
+                return
             try:
                 setattr(self, attr, float(payload))
                 get_mqtt_data(self.hass).state_write_requests.write_state_request(self)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MQTT climate attributes: `_attr_current_temperature`, `_attr_target_temperature`, `_attr_target_temperature_low`, `_attr_target_temperature_high`, `_attr_current_humidity`, and `_attr_target_humidity` allow an empty value, but after setting it it cannot be set to `None` thru a state update.

Some examples:
In some occations wewant to be able to only set the `target_temperature` using a single setpoint, and in e.g. in auto mode we want to be able to a set min andmax set point.
The current temperature or humidity can become unavailble, in that case we want to set these attributes to none.

This PR does 2 things:
1. It allows to reset above attributes to `None` using a `"None"` payload. When using a JSON null value, a value template will also render to None.
2. It will no longer raise an exception when an empty payload/template rendered value is received, and will silently ignore the update,

The 2 features above will now be applicable for the following config config options:

- `current_humidity_topic` for attribute `_attr_current_humidity`
- `current_temperature_topic` for attribute `_attr_current_temperature`
- `target_humidity_state_topic` for attribute `_attr_target_humidity`
- `temperature_low_state_topic` for attribute `_attr_target_temperature_low`
- `temperature_high_state_topic` for attribute `_attr_target_temperature_high`
- `temperature_state_topic` for attribute `_attr_target_temperature`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26223

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
