### PR TITLE
The recorder/statistic(s)_during_period websocket API now require the statistic_id(s) field

### DIFF
--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -199,12 +199,6 @@ async def ws_handle_get_statistics_during_period(
     else:
         end_time = None
 
-    if not (statistic_ids := msg["statistic_ids"]):
-        connection.send_error(
-            msg["id"], "invalid_statistic_ids", "Invalid statistic_ids"
-        )
-        return
-
     if (types := msg.get("types")) is None:
         types = {"last_reset", "max", "mean", "min", "state", "sum"}
     connection.send_message(
@@ -214,7 +208,7 @@ async def ws_handle_get_statistics_during_period(
             msg["id"],
             start_time,
             end_time,
-            statistic_ids,
+            msg["statistic_ids"],
             msg.get("period"),
             msg.get("units"),
             types,
@@ -227,7 +221,7 @@ async def ws_handle_get_statistics_during_period(
         vol.Required("type"): "recorder/statistics_during_period",
         vol.Required("start_time"): str,
         vol.Optional("end_time"): str,
-        vol.Required("statistic_ids"): [str],
+        vol.Required("statistic_ids"): vol.All([str], vol.Length(min=1)),
         vol.Required("period"): vol.Any("5minute", "hour", "day", "week", "month"),
         vol.Optional("units"): UNIT_SCHEMA,
         vol.Optional("types"): vol.All(

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1315,7 +1315,7 @@ async def test_statistics_during_period_empty_statistic_ids(
     )
     response = await client.receive_json()
     assert not response["success"]
-    assert response["error"]["code"] == "invalid_statistic_ids"
+    assert response["error"]["code"] == "invalid_format"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1089,6 +1089,7 @@ async def test_statistics_during_period_invalid_unit_conversion(
             "id": 1,
             "type": "recorder/statistics_during_period",
             "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
             "period": "5minute",
         }
     )
@@ -1102,6 +1103,7 @@ async def test_statistics_during_period_invalid_unit_conversion(
             "id": 2,
             "type": "recorder/statistics_during_period",
             "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test"],
             "period": "5minute",
             "units": custom_units,
         }
@@ -1242,6 +1244,7 @@ async def test_statistics_during_period_bad_start_time(
             "id": 1,
             "type": "recorder/statistics_during_period",
             "start_time": "cats",
+            "statistic_ids": ["sensor.test"],
             "period": "5minute",
         }
     )
@@ -1263,12 +1266,56 @@ async def test_statistics_during_period_bad_end_time(
             "type": "recorder/statistics_during_period",
             "start_time": now.isoformat(),
             "end_time": "dogs",
+            "statistic_ids": ["sensor.test"],
             "period": "5minute",
         }
     )
     response = await client.receive_json()
     assert not response["success"]
     assert response["error"]["code"] == "invalid_end_time"
+
+
+async def test_statistics_during_period_no_statistic_ids(
+    recorder_mock, hass, hass_ws_client
+):
+    """Test statistics_during_period without passing statistic_ids."""
+    now = dt_util.utcnow()
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(seconds=1)).isoformat(),
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_format"
+
+
+async def test_statistics_during_period_empty_statistic_ids(
+    recorder_mock, hass, hass_ws_client
+):
+    """Test statistics_during_period with passing an empty list of statistic_ids."""
+    now = dt_util.utcnow()
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": [],
+            "end_time": (now + timedelta(seconds=1)).isoformat(),
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_statistic_ids"
 
 
 @pytest.mark.parametrize(
@@ -1606,6 +1653,7 @@ async def test_clear_statistics(recorder_mock, hass, hass_ws_client):
             "id": 1,
             "type": "recorder/statistics_during_period",
             "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.test1", "sensor.test2", "sensor.test3"],
             "period": "5minute",
         }
     )
@@ -1667,6 +1715,7 @@ async def test_clear_statistics(recorder_mock, hass, hass_ws_client):
         {
             "id": 3,
             "type": "recorder/statistics_during_period",
+            "statistic_ids": ["sensor.test1", "sensor.test2", "sensor.test3"],
             "start_time": now.isoformat(),
             "period": "5minute",
         }
@@ -1691,6 +1740,7 @@ async def test_clear_statistics(recorder_mock, hass, hass_ws_client):
         {
             "id": 5,
             "type": "recorder/statistics_during_period",
+            "statistic_ids": ["sensor.test1", "sensor.test2", "sensor.test3"],
             "start_time": now.isoformat(),
             "period": "5minute",
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Previously these APIs would accept an empty set of statistic_id(s) which could result in selecting all statistic_ids and bringing system to a stall. For yearly energy stats that would effectively select the entire statistics database.

I'm only marking this as a breaking change because someone could still be using an old version of the frontend which doesn't have the [fix](https://github.com/home-assistant/frontend/pull/15428) and needs to clear their cache since the energy panel will be empty when using a frontend without the fix.

For developers its unlikely anyone was intentionally using the API in this manner without some bad side effects so there is no blog post for it. 

This is more about having better validation in the API to fail early instead of letting the developer do something by accident that will impact the stability of the system. It was far too easy to do based on how long https://github.com/home-assistant/frontend/pull/15428 lived in production.  This issue shows that the backend needs to be better at preventing implementation error since it was trivial to trigger this and overload the system. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
