### PR TITLE
Avoid subprocess memory copy when c library supports posix_spawn

### DIFF
--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -68,6 +68,7 @@ class CommandLineAuthProvider(AuthProvider):
                 *self.config[CONF_ARGS],
                 env=env,
                 stdout=asyncio.subprocess.PIPE if self.config[CONF_META] else None,
+                close_fds=False,  # required for posix_spawn
             )
             stdout, _ = await process.communicate()
         except OSError as err:

--- a/homeassistant/components/command_line/__init__.py
+++ b/homeassistant/components/command_line/__init__.py
@@ -18,7 +18,10 @@ def call_shell_with_timeout(
     try:
         _LOGGER.debug("Running command: %s", command)
         subprocess.check_output(
-            command, shell=True, timeout=timeout  # nosec # shell by design
+            command,
+            shell=True,  # nosec # shell by design
+            timeout=timeout,
+            close_fds=False,  # required for posix_spawn
         )
         return 0
     except subprocess.CalledProcessError as proc_exception:
@@ -41,7 +44,10 @@ def check_output_or_log(command: str, timeout: int) -> str | None:
     """Run a shell command with a timeout and return the output."""
     try:
         return_value = subprocess.check_output(
-            command, shell=True, timeout=timeout  # nosec # shell by design
+            command,
+            shell=True,  # nosec # shell by design
+            timeout=timeout,
+            close_fds=False,  # required for posix_spawn
         )
         return return_value.strip().decode("utf-8")
     except subprocess.CalledProcessError as err:

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -52,6 +52,7 @@ class CommandLineNotificationService(BaseNotificationService):
             self.command,
             universal_newlines=True,
             stdin=subprocess.PIPE,
+            close_fds=False,  # required for posix_spawn
             shell=True,  # nosec # shell by design
         ) as proc:
             try:

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -227,6 +227,7 @@ class PingDataSubProcess(PingData):
             stdin=None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            close_fds=False,  # required for posix_spawn
         )
         try:
             out_data, out_error = await asyncio.wait_for(

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -55,7 +55,10 @@ class HostSubProcess:
     def ping(self):
         """Send an ICMP echo request and return True if success."""
         with subprocess.Popen(
-            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+            self._ping_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            close_fds=False,  # required for posix_spawn
         ) as pinger:
             try:
                 pinger.communicate(timeout=1 + PING_TIMEOUT)

--- a/homeassistant/components/rpi_camera/camera.py
+++ b/homeassistant/components/rpi_camera/camera.py
@@ -32,7 +32,10 @@ _LOGGER = logging.getLogger(__name__)
 def kill_raspistill(*args):
     """Kill any previously running raspistill process.."""
     with subprocess.Popen(
-        ["killall", "raspistill"], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
+        ["killall", "raspistill"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        close_fds=False,  # required for posix_spawn
     ):
         pass
 
@@ -132,7 +135,10 @@ class RaspberryCamera(Camera):
         # Therefore it must not be wrapped with "with", since that
         # waits for the subprocess to exit before continuing.
         subprocess.Popen(  # pylint: disable=consider-using-with
-            cmd_args, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
+            cmd_args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+            close_fds=False,  # required for posix_spawn
         )
 
     def camera_image(

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -130,7 +130,10 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         img.save(self.filepath, "png")
 
         with subprocess.Popen(
-            self._command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            self._command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=False,  # Required for posix_spawn
         ) as ocr:
             out = ocr.communicate()
             if out[0] != b"":

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -65,6 +65,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 stdin=None,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                close_fds=False,  # required for posix_spawn
             )
         else:
             # Template used. Break into list and use create_subprocess_exec
@@ -76,6 +77,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 stdin=None,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                close_fds=False,  # required for posix_spawn
             )
 
         process = await create_process

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import os
+import subprocess
 import threading
 import traceback
 from typing import Any
@@ -26,6 +28,7 @@ from .util.thread import deadlock_safe_shutdown
 #
 MAX_EXECUTOR_WORKERS = 64
 TASK_CANCELATION_TIMEOUT = 5
+ALPINE_RELEASE_FILE = "/etc/alpine-release"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,6 +123,16 @@ async def setup_and_run_hass(runtime_config: RuntimeConfig) -> int:
 
 def run(runtime_config: RuntimeConfig) -> int:
     """Run Home Assistant."""
+    if not subprocess._USE_POSIX_SPAWN:  # pylint: disable=protected-access
+        # The subprocess module does not know about Alpine Linux/musl
+        # and will use fork() instead of posix_spawn() which significantly
+        # less efficient. This is a workaround to force posix_spawn()
+        # on Alpine Linux which is supported by musl.
+        _exists = os.path.exists
+        subprocess._USE_POSIX_SPAWN = _exists(  # pylint: disable=protected-access
+            ALPINE_RELEASE_FILE
+        )
+
     asyncio.set_event_loop_policy(HassEventLoopPolicy(runtime_config.debug))
     # Backport of cpython 3.9 asyncio.run with a _cancel_all_tasks that times out
     loop = asyncio.new_event_loop()

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -121,18 +121,22 @@ async def setup_and_run_hass(runtime_config: RuntimeConfig) -> int:
     return await hass.async_run()
 
 
+def _enable_posix_spawn() -> None:
+    """Enable posix_spawn on Alpine Linux."""
+    # pylint: disable=protected-access
+    if subprocess._USE_POSIX_SPAWN:
+        return
+
+    # The subprocess module does not know about Alpine Linux/musl
+    # and will use fork() instead of posix_spawn() which significantly
+    # less efficient. This is a workaround to force posix_spawn()
+    # on Alpine Linux which is supported by musl.
+    subprocess._USE_POSIX_SPAWN = os.path.exists(ALPINE_RELEASE_FILE)
+
+
 def run(runtime_config: RuntimeConfig) -> int:
     """Run Home Assistant."""
-    if not subprocess._USE_POSIX_SPAWN:  # pylint: disable=protected-access
-        # The subprocess module does not know about Alpine Linux/musl
-        # and will use fork() instead of posix_spawn() which significantly
-        # less efficient. This is a workaround to force posix_spawn()
-        # on Alpine Linux which is supported by musl.
-        _exists = os.path.exists
-        subprocess._USE_POSIX_SPAWN = _exists(  # pylint: disable=protected-access
-            ALPINE_RELEASE_FILE
-        )
-
+    _enable_posix_spawn()
     asyncio.set_event_loop_policy(HassEventLoopPolicy(runtime_config.debug))
     # Backport of cpython 3.9 asyncio.run with a _cancel_all_tasks that times out
     loop = asyncio.new_event_loop()

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -94,7 +94,14 @@ def install_package(
         args += ["--user"]
         env["PYTHONUSERBASE"] = os.path.abspath(target)
     _LOGGER.debug("Running pip command: args=%s", args)
-    with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env) as process:
+    with Popen(
+        args,
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        env=env,
+        close_fds=False,  # required for posix_spawn
+    ) as process:
         _, stderr = process.communicate()
         if process.returncode != 0:
             _LOGGER.error(

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -121,6 +121,7 @@ async def async_get_user_site(deps_dir: str) -> str:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
         env=env,
+        close_fds=False,  # required for posix_spawn
     )
     stdout, _ = await process.communicate()
     lib_dir = stdout.decode().strip()

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -73,7 +73,10 @@ async def test_poll_when_cover_has_command_state(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
         await hass.async_block_till_done()
         check_output.assert_called_once_with(
-            "echo state", shell=True, timeout=15  # nosec # shell by design
+            "echo state",
+            shell=True,  # nosec # shell by design
+            timeout=15,
+            close_fds=False,
         )
 
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -97,6 +97,7 @@ async def test_template_render_with_quote(hass: HomeAssistant) -> None:
             'echo "template_value" "3 4"',
             shell=True,  # nosec # shell by design
             timeout=15,
+            close_fds=False,
         )
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -137,3 +137,22 @@ async def test_unhandled_exception_traceback(hass, caplog):
     assert "Task exception was never retrieved" in caplog.text
     assert "This is unhandled" in caplog.text
     assert "_unhandled_exception" in caplog.text
+
+
+def test__enable_posix_spawn():
+    """Test that we can enable posix_spawn on Alpine."""
+
+    def _mock_alpine_exists(path):
+        return path == "/etc/alpine-release"
+
+    with patch.object(runner.subprocess, "_USE_POSIX_SPAWN", False), patch.object(
+        runner.os.path, "exists", _mock_alpine_exists
+    ):
+        runner._enable_posix_spawn()
+        assert runner.subprocess._USE_POSIX_SPAWN is True
+
+    with patch.object(runner.subprocess, "_USE_POSIX_SPAWN", False), patch.object(
+        runner.os.path, "exists", return_value=False
+    ):
+        runner._enable_posix_spawn()
+        assert runner.subprocess._USE_POSIX_SPAWN is False

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -95,6 +95,7 @@ def test_install(mock_sys, mock_popen, mock_env_copy, mock_venv):
         stdout=PIPE,
         stderr=PIPE,
         env=env,
+        close_fds=False,
     )
     assert mock_popen.return_value.communicate.call_count == 1
 
@@ -118,6 +119,7 @@ def test_install_upgrade(mock_sys, mock_popen, mock_env_copy, mock_venv):
         stdout=PIPE,
         stderr=PIPE,
         env=env,
+        close_fds=False,
     )
     assert mock_popen.return_value.communicate.call_count == 1
 
@@ -142,7 +144,7 @@ def test_install_target(mock_sys, mock_popen, mock_env_copy, mock_venv):
     assert package.install_package(TEST_NEW_REQ, False, target=target)
     assert mock_popen.call_count == 2
     assert mock_popen.mock_calls[0] == call(
-        args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env
+        args, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env, close_fds=False
     )
     assert mock_popen.return_value.communicate.call_count == 1
 
@@ -185,6 +187,7 @@ def test_install_constraint(mock_sys, mock_popen, mock_env_copy, mock_venv):
         stdout=PIPE,
         stderr=PIPE,
         env=env,
+        close_fds=False,
     )
     assert mock_popen.return_value.communicate.call_count == 1
 
@@ -211,6 +214,7 @@ def test_install_find_links(mock_sys, mock_popen, mock_env_copy, mock_venv):
         stdout=PIPE,
         stderr=PIPE,
         env=env,
+        close_fds=False,
     )
     assert mock_popen.return_value.communicate.call_count == 1
 
@@ -233,6 +237,7 @@ async def test_async_get_user_site(mock_env_copy):
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
         env=env,
+        close_fds=False,
     )
     assert ret == os.path.join(deps_dir, "lib_dir")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The [`command_line`](https://www.home-assistant.io/integrations/command_line) ([8.2%](https://analytics.home-assistant.io/integrations) of the active installations) and [`shell_command`](https://www.home-assistant.io/integrations/shell_command) ([4.7%](https://analytics.home-assistant.io/integrations) of the active installations) integrations are quite popular.  They suffer from a performance issue due to the memory size of the Home Assistant python instance and python's subprocess implementation when using **musl**. We also experience the issue when pip is called to install a new module.

By default python 3.10 will use `fork()` which has to copy memory of the parent process. In our case
this can be huge since Home Assistant core can use hundreds of megabytes of RAM. By using `posix_spawn` this is avoided and subprocess creation does not get discernibly slower the larger the Home Assistant python process grows.

Additional reading: https://github.com/rtomayko/posix-spawn
<img src="https://camo.githubusercontent.com/23ad36e4212bf37855e5945d42c241ad98cf05b6bd3f69f0d49febb10f5c63ff/68747470733a2f2f63686172742e676f6f676c65617069732e636f6d2f63686172743f636862683d612c352c323526636878723d312c302c33362c37266368643d743a352e37372c31302e33372c31352e37322c31382e33312c31392e37332c32352e31332c32362e37302c32392e33312c33312e34342c33352e3439253743302e38362c302e38322c312e30362c302e39392c302e37392c312e30362c302e38342c302e37392c302e39332c302e393426636878733d314e2a2a25323073656373266368733d3930307832303026636864733d302c3336266368786c3d303a25374335302532304d422537433130302532304d422537433135302532304d422537433230302532304d422537433235302532304d422537433330302532304d422537433335302532304d422537433430302532304d422537433435302532304d422537433530302532304d42266368743d627667266368646c3d66737061776e253230253238666f726b2532426578656325323925374370737061776e253230253238706f7369785f737061776e25323926636874743d706f7369782d737061776e2d62656e63686d61726b2532302d2d67726170682532302d2d636f756e742532303530302532302d2d6d656d2d73697a652532303530302532302532387838365f36342d6c696e7578253239266368636f3d3166373762342c666637663065266368663d62672c732c66386638663826636878743d782c79232e706e67">

In python 3.11 vfork will also be available ([vfork is stubbed out in 3.10](https://github.com/python/cpython/blob/6c0e3dc8ef958e1d2eb2fc4e59a9152e85e65da0/Lib/subprocess.py#L699))
https://github.com/python/cpython/issues/80004#issuecomment-1093810689 https://github.com/python/cpython/pull/11671 but we won't always be able to use it and posix_spawn is likely safer https://bugzilla.kernel.org/show_bug.cgi?id=215813#c14

The subprocess library doesn't know about `musl` though even though it supports `posix_spawn` https://git.musl-libc.org/cgit/musl/log/src/process/posix_spawn.c so we have to teach it since it only has checks for `glibc` https://github.com/python/cpython/blob/1b736838e6ae1b4ef42cdd27c2708face908f92c/Lib/subprocess.py#L745

The constant is documented as being able to be flipped off at https://docs.python.org/3/library/subprocess.html#disabling-use-of-vfork-or-posix-spawn so it seems likely to not change in the future.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
