### PR TITLE
Keep task references while running

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -528,7 +528,9 @@ async def _async_set_up_integrations(
     hass.data[DATA_SETUP_STARTED] = {}
     setup_time: dict[str, timedelta] = hass.data.setdefault(DATA_SETUP_TIME, {})
 
-    watch_task = asyncio.create_task(_async_watch_pending_setups(hass))
+    watch_task = hass.background_tasks.async_create_task(
+        _async_watch_pending_setups(hass), "watch_pending_setups"
+    )
 
     domains_to_setup = _get_domains(hass, config)
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -528,9 +528,7 @@ async def _async_set_up_integrations(
     hass.data[DATA_SETUP_STARTED] = {}
     setup_time: dict[str, timedelta] = hass.data.setdefault(DATA_SETUP_TIME, {})
 
-    watch_task = hass.background_tasks.async_create_task(
-        _async_watch_pending_setups(hass), "watch_pending_setups"
-    )
+    watch_task = asyncio.create_task(_async_watch_pending_setups(hass))
 
     domains_to_setup = _get_domains(hass, config)
 

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -69,7 +69,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     else:
         _LOGGER.debug("No connection check for UDP possible")
 
-    GraphiteFeeder(hass, host, port, protocol, prefix)
+    hass.data[DOMAIN] = GraphiteFeeder(hass, host, port, protocol, prefix)
     return True
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -671,7 +671,6 @@ class HomeAssistant:
         """Block until all pending work is done."""
         # To flush out any call_soon_threadsafe
         await asyncio.sleep(0)
-        await asyncio.sleep(0)
         start_time: float | None = None
         current_task = asyncio.current_task()
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -260,6 +260,49 @@ class CoreState(enum.Enum):
         return self.value
 
 
+class BackgroundTasks:
+    """Class to manage background tasks."""
+
+    def __init__(self) -> None:
+        """Initialize the background task runner."""
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._loop = asyncio.get_running_loop()
+        self._running = True
+
+    def async_create_task(
+        self,
+        target: Coroutine[Any, Any, _R],
+        name: str,
+    ) -> asyncio.Task[_R]:
+        """Create a task and add it to the set of tasks."""
+        if not self._running:
+            raise RuntimeError("BackgroundTasks is no longer running")
+        task = self._loop.create_task(target, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
+        return task
+
+    async def async_cancel_all(self) -> None:
+        """Cancel all tasks."""
+        self._running = False
+
+        if not self._tasks:
+            return
+
+        for task in self._tasks:
+            task.cancel()
+
+        for task in list(self._tasks):
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Error cancelling task %s", task)
+
+        self._tasks.clear()
+
+
 class HomeAssistant:
     """Root object of the Home Assistant home automation."""
 
@@ -276,8 +319,8 @@ class HomeAssistant:
     def __init__(self) -> None:
         """Initialize new Home Assistant object."""
         self.loop = asyncio.get_running_loop()
-        self._pending_tasks: list[asyncio.Future[Any]] = []
-        self._track_task = True
+        self._tasks: set[asyncio.Future[Any]] = set()
+        self.background_tasks = BackgroundTasks()
         self.bus = EventBus(self)
         self.services = ServiceRegistry(self)
         self.states = StateMachine(self.bus, self.loop)
@@ -353,12 +396,14 @@ class HomeAssistant:
         self.bus.async_fire(EVENT_CORE_CONFIG_UPDATE)
         self.bus.async_fire(EVENT_HOMEASSISTANT_START)
 
-        try:
-            # Only block for EVENT_HOMEASSISTANT_START listener
-            self.async_stop_track_tasks()
-            async with self.timeout.async_timeout(TIMEOUT_EVENT_START):
-                await self.async_block_till_done()
-        except asyncio.TimeoutError:
+        if not self._tasks:
+            pending: set[asyncio.Future[Any]] | None = None
+        else:
+            _done, pending = await asyncio.wait(
+                self._tasks, timeout=TIMEOUT_EVENT_START
+            )
+
+        if pending:
             _LOGGER.warning(
                 (
                     "Something is blocking Home Assistant from wrapping up the start up"
@@ -494,9 +539,8 @@ class HomeAssistant:
                 hassjob.target = cast(Callable[..., _R], hassjob.target)
             task = self.loop.run_in_executor(None, hassjob.target, *args)
 
-        # If a task is scheduled
-        if self._track_task:
-            self._pending_tasks.append(task)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
 
         return task
 
@@ -517,8 +561,8 @@ class HomeAssistant:
         """
         task = self.loop.create_task(target)
 
-        if self._track_task:
-            self._pending_tasks.append(task)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
 
         return task
 
@@ -530,20 +574,10 @@ class HomeAssistant:
         task = self.loop.run_in_executor(None, target, *args)
 
         # If a task is scheduled
-        if self._track_task:
-            self._pending_tasks.append(task)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
 
         return task
-
-    @callback
-    def async_track_tasks(self) -> None:
-        """Track tasks so you can wait for all tasks to be done."""
-        self._track_task = True
-
-    @callback
-    def async_stop_track_tasks(self) -> None:
-        """Stop track tasks so you can't wait for all tasks to be done."""
-        self._track_task = False
 
     @overload
     @callback
@@ -637,30 +671,27 @@ class HomeAssistant:
         """Block until all pending work is done."""
         # To flush out any call_soon_threadsafe
         await asyncio.sleep(0)
+        await asyncio.sleep(0)
         start_time: float | None = None
+        current_task = asyncio.current_task()
 
-        while self._pending_tasks:
-            pending = [task for task in self._pending_tasks if not task.done()]
-            self._pending_tasks.clear()
-            if pending:
-                await self._await_and_log_pending(pending)
+        while tasks := [task for task in self._tasks if task is not current_task]:
+            await self._await_and_log_pending(tasks)
 
-                if start_time is None:
-                    # Avoid calling monotonic() until we know
-                    # we may need to start logging blocked tasks.
-                    start_time = 0
-                elif start_time == 0:
-                    # If we have waited twice then we set the start
-                    # time
-                    start_time = monotonic()
-                elif monotonic() - start_time > BLOCK_LOG_TIMEOUT:
-                    # We have waited at least three loops and new tasks
-                    # continue to block. At this point we start
-                    # logging all waiting tasks.
-                    for task in pending:
-                        _LOGGER.debug("Waiting for task: %s", task)
-            else:
-                await asyncio.sleep(0)
+            if start_time is None:
+                # Avoid calling monotonic() until we know
+                # we may need to start logging blocked tasks.
+                start_time = 0
+            elif start_time == 0:
+                # If we have waited twice then we set the start
+                # time
+                start_time = monotonic()
+            elif monotonic() - start_time > BLOCK_LOG_TIMEOUT:
+                # We have waited at least three loops and new tasks
+                # continue to block. At this point we start
+                # logging all waiting tasks.
+                for task in tasks:
+                    _LOGGER.debug("Waiting for task: %s", task)
 
     async def _await_and_log_pending(self, pending: Collection[Awaitable[Any]]) -> None:
         """Await and log tasks that take a long time."""
@@ -702,9 +733,12 @@ class HomeAssistant:
                     "Stopping Home Assistant before startup has completed may fail"
                 )
 
+        cancel_background_tasks = asyncio.create_task(
+            self.background_tasks.async_cancel_all()
+        )
+
         # stage 1
         self.state = CoreState.stopping
-        self.async_track_tasks()
         self.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         try:
             async with self.timeout.async_timeout(STAGE_1_SHUTDOWN_TIMEOUT):
@@ -737,6 +771,11 @@ class HomeAssistant:
         # which will cause the futures to block forever when waiting for
         # the `result()` which will cause a deadlock when shutting down the executor.
         shutdown_run_callback_threadsafe(self.loop)
+
+        # Run this as part of stage 3.
+        if not cancel_background_tasks.done():
+            self._tasks.add(cancel_background_tasks)
+            cancel_background_tasks.add_done_callback(self._tasks.remove)
 
         try:
             async with self.timeout.async_timeout(STAGE_3_SHUTDOWN_TIMEOUT):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -297,7 +297,9 @@ class BackgroundTasks:
         await asyncio.wait(tasks)
 
         for task in tasks:
-            if (exception := task.exception()) is None:
+            if (exception := task.exception()) is None or isinstance(
+                exception, asyncio.CancelledError
+            ):
                 continue
 
             _LOGGER.error(

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from collections.abc import (
-    Awaitable,
-    Callable,
-    Collection,
-    Generator,
-    Mapping,
-    Sequence,
-)
+from collections.abc import Awaitable, Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 import functools as ft
@@ -22,7 +15,6 @@ import os
 import pathlib
 import threading
 import time
-import types
 from typing import Any, NoReturn
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -50,7 +42,6 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import (
-    BLOCK_LOG_TIMEOUT,
     CoreState,
     Event,
     HomeAssistant,
@@ -220,37 +211,9 @@ async def async_test_home_assistant(event_loop, load_registries=True):
 
         return orig_async_create_task(coroutine)
 
-    async def _await_count_and_log_pending(
-        self, pending: Collection[Awaitable[Any]], max_remaining_tasks: int = 0
-    ) -> Collection[Awaitable[Any]]:
-        """Block at most max_remaining_tasks remain and log tasks that take a long time.
-
-        Based on HomeAssistant._await_and_log_pending
-        """
-        wait_time = 0
-
-        return_when = asyncio.ALL_COMPLETED
-        if max_remaining_tasks:
-            return_when = asyncio.FIRST_COMPLETED
-
-        while len(pending) > max_remaining_tasks:
-            _, pending = await asyncio.wait(
-                pending, timeout=BLOCK_LOG_TIMEOUT, return_when=return_when
-            )
-            if not pending or max_remaining_tasks:
-                return pending
-            wait_time += BLOCK_LOG_TIMEOUT
-            for task in pending:
-                _LOGGER.debug("Waited %s seconds for task: %s", wait_time, task)
-
-        return []
-
     hass.async_add_job = async_add_job
     hass.async_add_executor_job = async_add_executor_job
     hass.async_create_task = async_create_task
-    hass._await_count_and_log_pending = types.MethodType(
-        _await_count_and_log_pending, hass
-    )
 
     hass.data[loader.DATA_CUSTOM_COMPONENTS] = {}
 

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -239,5 +239,6 @@ async def test_initialize_start(hass: HomeAssistant) -> None:
     ) as mock_activate:
         hass.bus.fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert len(mock_activate.mock_calls) == 1

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -118,6 +118,7 @@ async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
 
     hass.states.async_set("test.entity", STATE_ON)
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -136,6 +137,7 @@ async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
 
     hass.states.async_set("test.entity", STATE_OFF)
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 0
     assert mock_socket.return_value.sendall.call_count == 0
@@ -161,6 +163,7 @@ async def test_report_attributes(hass: HomeAssistant, mock_socket, mock_time) ->
 
     hass.states.async_set("test.entity", STATE_ON, attrs)
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -192,6 +195,7 @@ async def test_report_with_string_state(
 
     hass.states.async_set("test.entity", "above_horizon", {"foo": 1.0})
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -207,6 +211,7 @@ async def test_report_with_string_state(
 
     hass.states.async_set("test.entity", "not_float")
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 0
     assert mock_socket.return_value.sendall.call_count == 0
@@ -232,6 +237,7 @@ async def test_report_with_binary_state(
     ]
     hass.states.async_set("test.entity", STATE_ON, {"foo": 1.0})
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -251,6 +257,7 @@ async def test_report_with_binary_state(
     ]
     hass.states.async_set("test.entity", STATE_OFF, {"foo": 1.0})
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Graphite component."""
-import asyncio
 import socket
 from unittest import mock
 from unittest.mock import patch
@@ -91,9 +90,10 @@ async def test_start(hass: HomeAssistant, mock_socket, mock_time) -> None:
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", STATE_ON)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -114,9 +114,10 @@ async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", STATE_ON)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -134,7 +135,7 @@ async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
     await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", STATE_OFF)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 0
     assert mock_socket.return_value.sendall.call_count == 0
@@ -156,9 +157,10 @@ async def test_report_attributes(hass: HomeAssistant, mock_socket, mock_time) ->
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", STATE_ON, attrs)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -186,9 +188,10 @@ async def test_report_with_string_state(
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     hass.states.async_set("test.entity", "above_horizon", {"foo": 1.0})
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -203,7 +206,7 @@ async def test_report_with_string_state(
     mock_socket.reset_mock()
 
     hass.states.async_set("test.entity", "not_float")
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 0
     assert mock_socket.return_value.sendall.call_count == 0
@@ -221,13 +224,14 @@ async def test_report_with_binary_state(
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     expected = [
         "ha.test.entity.foo 1.000000 12345",
         "ha.test.entity.state 1.000000 12345",
     ]
     hass.states.async_set("test.entity", STATE_ON, {"foo": 1.0})
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -246,7 +250,7 @@ async def test_report_with_binary_state(
         "ha.test.entity.state 0.000000 12345",
     ]
     hass.states.async_set("test.entity", STATE_OFF, {"foo": 1.0})
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))
@@ -282,10 +286,12 @@ async def test_send_to_graphite_errors(
     mock_socket.reset_mock()
 
     await hass.async_start()
+    await hass.async_block_till_done()
 
     mock_socket.return_value.connect.side_effect = error
 
     hass.states.async_set("test.entity", STATE_ON)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert log_text in caplog.text

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -94,6 +94,7 @@ async def test_start(hass: HomeAssistant, mock_socket, mock_time) -> None:
 
     hass.states.async_set("test.entity", STATE_ON)
     await hass.async_block_till_done()
+    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 1
     assert mock_socket.return_value.connect.call_args == mock.call(("localhost", 2003))

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -137,7 +137,6 @@ async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
 
     hass.states.async_set("test.entity", STATE_OFF)
     await hass.async_block_till_done()
-    hass.data[graphite.DOMAIN]._queue.join()
 
     assert mock_socket.return_value.connect.call_count == 0
     assert mock_socket.return_value.sendall.call_count == 0

--- a/tests/components/hardware/test_websocket_api.py
+++ b/tests/components/hardware/test_websocket_api.py
@@ -71,6 +71,7 @@ async def test_system_status_subscription(
     ):
         freezer.tick(TEST_TIME_ADVANCE_INTERVAL)
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     response = await client.receive_json()
     assert response["event"] == {

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -239,7 +239,7 @@ async def test_receive_code(mock_debug, hass):
             },
             **PilightDaemonSim.test_message["message"],
         )
-        debug_log_call = mock_debug.call_args_list[-3]
+        debug_log_call = mock_debug.call_args_list[-1]
 
         # Check if all message parts are put on event bus
         for key, value in expected_message.items():
@@ -272,7 +272,7 @@ async def test_whitelist_exact_match(mock_debug, hass):
             },
             **PilightDaemonSim.test_message["message"],
         )
-        debug_log_call = mock_debug.call_args_list[-3]
+        debug_log_call = mock_debug.call_args_list[-1]
 
         # Check if all message parts are put on event bus
         for key, value in expected_message.items():
@@ -303,7 +303,7 @@ async def test_whitelist_partial_match(mock_debug, hass):
             },
             **PilightDaemonSim.test_message["message"],
         )
-        debug_log_call = mock_debug.call_args_list[-3]
+        debug_log_call = mock_debug.call_args_list[-1]
 
         # Check if all message parts are put on event bus
         for key, value in expected_message.items():
@@ -337,7 +337,7 @@ async def test_whitelist_or_match(mock_debug, hass):
             },
             **PilightDaemonSim.test_message["message"],
         )
-        debug_log_call = mock_debug.call_args_list[-3]
+        debug_log_call = mock_debug.call_args_list[-1]
 
         # Check if all message parts are put on event bus
         for key, value in expected_message.items():
@@ -360,7 +360,7 @@ async def test_whitelist_no_match(mock_debug, hass):
 
         await hass.async_start()
         await hass.async_block_till_done()
-        debug_log_call = mock_debug.call_args_list[-3]
+        debug_log_call = mock_debug.call_args_list[-1]
 
         assert "Event pilight_received" not in debug_log_call
 

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -43,8 +43,9 @@ async def test_basic_usage(hass, tmpdir):
         return last_filename
 
     with patch("cProfile.Profile"), patch.object(hass.config, "path", _mock_path):
-        await hass.services.async_call(DOMAIN, SERVICE_START, {CONF_SECONDS: 0.000001})
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            DOMAIN, SERVICE_START, {CONF_SECONDS: 0.000001}, blocking=True
+        )
 
     assert os.path.exists(last_filename)
 
@@ -72,8 +73,9 @@ async def test_memory_usage(hass, tmpdir):
         return last_filename
 
     with patch("guppy.hpy") as mock_hpy, patch.object(hass.config, "path", _mock_path):
-        await hass.services.async_call(DOMAIN, SERVICE_MEMORY, {CONF_SECONDS: 0.000001})
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            DOMAIN, SERVICE_MEMORY, {CONF_SECONDS: 0.000001}, blocking=True
+        )
 
         mock_hpy.assert_called_once()
 
@@ -97,9 +99,8 @@ async def test_object_growth_logging(
 
     with patch("objgraph.growth"):
         await hass.services.async_call(
-            DOMAIN, SERVICE_START_LOG_OBJECTS, {CONF_SCAN_INTERVAL: 10}
+            DOMAIN, SERVICE_START_LOG_OBJECTS, {CONF_SCAN_INTERVAL: 10}, blocking=True
         )
-        await hass.async_block_till_done()
 
     assert "Growth" in caplog.text
     caplog.clear()
@@ -108,8 +109,7 @@ async def test_object_growth_logging(
     await hass.async_block_till_done()
     assert "Growth" in caplog.text
 
-    await hass.services.async_call(DOMAIN, SERVICE_STOP_LOG_OBJECTS, {})
-    await hass.async_block_till_done()
+    await hass.services.async_call(DOMAIN, SERVICE_STOP_LOG_OBJECTS, {}, blocking=True)
     caplog.clear()
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=21))
@@ -150,9 +150,8 @@ async def test_dump_log_object(
     assert hass.services.has_service(DOMAIN, SERVICE_DUMP_LOG_OBJECTS)
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_DUMP_LOG_OBJECTS, {CONF_TYPE: "DumpLogDummy"}
+        DOMAIN, SERVICE_DUMP_LOG_OBJECTS, {CONF_TYPE: "DumpLogDummy"}, blocking=True
     )
-    await hass.async_block_till_done()
 
     assert "<DumpLogDummy success>" in caplog.text
     assert "Failed to serialize" in caplog.text
@@ -174,8 +173,7 @@ async def test_log_thread_frames(
 
     assert hass.services.has_service(DOMAIN, SERVICE_LOG_THREAD_FRAMES)
 
-    await hass.services.async_call(DOMAIN, SERVICE_LOG_THREAD_FRAMES, {})
-    await hass.async_block_till_done()
+    await hass.services.async_call(DOMAIN, SERVICE_LOG_THREAD_FRAMES, {}, blocking=True)
 
     assert "SyncWorker_0" in caplog.text
     caplog.clear()
@@ -197,8 +195,9 @@ async def test_log_scheduled(
 
     assert hass.services.has_service(DOMAIN, SERVICE_LOG_EVENT_LOOP_SCHEDULED)
 
-    await hass.services.async_call(DOMAIN, SERVICE_LOG_EVENT_LOOP_SCHEDULED, {})
-    await hass.async_block_till_done()
+    await hass.services.async_call(
+        DOMAIN, SERVICE_LOG_EVENT_LOOP_SCHEDULED, {}, blocking=True
+    )
 
     assert "Scheduled" in caplog.text
     caplog.clear()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -815,7 +815,7 @@ async def test_wait_for_trigger_variables(hass: HomeAssistant) -> None:
     actions = [
         {
             "alias": "variables",
-            "variables": {"seconds": 5},
+            "variables": {"seconds": 0.01},
         },
         {
             "alias": wait_alias,
@@ -839,9 +839,6 @@ async def test_wait_for_trigger_variables(hass: HomeAssistant) -> None:
         assert script_obj.is_running
         assert script_obj.last_action == wait_alias
         hass.states.async_set("switch.test", "off")
-        # the script task +  2 tasks created by wait_for_trigger script step
-        await hass.async_wait_for_task_count(3)
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
         await hass.async_block_till_done()
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -815,15 +815,13 @@ async def test_wait_for_trigger_variables(hass: HomeAssistant) -> None:
     actions = [
         {
             "alias": "variables",
-            "variables": {"seconds": 0.01},
+            "variables": {"state": "off"},
         },
         {
             "alias": wait_alias,
             "wait_for_trigger": {
-                "platform": "state",
-                "entity_id": "switch.test",
-                "to": "off",
-                "for": {"seconds": "{{ seconds }}"},
+                "platform": "template",
+                "value_template": "{{ states.switch.test.state == state }}",
             },
         },
     ]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -774,8 +774,6 @@ async def test_warning_logged_on_wrap_up_timeout(hass, caplog):
 
     def gen_domain_setup(domain):
         async def async_setup(hass, config):
-            await asyncio.sleep(0.1)
-
             async def _background_task():
                 await asyncio.sleep(0.2)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -779,7 +779,7 @@ async def test_warning_logged_on_wrap_up_timeout(hass, caplog):
             async def _background_task():
                 await asyncio.sleep(0.2)
 
-            await hass.async_create_task(_background_task())
+            hass.async_create_task(_background_task())
             return True
 
         return async_setup

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3559,14 +3559,17 @@ async def test_initializing_flows_canceled_on_shutdown(hass: HomeAssistant, mana
             """Mock Reauth."""
             await asyncio.sleep(1)
 
+    mock_integration(hass, MockModule("test"))
+    mock_entity_platform(hass, "config_flow.test", None)
+
     with patch.dict(
         config_entries.HANDLERS, {"comp": MockFlowHandler, "test": MockFlowHandler}
     ):
         task = asyncio.create_task(
             manager.flow.async_init("test", context={"source": "reauth"})
         )
-    await hass.async_block_till_done()
-    await manager.flow.async_shutdown()
+        await hass.async_block_till_done()
+        await manager.flow.async_shutdown()
 
-    with pytest.raises(asyncio.exceptions.CancelledError):
-        await task
+        with pytest.raises(asyncio.exceptions.CancelledError):
+            await task


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attempt 2 to make sure we track all tasks created in HA. This time we only track it for tasks created via `hass.async_create_task` and not for all tasks created on our event loop (which was attempt 1 at #87959)

Will always track tasks but make sure tasks clean up themselves.

This feels a bit like heart surgery…

~~Also added a new `hass.background_task.async_create_task` for tasks you know are going to be in the background. They will never block `async_block_till_done` but still get canceled when HA shuts down.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
