### PR TITLE
Fix kegtron state class for volume sensors

### DIFF
--- a/homeassistant/components/kegtron/sensor.py
+++ b/homeassistant/components/kegtron/sensor.py
@@ -42,7 +42,6 @@ SENSOR_DESCRIPTIONS = {
         icon="mdi:keg",
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.VOLUME,
-        state_class=SensorStateClass.MEASUREMENT,
     ),
     KegtronSensorDeviceClass.KEG_TYPE: SensorEntityDescription(
         key=KegtronSensorDeviceClass.KEG_TYPE,
@@ -53,7 +52,6 @@ SENSOR_DESCRIPTIONS = {
         icon="mdi:keg",
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.VOLUME,
-        state_class=SensorStateClass.MEASUREMENT,
     ),
     KegtronSensorDeviceClass.VOLUME_DISPENSED: SensorEntityDescription(
         key=KegtronSensorDeviceClass.VOLUME_DISPENSED,

--- a/tests/components/kegtron/test_sensor.py
+++ b/tests/components/kegtron/test_sensor.py
@@ -46,7 +46,6 @@ async def test_sensors_kt100(hass: HomeAssistant) -> None:
     assert keg_size_sensor.state == "18.927"
     assert keg_size_sensor_attrs[ATTR_FRIENDLY_NAME] == "Kegtron KT-100 9B75 Keg Size"
     assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     keg_type_sensor = hass.states.get("sensor.kegtron_kt_100_9b75_keg_type")
     keg_type_sensor_attrs = keg_type_sensor.attributes
@@ -61,7 +60,6 @@ async def test_sensors_kt100(hass: HomeAssistant) -> None:
         == "Kegtron KT-100 9B75 Volume Start"
     )
     assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     volume_dispensed_sensor = hass.states.get(
         "sensor.kegtron_kt_100_9b75_volume_dispensed"
@@ -127,7 +125,6 @@ async def test_sensors_kt200(hass: HomeAssistant) -> None:
         == "Kegtron KT-200 9B75 Keg Size Port 2"
     )
     assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     keg_type_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_type_port_2")
     keg_type_sensor_attrs = keg_type_sensor.attributes
@@ -147,7 +144,6 @@ async def test_sensors_kt200(hass: HomeAssistant) -> None:
         == "Kegtron KT-200 9B75 Volume Start Port 2"
     )
     assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     volume_dispensed_sensor = hass.states.get(
         "sensor.kegtron_kt_200_9b75_volume_dispensed_port_2"
@@ -197,7 +193,6 @@ async def test_sensors_kt200(hass: HomeAssistant) -> None:
         == "Kegtron KT-200 9B75 Keg Size Port 1"
     )
     assert keg_size_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert keg_size_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     keg_type_sensor = hass.states.get("sensor.kegtron_kt_200_9b75_keg_type_port_1")
     keg_type_sensor_attrs = keg_type_sensor.attributes
@@ -217,7 +212,6 @@ async def test_sensors_kt200(hass: HomeAssistant) -> None:
         == "Kegtron KT-200 9B75 Volume Start Port 1"
     )
     assert volume_start_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "L"
-    assert volume_start_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
     volume_dispensed_sensor = hass.states.get(
         "sensor.kegtron_kt_200_9b75_volume_dispensed_port_1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix for the following error, as reported in #87888

```
Etity sensor.kegtron_kt_200_93f5_volume_start_port_2 (<class 'homeassistant.components.kegtron.sensor.KegtronBluetoothSensorEntity'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total_increasing', 'total'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+kegtron%22
```

I think the default state class `None` is ok for the the `volume_start` and `keg_size` sensors. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87888
- This PR is related to issue: #87888
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
