### PR TITLE
Add type hints to integration tests (part 6)

### DIFF
--- a/tests/components/dormakaba_dkey/test_config_flow.py
+++ b/tests/components/dormakaba_dkey/test_config_flow.py
@@ -104,7 +104,9 @@ async def test_user_step_device_added_between_steps_1(hass: HomeAssistant) -> No
     assert result["reason"] == "already_configured"
 
 
-async def test_async_step_user_takes_precedence_over_discovery(hass):
+async def test_async_step_user_takes_precedence_over_discovery(
+    hass: HomeAssistant,
+) -> None:
     """Test manual setup takes precedence over discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -198,7 +200,7 @@ async def test_bluetooth_step_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_bluetooth_step_already_in_progress(hass):
+async def test_bluetooth_step_already_in_progress(hass: HomeAssistant) -> None:
     """Test we can't start a flow for the same device twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/emulated_roku/test_config_flow.py
+++ b/tests/components/emulated_roku/test_config_flow.py
@@ -1,11 +1,12 @@
 """Tests for emulated_roku config flow."""
 from homeassistant import config_entries
 from homeassistant.components.emulated_roku import config_flow
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_flow_works(hass, mock_get_source_ip):
+async def test_flow_works(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test that config flow works."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
@@ -18,7 +19,9 @@ async def test_flow_works(hass, mock_get_source_ip):
     assert result["data"] == {"name": "Emulated Roku Test", "listen_port": 8060}
 
 
-async def test_flow_already_registered_entry(hass, mock_get_source_ip):
+async def test_flow_already_registered_entry(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test that config flow doesn't allow existing names."""
     MockConfigEntry(
         domain="emulated_roku", data={"name": "Emulated Roku Test", "listen_port": 8062}

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_config_required_fields(hass, mock_get_source_ip):
+async def test_config_required_fields(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test that configuration is successful with required fields."""
     with patch.object(emulated_roku, "configured_servers", return_value=[]), patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",
@@ -31,7 +31,9 @@ async def test_config_required_fields(hass, mock_get_source_ip):
         )
 
 
-async def test_config_already_registered_not_configured(hass, mock_get_source_ip):
+async def test_config_already_registered_not_configured(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test that an already registered name causes the entry to be ignored."""
     with patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -22,12 +22,14 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfVolume,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.components.recorder.common import async_wait_recording_done
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -68,7 +70,9 @@ def get_statistics_for_entity(statistics_results, entity_id):
     return None
 
 
-async def test_cost_sensor_no_states(setup_integration, hass, hass_storage) -> None:
+async def test_cost_sensor_no_states(
+    setup_integration, hass: HomeAssistant, hass_storage
+) -> None:
     """Test sensors are created."""
     energy_data = data.EnergyManager.default_preferences()
     energy_data["energy_sources"].append(
@@ -94,7 +98,9 @@ async def test_cost_sensor_no_states(setup_integration, hass, hass_storage) -> N
     # TODO: No states, should the cost entity refuse to setup?
 
 
-async def test_cost_sensor_attributes(setup_integration, hass, hass_storage) -> None:
+async def test_cost_sensor_attributes(
+    setup_integration, hass: HomeAssistant, hass_storage
+) -> None:
     """Test sensor attributes."""
     energy_data = data.EnergyManager.default_preferences()
     energy_data["energy_sources"].append(
@@ -144,9 +150,9 @@ async def test_cost_sensor_attributes(setup_integration, hass, hass_storage) -> 
 )
 async def test_cost_sensor_price_entity_total_increasing(
     setup_integration,
-    hass,
+    hass: HomeAssistant,
     hass_storage,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
     price_entity,
@@ -347,9 +353,9 @@ async def test_cost_sensor_price_entity_total_increasing(
 @pytest.mark.parametrize("energy_state_class", ["total", "measurement"])
 async def test_cost_sensor_price_entity_total(
     setup_integration,
-    hass,
+    hass: HomeAssistant,
     hass_storage,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
     price_entity,
@@ -553,9 +559,9 @@ async def test_cost_sensor_price_entity_total(
 @pytest.mark.parametrize("energy_state_class", ["total"])
 async def test_cost_sensor_price_entity_total_no_reset(
     setup_integration,
-    hass,
+    hass: HomeAssistant,
     hass_storage,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
     price_entity,
@@ -726,7 +732,7 @@ async def test_cost_sensor_price_entity_total_no_reset(
     ],
 )
 async def test_cost_sensor_handle_energy_units(
-    setup_integration, hass, hass_storage, energy_unit, factor
+    setup_integration, hass: HomeAssistant, hass_storage, energy_unit, factor
 ) -> None:
     """Test energy cost price from sensor entity."""
     energy_attributes = {
@@ -792,7 +798,7 @@ async def test_cost_sensor_handle_energy_units(
     ],
 )
 async def test_cost_sensor_handle_price_units(
-    setup_integration, hass, hass_storage, price_unit, factor
+    setup_integration, hass: HomeAssistant, hass_storage, price_unit, factor
 ) -> None:
     """Test energy cost price from sensor entity."""
     energy_attributes = {
@@ -858,7 +864,7 @@ async def test_cost_sensor_handle_price_units(
     (UnitOfVolume.CUBIC_FEET, UnitOfVolume.CUBIC_METERS),
 )
 async def test_cost_sensor_handle_gas(
-    setup_integration, hass, hass_storage, unit
+    setup_integration, hass: HomeAssistant, hass_storage, unit
 ) -> None:
     """Test gas cost price from sensor entity."""
     energy_attributes = {
@@ -908,7 +914,7 @@ async def test_cost_sensor_handle_gas(
 
 
 async def test_cost_sensor_handle_gas_kwh(
-    setup_integration, hass, hass_storage
+    setup_integration, hass: HomeAssistant, hass_storage
 ) -> None:
     """Test gas cost price from sensor entity."""
     energy_attributes = {
@@ -967,7 +973,12 @@ async def test_cost_sensor_handle_gas_kwh(
     ),
 )
 async def test_cost_sensor_handle_water(
-    setup_integration, hass, hass_storage, unit_system, usage_unit, growth
+    setup_integration,
+    hass: HomeAssistant,
+    hass_storage,
+    unit_system,
+    usage_unit,
+    growth,
 ) -> None:
     """Test water cost price from sensor entity."""
     hass.config.units = unit_system
@@ -1019,7 +1030,11 @@ async def test_cost_sensor_handle_water(
 
 @pytest.mark.parametrize("state_class", [None])
 async def test_cost_sensor_wrong_state_class(
-    setup_integration, hass, hass_storage, caplog, state_class
+    setup_integration,
+    hass: HomeAssistant,
+    hass_storage,
+    caplog: pytest.LogCaptureFixture,
+    state_class,
 ) -> None:
     """Test energy sensor rejects sensor with wrong state_class."""
     energy_attributes = {
@@ -1080,7 +1095,11 @@ async def test_cost_sensor_wrong_state_class(
 
 @pytest.mark.parametrize("state_class", [SensorStateClass.MEASUREMENT])
 async def test_cost_sensor_state_class_measurement_no_reset(
-    setup_integration, hass, hass_storage, caplog, state_class
+    setup_integration,
+    hass: HomeAssistant,
+    hass_storage,
+    caplog: pytest.LogCaptureFixture,
+    state_class,
 ) -> None:
     """Test energy sensor rejects state_class measurement with no last_reset."""
     energy_attributes = {
@@ -1135,7 +1154,9 @@ async def test_cost_sensor_state_class_measurement_no_reset(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_inherit_source_unique_id(setup_integration, hass, hass_storage):
+async def test_inherit_source_unique_id(
+    setup_integration, hass: HomeAssistant, hass_storage
+) -> None:
     """Test sensor inherits unique ID from source."""
     energy_data = data.EnergyManager.default_preferences()
     energy_data["energy_sources"].append(

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -74,8 +74,13 @@ async def test_validation_empty_config(hass: HomeAssistant) -> None:
     ],
 )
 async def test_validation(
-    hass, mock_energy_manager, mock_get_metadata, state_class, energy_unit, extra
-):
+    hass: HomeAssistant,
+    mock_energy_manager,
+    mock_get_metadata,
+    state_class,
+    energy_unit,
+    extra,
+) -> None:
     """Test validating success."""
     for key in ("device_cons", "battery_import", "battery_export", "solar_production"):
         hass.states.async_set(
@@ -108,7 +113,9 @@ async def test_validation(
     }
 
 
-async def test_validation_device_consumption_entity_missing(hass, mock_energy_manager):
+async def test_validation_device_consumption_entity_missing(
+    hass: HomeAssistant, mock_energy_manager
+) -> None:
     """Test validating missing entity for device."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "sensor.not_exist"}]}
@@ -132,7 +139,9 @@ async def test_validation_device_consumption_entity_missing(hass, mock_energy_ma
     }
 
 
-async def test_validation_device_consumption_stat_missing(hass, mock_energy_manager):
+async def test_validation_device_consumption_stat_missing(
+    hass: HomeAssistant, mock_energy_manager
+) -> None:
     """Test validating missing statistic for device with non entity stats."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "external:not_exist"}]}
@@ -152,8 +161,8 @@ async def test_validation_device_consumption_stat_missing(hass, mock_energy_mana
 
 
 async def test_validation_device_consumption_entity_unavailable(
-    hass, mock_energy_manager, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating missing stat for device."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "sensor.unavailable"}]}
@@ -175,8 +184,8 @@ async def test_validation_device_consumption_entity_unavailable(
 
 
 async def test_validation_device_consumption_entity_non_numeric(
-    hass, mock_energy_manager, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating missing stat for device."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "sensor.non_numeric"}]}
@@ -198,8 +207,8 @@ async def test_validation_device_consumption_entity_non_numeric(
 
 
 async def test_validation_device_consumption_entity_unexpected_unit(
-    hass, mock_energy_manager, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating missing stat for device."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "sensor.unexpected_unit"}]}
@@ -231,8 +240,8 @@ async def test_validation_device_consumption_entity_unexpected_unit(
 
 
 async def test_validation_device_consumption_recorder_not_tracked(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating device based on untracked entity."""
     mock_is_entity_recorded["sensor.not_recorded"] = False
     await mock_energy_manager.async_update(
@@ -254,8 +263,8 @@ async def test_validation_device_consumption_recorder_not_tracked(
 
 
 async def test_validation_device_consumption_no_last_reset(
-    hass, mock_energy_manager, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating device based on untracked entity."""
     await mock_energy_manager.async_update(
         {"device_consumption": [{"stat_consumption": "sensor.no_last_reset"}]}
@@ -284,7 +293,9 @@ async def test_validation_device_consumption_no_last_reset(
     }
 
 
-async def test_validation_solar(hass, mock_energy_manager, mock_get_metadata):
+async def test_validation_solar(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating missing stat for device."""
     await mock_energy_manager.async_update(
         {
@@ -319,7 +330,9 @@ async def test_validation_solar(hass, mock_energy_manager, mock_get_metadata):
     }
 
 
-async def test_validation_battery(hass, mock_energy_manager, mock_get_metadata):
+async def test_validation_battery(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
     """Test validating missing stat for device."""
     await mock_energy_manager.async_update(
         {
@@ -371,8 +384,8 @@ async def test_validation_battery(hass, mock_energy_manager, mock_get_metadata):
 
 
 async def test_validation_grid(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating grid with sensors for energy and cost/compensation."""
     mock_is_entity_recorded["sensor.grid_cost_1"] = False
     mock_is_entity_recorded["sensor.grid_compensation_1"] = False
@@ -466,8 +479,8 @@ async def test_validation_grid(
 
 
 async def test_validation_grid_external_cost_compensation(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating grid with non entity stats for energy and cost/compensation."""
     mock_get_metadata["external:grid_cost_1"] = None
     mock_get_metadata["external:grid_compensation_1"] = None
@@ -539,8 +552,8 @@ async def test_validation_grid_external_cost_compensation(
 
 
 async def test_validation_grid_price_not_exist(
-    hass, mock_energy_manager, mock_get_metadata, mock_is_entity_recorded
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata, mock_is_entity_recorded
+) -> None:
     """Test validating grid with errors.
 
     - The price entity for the auto generated cost entity does not exist.
@@ -614,8 +627,12 @@ async def test_validation_grid_price_not_exist(
 
 
 async def test_validation_grid_auto_cost_entity_errors(
-    hass, mock_energy_manager, mock_get_metadata, mock_is_entity_recorded, caplog
-):
+    hass: HomeAssistant,
+    mock_energy_manager,
+    mock_get_metadata,
+    mock_is_entity_recorded,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test validating grid when the auto generated cost entity config is incorrect.
 
     The intention of the test is to make sure the validation does not throw due to the
@@ -696,8 +713,8 @@ async def test_validation_grid_auto_cost_entity_errors(
     ),
 )
 async def test_validation_grid_price_errors(
-    hass, mock_energy_manager, mock_get_metadata, state, unit, expected
-):
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata, state, unit, expected
+) -> None:
     """Test validating grid with price data that gives errors."""
     hass.states.async_set(
         "sensor.grid_consumption_1",
@@ -741,8 +758,8 @@ async def test_validation_grid_price_errors(
 
 
 async def test_validation_gas(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating gas with sensors for energy and cost/compensation."""
     mock_is_entity_recorded["sensor.gas_cost_1"] = False
     mock_is_entity_recorded["sensor.gas_compensation_1"] = False
@@ -874,8 +891,8 @@ async def test_validation_gas(
 
 
 async def test_validation_gas_no_costs_tracking(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating gas with sensors without cost tracking."""
     await mock_energy_manager.async_update(
         {
@@ -907,8 +924,8 @@ async def test_validation_gas_no_costs_tracking(
 
 
 async def test_validation_grid_no_costs_tracking(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating grid with sensors for energy without cost tracking."""
     await mock_energy_manager.async_update(
         {
@@ -953,8 +970,8 @@ async def test_validation_grid_no_costs_tracking(
 
 
 async def test_validation_water(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating water with sensors for energy and cost/compensation."""
     mock_is_entity_recorded["sensor.water_cost_1"] = False
     mock_is_entity_recorded["sensor.water_compensation_1"] = False
@@ -1081,8 +1098,8 @@ async def test_validation_water(
 
 
 async def test_validation_water_no_costs_tracking(
-    hass, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
-):
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
     """Test validating water with sensors without cost tracking."""
     await mock_energy_manager.async_update(
         {

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from homeassistant.components.energy import data, is_configured
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.statistics import async_add_external_statistics
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -58,7 +59,9 @@ async def test_get_preferences_no_data(
     assert msg["error"] == {"code": "not_found", "message": "No prefs"}
 
 
-async def test_get_preferences_default(hass, hass_ws_client, hass_storage) -> None:
+async def test_get_preferences_default(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test we get preferences."""
     assert not await is_configured(hass)
     manager = await data.async_get_manager(hass)
@@ -77,7 +80,10 @@ async def test_get_preferences_default(hass, hass_ws_client, hass_storage) -> No
 
 
 async def test_save_preferences(
-    hass, hass_ws_client, hass_storage, mock_energy_platform
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage,
+    mock_energy_platform,
 ) -> None:
     """Test we can save preferences."""
     client = await hass_ws_client(hass)
@@ -266,7 +272,9 @@ async def test_validate(
     }
 
 
-async def test_get_solar_forecast(hass, hass_ws_client, mock_energy_platform) -> None:
+async def test_get_solar_forecast(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_energy_platform
+) -> None:
     """Test we get preferences."""
     entry = MockConfigEntry(domain="some_domain")
     entry.add_to_hass(hass)
@@ -299,7 +307,9 @@ async def test_get_solar_forecast(hass, hass_ws_client, mock_energy_platform) ->
 
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
-async def test_fossil_energy_consumption_no_co2(recorder_mock, hass, hass_ws_client):
+async def test_fossil_energy_consumption_no_co2(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test fossil_energy_consumption when co2 data is missing."""
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2022-09-01 00:00:00"))
@@ -460,7 +470,9 @@ async def test_fossil_energy_consumption_no_co2(recorder_mock, hass, hass_ws_cli
 
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
-async def test_fossil_energy_consumption_hole(recorder_mock, hass, hass_ws_client):
+async def test_fossil_energy_consumption_hole(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test fossil_energy_consumption when some data points lack sum."""
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2022-09-01 00:00:00"))
@@ -621,7 +633,9 @@ async def test_fossil_energy_consumption_hole(recorder_mock, hass, hass_ws_clien
 
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
-async def test_fossil_energy_consumption_no_data(recorder_mock, hass, hass_ws_client):
+async def test_fossil_energy_consumption_no_data(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test fossil_energy_consumption when there is no data."""
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2022-09-01 00:00:00"))
@@ -769,7 +783,9 @@ async def test_fossil_energy_consumption_no_data(recorder_mock, hass, hass_ws_cl
 
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
-async def test_fossil_energy_consumption(recorder_mock, hass, hass_ws_client):
+async def test_fossil_energy_consumption(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test fossil_energy_consumption with co2 sensor data."""
     now = dt_util.utcnow()
     later = dt_util.as_utc(dt_util.parse_datetime("2022-09-01 00:00:00"))

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test Enphase Envoy diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_enphase_envoy):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_enphase_envoy,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/environment_canada/test_config_flow.py
+++ b/tests/components/environment_canada/test_config_flow.py
@@ -104,7 +104,7 @@ async def test_create_same_entry_twice(hass: HomeAssistant) -> None:
         (ValueError, "unknown"),
     ],
 )
-async def test_exception_handling(hass, error):
+async def test_exception_handling(hass: HomeAssistant, error) -> None:
     """Test exception handling."""
     exc, base_error = error
     with patch(

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -39,7 +39,9 @@ def mock_setup_entry():
         yield
 
 
-async def test_user_connection_works(hass, mock_client, mock_zeroconf):
+async def test_user_connection_works(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
         "esphome",
@@ -76,7 +78,9 @@ async def test_user_connection_works(hass, mock_client, mock_zeroconf):
     assert mock_client.noise_psk is None
 
 
-async def test_user_connection_updates_host(hass, mock_client, mock_zeroconf):
+async def test_user_connection_updates_host(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test setup up the same name updates the host."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -103,7 +107,9 @@ async def test_user_connection_updates_host(hass, mock_client, mock_zeroconf):
     assert entry.data[CONF_HOST] == "127.0.0.1"
 
 
-async def test_user_resolve_error(hass, mock_client, mock_zeroconf):
+async def test_user_resolve_error(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with IP resolve error."""
 
     with patch(
@@ -126,7 +132,9 @@ async def test_user_resolve_error(hass, mock_client, mock_zeroconf):
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
-async def test_user_connection_error(hass, mock_client, mock_zeroconf):
+async def test_user_connection_error(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with connection error."""
     mock_client.device_info.side_effect = APIConnectionError
 
@@ -145,7 +153,9 @@ async def test_user_connection_error(hass, mock_client, mock_zeroconf):
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
-async def test_user_with_password(hass, mock_client, mock_zeroconf):
+async def test_user_with_password(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with password."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
 
@@ -173,7 +183,9 @@ async def test_user_with_password(hass, mock_client, mock_zeroconf):
     assert mock_client.password == "password1"
 
 
-async def test_user_invalid_password(hass, mock_client, mock_zeroconf):
+async def test_user_invalid_password(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with invalid password."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
 
@@ -197,7 +209,9 @@ async def test_user_invalid_password(hass, mock_client, mock_zeroconf):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_login_connection_error(hass, mock_client, mock_zeroconf):
+async def test_login_connection_error(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with connection error on login attempt."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
 
@@ -221,7 +235,9 @@ async def test_login_connection_error(hass, mock_client, mock_zeroconf):
     assert result["errors"] == {"base": "connection_error"}
 
 
-async def test_discovery_initiation(hass, mock_client, mock_zeroconf):
+async def test_discovery_initiation(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test discovery importing works."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.43.183",
@@ -251,7 +267,9 @@ async def test_discovery_initiation(hass, mock_client, mock_zeroconf):
     assert result["result"].unique_id == "11:22:33:44:55:aa"
 
 
-async def test_discovery_no_mac(hass, mock_client, mock_zeroconf):
+async def test_discovery_no_mac(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test discovery aborted if old ESPHome without mac in zeroconf."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.43.183",
@@ -269,7 +287,7 @@ async def test_discovery_no_mac(hass, mock_client, mock_zeroconf):
     assert flow["reason"] == "mdns_missing_mac"
 
 
-async def test_discovery_already_configured(hass, mock_client):
+async def test_discovery_already_configured(hass: HomeAssistant, mock_client) -> None:
     """Test discovery aborts if already configured via hostname."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -296,7 +314,7 @@ async def test_discovery_already_configured(hass, mock_client):
     assert result["reason"] == "already_configured"
 
 
-async def test_discovery_duplicate_data(hass, mock_client):
+async def test_discovery_duplicate_data(hass: HomeAssistant, mock_client) -> None:
     """Test discovery aborts if same mDNS packet arrives."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.43.183",
@@ -321,7 +339,7 @@ async def test_discovery_duplicate_data(hass, mock_client):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_discovery_updates_unique_id(hass, mock_client):
+async def test_discovery_updates_unique_id(hass: HomeAssistant, mock_client) -> None:
     """Test a duplicate discovery host aborts and updates existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -350,7 +368,9 @@ async def test_discovery_updates_unique_id(hass, mock_client):
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
-async def test_user_requires_psk(hass, mock_client, mock_zeroconf):
+async def test_user_requires_psk(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test user step with requiring encryption key."""
     mock_client.device_info.side_effect = RequiresEncryptionAPIError
 
@@ -369,7 +389,9 @@ async def test_user_requires_psk(hass, mock_client, mock_zeroconf):
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
-async def test_encryption_key_valid_psk(hass, mock_client, mock_zeroconf):
+async def test_encryption_key_valid_psk(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test encryption key step with valid key."""
 
     mock_client.device_info.side_effect = RequiresEncryptionAPIError
@@ -401,7 +423,9 @@ async def test_encryption_key_valid_psk(hass, mock_client, mock_zeroconf):
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
-async def test_encryption_key_invalid_psk(hass, mock_client, mock_zeroconf):
+async def test_encryption_key_invalid_psk(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test encryption key step with invalid key."""
 
     mock_client.device_info.side_effect = RequiresEncryptionAPIError
@@ -426,7 +450,9 @@ async def test_encryption_key_invalid_psk(hass, mock_client, mock_zeroconf):
     assert mock_client.noise_psk == INVALID_NOISE_PSK
 
 
-async def test_reauth_initiation(hass, mock_client, mock_zeroconf):
+async def test_reauth_initiation(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test reauth initiation shows form."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -446,7 +472,9 @@ async def test_reauth_initiation(hass, mock_client, mock_zeroconf):
     assert result["step_id"] == "reauth_confirm"
 
 
-async def test_reauth_confirm_valid(hass, mock_client, mock_zeroconf):
+async def test_reauth_confirm_valid(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test reauth initiation with valid PSK."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -474,8 +502,8 @@ async def test_reauth_confirm_valid(hass, mock_client, mock_zeroconf):
 
 
 async def test_reauth_fixed_via_dashboard(
-    hass, mock_client, mock_zeroconf, mock_dashboard
-):
+    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_dashboard
+) -> None:
     """Test reauth fixed automatically via dashboard."""
 
     entry = MockConfigEntry(
@@ -521,8 +549,12 @@ async def test_reauth_fixed_via_dashboard(
 
 
 async def test_reauth_fixed_via_dashboard_add_encryption_remove_password(
-    hass, mock_client, mock_zeroconf, mock_dashboard, mock_config_entry
-):
+    hass: HomeAssistant,
+    mock_client,
+    mock_zeroconf: None,
+    mock_dashboard,
+    mock_config_entry,
+) -> None:
     """Test reauth fixed automatically via dashboard with password removed."""
     mock_client.device_info.side_effect = (
         InvalidAuthAPIError,
@@ -559,7 +591,9 @@ async def test_reauth_fixed_via_dashboard_add_encryption_remove_password(
     assert len(mock_get_encryption_key.mock_calls) == 1
 
 
-async def test_reauth_fixed_via_remove_password(hass, mock_client, mock_config_entry):
+async def test_reauth_fixed_via_remove_password(
+    hass: HomeAssistant, mock_client, mock_config_entry
+) -> None:
     """Test reauth fixed automatically by seeing password removed."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=False, name="test")
 
@@ -578,8 +612,8 @@ async def test_reauth_fixed_via_remove_password(hass, mock_client, mock_config_e
 
 
 async def test_reauth_fixed_via_dashboard_at_confirm(
-    hass, mock_client, mock_zeroconf, mock_dashboard
-):
+    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_dashboard
+) -> None:
     """Test reauth fixed automatically via dashboard at confirm step."""
 
     entry = MockConfigEntry(
@@ -630,7 +664,9 @@ async def test_reauth_fixed_via_dashboard_at_confirm(
     assert len(mock_get_encryption_key.mock_calls) == 1
 
 
-async def test_reauth_confirm_invalid(hass, mock_client, mock_zeroconf):
+async def test_reauth_confirm_invalid(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test reauth initiation with invalid PSK."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -669,7 +705,9 @@ async def test_reauth_confirm_invalid(hass, mock_client, mock_zeroconf):
     assert entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
 
 
-async def test_reauth_confirm_invalid_with_unique_id(hass, mock_client, mock_zeroconf):
+async def test_reauth_confirm_invalid_with_unique_id(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test reauth initiation with invalid PSK."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -709,7 +747,7 @@ async def test_reauth_confirm_invalid_with_unique_id(hass, mock_client, mock_zer
     assert entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
 
 
-async def test_discovery_dhcp_updates_host(hass, mock_client):
+async def test_discovery_dhcp_updates_host(hass: HomeAssistant, mock_client) -> None:
     """Test dhcp discovery updates host and aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -733,7 +771,7 @@ async def test_discovery_dhcp_updates_host(hass, mock_client):
     assert entry.data[CONF_HOST] == "192.168.43.184"
 
 
-async def test_discovery_dhcp_no_changes(hass, mock_client):
+async def test_discovery_dhcp_no_changes(hass: HomeAssistant, mock_client) -> None:
     """Test dhcp discovery updates host and aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -785,8 +823,8 @@ async def test_discovery_hassio(hass: HomeAssistant) -> None:
 
 
 async def test_zeroconf_encryption_key_via_dashboard(
-    hass, mock_client, mock_zeroconf, mock_dashboard
-):
+    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_dashboard
+) -> None:
     """Test encryption key retrieved from dashboard."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.43.183",
@@ -847,8 +885,8 @@ async def test_zeroconf_encryption_key_via_dashboard(
 
 
 async def test_zeroconf_no_encryption_key_via_dashboard(
-    hass, mock_client, mock_zeroconf, mock_dashboard
-):
+    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_dashboard
+) -> None:
     """Test encryption key not retrieved from dashboard."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.43.183",

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -5,12 +5,15 @@ from aioesphomeapi import DeviceInfo, InvalidAuthAPIError
 
 from homeassistant.components.esphome import CONF_NOISE_PSK, dashboard
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import VALID_NOISE_PSK
 
 
-async def test_new_info_reload_config_entries(hass, init_integration, mock_dashboard):
+async def test_new_info_reload_config_entries(
+    hass: HomeAssistant, init_integration, mock_dashboard
+) -> None:
     """Test config entries are reloaded when new info is set."""
     assert init_integration.state == ConfigEntryState.LOADED
 
@@ -28,8 +31,8 @@ async def test_new_info_reload_config_entries(hass, init_integration, mock_dashb
 
 
 async def test_new_dashboard_fix_reauth(
-    hass, mock_client, mock_config_entry, mock_dashboard
-):
+    hass: HomeAssistant, mock_client, mock_config_entry, mock_dashboard
+) -> None:
     """Test config entries waiting for reauth are triggered."""
     mock_client.device_info.side_effect = (
         InvalidAuthAPIError,
@@ -75,7 +78,7 @@ async def test_new_dashboard_fix_reauth(
     assert mock_config_entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
 
 
-async def test_dashboard_supports_update(hass, mock_dashboard):
+async def test_dashboard_supports_update(hass: HomeAssistant, mock_dashboard) -> None:
     """Test dashboard supports update."""
     dash = dashboard.async_get_dashboard(hass)
 

--- a/tests/components/esphome/test_diagnostics.py
+++ b/tests/components/esphome/test_diagnostics.py
@@ -1,6 +1,5 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
 
-import pytest
 
 from homeassistant.components.esphome import CONF_DEVICE_NAME, CONF_NOISE_PSK
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
@@ -17,9 +16,9 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-    enable_bluetooth: pytest.fixture,
+    enable_bluetooth: None,
     mock_dashboard,
-):
+) -> None:
     """Test diagnostics for config entry."""
     result = await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
 

--- a/tests/components/esphome/test_init.py
+++ b/tests/components/esphome/test_init.py
@@ -5,11 +5,14 @@ from aioesphomeapi import DeviceInfo
 
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_unique_id_updated_to_mac(hass, mock_client, mock_zeroconf):
+async def test_unique_id_updated_to_mac(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
     """Test we update config entry unique ID to MAC address."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.esphome.dashboard import async_get_dashboard
 from homeassistant.components.update import UpdateEntityFeature
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 
@@ -56,14 +57,14 @@ def stub_reconnect():
     ],
 )
 async def test_update_entity(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_device_info,
     mock_dashboard,
     devices_payload,
     expected_state,
     expected_attributes,
-):
+) -> None:
     """Test ESPHome update entity."""
     mock_dashboard["configured"] = devices_payload
     await async_get_dashboard(hass).async_refresh()
@@ -105,11 +106,11 @@ async def test_update_entity(
 
 
 async def test_update_static_info(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_device_info,
     mock_dashboard,
-):
+) -> None:
     """Test ESPHome update entity."""
     mock_dashboard["configured"] = [
         {
@@ -148,11 +149,11 @@ async def test_update_static_info(
 
 
 async def test_update_device_state_for_availability(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_device_info,
     mock_dashboard,
-):
+) -> None:
     """Test ESPHome update entity changes availability with the device."""
     mock_dashboard["configured"] = [
         {

--- a/tests/components/evil_genius_labs/test_config_flow.py
+++ b/tests/components/evil_genius_labs/test_config_flow.py
@@ -3,6 +3,7 @@ import asyncio
 from unittest.mock import patch
 
 import aiohttp
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.evil_genius_labs.const import DOMAIN
@@ -49,7 +50,9 @@ async def test_form(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass: HomeAssistant, caplog) -> None:
+async def test_form_cannot_connect(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/evil_genius_labs/test_diagnostics.py
+++ b/tests/components/evil_genius_labs/test_diagnostics.py
@@ -2,14 +2,21 @@
 import pytest
 
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.parametrize("platforms", [[]])
 async def test_entry_diagnostics(
-    hass, hass_client, setup_evil_genius_labs, config_entry, all_fixture, info_fixture
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup_evil_genius_labs,
+    config_entry,
+    all_fixture,
+    info_fixture,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "info": {

--- a/tests/components/evil_genius_labs/test_init.py
+++ b/tests/components/evil_genius_labs/test_init.py
@@ -3,10 +3,13 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.evil_genius_labs import PLATFORMS
+from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize("platforms", [PLATFORMS])
-async def test_setup_unload_entry(hass, setup_evil_genius_labs, config_entry):
+async def test_setup_unload_entry(
+    hass: HomeAssistant, setup_evil_genius_labs, config_entry
+) -> None:
     """Test setting up and unloading a config entry."""
     assert len(hass.states.async_entity_ids()) == 1
     assert await hass.config_entries.async_unload(config_entry.entry_id)

--- a/tests/components/evil_genius_labs/test_light.py
+++ b/tests/components/evil_genius_labs/test_light.py
@@ -10,10 +10,11 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.const import ATTR_SUPPORTED_FEATURES
+from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize("platforms", [("light",)])
-async def test_works(hass, setup_evil_genius_labs):
+async def test_works(hass: HomeAssistant, setup_evil_genius_labs) -> None:
     """Test it works."""
     state = hass.states.get("light.fibonacci256_23d4")
     assert state is not None
@@ -25,7 +26,7 @@ async def test_works(hass, setup_evil_genius_labs):
 
 
 @pytest.mark.parametrize("platforms", [("light",)])
-async def test_turn_on_color(hass, setup_evil_genius_labs):
+async def test_turn_on_color(hass: HomeAssistant, setup_evil_genius_labs) -> None:
     """Test turning on with a color."""
     with patch(
         "pyevilgenius.EvilGeniusDevice.set_path_value"
@@ -52,7 +53,7 @@ async def test_turn_on_color(hass, setup_evil_genius_labs):
 
 
 @pytest.mark.parametrize("platforms", [("light",)])
-async def test_turn_on_effect(hass, setup_evil_genius_labs):
+async def test_turn_on_effect(hass: HomeAssistant, setup_evil_genius_labs) -> None:
     """Test turning on with an effect."""
     with patch("pyevilgenius.EvilGeniusDevice.set_path_value") as mock_set_path_value:
         await hass.services.async_call(
@@ -71,7 +72,7 @@ async def test_turn_on_effect(hass, setup_evil_genius_labs):
 
 
 @pytest.mark.parametrize("platforms", [("light",)])
-async def test_turn_off(hass, setup_evil_genius_labs):
+async def test_turn_off(hass: HomeAssistant, setup_evil_genius_labs) -> None:
     """Test turning off."""
     with patch("pyevilgenius.EvilGeniusDevice.set_path_value") as mock_set_path_value:
         await hass.services.async_call(

--- a/tests/components/ezviz/test_config_flow.py
+++ b/tests/components/ezviz/test_config_flow.py
@@ -40,7 +40,7 @@ from . import (
 )
 
 
-async def test_user_form(hass, ezviz_config_flow):
+async def test_user_form(hass: HomeAssistant, ezviz_config_flow) -> None:
     """Test the user initiated form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -70,7 +70,7 @@ async def test_user_form(hass, ezviz_config_flow):
     assert result["reason"] == "already_configured_account"
 
 
-async def test_user_custom_url(hass, ezviz_config_flow):
+async def test_user_custom_url(hass: HomeAssistant, ezviz_config_flow) -> None:
     """Test custom url step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -128,8 +128,8 @@ async def test_step_discovery_abort_if_cloud_account_missing(
 
 
 async def test_async_step_integration_discovery(
-    hass, ezviz_config_flow, ezviz_test_rtsp_config_flow
-):
+    hass: HomeAssistant, ezviz_config_flow, ezviz_test_rtsp_config_flow
+) -> None:
     """Test discovery and confirm step."""
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
@@ -187,7 +187,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_exception(hass, ezviz_config_flow):
+async def test_user_form_exception(hass: HomeAssistant, ezviz_config_flow) -> None:
     """Test we handle exception on user form."""
     ezviz_config_flow.side_effect = PyEzvizError
 
@@ -238,9 +238,9 @@ async def test_user_form_exception(hass, ezviz_config_flow):
 
 
 async def test_discover_exception_step1(
-    hass,
+    hass: HomeAssistant,
     ezviz_config_flow,
-):
+) -> None:
     """Test we handle unexpected exception on discovery."""
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
@@ -312,10 +312,10 @@ async def test_discover_exception_step1(
 
 
 async def test_discover_exception_step3(
-    hass,
+    hass: HomeAssistant,
     ezviz_config_flow,
     ezviz_test_rtsp_config_flow,
-):
+) -> None:
     """Test we handle unexpected exception on discovery."""
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
@@ -372,7 +372,9 @@ async def test_discover_exception_step3(
     assert result["reason"] == "unknown"
 
 
-async def test_user_custom_url_exception(hass, ezviz_config_flow):
+async def test_user_custom_url_exception(
+    hass: HomeAssistant, ezviz_config_flow
+) -> None:
     """Test we handle unexpected exception."""
     ezviz_config_flow.side_effect = PyEzvizError()
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/facebook/test_notify.py
+++ b/tests/components/facebook/test_notify.py
@@ -5,6 +5,7 @@ import pytest
 import requests_mock
 
 import homeassistant.components.facebook.notify as fb
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
@@ -14,7 +15,7 @@ def facebook():
     return fb.FacebookNotificationService(access_token)
 
 
-async def test_send_simple_message(hass, facebook):
+async def test_send_simple_message(hass: HomeAssistant, facebook) -> None:
     """Test sending a simple message with success."""
     with requests_mock.Mocker() as mock:
         mock.register_uri(requests_mock.POST, fb.BASE_URL, status_code=HTTPStatus.OK)
@@ -38,7 +39,7 @@ async def test_send_simple_message(hass, facebook):
         assert mock.last_request.qs == expected_params
 
 
-async def test_send_multiple_message(hass, facebook):
+async def test_send_multiple_message(hass: HomeAssistant, facebook) -> None:
     """Test sending a message to multiple targets."""
     with requests_mock.Mocker() as mock:
         mock.register_uri(requests_mock.POST, fb.BASE_URL, status_code=HTTPStatus.OK)
@@ -64,7 +65,7 @@ async def test_send_multiple_message(hass, facebook):
             assert request.qs == expected_params
 
 
-async def test_send_message_attachment(hass, facebook):
+async def test_send_message_attachment(hass: HomeAssistant, facebook) -> None:
     """Test sending a message with a remote attachment."""
     with requests_mock.Mocker() as mock:
         mock.register_uri(requests_mock.POST, fb.BASE_URL, status_code=HTTPStatus.OK)

--- a/tests/components/facebox/test_image_processing.py
+++ b/tests/components/facebox/test_image_processing.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     STATE_UNKNOWN,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 MOCK_IP = "192.168.0.1"
@@ -114,7 +114,7 @@ def mock_open_file():
         yield _mock_open
 
 
-def test_check_box_health(caplog):
+def test_check_box_health(caplog: pytest.LogCaptureFixture) -> None:
     """Test check box health."""
     with requests_mock.Mocker() as mock_req:
         url = f"http://{MOCK_IP}:{MOCK_PORT}/healthz"
@@ -151,14 +151,14 @@ def test_valid_file_path() -> None:
     assert not fb.valid_file_path("test_path")
 
 
-async def test_setup_platform(hass, mock_healthybox):
+async def test_setup_platform(hass: HomeAssistant, mock_healthybox) -> None:
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
 
-async def test_setup_platform_with_auth(hass, mock_healthybox):
+async def test_setup_platform_with_auth(hass: HomeAssistant, mock_healthybox) -> None:
     """Set up platform with one entity and auth."""
     valid_config_auth = VALID_CONFIG.copy()
     valid_config_auth[ip.DOMAIN][CONF_USERNAME] = MOCK_USERNAME
@@ -169,7 +169,7 @@ async def test_setup_platform_with_auth(hass, mock_healthybox):
     assert hass.states.get(VALID_ENTITY_ID)
 
 
-async def test_process_image(hass, mock_healthybox, mock_image):
+async def test_process_image(hass: HomeAssistant, mock_healthybox, mock_image) -> None:
     """Test successful processing of an image."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
@@ -213,7 +213,9 @@ async def test_process_image(hass, mock_healthybox, mock_image):
     )
 
 
-async def test_process_image_errors(hass, mock_healthybox, mock_image, caplog):
+async def test_process_image_errors(
+    hass: HomeAssistant, mock_healthybox, mock_image, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test process_image errors."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
@@ -244,8 +246,13 @@ async def test_process_image_errors(hass, mock_healthybox, mock_image, caplog):
 
 
 async def test_teach_service(
-    hass, mock_healthybox, mock_image, mock_isfile, mock_open_file, caplog
-):
+    hass: HomeAssistant,
+    mock_healthybox,
+    mock_image,
+    mock_isfile,
+    mock_open_file,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test teaching of facebox."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
@@ -314,7 +321,7 @@ async def test_teach_service(
         assert "ConnectionError: Is facebox running?" in caplog.text
 
 
-async def test_setup_platform_with_name(hass, mock_healthybox):
+async def test_setup_platform_with_name(hass: HomeAssistant, mock_healthybox) -> None:
     """Set up platform with one entity and a name."""
     named_entity_id = f"image_processing.{MOCK_NAME}"
 

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -6,7 +6,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -19,7 +19,11 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a fan."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -57,12 +61,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -5,7 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +25,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a fan."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -62,12 +67,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -100,7 +105,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("fan.entity", STATE_ON)
 

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a fan."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a switch trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,7 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off triggers firing."""
     hass.states.async_set("fan.entity", STATE_OFF)
 
@@ -229,7 +238,7 @@ async def test_if_fires_on_state_change(hass, calls):
     }
 
 
-async def test_if_fires_on_state_change_with_for(hass, calls):
+async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for triggers firing with delay."""
     entity_id = "fan.entity"
     hass.states.async_set(entity_id, STATE_ON)

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -77,7 +77,7 @@ async def test_async_fanentity(hass: HomeAssistant) -> None:
         ("supported_features", 1),
     ],
 )
-def test_fanentity_attributes(attribute_name, attribute_value):
+def test_fanentity_attributes(attribute_name, attribute_value) -> None:
     """Test fan entity attribute shorthand."""
     fan = BaseFan()
     setattr(fan, f"_attr_{attribute_name}", attribute_value)

--- a/tests/components/fan/test_recorder.py
+++ b/tests/components/fan/test_recorder.py
@@ -5,10 +5,11 @@ from datetime import timedelta
 
 from homeassistant.components import fan
 from homeassistant.components.fan import ATTR_PRESET_MODES
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -16,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test fan registered attributes to be excluded."""
     await async_setup_component(hass, fan.DOMAIN, {fan.DOMAIN: {"platform": "demo"}})
     await hass.async_block_till_done()

--- a/tests/components/fan/test_reproduce_state.py
+++ b/tests/components/fan/test_reproduce_state.py
@@ -172,7 +172,7 @@ MODERN_FAN_PRESET_MODE_AUTO_REVERSE_STATE = {
         MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_turn_on_invalid(hass, start_state):
+async def test_modern_turn_on_invalid(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, turning on with invalid state."""
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
@@ -217,7 +217,9 @@ async def test_modern_turn_on_invalid(hass, start_state):
         MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_turn_on_percentage_from_different_speed(hass, start_state):
+async def test_modern_turn_on_percentage_from_different_speed(
+    hass: HomeAssistant, start_state
+) -> None:
     """Test modern fan state reproduction, turning on with a different percentage of the state."""
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
@@ -283,7 +285,9 @@ async def test_modern_turn_on_percentage_from_same_speed(hass: HomeAssistant) ->
         MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_turn_on_preset_mode_from_different_speed(hass, start_state):
+async def test_modern_turn_on_preset_mode_from_different_speed(
+    hass: HomeAssistant, start_state
+) -> None:
     """Test modern fan state reproduction, turning on with a different preset mode from the state."""
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
@@ -351,7 +355,9 @@ async def test_modern_turn_on_preset_mode_from_same_speed(hass: HomeAssistant) -
         MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_turn_on_preset_mode_reverse(hass, start_state):
+async def test_modern_turn_on_preset_mode_reverse(
+    hass: HomeAssistant, start_state
+) -> None:
     """Test modern fan state reproduction, turning on with preset mode "Auto" and reverse direction."""
     hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
 
@@ -394,7 +400,7 @@ async def test_modern_turn_on_preset_mode_reverse(hass, start_state):
         MODERN_FAN_ON_PRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_to_preset(hass, start_state):
+async def test_modern_to_preset(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, switching to preset mode "Auto"."""
     hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
 
@@ -430,7 +436,7 @@ async def test_modern_to_preset(hass, start_state):
         MODERN_FAN_ON_PRESET_MODE_ECO_STATE,
     ],
 )
-async def test_modern_to_percentage(hass, start_state):
+async def test_modern_to_percentage(hass: HomeAssistant, start_state) -> None:
     """Test modern fan state reproduction, switching to 15% speed."""
     hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
 

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -105,7 +105,7 @@ async def test_setup_max_entries(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_feed(hass, events, feed_one_event):
+async def test_feed(hass: HomeAssistant, events, feed_one_event) -> None:
     """Test simple rss feed with valid data."""
     with patch(
         "feedparser.http.get",
@@ -128,7 +128,7 @@ async def test_feed(hass, events, feed_one_event):
     assert events[0].data.published_parsed.tm_min == 10
 
 
-async def test_atom_feed(hass, events, feed_atom_event):
+async def test_atom_feed(hass: HomeAssistant, events, feed_atom_event) -> None:
     """Test simple atom feed with valid data."""
     with patch(
         "feedparser.http.get",
@@ -151,7 +151,9 @@ async def test_atom_feed(hass, events, feed_atom_event):
     assert events[0].data.updated_parsed.tm_min == 30
 
 
-async def test_feed_updates(hass, events, feed_one_event, feed_two_event):
+async def test_feed_updates(
+    hass: HomeAssistant, events, feed_one_event, feed_two_event
+) -> None:
     """Test feed updates."""
     side_effect = [
         feed_one_event,
@@ -182,7 +184,9 @@ async def test_feed_updates(hass, events, feed_one_event, feed_two_event):
         assert len(events) == 2
 
 
-async def test_feed_default_max_length(hass, events, feed_21_events):
+async def test_feed_default_max_length(
+    hass: HomeAssistant, events, feed_21_events
+) -> None:
     """Test long feed beyond the default 20 entry limit."""
     with patch("feedparser.http.get", return_value=feed_21_events):
         assert await async_setup_component(hass, feedreader.DOMAIN, VALID_CONFIG_2)
@@ -193,7 +197,7 @@ async def test_feed_default_max_length(hass, events, feed_21_events):
     assert len(events) == 20
 
 
-async def test_feed_max_length(hass, events, feed_21_events):
+async def test_feed_max_length(hass: HomeAssistant, events, feed_21_events) -> None:
     """Test long feed beyond a configured 5 entry limit."""
     with patch("feedparser.http.get", return_value=feed_21_events):
         assert await async_setup_component(hass, feedreader.DOMAIN, VALID_CONFIG_4)
@@ -204,7 +208,9 @@ async def test_feed_max_length(hass, events, feed_21_events):
     assert len(events) == 5
 
 
-async def test_feed_without_publication_date_and_title(hass, events, feed_three_events):
+async def test_feed_without_publication_date_and_title(
+    hass: HomeAssistant, events, feed_three_events
+) -> None:
     """Test simple feed with entry without publication date and title."""
     with patch("feedparser.http.get", return_value=feed_three_events):
         assert await async_setup_component(hass, feedreader.DOMAIN, VALID_CONFIG_2)
@@ -215,7 +221,9 @@ async def test_feed_without_publication_date_and_title(hass, events, feed_three_
     assert len(events) == 3
 
 
-async def test_feed_with_unrecognized_publication_date(hass, events):
+async def test_feed_with_unrecognized_publication_date(
+    hass: HomeAssistant, events
+) -> None:
     """Test simple feed with entry with unrecognized publication date."""
     with patch(
         "feedparser.http.get", return_value=load_fixture_bytes("feedreader4.xml")
@@ -228,7 +236,7 @@ async def test_feed_with_unrecognized_publication_date(hass, events):
     assert len(events) == 1
 
 
-async def test_feed_invalid_data(hass, events):
+async def test_feed_invalid_data(hass: HomeAssistant, events) -> None:
     """Test feed with invalid data."""
     invalid_data = bytes("INVALID DATA", "utf-8")
     with patch("feedparser.http.get", return_value=invalid_data):
@@ -240,7 +248,9 @@ async def test_feed_invalid_data(hass, events):
     assert len(events) == 0
 
 
-async def test_feed_parsing_failed(hass, events, caplog):
+async def test_feed_parsing_failed(
+    hass: HomeAssistant, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test feed where parsing fails."""
     assert "Error fetching feed data" not in caplog.text
 

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -40,7 +40,7 @@ class FidoClientMockError(FidoClientMock):
         raise PyFidoError("Fake Error")
 
 
-async def test_fido_sensor(event_loop, hass):
+async def test_fido_sensor(event_loop, hass: HomeAssistant) -> None:
     """Test the Fido number sensor."""
     with patch("homeassistant.components.fido.sensor.FidoClient", new=FidoClientMock):
         config = {

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -13,7 +13,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import assert_setup_component
 
 
-async def test_bad_config(hass: HomeAssistant):
+async def test_bad_config(hass: HomeAssistant) -> None:
     """Test set up the platform with bad/missing config."""
     config = {notify.DOMAIN: {"name": "test", "platform": "file"}}
     with assert_setup_component(0) as handle_config:
@@ -28,7 +28,7 @@ async def test_bad_config(hass: HomeAssistant):
         True,
     ],
 )
-async def test_notify_file(hass: HomeAssistant, timestamp: bool):
+async def test_notify_file(hass: HomeAssistant, timestamp: bool) -> None:
     """Test the notify file output."""
     filename = "mock_file"
     message = "one, two, testing, testing"

--- a/tests/components/file_upload/test_init.py
+++ b/tests/components/file_upload/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.components.image_upload import TEST_IMAGE
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -33,7 +34,7 @@ async def uploaded_file_dir(hass: HomeAssistant, hass_client) -> Path:
     return file_dir
 
 
-async def test_using_file(hass: HomeAssistant, uploaded_file_dir):
+async def test_using_file(hass: HomeAssistant, uploaded_file_dir) -> None:
     """Test uploading and using a file."""
     # Test we can use it
     with file_upload.process_uploaded_file(hass, uploaded_file_dir.name) as file_path:
@@ -45,7 +46,9 @@ async def test_using_file(hass: HomeAssistant, uploaded_file_dir):
     assert not uploaded_file_dir.exists()
 
 
-async def test_removing_file(hass: HomeAssistant, hass_client, uploaded_file_dir):
+async def test_removing_file(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, uploaded_file_dir
+) -> None:
     """Test uploading and using a file."""
     client = await hass_client()
 
@@ -58,7 +61,9 @@ async def test_removing_file(hass: HomeAssistant, hass_client, uploaded_file_dir
     assert not uploaded_file_dir.exists()
 
 
-async def test_removed_on_stop(hass: HomeAssistant, hass_client, uploaded_file_dir):
+async def test_removed_on_stop(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, uploaded_file_dir
+) -> None:
     """Test uploading and using a file."""
     await hass.async_stop()
 
@@ -66,7 +71,9 @@ async def test_removed_on_stop(hass: HomeAssistant, hass_client, uploaded_file_d
     assert not uploaded_file_dir.exists()
 
 
-async def test_upload_large_file(hass: HomeAssistant, hass_client, large_file_io):
+async def test_upload_large_file(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, large_file_io
+) -> None:
     """Test uploading large file."""
     assert await async_setup_component(hass, "file_upload", {})
     client = await hass_client()
@@ -96,8 +103,8 @@ async def test_upload_large_file(hass: HomeAssistant, hass_client, large_file_io
 
 
 async def test_upload_with_wrong_key_fails(
-    hass: HomeAssistant, hass_client, large_file_io
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, large_file_io
+) -> None:
     """Test uploading fails."""
     assert await async_setup_component(hass, "file_upload", {})
     client = await hass_client()

--- a/tests/components/flipr/test_config_flow.py
+++ b/tests/components/flipr/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == config_entries.SOURCE_USER
 
 
-async def test_invalid_credential(hass, mock_setup):
+async def test_invalid_credential(hass: HomeAssistant, mock_setup) -> None:
     """Test invalid credential."""
     with patch(
         "flipr_api.FliprAPIRestClient.search_flipr_ids", side_effect=HTTPError()
@@ -49,7 +49,7 @@ async def test_invalid_credential(hass, mock_setup):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_nominal_case(hass, mock_setup):
+async def test_nominal_case(hass: HomeAssistant, mock_setup) -> None:
     """Test valid login form."""
     with patch(
         "flipr_api.FliprAPIRestClient.search_flipr_ids",
@@ -77,7 +77,7 @@ async def test_nominal_case(hass, mock_setup):
     }
 
 
-async def test_multiple_flip_id(hass, mock_setup):
+async def test_multiple_flip_id(hass: HomeAssistant, mock_setup) -> None:
     """Test multiple flipr id adding a config step."""
     with patch(
         "flipr_api.FliprAPIRestClient.search_flipr_ids",
@@ -111,7 +111,7 @@ async def test_multiple_flip_id(hass, mock_setup):
     }
 
 
-async def test_no_flip_id(hass, mock_setup):
+async def test_no_flip_id(hass: HomeAssistant, mock_setup) -> None:
     """Test no flipr id found."""
     with patch(
         "flipr_api.FliprAPIRestClient.search_flipr_ids",
@@ -133,7 +133,7 @@ async def test_no_flip_id(hass, mock_setup):
     assert len(mock_flipr_client.mock_calls) == 1
 
 
-async def test_http_errors(hass, mock_setup):
+async def test_http_errors(hass: HomeAssistant, mock_setup) -> None:
     """Test HTTP Errors."""
     with patch("flipr_api.FliprAPIRestClient.search_flipr_ids", side_effect=Timeout()):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/flipr/test_init.py
+++ b/tests/components/flipr/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test unload entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/flo/test_binary_sensor.py
+++ b/tests/components/flo/test_binary_sensor.py
@@ -7,12 +7,15 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
 
-async def test_binary_sensors(hass, config_entry, aioclient_mock_fixture):
+async def test_binary_sensors(
+    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+) -> None:
     """Test Flo by Moen sensors."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_config_flow.py
+++ b/tests/components/flo/test_config_flow.py
@@ -14,7 +14,7 @@ from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_form(hass, aioclient_mock_fixture):
+async def test_form(hass: HomeAssistant, aioclient_mock_fixture) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.flo.device import FloDeviceDataUpdateCoordinator
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
@@ -15,9 +16,15 @@ from homeassistant.util import dt
 from .common import TEST_PASSWORD, TEST_USER_ID
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_device(hass, config_entry, aioclient_mock_fixture, aioclient_mock):
+async def test_device(
+    hass: HomeAssistant,
+    config_entry,
+    aioclient_mock_fixture,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test Flo by Moen devices."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_init.py
+++ b/tests/components/flo/test_init.py
@@ -1,12 +1,15 @@
 """Test init."""
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
 
-async def test_setup_entry(hass, config_entry, aioclient_mock_fixture):
+async def test_setup_entry(
+    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+) -> None:
     """Test migration of config entry from v1."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -2,13 +2,18 @@
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_sensors(hass, config_entry, aioclient_mock_fixture):
+
+async def test_sensors(
+    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+) -> None:
     """Test Flo by Moen sensors."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     config_entry.add_to_hass(hass)
@@ -80,8 +85,11 @@ async def test_sensors(hass, config_entry, aioclient_mock_fixture):
 
 
 async def test_manual_update_entity(
-    hass, config_entry, aioclient_mock_fixture, aioclient_mock
-):
+    hass: HomeAssistant,
+    config_entry,
+    aioclient_mock_fixture,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test manual update entity via service homeasasistant/update_entity."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -13,14 +13,22 @@ from homeassistant.components.flo.switch import (
     SYSTEM_MODE_HOME,
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 SWITCH_ENTITY_ID = "switch.smart_water_shutoff_shutoff_valve"
 
 
-async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mock):
+async def test_services(
+    hass: HomeAssistant,
+    config_entry,
+    aioclient_mock_fixture,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test Flo services."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_switch.py
+++ b/tests/components/flo/test_switch.py
@@ -2,12 +2,15 @@
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
 
-async def test_valve_switches(hass, config_entry, aioclient_mock_fixture):
+async def test_valve_switches(
+    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+) -> None:
     """Test Flo by Moen valve switches."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -134,7 +134,9 @@ async def test_invalid_config_no_lights(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
 
-async def test_flux_when_switch_is_off(hass, enable_custom_integrations):
+async def test_flux_when_switch_is_off(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch when it is off."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -183,7 +185,9 @@ async def test_flux_when_switch_is_off(hass, enable_custom_integrations):
     assert not turn_on_calls
 
 
-async def test_flux_before_sunrise(hass, enable_custom_integrations):
+async def test_flux_before_sunrise(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch before sunrise."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -240,7 +244,9 @@ async def test_flux_before_sunrise(hass, enable_custom_integrations):
     assert call.data[light.ATTR_XY_COLOR] == [0.606, 0.379]
 
 
-async def test_flux_before_sunrise_known_location(hass, enable_custom_integrations):
+async def test_flux_before_sunrise_known_location(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch before sunrise."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -297,7 +303,9 @@ async def test_flux_before_sunrise_known_location(hass, enable_custom_integratio
 
 
 # pylint: disable=invalid-name
-async def test_flux_after_sunrise_before_sunset(hass, enable_custom_integrations):
+async def test_flux_after_sunrise_before_sunset(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after sunrise and before sunset."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -354,7 +362,9 @@ async def test_flux_after_sunrise_before_sunset(hass, enable_custom_integrations
 
 
 # pylint: disable=invalid-name
-async def test_flux_after_sunset_before_stop(hass, enable_custom_integrations):
+async def test_flux_after_sunset_before_stop(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after sunset and before stop."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -412,7 +422,9 @@ async def test_flux_after_sunset_before_stop(hass, enable_custom_integrations):
 
 
 # pylint: disable=invalid-name
-async def test_flux_after_stop_before_sunrise(hass, enable_custom_integrations):
+async def test_flux_after_stop_before_sunrise(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after stop and before sunrise."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -469,7 +481,9 @@ async def test_flux_after_stop_before_sunrise(hass, enable_custom_integrations):
 
 
 # pylint: disable=invalid-name
-async def test_flux_with_custom_start_stop_times(hass, enable_custom_integrations):
+async def test_flux_with_custom_start_stop_times(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux with custom start and stop times."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -527,7 +541,9 @@ async def test_flux_with_custom_start_stop_times(hass, enable_custom_integration
     assert call.data[light.ATTR_XY_COLOR] == [0.504, 0.385]
 
 
-async def test_flux_before_sunrise_stop_next_day(hass, enable_custom_integrations):
+async def test_flux_before_sunrise_stop_next_day(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch before sunrise.
 
     This test has the stop_time on the next day (after midnight).
@@ -589,8 +605,8 @@ async def test_flux_before_sunrise_stop_next_day(hass, enable_custom_integration
 
 # pylint: disable=invalid-name
 async def test_flux_after_sunrise_before_sunset_stop_next_day(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after sunrise and before sunset.
 
     This test has the stop_time on the next day (after midnight).
@@ -653,8 +669,8 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
 # pylint: disable=invalid-name
 @pytest.mark.parametrize("x", [0, 1])
 async def test_flux_after_sunset_before_midnight_stop_next_day(
-    hass, x, enable_custom_integrations
-):
+    hass: HomeAssistant, x, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
@@ -716,8 +732,8 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
 
 # pylint: disable=invalid-name
 async def test_flux_after_sunset_after_midnight_stop_next_day(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
@@ -779,8 +795,8 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
 
 # pylint: disable=invalid-name
 async def test_flux_after_stop_before_sunrise_stop_next_day(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch after stop and before sunrise.
 
     This test has the stop_time on the next day (after midnight).
@@ -841,7 +857,9 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
 
 
 # pylint: disable=invalid-name
-async def test_flux_with_custom_colortemps(hass, enable_custom_integrations):
+async def test_flux_with_custom_colortemps(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux with custom start and stop colortemps."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -901,7 +919,9 @@ async def test_flux_with_custom_colortemps(hass, enable_custom_integrations):
 
 
 # pylint: disable=invalid-name
-async def test_flux_with_custom_brightness(hass, enable_custom_integrations):
+async def test_flux_with_custom_brightness(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux with custom start and stop colortemps."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -959,7 +979,9 @@ async def test_flux_with_custom_brightness(hass, enable_custom_integrations):
     assert call.data[light.ATTR_XY_COLOR] == [0.506, 0.385]
 
 
-async def test_flux_with_multiple_lights(hass, enable_custom_integrations):
+async def test_flux_with_multiple_lights(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch with multiple light entities."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -1038,7 +1060,9 @@ async def test_flux_with_multiple_lights(hass, enable_custom_integrations):
     assert call.data[light.ATTR_XY_COLOR] == [0.46, 0.376]
 
 
-async def test_flux_with_mired(hass, enable_custom_integrations):
+async def test_flux_with_mired(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch´s mode mired."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -1093,7 +1117,9 @@ async def test_flux_with_mired(hass, enable_custom_integrations):
     assert call.data[light.ATTR_COLOR_TEMP] == 269
 
 
-async def test_flux_with_rgb(hass, enable_custom_integrations):
+async def test_flux_with_rgb(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test the flux switch´s mode rgb."""
     platform = getattr(hass.components, "test.light")
     platform.init()

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -47,7 +47,7 @@ from tests.common import MockConfigEntry
 MAC_ADDRESS_DIFFERENT = "ff:bb:ff:dd:ee:ff"
 
 
-async def test_discovery(hass: HomeAssistant):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     with _patch_discovery(), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
@@ -121,7 +121,7 @@ async def test_discovery(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_legacy(hass: HomeAssistant):
+async def test_discovery_legacy(hass: HomeAssistant) -> None:
     """Test setting up discovery with a legacy device."""
     with _patch_discovery(device=FLUX_DISCOVERY_PARTIAL), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
@@ -195,7 +195,7 @@ async def test_discovery_legacy(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_with_existing_device_present(hass: HomeAssistant):
+async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.2"}, unique_id="dd:dd:dd:dd:dd:dd"
@@ -277,7 +277,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_no_device(hass: HomeAssistant):
+async def test_discovery_no_device(hass: HomeAssistant) -> None:
     """Test discovery without device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -291,7 +291,7 @@ async def test_discovery_no_device(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_manual_working_discovery(hass: HomeAssistant):
+async def test_manual_working_discovery(hass: HomeAssistant) -> None:
     """Test manually setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -347,7 +347,7 @@ async def test_manual_working_discovery(hass: HomeAssistant):
     assert result2["reason"] == "already_configured"
 
 
-async def test_manual_no_discovery_data(hass: HomeAssistant):
+async def test_manual_no_discovery_data(hass: HomeAssistant) -> None:
     """Test manually setup without discovery data."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -570,8 +570,8 @@ async def test_discovered_by_dhcp_no_udp_response_or_tcp_response(
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we can setup when discovered from dhcp or discovery."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: IP_ADDRESS})
     config_entry.add_to_hass(hass)
@@ -640,8 +640,8 @@ async def test_mac_address_off_by_one_not_updated_from_dhcp(
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already_configured(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort if the host is already configured but the mac does not match."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS_DIFFERENT
@@ -660,7 +660,7 @@ async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already
     assert config_entry.unique_id == MAC_ADDRESS_DIFFERENT
 
 
-async def test_options(hass: HomeAssistant):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options flow."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -706,7 +706,7 @@ async def test_options(hass: HomeAssistant):
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, FLUX_DISCOVERY),
     ],
 )
-async def test_discovered_can_be_ignored(hass, source, data):
+async def test_discovered_can_be_ignored(hass: HomeAssistant, source, data) -> None:
     """Test we abort if the mac was already ignored."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/forecast_solar/test_diagnostics.py
+++ b/tests/components/forecast_solar/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -1,7 +1,8 @@
 """Media browsing tests for the forked_daapd media player platform."""
-
 from http import HTTPStatus
 from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components import media_source, spotify
 from homeassistant.components.forked_daapd.browse_media import (
@@ -14,12 +15,17 @@ from homeassistant.components.spotify.const import (
     MEDIA_PLAYER_PREFIX as SPOTIFY_MEDIA_PLAYER_PREFIX,
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 TEST_MASTER_ENTITY_NAME = "media_player.owntone_server"
 
 
-async def test_async_browse_media(hass, hass_ws_client, config_entry):
+async def test_async_browse_media(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+) -> None:
     """Test browse media."""
 
     assert await async_setup_component(hass, media_source.DOMAIN, {})
@@ -194,7 +200,9 @@ async def test_async_browse_media(hass, hass_ws_client, config_entry):
         await browse_children(msg["result"]["children"])
 
 
-async def test_async_browse_media_not_found(hass, hass_ws_client, config_entry):
+async def test_async_browse_media_not_found(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+) -> None:
     """Test browse media not found."""
 
     assert await async_setup_component(hass, media_source.DOMAIN, {})
@@ -249,7 +257,9 @@ async def test_async_browse_media_not_found(hass, hass_ws_client, config_entry):
             msg_id += 1
 
 
-async def test_async_browse_spotify(hass, hass_ws_client, config_entry):
+async def test_async_browse_spotify(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+) -> None:
     """Test browsing spotify."""
 
     assert await async_setup_component(hass, spotify.DOMAIN, {})
@@ -299,7 +309,9 @@ async def test_async_browse_spotify(hass, hass_ws_client, config_entry):
         assert msg["success"]
 
 
-async def test_async_browse_media_source(hass, hass_ws_client, config_entry):
+async def test_async_browse_media_source(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+) -> None:
     """Test browsing media_source."""
 
     config_entry.add_to_hass(hass)
@@ -345,7 +357,9 @@ async def test_async_browse_media_source(hass, hass_ws_client, config_entry):
         assert msg["success"]
 
 
-async def test_async_browse_image(hass, hass_client, config_entry):
+async def test_async_browse_image(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, config_entry
+) -> None:
     """Test browse media images."""
 
     with patch(
@@ -395,7 +409,12 @@ async def test_async_browse_image(hass, hass_client, config_entry):
                 assert await resp.read() == b"image_bytes"
 
 
-async def test_async_browse_image_missing(hass, hass_client, config_entry, caplog):
+async def test_async_browse_image_missing(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test browse media images with no image available."""
 
     with patch(

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == SOURCE_USER
 
 
-async def test_config_flow(hass, config_entry):
+async def test_config_flow(hass: HomeAssistant, config_entry) -> None:
     """Test that the user step works."""
     with patch(
         "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection",
@@ -95,7 +95,7 @@ async def test_config_flow(hass, config_entry):
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_zeroconf_updates_title(hass, config_entry):
+async def test_zeroconf_updates_title(hass: HomeAssistant, config_entry) -> None:
     """Test that zeroconf updates title and aborts with same host."""
     MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "different host"}).add_to_hass(hass)
     config_entry.add_to_hass(hass)
@@ -118,7 +118,7 @@ async def test_zeroconf_updates_title(hass, config_entry):
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
 
-async def test_config_flow_no_websocket(hass, config_entry):
+async def test_config_flow_no_websocket(hass: HomeAssistant, config_entry) -> None:
     """Test config flow setup without websocket enabled on server."""
     with patch(
         "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection",
@@ -217,7 +217,7 @@ async def test_config_flow_zeroconf_valid(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
-async def test_options_flow(hass, config_entry):
+async def test_options_flow(hass: HomeAssistant, config_entry) -> None:
     """Test config flow options."""
 
     with patch(

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -1,5 +1,4 @@
 """The media player tests for the forked_daapd media player platform."""
-
 from unittest.mock import patch
 
 import pytest
@@ -63,6 +62,7 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_signal
 
@@ -340,7 +340,9 @@ async def mock_api_object_fixture(hass, config_entry, get_request_return_values)
     return mock_api.return_value
 
 
-async def test_unload_config_entry(hass, config_entry, mock_api_object):
+async def test_unload_config_entry(
+    hass: HomeAssistant, config_entry, mock_api_object
+) -> None:
     """Test the player is set unavailable when the config entry is unloaded."""
     assert hass.states.get(TEST_MASTER_ENTITY_NAME)
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0])
@@ -349,7 +351,7 @@ async def test_unload_config_entry(hass, config_entry, mock_api_object):
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state == STATE_UNAVAILABLE
 
 
-def test_master_state(hass, mock_api_object):
+def test_master_state(hass: HomeAssistant, mock_api_object) -> None:
     """Test master state attributes."""
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     assert state.state == STATE_PAUSED
@@ -370,8 +372,8 @@ def test_master_state(hass, mock_api_object):
 
 
 async def test_no_update_when_get_request_returns_none(
-    hass, config_entry, mock_api_object
-):
+    hass: HomeAssistant, config_entry, mock_api_object
+) -> None:
     """Test when get request returns None."""
 
     async def get_request_side_effect(update_type):
@@ -408,7 +410,7 @@ async def _service_call(
     )
 
 
-async def test_zone(hass, mock_api_object):
+async def test_zone(hass: HomeAssistant, mock_api_object) -> None:
     """Test zone attributes and methods."""
     zone_entity_name = TEST_ZONE_ENTITY_NAMES[0]
     state = hass.states.get(zone_entity_name)
@@ -447,7 +449,7 @@ async def test_zone(hass, mock_api_object):
     mock_api_object.change_output.assert_any_call(output_id, selected=True)
 
 
-async def test_last_outputs_master(hass, mock_api_object):
+async def test_last_outputs_master(hass: HomeAssistant, mock_api_object) -> None:
     """Test restoration of _last_outputs."""
     # Test turning on sends API call
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_ON)
@@ -463,7 +465,9 @@ async def test_last_outputs_master(hass, mock_api_object):
     assert mock_api_object.set_enabled_outputs.call_count == 2
 
 
-async def test_bunch_of_stuff_master(hass, get_request_return_values, mock_api_object):
+async def test_bunch_of_stuff_master(
+    hass: HomeAssistant, get_request_return_values, mock_api_object
+) -> None:
     """Run bunch of stuff."""
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_ON)
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_OFF)
@@ -546,7 +550,9 @@ async def test_bunch_of_stuff_master(hass, get_request_return_values, mock_api_o
     mock_api_object.clear_queue.assert_called_once()
 
 
-async def test_async_play_media_from_paused(hass, mock_api_object):
+async def test_async_play_media_from_paused(
+    hass: HomeAssistant, mock_api_object
+) -> None:
     """Test async play media from paused."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -564,8 +570,8 @@ async def test_async_play_media_from_paused(hass, mock_api_object):
 
 
 async def test_async_play_media_announcement_from_stopped(
-    hass, get_request_return_values, mock_api_object
-):
+    hass: HomeAssistant, get_request_return_values, mock_api_object
+) -> None:
     """Test async play media announcement (from stopped)."""
     updater_update = mock_api_object.start_websocket_handler.call_args[0][2]
 
@@ -590,7 +596,9 @@ async def test_async_play_media_announcement_from_stopped(
     assert state.last_updated > initial_state.last_updated
 
 
-async def test_async_play_media_unsupported(hass, mock_api_object):
+async def test_async_play_media_unsupported(
+    hass: HomeAssistant, mock_api_object
+) -> None:
     """Test async play media on unsupported media type."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -606,7 +614,9 @@ async def test_async_play_media_unsupported(hass, mock_api_object):
     assert state.last_updated == initial_state.last_updated
 
 
-async def test_async_play_media_announcement_tts_timeout(hass, mock_api_object):
+async def test_async_play_media_announcement_tts_timeout(
+    hass: HomeAssistant, mock_api_object
+) -> None:
     """Test async play media announcement with TTS timeout."""
     mock_api_object.add_to_queue.side_effect = None
     with patch("homeassistant.components.forked_daapd.media_player.TTS_TIMEOUT", 0):
@@ -626,7 +636,9 @@ async def test_async_play_media_announcement_tts_timeout(hass, mock_api_object):
         assert state.last_updated > initial_state.last_updated
 
 
-async def test_use_pipe_control_with_no_api(hass, mock_api_object):
+async def test_use_pipe_control_with_no_api(
+    hass: HomeAssistant, mock_api_object
+) -> None:
     """Test using pipe control with no api set."""
     await _service_call(
         hass,
@@ -638,7 +650,7 @@ async def test_use_pipe_control_with_no_api(hass, mock_api_object):
     assert mock_api_object.start_playback.call_count == 0
 
 
-async def test_clear_source(hass, mock_api_object):
+async def test_clear_source(hass: HomeAssistant, mock_api_object) -> None:
     """Test changing source to clear."""
     await _service_call(
         hass,
@@ -683,8 +695,11 @@ async def pipe_control_api_object_fixture(
 
 
 async def test_librespot_java_stuff(
-    hass, get_request_return_values, mock_api_object, pipe_control_api_object
-):
+    hass: HomeAssistant,
+    get_request_return_values,
+    mock_api_object,
+    pipe_control_api_object,
+) -> None:
     """Test options update and librespot-java stuff."""
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     assert state.attributes[ATTR_INPUT_SOURCE] == "librespot-java (pipe)"
@@ -718,7 +733,9 @@ async def test_librespot_java_stuff(
     assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "some album"
 
 
-async def test_librespot_java_play_announcement(hass, pipe_control_api_object):
+async def test_librespot_java_play_announcement(
+    hass: HomeAssistant, pipe_control_api_object
+) -> None:
     """Test play announcement with librespot-java pipe."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -736,7 +753,9 @@ async def test_librespot_java_play_announcement(hass, pipe_control_api_object):
     assert state.last_updated > initial_state.last_updated
 
 
-async def test_librespot_java_play_media_pause_timeout(hass, pipe_control_api_object):
+async def test_librespot_java_play_media_pause_timeout(
+    hass: HomeAssistant, pipe_control_api_object
+) -> None:
     """Test play media with librespot-java pipe."""
     # test media play with pause timeout
     pipe_control_api_object.player_pause.side_effect = None
@@ -758,7 +777,7 @@ async def test_librespot_java_play_media_pause_timeout(hass, pipe_control_api_ob
         assert state.last_updated > initial_state.last_updated
 
 
-async def test_unsupported_update(hass, mock_api_object):
+async def test_unsupported_update(hass: HomeAssistant, mock_api_object) -> None:
     """Test unsupported update type."""
     last_updated = hass.states.get(TEST_MASTER_ENTITY_NAME).last_updated
     updater_update = mock_api_object.start_websocket_handler.call_args[0][2]
@@ -767,7 +786,7 @@ async def test_unsupported_update(hass, mock_api_object):
     assert hass.states.get(TEST_MASTER_ENTITY_NAME).last_updated == last_updated
 
 
-async def test_invalid_websocket_port(hass, config_entry):
+async def test_invalid_websocket_port(hass: HomeAssistant, config_entry) -> None:
     """Test invalid websocket port on async_init."""
     with patch(
         "homeassistant.components.forked_daapd.media_player.ForkedDaapdAPI",
@@ -780,7 +799,7 @@ async def test_invalid_websocket_port(hass, config_entry):
         assert hass.states.get(TEST_MASTER_ENTITY_NAME).state == STATE_UNAVAILABLE
 
 
-async def test_websocket_disconnect(hass, mock_api_object):
+async def test_websocket_disconnect(hass: HomeAssistant, mock_api_object) -> None:
     """Test websocket disconnection."""
     assert hass.states.get(TEST_MASTER_ENTITY_NAME).state != STATE_UNAVAILABLE
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state != STATE_UNAVAILABLE
@@ -791,7 +810,7 @@ async def test_websocket_disconnect(hass, mock_api_object):
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state == STATE_UNAVAILABLE
 
 
-async def test_async_play_media_enqueue(hass, mock_api_object):
+async def test_async_play_media_enqueue(hass: HomeAssistant, mock_api_object) -> None:
     """Test async play media with different enqueue options."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -867,7 +886,7 @@ async def test_async_play_media_enqueue(hass, mock_api_object):
     )
 
 
-async def test_play_owntone_media(hass, mock_api_object):
+async def test_play_owntone_media(hass: HomeAssistant, mock_api_object) -> None:
     """Test async play media with an owntone source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -893,7 +912,7 @@ async def test_play_owntone_media(hass, mock_api_object):
     )
 
 
-async def test_play_spotify_media(hass, mock_api_object):
+async def test_play_spotify_media(hass: HomeAssistant, mock_api_object) -> None:
     """Test async play media with a spotify source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -917,7 +936,7 @@ async def test_play_spotify_media(hass, mock_api_object):
     )
 
 
-async def test_play_media_source(hass, mock_api_object):
+async def test_play_media_source(hass: HomeAssistant, mock_api_object) -> None:
     """Test async play media with a spotify source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     with patch(

--- a/tests/components/freebox/test_button.py
+++ b/tests/components/freebox/test_button.py
@@ -12,7 +12,7 @@ from .const import MOCK_HOST, MOCK_PORT
 from tests.common import MockConfigEntry
 
 
-async def test_reboot_button(hass: HomeAssistant, router: Mock):
+async def test_reboot_button(hass: HomeAssistant, router: Mock) -> None:
     """Test reboot button."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -39,7 +39,7 @@ MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
 )
 
 
-async def test_user(hass: HomeAssistant):
+async def test_user(hass: HomeAssistant) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -57,7 +57,7 @@ async def test_user(hass: HomeAssistant):
     assert result["step_id"] == "link"
 
 
-async def test_import(hass: HomeAssistant):
+async def test_import(hass: HomeAssistant) -> None:
     """Test import step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -68,7 +68,7 @@ async def test_import(hass: HomeAssistant):
     assert result["step_id"] == "link"
 
 
-async def test_zeroconf(hass: HomeAssistant):
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test zeroconf step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -79,7 +79,7 @@ async def test_zeroconf(hass: HomeAssistant):
     assert result["step_id"] == "link"
 
 
-async def test_link(hass: HomeAssistant, router: Mock):
+async def test_link(hass: HomeAssistant, router: Mock) -> None:
     """Test linking."""
     with patch(
         "homeassistant.components.freebox.async_setup", return_value=True
@@ -104,7 +104,7 @@ async def test_link(hass: HomeAssistant, router: Mock):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_abort_if_already_setup(hass: HomeAssistant):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if component is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -131,7 +131,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_on_link_failed(hass: HomeAssistant):
+async def test_on_link_failed(hass: HomeAssistant) -> None:
     """Test when we have errors during linking the router."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -15,7 +15,7 @@ from .const import MOCK_HOST, MOCK_PORT
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistant, router: Mock):
+async def test_setup(hass: HomeAssistant, router: Mock) -> None:
     """Test setup of integration."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -44,7 +44,7 @@ async def test_setup(hass: HomeAssistant, router: Mock):
         mock_service.assert_called_once()
 
 
-async def test_setup_import(hass: HomeAssistant, router: Mock):
+async def test_setup_import(hass: HomeAssistant, router: Mock) -> None:
     """Test setup of integration from import."""
 
     entry = MockConfigEntry(
@@ -65,7 +65,7 @@ async def test_setup_import(hass: HomeAssistant, router: Mock):
     assert hass.services.has_service(DOMAIN, SERVICE_REBOOT)
 
 
-async def test_unload_remove(hass: HomeAssistant, router: Mock):
+async def test_unload_remove(hass: HomeAssistant, router: Mock) -> None:
     """Test unload and remove of integration."""
     entity_id_dt = f"{DT_DOMAIN}.freebox_server_r2"
     entity_id_sensor = f"{SENSOR_DOMAIN}.freebox_download_speed"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
