### PR TITLE
Add type hints to integration tests (part 7)

### DIFF
--- a/tests/components/freedompro/test_binary_sensor.py
+++ b/tests/components/freedompro/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -43,8 +44,13 @@ from tests.common import async_fire_time_changed
     ],
 )
 async def test_binary_sensor_get_state(
-    hass, init_integration, entity_id: str, uid: str, name: str, model: str
-):
+    hass: HomeAssistant,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
+    model: str,
+) -> None:
     """Test states of the binary_sensor."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -27,7 +28,7 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*TWMYQKL3UVED4HSIIB9GXJWJZBQCXG-9VE-N2IUAIWI"
 
 
-async def test_climate_get_state(hass, init_integration):
+async def test_climate_get_state(hass: HomeAssistant, init_integration) -> None:
     """Test states of the climate."""
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
@@ -83,7 +84,7 @@ async def test_climate_get_state(hass, init_integration):
         assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 20
 
 
-async def test_climate_set_off(hass, init_integration):
+async def test_climate_set_off(hass: HomeAssistant, init_integration) -> None:
     """Test set off climate."""
     init_integration
     entity_registry = er.async_get(hass)
@@ -113,7 +114,9 @@ async def test_climate_set_off(hass, init_integration):
     assert state.state == HVACMode.HEAT
 
 
-async def test_climate_set_unsupported_hvac_mode(hass, init_integration):
+async def test_climate_set_unsupported_hvac_mode(
+    hass: HomeAssistant, init_integration
+) -> None:
     """Test set unsupported hvac mode climate."""
     init_integration
     entity_registry = er.async_get(hass)
@@ -136,7 +139,7 @@ async def test_climate_set_unsupported_hvac_mode(hass, init_integration):
         )
 
 
-async def test_climate_set_temperature(hass, init_integration):
+async def test_climate_set_temperature(hass: HomeAssistant, init_integration) -> None:
     """Test set temperature climate."""
     init_integration
     entity_registry = er.async_get(hass)
@@ -181,7 +184,9 @@ async def test_climate_set_temperature(hass, init_integration):
     assert state.attributes[ATTR_TEMPERATURE] == 21
 
 
-async def test_climate_set_temperature_unsupported_hvac_mode(hass, init_integration):
+async def test_climate_set_temperature_unsupported_hvac_mode(
+    hass: HomeAssistant, init_integration
+) -> None:
     """Test set temperature climate unsupported hvac mode."""
     init_integration
     entity_registry = er.async_get(hass)

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_CLOSED,
     STATE_OPEN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util.dt import utcnow
@@ -34,8 +35,13 @@ from tests.common import async_fire_time_changed
     ],
 )
 async def test_cover_get_state(
-    hass, init_integration, entity_id: str, uid: str, name: str, model: str
-):
+    hass: HomeAssistant,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
+    model: str,
+) -> None:
     """Test states of the cover."""
     init_integration
     registry = er.async_get(hass)
@@ -89,8 +95,13 @@ async def test_cover_get_state(
     ],
 )
 async def test_cover_set_position(
-    hass, init_integration, entity_id: str, uid: str, name: str, model: str
-):
+    hass: HomeAssistant,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
+    model: str,
+) -> None:
     """Test set position of the cover."""
     init_integration
     registry = er.async_get(hass)
@@ -139,8 +150,13 @@ async def test_cover_set_position(
     ],
 )
 async def test_cover_close(
-    hass, init_integration, entity_id: str, uid: str, name: str, model: str
-):
+    hass: HomeAssistant,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
+    model: str,
+) -> None:
     """Test close cover."""
     init_integration
     registry = er.async_get(hass)
@@ -197,8 +213,13 @@ async def test_cover_close(
     ],
 )
 async def test_cover_open(
-    hass, init_integration, entity_id: str, uid: str, name: str, model: str
-):
+    hass: HomeAssistant,
+    init_integration,
+    entity_id: str,
+    uid: str,
+    name: str,
+    model: str,
+) -> None:
     """Test open cover."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -9,6 +9,7 @@ from homeassistant.components.fan import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util.dt import utcnow
@@ -20,7 +21,7 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
 
 
-async def test_fan_get_state(hass, init_integration):
+async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
     """Test states of the fan."""
     init_integration
     registry = er.async_get(hass)
@@ -66,7 +67,7 @@ async def test_fan_get_state(hass, init_integration):
         assert state.attributes[ATTR_PERCENTAGE] == 50
 
 
-async def test_fan_set_off(hass, init_integration):
+async def test_fan_set_off(hass: HomeAssistant, init_integration) -> None:
     """Test turn off the fan."""
     init_integration
     registry = er.async_get(hass)
@@ -119,7 +120,7 @@ async def test_fan_set_off(hass, init_integration):
     assert state.state == STATE_OFF
 
 
-async def test_fan_set_on(hass, init_integration):
+async def test_fan_set_on(hass: HomeAssistant, init_integration) -> None:
     """Test turn on the fan."""
     init_integration
     registry = er.async_get(hass)
@@ -159,7 +160,7 @@ async def test_fan_set_on(hass, init_integration):
     assert state.state == STATE_ON
 
 
-async def test_fan_set_percent(hass, init_integration):
+async def test_fan_set_percent(hass: HomeAssistant, init_integration) -> None:
     """Test turn on the fan."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_init.py
+++ b/tests/components/freedompro/test_init.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def test_async_setup_entry(hass, init_integration):
+async def test_async_setup_entry(hass: HomeAssistant, init_integration) -> None:
     """Test a successful setup entry."""
     entry = init_integration
     assert entry is not None
@@ -43,7 +43,7 @@ async def test_config_not_ready(hass: HomeAssistant) -> None:
         assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass, init_integration):
+async def test_unload_entry(hass: HomeAssistant, init_integration) -> None:
     """Test successful unload of entry."""
     entry = init_integration
 

--- a/tests/components/freedompro/test_light.py
+++ b/tests/components/freedompro/test_light.py
@@ -10,6 +10,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
@@ -20,7 +21,7 @@ def mock_freedompro_put_state():
         yield
 
 
-async def test_light_get_state(hass, init_integration):
+async def test_light_get_state(hass: HomeAssistant, init_integration) -> None:
     """Test states of the light."""
     init_integration
     registry = er.async_get(hass)
@@ -39,7 +40,7 @@ async def test_light_get_state(hass, init_integration):
     )
 
 
-async def test_light_set_on(hass, init_integration):
+async def test_light_set_on(hass: HomeAssistant, init_integration) -> None:
     """Test set on of the light."""
     init_integration
     registry = er.async_get(hass)
@@ -69,7 +70,7 @@ async def test_light_set_on(hass, init_integration):
     assert state.state == STATE_ON
 
 
-async def test_light_set_off(hass, init_integration):
+async def test_light_set_off(hass: HomeAssistant, init_integration) -> None:
     """Test set off of the light."""
     init_integration
     registry = er.async_get(hass)
@@ -99,7 +100,7 @@ async def test_light_set_off(hass, init_integration):
     assert state.state == STATE_OFF
 
 
-async def test_light_set_brightness(hass, init_integration):
+async def test_light_set_brightness(hass: HomeAssistant, init_integration) -> None:
     """Test set brightness of the light."""
     init_integration
     registry = er.async_get(hass)
@@ -130,7 +131,7 @@ async def test_light_set_brightness(hass, init_integration):
     assert int(state.attributes[ATTR_BRIGHTNESS]) == 0
 
 
-async def test_light_set_hue(hass, init_integration):
+async def test_light_set_hue(hass: HomeAssistant, init_integration) -> None:
     """Test set brightness of the light."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_lock.py
+++ b/tests/components/freedompro/test_lock.py
@@ -8,6 +8,7 @@ from homeassistant.components.lock import (
     SERVICE_UNLOCK,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util.dt import utcnow
@@ -19,7 +20,7 @@ from tests.common import async_fire_time_changed
 uid = "2WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*2VAS3HTWINNZ5N6HVEIPDJ6NX85P2-AM-GSYWUCNPU0"
 
 
-async def test_lock_get_state(hass, init_integration):
+async def test_lock_get_state(hass: HomeAssistant, init_integration) -> None:
     """Test states of the lock."""
     init_integration
     registry = er.async_get(hass)
@@ -62,7 +63,7 @@ async def test_lock_get_state(hass, init_integration):
         assert state.state == STATE_LOCKED
 
 
-async def test_lock_set_unlock(hass, init_integration):
+async def test_lock_set_unlock(hass: HomeAssistant, init_integration) -> None:
     """Test set on of the lock."""
     init_integration
     registry = er.async_get(hass)
@@ -110,7 +111,7 @@ async def test_lock_set_unlock(hass, init_integration):
     assert state.state == STATE_UNLOCKED
 
 
-async def test_lock_set_lock(hass, init_integration):
+async def test_lock_set_lock(hass: HomeAssistant, init_integration) -> None:
     """Test set on of the lock."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_sensor.py
+++ b/tests/components/freedompro/test_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -33,8 +34,8 @@ from tests.common import async_fire_time_changed
     ],
 )
 async def test_sensor_get_state(
-    hass, init_integration, entity_id: str, uid: str, name: str
-):
+    hass: HomeAssistant, init_integration, entity_id: str, uid: str, name: str
+) -> None:
     """Test states of the sensor."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/freedompro/test_switch.py
+++ b/tests/components/freedompro/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_ON
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util.dt import utcnow
@@ -15,7 +16,7 @@ from tests.common import async_fire_time_changed
 uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*1JKU1MVWHQL-Z9SCUS85VFXMRGNDCDNDDUVVDKBU31W"
 
 
-async def test_switch_get_state(hass, init_integration):
+async def test_switch_get_state(hass: HomeAssistant, init_integration) -> None:
     """Test states of the switch."""
     init_integration
     registry = er.async_get(hass)
@@ -50,7 +51,7 @@ async def test_switch_get_state(hass, init_integration):
         assert state.state == STATE_ON
 
 
-async def test_switch_set_off(hass, init_integration):
+async def test_switch_set_off(hass: HomeAssistant, init_integration) -> None:
     """Test set off of the switch."""
     init_integration
     registry = er.async_get(hass)
@@ -100,7 +101,7 @@ async def test_switch_set_off(hass, init_integration):
     assert state.state == STATE_OFF
 
 
-async def test_switch_set_on(hass, init_integration):
+async def test_switch_set_on(hass: HomeAssistant, init_integration) -> None:
     """Test set on of the switch."""
     init_integration
     registry = er.async_get(hass)

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -15,7 +15,7 @@ from .const import MOCK_USER_DATA
 from tests.common import MockConfigEntry
 
 
-async def test_button_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+async def test_button_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
     """Test setup of Fritz!Tools buttons."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -47,7 +47,7 @@ async def test_buttons(
     wrapper_method: str,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test Fritz!Tools buttons."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -37,7 +37,7 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
+async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> None:
     """Test starting a flow by user."""
     with patch(
         "homeassistant.components.fritz.config_flow.FritzConnection",
@@ -85,7 +85,7 @@ async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
 
 async def test_user_already_configured(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a flow by user with an already configured device."""
 
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -128,7 +128,9 @@ async def test_user_already_configured(
     "error",
     FRITZ_AUTH_EXCEPTIONS,
 )
-async def test_exception_security(hass: HomeAssistant, mock_get_source_ip, error):
+async def test_exception_security(
+    hass: HomeAssistant, mock_get_source_ip, error
+) -> None:
     """Test starting a flow by user with invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(
@@ -150,7 +152,7 @@ async def test_exception_security(hass: HomeAssistant, mock_get_source_ip, error
         assert result["errors"]["base"] == ERROR_AUTH_INVALID
 
 
-async def test_exception_connection(hass: HomeAssistant, mock_get_source_ip):
+async def test_exception_connection(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test starting a flow by user with a connection error."""
 
     result = await hass.config_entries.flow.async_init(
@@ -172,7 +174,7 @@ async def test_exception_connection(hass: HomeAssistant, mock_get_source_ip):
         assert result["errors"]["base"] == ERROR_CANNOT_CONNECT
 
 
-async def test_exception_unknown(hass: HomeAssistant, mock_get_source_ip):
+async def test_exception_unknown(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test starting a flow by user with an unknown exception."""
 
     result = await hass.config_entries.flow.async_init(
@@ -196,7 +198,7 @@ async def test_exception_unknown(hass: HomeAssistant, mock_get_source_ip):
 
 async def test_reauth_successful(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a reauthentication flow."""
 
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -253,7 +255,7 @@ async def test_reauth_successful(
 )
 async def test_reauth_not_successful(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip, side_effect, error
-):
+) -> None:
     """Test starting a reauthentication flow but no connection found."""
 
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -287,7 +289,7 @@ async def test_reauth_not_successful(
 
 async def test_ssdp_already_configured(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a flow from discovery with an already configured device."""
 
     mock_config = MockConfigEntry(
@@ -313,7 +315,7 @@ async def test_ssdp_already_configured(
 
 async def test_ssdp_already_configured_host(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a flow from discovery with an already configured host."""
 
     mock_config = MockConfigEntry(
@@ -339,7 +341,7 @@ async def test_ssdp_already_configured_host(
 
 async def test_ssdp_already_configured_host_uuid(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a flow from discovery with an already configured uuid."""
 
     mock_config = MockConfigEntry(
@@ -365,7 +367,7 @@ async def test_ssdp_already_configured_host_uuid(
 
 async def test_ssdp_already_in_progress_host(
     hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-):
+) -> None:
     """Test starting a flow from discovery twice."""
     with patch(
         "homeassistant.components.fritz.config_flow.FritzConnection",
@@ -387,7 +389,7 @@ async def test_ssdp_already_in_progress_host(
         assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
+async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> None:
     """Test starting a flow from discovery."""
     with patch(
         "homeassistant.components.fritz.config_flow.FritzConnection",
@@ -429,7 +431,7 @@ async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
     assert mock_setup_entry.called
 
 
-async def test_ssdp_exception(hass: HomeAssistant, mock_get_source_ip):
+async def test_ssdp_exception(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.fritz.config_flow.FritzConnection",
@@ -453,7 +455,9 @@ async def test_ssdp_exception(hass: HomeAssistant, mock_get_source_ip):
         assert result["step_id"] == "confirm"
 
 
-async def test_options_flow(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
+async def test_options_flow(
+    hass: HomeAssistant, fc_class_mock, mock_get_source_ip
+) -> None:
     """Test options flow."""
 
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)

--- a/tests/components/fritz/test_diagnostics.py
+++ b/tests/components/fritz/test_diagnostics.py
@@ -21,7 +21,7 @@ async def test_entry_diagnostics(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test config entry diagnostics."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -21,7 +21,7 @@ from .const import MOCK_USER_DATA
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
     """Test setup and unload of Fritz!Tools."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -35,7 +35,9 @@ async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
     assert entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_options_reload(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+async def test_options_reload(
+    hass: HomeAssistant, fc_class_mock, fh_class_mock
+) -> None:
     """Test reload of Fritz!Tools, when options changed."""
 
     entry = MockConfigEntry(
@@ -67,7 +69,7 @@ async def test_options_reload(hass: HomeAssistant, fc_class_mock, fh_class_mock)
     "error",
     FRITZ_AUTH_EXCEPTIONS,
 )
-async def test_setup_auth_fail(hass: HomeAssistant, error):
+async def test_setup_auth_fail(hass: HomeAssistant, error) -> None:
     """Test starting a flow by user with an already configured device."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -87,7 +89,7 @@ async def test_setup_auth_fail(hass: HomeAssistant, error):
     "error",
     FRITZ_EXCEPTIONS,
 )
-async def test_setup_fail(hass: HomeAssistant, error):
+async def test_setup_fail(hass: HomeAssistant, error) -> None:
     """Test starting a flow by user with an already configured device."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -114,7 +114,7 @@ SENSOR_STATES: dict[str, dict[str, Any]] = {
 }
 
 
-async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
     """Test setup of Fritz!Tools sesnors."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -136,7 +136,9 @@ async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
                 assert sensor.attributes.get(key) == val
 
 
-async def test_sensor_update_fail(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+async def test_sensor_update_fail(
+    hass: HomeAssistant, fc_class_mock, fh_class_mock
+) -> None:
     """Test failed update of Fritz!Tools sesnors."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -24,7 +24,7 @@ async def test_update_entities_initialized(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test update entities."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -43,7 +43,7 @@ async def test_update_available(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test update entities."""
 
     with patch(
@@ -70,7 +70,7 @@ async def test_no_update_available(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test update entities."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -92,7 +92,7 @@ async def test_available_update_can_be_installed(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
-):
+) -> None:
     """Test update entities."""
 
     with patch(

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -29,7 +29,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceBinarySensorMock()
     assert await setup_config_entry(
@@ -70,7 +70,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert ATTR_STATE_CLASS not in state.attributes
 
 
-async def test_is_off(hass: HomeAssistant, fritz: Mock):
+async def test_is_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test state of platform."""
     device = FritzDeviceBinarySensorMock()
     device.present = False
@@ -91,7 +91,7 @@ async def test_is_off(hass: HomeAssistant, fritz: Mock):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update(hass: HomeAssistant, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update without error."""
     device = FritzDeviceBinarySensorMock()
     assert await setup_config_entry(
@@ -109,7 +109,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistant, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceBinarySensorMock()
     device.update.side_effect = [mock.DEFAULT, HTTPError("Boom")]

--- a/tests/components/fritzbox/test_button.py
+++ b/tests/components/fritzbox/test_button.py
@@ -17,7 +17,7 @@ from .const import CONF_FAKE_NAME, MOCK_CONFIG
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test if is initialized correctly."""
     template = FritzEntityBaseMock()
     assert await setup_config_entry(
@@ -30,7 +30,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_apply_template(hass: HomeAssistant, fritz: Mock):
+async def test_apply_template(hass: HomeAssistant, fritz: Mock) -> None:
     """Test if applies works."""
     template = FritzEntityBaseMock()
     assert await setup_config_entry(

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -49,7 +49,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -157,7 +157,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.state == PRESET_COMFORT
 
 
-async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):
+async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device on."""
     device = FritzDeviceClimateMock()
     device.target_temperature = 127.0
@@ -170,7 +170,7 @@ async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 30
 
 
-async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock):
+async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device on."""
     device = FritzDeviceClimateMock()
     device.target_temperature = 126.5
@@ -183,7 +183,7 @@ async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 0
 
 
-async def test_update(hass: HomeAssistant, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update without error."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -211,7 +211,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 20
 
 
-async def test_automatic_offset(hass: HomeAssistant, fritz: Mock):
+async def test_automatic_offset(hass: HomeAssistant, fritz: Mock) -> None:
     """Test when automatic offset is configured on fritz!box device."""
     device = FritzDeviceClimateMock()
     device.temperature = 18
@@ -229,7 +229,7 @@ async def test_automatic_offset(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 20
 
 
-async def test_update_error(hass: HomeAssistant, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceClimateMock()
     fritz().update_devices.side_effect = HTTPError("Boom")
@@ -248,7 +248,7 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 4
 
 
-async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock):
+async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting temperature by temperature."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -264,7 +264,7 @@ async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(123)]
 
 
-async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock):
+async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -284,7 +284,7 @@ async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(0)]
 
 
-async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock):
+async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -304,7 +304,7 @@ async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock):
+async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -320,7 +320,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(0)]
 
 
-async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock):
+async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -336,7 +336,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock):
+async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -352,7 +352,7 @@ async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock):
+async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
@@ -368,7 +368,7 @@ async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(16)]
 
 
-async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock):
+async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test preset mode."""
     device = FritzDeviceClimateMock()
     device.comfort_temperature = 98

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -61,7 +61,7 @@ def fritz_fixture() -> Mock:
         yield fritz
 
 
-async def test_user(hass: HomeAssistant, fritz: Mock):
+async def test_user(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow by user."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -80,7 +80,7 @@ async def test_user(hass: HomeAssistant, fritz: Mock):
     assert not result["result"].unique_id
 
 
-async def test_user_auth_failed(hass: HomeAssistant, fritz: Mock):
+async def test_user_auth_failed(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow by user with authentication failure."""
     fritz().login.side_effect = [LoginError("Boom"), mock.DEFAULT]
 
@@ -92,7 +92,7 @@ async def test_user_auth_failed(hass: HomeAssistant, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_user_not_successful(hass: HomeAssistant, fritz: Mock):
+async def test_user_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow by user but no connection found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -103,7 +103,7 @@ async def test_user_not_successful(hass: HomeAssistant, fritz: Mock):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_user_already_configured(hass: HomeAssistant, fritz: Mock):
+async def test_user_already_configured(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow by user when already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
@@ -118,7 +118,7 @@ async def test_user_already_configured(hass: HomeAssistant, fritz: Mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_reauth_success(hass: HomeAssistant, fritz: Mock):
+async def test_reauth_success(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow."""
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     mock_config.add_to_hass(hass)
@@ -145,7 +145,7 @@ async def test_reauth_success(hass: HomeAssistant, fritz: Mock):
     assert mock_config.data[CONF_PASSWORD] == "other_fake_password"
 
 
-async def test_reauth_auth_failed(hass: HomeAssistant, fritz: Mock):
+async def test_reauth_auth_failed(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow with authentication failure."""
     fritz().login.side_effect = LoginError("Boom")
 
@@ -173,7 +173,7 @@ async def test_reauth_auth_failed(hass: HomeAssistant, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock):
+async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow but no connection found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -213,7 +213,7 @@ async def test_ssdp(
     fritz: Mock,
     test_data: ssdp.SsdpServiceInfo,
     expected_result: str,
-):
+) -> None:
     """Test starting a flow from discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=test_data
@@ -237,7 +237,7 @@ async def test_ssdp(
     assert result["result"].unique_id == "only-a-test"
 
 
-async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery without friendly name."""
     MOCK_NO_NAME = dataclasses.replace(MOCK_SSDP_DATA["ip4_valid"])
     MOCK_NO_NAME.upnp = MOCK_NO_NAME.upnp.copy()
@@ -260,7 +260,7 @@ async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock):
     assert result["result"].unique_id == "only-a-test"
 
 
-async def test_ssdp_auth_failed(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_auth_failed(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery with authentication failure."""
     fritz().login.side_effect = LoginError("Boom")
 
@@ -280,7 +280,7 @@ async def test_ssdp_auth_failed(hass: HomeAssistant, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_ssdp_not_successful(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery but no device found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -298,7 +298,7 @@ async def test_ssdp_not_successful(hass: HomeAssistant, fritz: Mock):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_ssdp_not_supported(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_not_supported(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery with unsupported device."""
     fritz().get_device_elements.side_effect = HTTPError("Boom")
 
@@ -316,7 +316,9 @@ async def test_ssdp_not_supported(hass: HomeAssistant, fritz: Mock):
     assert result["reason"] == "not_supported"
 
 
-async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_already_in_progress_unique_id(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA["ip4_valid"]
@@ -331,7 +333,7 @@ async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistant, fritz: Mo
     assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp_already_in_progress_host(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_already_in_progress_host(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA["ip4_valid"]
@@ -349,7 +351,7 @@ async def test_ssdp_already_in_progress_host(hass: HomeAssistant, fritz: Mock):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp_already_configured(hass: HomeAssistant, fritz: Mock):
+async def test_ssdp_already_configured(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a flow from discovery when already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA

--- a/tests/components/fritzbox/test_cover.py
+++ b/tests/components/fritzbox/test_cover.py
@@ -19,7 +19,7 @@ from .const import CONF_FAKE_NAME, MOCK_CONFIG
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceCoverMock()
     assert await setup_config_entry(
@@ -31,7 +31,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_open_cover(hass: HomeAssistant, fritz: Mock):
+async def test_open_cover(hass: HomeAssistant, fritz: Mock) -> None:
     """Test opening the cover."""
     device = FritzDeviceCoverMock()
     assert await setup_config_entry(
@@ -44,7 +44,7 @@ async def test_open_cover(hass: HomeAssistant, fritz: Mock):
     assert device.set_blind_open.call_count == 1
 
 
-async def test_close_cover(hass: HomeAssistant, fritz: Mock):
+async def test_close_cover(hass: HomeAssistant, fritz: Mock) -> None:
     """Test closing the device."""
     device = FritzDeviceCoverMock()
     assert await setup_config_entry(
@@ -57,7 +57,7 @@ async def test_close_cover(hass: HomeAssistant, fritz: Mock):
     assert device.set_blind_close.call_count == 1
 
 
-async def test_set_position_cover(hass: HomeAssistant, fritz: Mock):
+async def test_set_position_cover(hass: HomeAssistant, fritz: Mock) -> None:
     """Test stopping the device."""
     device = FritzDeviceCoverMock()
     assert await setup_config_entry(
@@ -73,7 +73,7 @@ async def test_set_position_cover(hass: HomeAssistant, fritz: Mock):
     assert device.set_level_percentage.call_args_list == [call(50)]
 
 
-async def test_stop_cover(hass: HomeAssistant, fritz: Mock):
+async def test_stop_cover(hass: HomeAssistant, fritz: Mock) -> None:
     """Test stopping the device."""
     device = FritzDeviceCoverMock()
     assert await setup_config_entry(

--- a/tests/components/fritzbox/test_diagnostics.py
+++ b/tests/components/fritzbox/test_diagnostics.py
@@ -18,7 +18,7 @@ from tests.typing import ClientSessionGenerator
 
 async def test_entry_diagnostics(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, fritz: Mock
-):
+) -> None:
     """Test config entry diagnostics."""
     assert await setup_config_entry(hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0])
 

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -30,7 +30,7 @@ from .const import CONF_FAKE_AIN, CONF_FAKE_NAME, MOCK_CONFIG
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of integration."""
     assert await setup_config_entry(hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0])
     entries = hass.config_entries.async_entries()
@@ -75,7 +75,7 @@ async def test_update_unique_id(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
-):
+) -> None:
     """Test unique_id update of integration."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -133,7 +133,7 @@ async def test_update_unique_id_no_change(
     fritz: Mock,
     entitydata: dict,
     unique_id: str,
-):
+) -> None:
     """Test unique_id is not updated of integration."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -156,7 +156,9 @@ async def test_update_unique_id_no_change(
     assert entity_migrated.unique_id == unique_id
 
 
-async def test_coordinator_update_after_reboot(hass: HomeAssistant, fritz: Mock):
+async def test_coordinator_update_after_reboot(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
     """Test coordinator after reboot."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -176,7 +178,7 @@ async def test_coordinator_update_after_reboot(hass: HomeAssistant, fritz: Mock)
 
 async def test_coordinator_update_after_password_change(
     hass: HomeAssistant, fritz: Mock
-):
+) -> None:
     """Test coordinator after password change."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -194,7 +196,9 @@ async def test_coordinator_update_after_password_change(
     assert fritz().login.call_count == 2
 
 
-async def test_coordinator_update_when_unreachable(hass: HomeAssistant, fritz: Mock):
+async def test_coordinator_update_when_unreachable(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
     """Test coordinator after reboot."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -208,7 +212,7 @@ async def test_coordinator_update_when_unreachable(hass: HomeAssistant, fritz: M
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_remove(hass: HomeAssistant, fritz: Mock):
+async def test_unload_remove(hass: HomeAssistant, fritz: Mock) -> None:
     """Test unload and remove of integration."""
     fritz().get_devices.return_value = [FritzDeviceSwitchMock()]
     entity_id = f"{SWITCH_DOMAIN}.{CONF_FAKE_NAME}"
@@ -247,7 +251,7 @@ async def test_unload_remove(hass: HomeAssistant, fritz: Mock):
     assert state is None
 
 
-async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant):
+async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant) -> None:
     """Config entry state is SETUP_RETRY when fritzbox is offline."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -268,7 +272,7 @@ async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_disable_smarthome_templates(hass: HomeAssistant, fritz: Mock):
+async def test_disable_smarthome_templates(hass: HomeAssistant, fritz: Mock) -> None:
     """Test smarthome templates are disabled."""
     entry = MockConfigEntry(
         domain=FB_DOMAIN,

--- a/tests/components/fritzbox/test_light.py
+++ b/tests/components/fritzbox/test_light.py
@@ -36,7 +36,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -59,7 +59,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_MAX_COLOR_TEMP_KELVIN] == 6500
 
 
-async def test_setup_color(hass: HomeAssistant, fritz: Mock):
+async def test_setup_color(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform in color mode."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -82,7 +82,7 @@ async def test_setup_color(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_HS_COLOR] == (100, 70)
 
 
-async def test_turn_on(hass: HomeAssistant, fritz: Mock):
+async def test_turn_on(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device on."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -106,7 +106,7 @@ async def test_turn_on(hass: HomeAssistant, fritz: Mock):
     assert device.set_level.call_args_list == [call(100)]
 
 
-async def test_turn_on_color(hass: HomeAssistant, fritz: Mock):
+async def test_turn_on_color(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device on in color mode."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -131,7 +131,9 @@ async def test_turn_on_color(hass: HomeAssistant, fritz: Mock):
     ]
 
 
-async def test_turn_on_color_unsupported_api_method(hass: HomeAssistant, fritz: Mock):
+async def test_turn_on_color_unsupported_api_method(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
     """Test turn device on in mapped color mode if unmapped is not supported."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -161,7 +163,7 @@ async def test_turn_on_color_unsupported_api_method(hass: HomeAssistant, fritz: 
     assert device.set_color.call_args_list == [call((100, 70))]
 
 
-async def test_turn_off(hass: HomeAssistant, fritz: Mock):
+async def test_turn_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device off."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -177,7 +179,7 @@ async def test_turn_off(hass: HomeAssistant, fritz: Mock):
     assert device.set_state_off.call_count == 1
 
 
-async def test_update(hass: HomeAssistant, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update without error."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]
@@ -198,7 +200,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistant, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceLightMock()
     device.get_color_temps.return_value = [2700, 6500]

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -24,7 +24,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceSensorMock()
     assert await setup_config_entry(
@@ -54,7 +54,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert ATTR_STATE_CLASS not in state.attributes
 
 
-async def test_update(hass: HomeAssistant, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update without error."""
     device = FritzDeviceSensorMock()
     assert await setup_config_entry(
@@ -71,7 +71,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistant, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceSensorMock()
     fritz().update_devices.side_effect = HTTPError("Boom")

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -37,7 +37,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
-async def test_setup(hass: HomeAssistant, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     """Test setup of platform."""
     device = FritzDeviceSwitchMock()
     assert await setup_config_entry(
@@ -100,7 +100,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
         assert state.attributes[ATTR_STATE_CLASS] == sensor[4]
 
 
-async def test_turn_on(hass: HomeAssistant, fritz: Mock):
+async def test_turn_on(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device on."""
     device = FritzDeviceSwitchMock()
     assert await setup_config_entry(
@@ -113,7 +113,7 @@ async def test_turn_on(hass: HomeAssistant, fritz: Mock):
     assert device.set_switch_state_on.call_count == 1
 
 
-async def test_turn_off(hass: HomeAssistant, fritz: Mock):
+async def test_turn_off(hass: HomeAssistant, fritz: Mock) -> None:
     """Test turn device off."""
     device = FritzDeviceSwitchMock()
     assert await setup_config_entry(
@@ -126,7 +126,7 @@ async def test_turn_off(hass: HomeAssistant, fritz: Mock):
     assert device.set_switch_state_off.call_count == 1
 
 
-async def test_update(hass: HomeAssistant, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update without error."""
     device = FritzDeviceSwitchMock()
     assert await setup_config_entry(
@@ -143,7 +143,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistant, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceSwitchMock()
     fritz().update_devices.side_effect = HTTPError("Boom")
@@ -161,7 +161,7 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     assert fritz().login.call_count == 4
 
 
-async def test_assume_device_unavailable(hass: HomeAssistant, fritz: Mock):
+async def test_assume_device_unavailable(hass: HomeAssistant, fritz: Mock) -> None:
     """Test assume device as unavailable."""
     device = FritzDeviceSwitchMock()
     device.voltage = 0
@@ -176,7 +176,7 @@ async def test_assume_device_unavailable(hass: HomeAssistant, fritz: Mock):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_device_current_unavailable(hass: HomeAssistant, fritz: Mock):
+async def test_device_current_unavailable(hass: HomeAssistant, fritz: Mock) -> None:
     """Test current in case voltage and power are not available."""
     device = FritzDeviceSwitchMock()
     device.voltage = None

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -2,7 +2,11 @@
 import pytest
 
 from homeassistant.components.frontend import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockUser
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -11,7 +15,9 @@ def setup_frontend(hass):
     hass.loop.run_until_complete(async_setup_component(hass, "frontend", {}))
 
 
-async def test_get_user_data_empty(hass, hass_ws_client, hass_storage):
+async def test_get_user_data_empty(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test get_user_data command."""
     client = await hass_ws_client(hass)
 
@@ -24,7 +30,12 @@ async def test_get_user_data_empty(hass, hass_ws_client, hass_storage):
     assert res["result"]["value"] is None
 
 
-async def test_get_user_data(hass, hass_ws_client, hass_admin_user, hass_storage):
+async def test_get_user_data(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+    hass_storage,
+) -> None:
     """Test get_user_data command."""
     storage_key = f"{DOMAIN}.user_data_{hass_admin_user.id}"
     hass_storage[storage_key] = {
@@ -65,7 +76,9 @@ async def test_get_user_data(hass, hass_ws_client, hass_admin_user, hass_storage
     assert res["result"]["value"]["test-complex"][0]["foo"] == "bar"
 
 
-async def test_set_user_data_empty(hass, hass_ws_client, hass_storage):
+async def test_set_user_data_empty(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+) -> None:
     """Test set_user_data command."""
     client = await hass_ws_client(hass)
 
@@ -100,7 +113,12 @@ async def test_set_user_data_empty(hass, hass_ws_client, hass_storage):
     assert res["result"]["value"] == "test-value"
 
 
-async def test_set_user_data(hass, hass_ws_client, hass_storage, hass_admin_user):
+async def test_set_user_data(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage,
+    hass_admin_user: MockUser,
+) -> None:
     """Test set_user_data command with initial data."""
     storage_key = f"{DOMAIN}.user_data_{hass_admin_user.id}"
     hass_storage[storage_key] = {

--- a/tests/components/fully_kiosk/test_media_player.py
+++ b/tests/components/fully_kiosk/test_media_player.py
@@ -1,8 +1,6 @@
 """Test the Fully Kiosk Browser media player."""
 from unittest.mock import MagicMock, Mock, patch
 
-from aiohttp import ClientSession
-
 from homeassistant.components.fully_kiosk.const import DOMAIN, MEDIA_SUPPORT_FULLYKIOSK
 import homeassistant.components.media_player as media_player
 from homeassistant.components.media_source import DOMAIN as MS_DOMAIN
@@ -12,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_media_player(
@@ -100,7 +99,7 @@ async def test_media_player(
 
 async def test_browse_media(
     hass: HomeAssistant,
-    hass_ws_client: ClientSession,
+    hass_ws_client: WebSocketGenerator,
     mock_fully_kiosk: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:

--- a/tests/components/gdacs/test_config_flow.py
+++ b/tests/components/gdacs/test_config_flow.py
@@ -22,7 +22,7 @@ def gdacs_setup_fixture():
         yield
 
 
-async def test_duplicate_error(hass, config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_LATITUDE: -41.2, CONF_LONGITUDE: 174.7, CONF_RADIUS: 25}
     config_entry.add_to_hass(hass)

--- a/tests/components/gdacs/test_init.py
+++ b/tests/components/gdacs/test_init.py
@@ -2,9 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.gdacs import DOMAIN, FEED
+from homeassistant.core import HomeAssistant
 
 
-async def test_component_unload_config_entry(hass, config_entry):
+async def test_component_unload_config_entry(hass: HomeAssistant, config_entry) -> None:
     """Test that loading and unloading of a config entry works."""
     config_entry.add_to_hass(hass)
     with patch("aio_georss_gdacs.GdacsFeedManager.update") as mock_feed_manager_update:

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -28,11 +28,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import AsyncMock, Mock, MockConfigEntry
-from tests.typing import ClientSessionGenerator
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @respx.mock
-async def test_fetching_url(hass, hass_client, fakeimgbytes_png):
+async def test_fetching_url(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, fakeimgbytes_png
+) -> None:
     """Test that it fetches the given url."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
 
@@ -66,7 +68,9 @@ async def test_fetching_url(hass, hass_client, fakeimgbytes_png):
 
 
 @respx.mock
-async def test_fetching_without_verify_ssl(hass, hass_client, fakeimgbytes_png):
+async def test_fetching_without_verify_ssl(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, fakeimgbytes_png
+) -> None:
     """Test that it fetches the given url when ssl verify is off."""
     respx.get("https://example.com").respond(stream=fakeimgbytes_png)
 
@@ -94,7 +98,9 @@ async def test_fetching_without_verify_ssl(hass, hass_client, fakeimgbytes_png):
 
 
 @respx.mock
-async def test_fetching_url_with_verify_ssl(hass, hass_client, fakeimgbytes_png):
+async def test_fetching_url_with_verify_ssl(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, fakeimgbytes_png
+) -> None:
     """Test that it fetches the given url when ssl verify is explicitly on."""
     respx.get("https://example.com").respond(stream=fakeimgbytes_png)
 
@@ -122,7 +128,12 @@ async def test_fetching_url_with_verify_ssl(hass, hass_client, fakeimgbytes_png)
 
 
 @respx.mock
-async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_jpg):
+async def test_limit_refetch(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    fakeimgbytes_png,
+    fakeimgbytes_jpg,
+) -> None:
     """Test that it fetches the given url."""
     respx.get("http://example.com/0a").respond(stream=fakeimgbytes_png)
     respx.get("http://example.com/5a").respond(stream=fakeimgbytes_png)
@@ -193,7 +204,12 @@ async def test_limit_refetch(hass, hass_client, fakeimgbytes_png, fakeimgbytes_j
 
 
 @respx.mock
-async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png):
+async def test_stream_source(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    fakeimgbytes_png,
+) -> None:
     """Test that the stream source is rendered."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
     respx.get("http://example.com/0a").respond(stream=fakeimgbytes_png)
@@ -245,7 +261,12 @@ async def test_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png
 
 
 @respx.mock
-async def test_stream_source_error(hass, hass_client, hass_ws_client, fakeimgbytes_png):
+async def test_stream_source_error(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    fakeimgbytes_png,
+) -> None:
     """Test that the stream source has an error."""
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)
 
@@ -290,7 +311,9 @@ async def test_stream_source_error(hass, hass_client, hass_ws_client, fakeimgbyt
 
 
 @respx.mock
-async def test_setup_alternative_options(hass, hass_ws_client, fakeimgbytes_png):
+async def test_setup_alternative_options(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, fakeimgbytes_png
+) -> None:
     """Test that the stream source is setup with different config options."""
     respx.get("https://example.com").respond(stream=fakeimgbytes_png)
 
@@ -315,7 +338,12 @@ async def test_setup_alternative_options(hass, hass_ws_client, fakeimgbytes_png)
 
 
 @respx.mock
-async def test_no_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_png):
+async def test_no_stream_source(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    fakeimgbytes_png,
+) -> None:
     """Test a stream request without stream source option set."""
     respx.get("https://example.com").respond(stream=fakeimgbytes_png)
 
@@ -358,8 +386,11 @@ async def test_no_stream_source(hass, hass_client, hass_ws_client, fakeimgbytes_
 
 @respx.mock
 async def test_camera_content_type(
-    hass, hass_client, fakeimgbytes_svg, fakeimgbytes_jpg
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    fakeimgbytes_svg,
+    fakeimgbytes_jpg,
+) -> None:
     """Test generic camera with custom content_type."""
     urlsvg = "https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
     respx.get(urlsvg).respond(stream=fakeimgbytes_svg)
@@ -417,7 +448,12 @@ async def test_camera_content_type(
 
 
 @respx.mock
-async def test_timeout_cancelled(hass, hass_client, fakeimgbytes_png, fakeimgbytes_jpg):
+async def test_timeout_cancelled(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    fakeimgbytes_png,
+    fakeimgbytes_jpg,
+) -> None:
     """Test that timeouts and cancellations return last image."""
 
     respx.get("http://example.com").respond(stream=fakeimgbytes_png)

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test The generic (IP Camera) config flow."""
-
 import errno
 from http import HTTPStatus
 import os.path
@@ -38,6 +37,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 TESTDATA = {
     CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -61,7 +61,13 @@ TESTDATA_YAML = {
 
 
 @respx.mock
-async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_stream):
+async def test_form(
+    hass: HomeAssistant,
+    fakeimgbytes_png,
+    hass_client: ClientSessionGenerator,
+    user_flow,
+    mock_create_stream,
+) -> None:
     """Test the form with a normal set of settings."""
 
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
@@ -108,7 +114,9 @@ async def test_form(hass, fakeimgbytes_png, hass_client, user_flow, mock_create_
 
 
 @respx.mock
-async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
+async def test_form_only_stillimage(
+    hass: HomeAssistant, fakeimg_png, user_flow
+) -> None:
     """Test we complete ok if the user wants still images only."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -148,8 +156,8 @@ async def test_form_only_stillimage(hass, fakeimg_png, user_flow):
 
 @respx.mock
 async def test_form_reject_still_preview(
-    hass, fakeimgbytes_png, mock_create_stream, user_flow
-):
+    hass: HomeAssistant, fakeimgbytes_png, mock_create_stream, user_flow
+) -> None:
     """Test we go back to the config screen if the user rejects the still preview."""
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
     with mock_create_stream:
@@ -169,8 +177,12 @@ async def test_form_reject_still_preview(
 
 @respx.mock
 async def test_form_still_preview_cam_off(
-    hass, fakeimg_png, mock_create_stream, user_flow, hass_client
-):
+    hass: HomeAssistant,
+    fakeimg_png,
+    mock_create_stream,
+    user_flow,
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test camera errors are triggered during preview."""
     with patch(
         "homeassistant.components.generic.camera.GenericCamera.is_on",
@@ -190,7 +202,9 @@ async def test_form_still_preview_cam_off(
 
 
 @respx.mock
-async def test_form_only_stillimage_gif(hass, fakeimg_gif, user_flow):
+async def test_form_only_stillimage_gif(
+    hass: HomeAssistant, fakeimg_gif, user_flow
+) -> None:
     """Test we complete ok if the user wants a gif."""
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
@@ -211,7 +225,9 @@ async def test_form_only_stillimage_gif(hass, fakeimg_gif, user_flow):
 
 
 @respx.mock
-async def test_form_only_svg_whitespace(hass, fakeimgbytes_svg, user_flow):
+async def test_form_only_svg_whitespace(
+    hass: HomeAssistant, fakeimgbytes_svg, user_flow
+) -> None:
     """Test we complete ok if svg starts with whitespace, issue #68889."""
     fakeimgbytes_wspace_svg = bytes("  \n ", encoding="utf-8") + fakeimgbytes_svg
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_wspace_svg)
@@ -243,7 +259,9 @@ async def test_form_only_svg_whitespace(hass, fakeimgbytes_svg, user_flow):
         ("sample5_webp.webp"),
     ],
 )
-async def test_form_only_still_sample(hass, user_flow, image_file):
+async def test_form_only_still_sample(
+    hass: HomeAssistant, user_flow, image_file
+) -> None:
     """Test various sample images #69037."""
     image_path = os.path.join(os.path.dirname(__file__), image_file)
     with open(image_path, "rb") as image:
@@ -303,7 +321,13 @@ async def test_form_only_still_sample(hass, user_flow, image_file):
     ],
 )
 async def test_still_template(
-    hass, user_flow, fakeimgbytes_png, template, url, expected_result, expected_errors
+    hass: HomeAssistant,
+    user_flow,
+    fakeimgbytes_png,
+    template,
+    url,
+    expected_result,
+    expected_errors,
 ) -> None:
     """Test we can handle various templates."""
     respx.get(url).respond(stream=fakeimgbytes_png)
@@ -321,7 +345,9 @@ async def test_still_template(
 
 
 @respx.mock
-async def test_form_rtsp_mode(hass, fakeimg_png, user_flow, mock_create_stream):
+async def test_form_rtsp_mode(
+    hass: HomeAssistant, fakeimg_png, user_flow, mock_create_stream
+) -> None:
     """Test we complete ok if the user enters a stream url."""
     data = TESTDATA.copy()
     data[CONF_RTSP_TRANSPORT] = "tcp"
@@ -357,7 +383,9 @@ async def test_form_rtsp_mode(hass, fakeimg_png, user_flow, mock_create_stream):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_form_only_stream(hass, fakeimgbytes_jpg, user_flow, mock_create_stream):
+async def test_form_only_stream(
+    hass: HomeAssistant, fakeimgbytes_jpg, user_flow, mock_create_stream
+) -> None:
     """Test we complete ok if the user wants stream only."""
     data = TESTDATA.copy()
     data.pop(CONF_STILL_IMAGE_URL)
@@ -398,7 +426,9 @@ async def test_form_only_stream(hass, fakeimgbytes_jpg, user_flow, mock_create_s
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_form_still_and_stream_not_provided(hass, user_flow):
+async def test_form_still_and_stream_not_provided(
+    hass: HomeAssistant, user_flow
+) -> None:
     """Test we show a suitable error if neither still or stream URL are provided."""
     result2 = await hass.config_entries.flow.async_configure(
         user_flow["flow_id"],
@@ -413,7 +443,9 @@ async def test_form_still_and_stream_not_provided(hass, user_flow):
 
 
 @respx.mock
-async def test_form_image_timeout(hass, user_flow, mock_create_stream):
+async def test_form_image_timeout(
+    hass: HomeAssistant, user_flow, mock_create_stream
+) -> None:
     """Test we handle invalid image timeout."""
     respx.get("http://127.0.0.1/testurl/1").side_effect = [
         httpx.TimeoutException,
@@ -431,7 +463,9 @@ async def test_form_image_timeout(hass, user_flow, mock_create_stream):
 
 
 @respx.mock
-async def test_form_stream_invalidimage(hass, user_flow, mock_create_stream):
+async def test_form_stream_invalidimage(
+    hass: HomeAssistant, user_flow, mock_create_stream
+) -> None:
     """Test we handle invalid image when a stream is specified."""
     respx.get("http://127.0.0.1/testurl/1").respond(stream=b"invalid")
     with mock_create_stream:
@@ -446,7 +480,9 @@ async def test_form_stream_invalidimage(hass, user_flow, mock_create_stream):
 
 
 @respx.mock
-async def test_form_stream_invalidimage2(hass, user_flow, mock_create_stream):
+async def test_form_stream_invalidimage2(
+    hass: HomeAssistant, user_flow, mock_create_stream
+) -> None:
     """Test we handle invalid image when a stream is specified."""
     respx.get("http://127.0.0.1/testurl/1").respond(content=None)
     with mock_create_stream:
@@ -461,7 +497,9 @@ async def test_form_stream_invalidimage2(hass, user_flow, mock_create_stream):
 
 
 @respx.mock
-async def test_form_stream_invalidimage3(hass, user_flow, mock_create_stream):
+async def test_form_stream_invalidimage3(
+    hass: HomeAssistant, user_flow, mock_create_stream
+) -> None:
     """Test we handle invalid image when a stream is specified."""
     respx.get("http://127.0.0.1/testurl/1").respond(content=bytes([0xFF]))
     with mock_create_stream:
@@ -476,7 +514,7 @@ async def test_form_stream_invalidimage3(hass, user_flow, mock_create_stream):
 
 
 @respx.mock
-async def test_form_stream_timeout(hass, fakeimg_png, user_flow):
+async def test_form_stream_timeout(hass: HomeAssistant, fakeimg_png, user_flow) -> None:
     """Test we handle invalid auth."""
     with patch(
         "homeassistant.components.generic.config_flow.create_stream"
@@ -495,7 +533,9 @@ async def test_form_stream_timeout(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_form_stream_worker_error(hass, fakeimg_png, user_flow):
+async def test_form_stream_worker_error(
+    hass: HomeAssistant, fakeimg_png, user_flow
+) -> None:
     """Test we handle a StreamWorkerError and pass the message through."""
     with patch(
         "homeassistant.components.generic.config_flow.create_stream",
@@ -510,7 +550,9 @@ async def test_form_stream_worker_error(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_form_stream_permission_error(hass, fakeimgbytes_png, user_flow):
+async def test_form_stream_permission_error(
+    hass: HomeAssistant, fakeimgbytes_png, user_flow
+) -> None:
     """Test we handle permission error."""
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
     with patch(
@@ -526,7 +568,9 @@ async def test_form_stream_permission_error(hass, fakeimgbytes_png, user_flow):
 
 
 @respx.mock
-async def test_form_no_route_to_host(hass, fakeimg_png, user_flow):
+async def test_form_no_route_to_host(
+    hass: HomeAssistant, fakeimg_png, user_flow
+) -> None:
     """Test we handle no route to host."""
     with patch(
         "homeassistant.components.generic.config_flow.create_stream",
@@ -541,7 +585,9 @@ async def test_form_no_route_to_host(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_form_stream_io_error(hass, fakeimg_png, user_flow):
+async def test_form_stream_io_error(
+    hass: HomeAssistant, fakeimg_png, user_flow
+) -> None:
     """Test we handle no io error when setting up stream."""
     with patch(
         "homeassistant.components.generic.config_flow.create_stream",
@@ -556,7 +602,7 @@ async def test_form_stream_io_error(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_form_oserror(hass, fakeimg_png, user_flow):
+async def test_form_oserror(hass: HomeAssistant, fakeimg_png, user_flow) -> None:
     """Test we handle OS error when setting up stream."""
     with patch(
         "homeassistant.components.generic.config_flow.create_stream",
@@ -569,7 +615,9 @@ async def test_form_oserror(hass, fakeimg_png, user_flow):
 
 
 @respx.mock
-async def test_options_template_error(hass, fakeimgbytes_png, mock_create_stream):
+async def test_options_template_error(
+    hass: HomeAssistant, fakeimgbytes_png, mock_create_stream
+) -> None:
     """Test the options flow with a template error."""
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_png)
     respx.get("http://127.0.0.1/testurl/2").respond(stream=fakeimgbytes_png)
@@ -665,7 +713,9 @@ async def test_slug(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> No
 
 
 @respx.mock
-async def test_options_only_stream(hass, fakeimgbytes_png, mock_create_stream):
+async def test_options_only_stream(
+    hass: HomeAssistant, fakeimgbytes_png, mock_create_stream
+) -> None:
     """Test the options flow without a still_image_url."""
     respx.get("http://127.0.0.1/testurl/2").respond(stream=fakeimgbytes_png)
     data = TESTDATA.copy()
@@ -703,7 +753,7 @@ async def test_options_only_stream(hass, fakeimgbytes_png, mock_create_stream):
 
 # These below can be deleted after deprecation period is finished.
 @respx.mock
-async def test_import(hass, fakeimg_png):
+async def test_import(hass: HomeAssistant, fakeimg_png) -> None:
     """Test configuration.yaml import used during migration."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TESTDATA_YAML
@@ -723,7 +773,7 @@ async def test_import(hass, fakeimg_png):
 # These above can be deleted after deprecation period is finished.
 
 
-async def test_unload_entry(hass, fakeimg_png):
+async def test_unload_entry(hass: HomeAssistant, fakeimg_png) -> None:
     """Test unloading the generic IP Camera entry."""
     mock_entry = MockConfigEntry(domain=DOMAIN, options=TESTDATA)
     mock_entry.add_to_hass(hass)
@@ -794,8 +844,8 @@ async def test_migrate_existing_ids(hass: HomeAssistant) -> None:
 
 @respx.mock
 async def test_use_wallclock_as_timestamps_option(
-    hass, fakeimg_png, mock_create_stream
-):
+    hass: HomeAssistant, fakeimg_png, mock_create_stream
+) -> None:
     """Test the use_wallclock_as_timestamps option flow."""
 
     mock_entry = MockConfigEntry(

--- a/tests/components/generic/test_diagnostics.py
+++ b/tests/components/generic/test_diagnostics.py
@@ -3,11 +3,15 @@ import pytest
 
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.generic.diagnostics import redact_url
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, hass_client, setup_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, setup_entry
+) -> None:
     """Test config entry diagnostics."""
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, setup_entry) == {
@@ -52,7 +56,7 @@ async def test_entry_diagnostics(hass, hass_client, setup_entry):
         ),
     ],
 )
-def test_redact_url(url_in, url_out_expected):
+def test_redact_url(url_in, url_out_expected) -> None:
     """Test url redaction."""
     url_out = redact_url(url_in)
     assert url_out == url_out_expected

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -85,7 +85,7 @@ async def setup_comp_1(hass):
     await hass.async_block_till_done()
 
 
-async def test_humidifier_input_boolean(hass, setup_comp_1):
+async def test_humidifier_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
     """Test humidifier switching input_boolean."""
     humidifier_switch = "input_boolean.test"
     assert await async_setup_component(
@@ -123,7 +123,9 @@ async def test_humidifier_input_boolean(hass, setup_comp_1):
     assert hass.states.get(humidifier_switch).state == STATE_ON
 
 
-async def test_humidifier_switch(hass, setup_comp_1, enable_custom_integrations):
+async def test_humidifier_switch(
+    hass: HomeAssistant, setup_comp_1, enable_custom_integrations: None
+) -> None:
     """Test humidifier switching test switch."""
     platform = getattr(hass.components, "test.switch")
     platform.init()
@@ -269,7 +271,7 @@ async def test_setup_defaults_to_unknown(hass: HomeAssistant) -> None:
     assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
 
 
-async def test_default_setup_params(hass, setup_comp_2):
+async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
     """Test the setup with default parameters."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_humidity") == 0
@@ -277,7 +279,9 @@ async def test_default_setup_params(hass, setup_comp_2):
     assert state.attributes.get("humidity") == 0
 
 
-async def test_default_setup_params_dehumidifier(hass, setup_comp_0):
+async def test_default_setup_params_dehumidifier(
+    hass: HomeAssistant, setup_comp_0
+) -> None:
     """Test the setup with default parameters for dehumidifier."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_humidity") == 0
@@ -285,14 +289,14 @@ async def test_default_setup_params_dehumidifier(hass, setup_comp_0):
     assert state.attributes.get("humidity") == 100
 
 
-async def test_get_modes(hass, setup_comp_2):
+async def test_get_modes(hass: HomeAssistant, setup_comp_2) -> None:
     """Test that the attributes returns the correct modes."""
     state = hass.states.get(ENTITY)
     modes = state.attributes.get("available_modes")
     assert modes == [MODE_NORMAL, MODE_AWAY]
 
 
-async def test_set_target_humidity(hass, setup_comp_2):
+async def test_set_target_humidity(hass: HomeAssistant, setup_comp_2) -> None:
     """Test the setting of the target humidity."""
     await hass.services.async_call(
         DOMAIN,
@@ -315,7 +319,7 @@ async def test_set_target_humidity(hass, setup_comp_2):
     assert state.attributes.get("humidity") == 40
 
 
-async def test_set_away_mode(hass, setup_comp_2):
+async def test_set_away_mode(hass: HomeAssistant, setup_comp_2) -> None:
     """Test the setting away mode."""
     await hass.services.async_call(
         DOMAIN,
@@ -335,7 +339,9 @@ async def test_set_away_mode(hass, setup_comp_2):
     assert state.attributes.get("humidity") == 35
 
 
-async def test_set_away_mode_and_restore_prev_humidity(hass, setup_comp_2):
+async def test_set_away_mode_and_restore_prev_humidity(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test the setting and removing away mode.
 
     Verify original humidity is restored.
@@ -367,7 +373,9 @@ async def test_set_away_mode_and_restore_prev_humidity(hass, setup_comp_2):
     assert state.attributes.get("humidity") == 44
 
 
-async def test_set_away_mode_twice_and_restore_prev_humidity(hass, setup_comp_2):
+async def test_set_away_mode_twice_and_restore_prev_humidity(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test the setting away mode twice in a row.
 
     Verify original humidity is restored.
@@ -406,7 +414,7 @@ async def test_set_away_mode_twice_and_restore_prev_humidity(hass, setup_comp_2)
     assert state.attributes.get("humidity") == 44
 
 
-async def test_sensor_bad_value(hass, setup_comp_2):
+async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
     """Test sensor that have None as state."""
     state = hass.states.get(ENTITY)
     humidity = state.attributes.get("current_humidity")
@@ -418,7 +426,9 @@ async def test_sensor_bad_value(hass, setup_comp_2):
     assert humidity == state.attributes.get("current_humidity")
 
 
-async def test_set_target_humidity_humidifier_on(hass, setup_comp_2):
+async def test_set_target_humidity_humidifier_on(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if target humidity turn humidifier on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 36)
@@ -437,7 +447,9 @@ async def test_set_target_humidity_humidifier_on(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_humidity_humidifier_off(hass, setup_comp_2):
+async def test_set_target_humidity_humidifier_off(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if target humidity turn humidifier off."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -456,7 +468,9 @@ async def test_set_target_humidity_humidifier_off(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_humidifier_on_within_tolerance(hass, setup_comp_2):
+async def test_humidity_change_humidifier_on_within_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if humidity change doesn't turn on within tolerance."""
     calls = await _setup_switch(hass, False)
     await hass.services.async_call(
@@ -471,7 +485,9 @@ async def test_humidity_change_humidifier_on_within_tolerance(hass, setup_comp_2
     assert len(calls) == 0
 
 
-async def test_humidity_change_humidifier_on_outside_tolerance(hass, setup_comp_2):
+async def test_humidity_change_humidifier_on_outside_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if humidity change turn humidifier on outside dry tolerance."""
     calls = await _setup_switch(hass, False)
     await hass.services.async_call(
@@ -490,7 +506,9 @@ async def test_humidity_change_humidifier_on_outside_tolerance(hass, setup_comp_
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_humidifier_off_within_tolerance(hass, setup_comp_2):
+async def test_humidity_change_humidifier_off_within_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if humidity change doesn't turn off within tolerance."""
     calls = await _setup_switch(hass, True)
     await hass.services.async_call(
@@ -505,7 +523,9 @@ async def test_humidity_change_humidifier_off_within_tolerance(hass, setup_comp_
     assert len(calls) == 0
 
 
-async def test_humidity_change_humidifier_off_outside_tolerance(hass, setup_comp_2):
+async def test_humidity_change_humidifier_off_outside_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if humidity change turn humidifier off outside wet tolerance."""
     calls = await _setup_switch(hass, True)
     await hass.services.async_call(
@@ -524,7 +544,7 @@ async def test_humidity_change_humidifier_off_outside_tolerance(hass, setup_comp
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_operation_mode_humidify(hass, setup_comp_2):
+async def test_operation_mode_humidify(hass: HomeAssistant, setup_comp_2) -> None:
     """Test change mode from OFF to HUMIDIFY.
 
     Switch turns on when humidity below setpoint and mode changes.
@@ -601,7 +621,7 @@ async def setup_comp_3(hass):
     await hass.async_block_till_done()
 
 
-async def test_set_target_humidity_dry_off(hass, setup_comp_3):
+async def test_set_target_humidity_dry_off(hass: HomeAssistant, setup_comp_3) -> None:
     """Test if target humidity turn dry off."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 50)
@@ -620,7 +640,7 @@ async def test_set_target_humidity_dry_off(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_turn_away_mode_on_drying(hass, setup_comp_3):
+async def test_turn_away_mode_on_drying(hass: HomeAssistant, setup_comp_3) -> None:
     """Test the setting away mode when drying."""
     await _setup_switch(hass, True)
     _setup_sensor(hass, 50)
@@ -643,7 +663,7 @@ async def test_turn_away_mode_on_drying(hass, setup_comp_3):
     assert state.attributes.get("humidity") == 30
 
 
-async def test_operation_mode_dry(hass, setup_comp_3):
+async def test_operation_mode_dry(hass: HomeAssistant, setup_comp_3) -> None:
     """Test change mode from OFF to DRY.
 
     Switch turns on when humidity below setpoint and state changes.
@@ -676,7 +696,7 @@ async def test_operation_mode_dry(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_humidity_dry_on(hass, setup_comp_3):
+async def test_set_target_humidity_dry_on(hass: HomeAssistant, setup_comp_3) -> None:
     """Test if target humidity turn dry on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -688,7 +708,7 @@ async def test_set_target_humidity_dry_on(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_init_ignores_tolerance(hass, setup_comp_3):
+async def test_init_ignores_tolerance(hass: HomeAssistant, setup_comp_3) -> None:
     """Test if tolerance is ignored on initialization."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 39)
@@ -700,7 +720,9 @@ async def test_init_ignores_tolerance(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_off_within_tolerance(hass, setup_comp_3):
+async def test_humidity_change_dry_off_within_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if humidity change doesn't turn dry off within tolerance."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -709,7 +731,9 @@ async def test_humidity_change_dry_off_within_tolerance(hass, setup_comp_3):
     assert len(calls) == 0
 
 
-async def test_set_humidity_change_dry_off_outside_tolerance(hass, setup_comp_3):
+async def test_set_humidity_change_dry_off_outside_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if humidity change turn dry off."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 36)
@@ -721,7 +745,9 @@ async def test_set_humidity_change_dry_off_outside_tolerance(hass, setup_comp_3)
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_on_within_tolerance(hass, setup_comp_3):
+async def test_humidity_change_dry_on_within_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if humidity change doesn't turn dry on within tolerance."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 37)
@@ -730,7 +756,9 @@ async def test_humidity_change_dry_on_within_tolerance(hass, setup_comp_3):
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_on_outside_tolerance(hass, setup_comp_3):
+async def test_humidity_change_dry_on_outside_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -742,7 +770,9 @@ async def test_humidity_change_dry_on_outside_tolerance(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
+async def test_running_when_operating_mode_is_off_2(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -761,7 +791,9 @@ async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_no_state_change_when_operation_mode_off_2(hass, setup_comp_3):
+async def test_no_state_change_when_operation_mode_off_2(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 30)
@@ -802,7 +834,9 @@ async def setup_comp_4(hass):
     await hass.async_block_till_done()
 
 
-async def test_humidity_change_dry_trigger_on_not_long_enough(hass, setup_comp_4):
+async def test_humidity_change_dry_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 35)
@@ -814,7 +848,9 @@ async def test_humidity_change_dry_trigger_on_not_long_enough(hass, setup_comp_4
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_trigger_on_long_enough(hass, setup_comp_4):
+async def test_humidity_change_dry_trigger_on_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if humidity change turn dry on."""
     fake_changed = datetime.datetime(
         1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
@@ -836,7 +872,9 @@ async def test_humidity_change_dry_trigger_on_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_trigger_off_not_long_enough(hass, setup_comp_4):
+async def test_humidity_change_dry_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -848,7 +886,9 @@ async def test_humidity_change_dry_trigger_off_not_long_enough(hass, setup_comp_
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_trigger_off_long_enough(hass, setup_comp_4):
+async def test_humidity_change_dry_trigger_off_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if humidity change turn dry on."""
     fake_changed = datetime.datetime(
         1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
@@ -870,7 +910,9 @@ async def test_humidity_change_dry_trigger_off_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_dry_trigger_off_not_long_enough(hass, setup_comp_4):
+async def test_mode_change_dry_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if mode change turns dry off despite minimum cycle."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -890,7 +932,9 @@ async def test_mode_change_dry_trigger_off_not_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_dry_trigger_on_not_long_enough(hass, setup_comp_4):
+async def test_mode_change_dry_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if mode change turns dry on despite minimum cycle."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 35)
@@ -943,8 +987,8 @@ async def setup_comp_6(hass):
 
 
 async def test_humidity_change_humidifier_trigger_off_not_long_enough(
-    hass, setup_comp_6
-):
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if humidity change doesn't turn humidifier off because of time."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 35)
@@ -957,8 +1001,8 @@ async def test_humidity_change_humidifier_trigger_off_not_long_enough(
 
 
 async def test_humidity_change_humidifier_trigger_on_not_long_enough(
-    hass, setup_comp_6
-):
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if humidity change doesn't turn humidifier on because of time."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -970,7 +1014,9 @@ async def test_humidity_change_humidifier_trigger_on_not_long_enough(
     assert len(calls) == 0
 
 
-async def test_humidity_change_humidifier_trigger_on_long_enough(hass, setup_comp_6):
+async def test_humidity_change_humidifier_trigger_on_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if humidity change turn humidifier on after min cycle."""
     fake_changed = datetime.datetime(
         1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
@@ -992,7 +1038,9 @@ async def test_humidity_change_humidifier_trigger_on_long_enough(hass, setup_com
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_humidifier_trigger_off_long_enough(hass, setup_comp_6):
+async def test_humidity_change_humidifier_trigger_off_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if humidity change turn humidifier off after min cycle."""
     fake_changed = datetime.datetime(
         1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
@@ -1014,7 +1062,9 @@ async def test_humidity_change_humidifier_trigger_off_long_enough(hass, setup_co
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_humidifier_trigger_off_not_long_enough(hass, setup_comp_6):
+async def test_mode_change_humidifier_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if mode change turns humidifier off despite minimum cycle."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 35)
@@ -1035,7 +1085,9 @@ async def test_mode_change_humidifier_trigger_off_not_long_enough(hass, setup_co
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_humidifier_trigger_on_not_long_enough(hass, setup_comp_6):
+async def test_mode_change_humidifier_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if mode change turns humidifier on despite minimum cycle."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -1094,7 +1146,9 @@ async def setup_comp_7(hass):
     await hass.async_block_till_done()
 
 
-async def test_humidity_change_dry_trigger_on_long_enough_3(hass, setup_comp_7):
+async def test_humidity_change_dry_trigger_on_long_enough_3(
+    hass: HomeAssistant, setup_comp_7
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -1112,7 +1166,9 @@ async def test_humidity_change_dry_trigger_on_long_enough_3(hass, setup_comp_7):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_trigger_off_long_enough_3(hass, setup_comp_7):
+async def test_humidity_change_dry_trigger_off_long_enough_3(
+    hass: HomeAssistant, setup_comp_7
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 35)
@@ -1154,7 +1210,9 @@ async def setup_comp_8(hass):
     await hass.async_block_till_done()
 
 
-async def test_humidity_change_humidifier_trigger_on_long_enough_2(hass, setup_comp_8):
+async def test_humidity_change_humidifier_trigger_on_long_enough_2(
+    hass: HomeAssistant, setup_comp_8
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 35)
@@ -1172,7 +1230,9 @@ async def test_humidity_change_humidifier_trigger_on_long_enough_2(hass, setup_c
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_humidifier_trigger_off_long_enough_2(hass, setup_comp_8):
+async def test_humidity_change_humidifier_trigger_off_long_enough_2(
+    hass: HomeAssistant, setup_comp_8
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -1582,7 +1642,9 @@ async def test_away_fixed_humidity_mode(hass: HomeAssistant) -> None:
     assert state.state == STATE_OFF
 
 
-async def test_sensor_stale_duration(hass, setup_comp_1, caplog):
+async def test_sensor_stale_duration(
+    hass: HomeAssistant, setup_comp_1, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test turn off on sensor stale."""
 
     humidifier_switch = "input_boolean.test"

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -103,7 +103,7 @@ async def setup_comp_1(hass):
     await hass.async_block_till_done()
 
 
-async def test_heater_input_boolean(hass, setup_comp_1):
+async def test_heater_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
     """Test heater switching input_boolean."""
     heater_switch = "input_boolean.test"
     assert await async_setup_component(
@@ -134,7 +134,9 @@ async def test_heater_input_boolean(hass, setup_comp_1):
     assert hass.states.get(heater_switch).state == STATE_ON
 
 
-async def test_heater_switch(hass, setup_comp_1, enable_custom_integrations):
+async def test_heater_switch(
+    hass: HomeAssistant, setup_comp_1, enable_custom_integrations: None
+) -> None:
     """Test heater switching test switch."""
     platform = getattr(hass.components, "test.switch")
     platform.init()
@@ -169,7 +171,7 @@ async def test_heater_switch(hass, setup_comp_1, enable_custom_integrations):
     assert hass.states.get(heater_switch).state == STATE_ON
 
 
-async def test_unique_id(hass, setup_comp_1):
+async def test_unique_id(hass: HomeAssistant, setup_comp_1) -> None:
     """Test heater switching input_boolean."""
     unique_id = "some_unique_id"
     _setup_sensor(hass, 18)
@@ -274,7 +276,7 @@ async def test_setup_gets_current_temp_from_sensor(hass: HomeAssistant) -> None:
     assert hass.states.get(ENTITY).attributes["current_temperature"] == 18
 
 
-async def test_default_setup_params(hass, setup_comp_2):
+async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
     """Test the setup with default parameters."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_temp") == 7
@@ -283,14 +285,14 @@ async def test_default_setup_params(hass, setup_comp_2):
     assert state.attributes.get("target_temp_step") == 0.1
 
 
-async def test_get_hvac_modes(hass, setup_comp_2):
+async def test_get_hvac_modes(hass: HomeAssistant, setup_comp_2) -> None:
     """Test that the operation list returns the correct modes."""
     state = hass.states.get(ENTITY)
     modes = state.attributes.get("hvac_modes")
     assert modes == [HVACMode.HEAT, HVACMode.OFF]
 
 
-async def test_set_target_temp(hass, setup_comp_2):
+async def test_set_target_temp(hass: HomeAssistant, setup_comp_2) -> None:
     """Test the setting of the target temperature."""
     await common.async_set_temperature(hass, 30)
     state = hass.states.get(ENTITY)
@@ -312,7 +314,7 @@ async def test_set_target_temp(hass, setup_comp_2):
         (PRESET_ACTIVITY, 21),
     ],
 )
-async def test_set_away_mode(hass, setup_comp_2, preset, temp):
+async def test_set_away_mode(hass: HomeAssistant, setup_comp_2, preset, temp) -> None:
     """Test the setting away mode."""
     await common.async_set_temperature(hass, 23)
     await common.async_set_preset_mode(hass, preset)
@@ -331,7 +333,9 @@ async def test_set_away_mode(hass, setup_comp_2, preset, temp):
         (PRESET_ACTIVITY, 21),
     ],
 )
-async def test_set_away_mode_and_restore_prev_temp(hass, setup_comp_2, preset, temp):
+async def test_set_away_mode_and_restore_prev_temp(
+    hass: HomeAssistant, setup_comp_2, preset, temp
+) -> None:
     """Test the setting and removing away mode.
 
     Verify original temperature is restored.
@@ -357,8 +361,8 @@ async def test_set_away_mode_and_restore_prev_temp(hass, setup_comp_2, preset, t
     ],
 )
 async def test_set_away_mode_twice_and_restore_prev_temp(
-    hass, setup_comp_2, preset, temp
-):
+    hass: HomeAssistant, setup_comp_2, preset, temp
+) -> None:
     """Test the setting away mode twice in a row.
 
     Verify original temperature is restored.
@@ -373,7 +377,7 @@ async def test_set_away_mode_twice_and_restore_prev_temp(
     assert state.attributes.get("temperature") == 23
 
 
-async def test_set_preset_mode_invalid(hass, setup_comp_2):
+async def test_set_preset_mode_invalid(hass: HomeAssistant, setup_comp_2) -> None:
     """Test an invalid mode raises an error and ignore case when checking modes."""
     await common.async_set_temperature(hass, 23)
     await common.async_set_preset_mode(hass, "away")
@@ -388,7 +392,7 @@ async def test_set_preset_mode_invalid(hass, setup_comp_2):
     assert state.attributes.get("preset_mode") == "none"
 
 
-async def test_sensor_bad_value(hass, setup_comp_2):
+async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
     """Test sensor that have None as state."""
     state = hass.states.get(ENTITY)
     temp = state.attributes.get("current_temperature")
@@ -449,7 +453,7 @@ async def test_sensor_unavailable(hass: HomeAssistant) -> None:
     assert state.attributes.get("current_temperature") is None
 
 
-async def test_set_target_temp_heater_on(hass, setup_comp_2):
+async def test_set_target_temp_heater_on(hass: HomeAssistant, setup_comp_2) -> None:
     """Test if target temperature turn heater on."""
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 25)
@@ -462,7 +466,7 @@ async def test_set_target_temp_heater_on(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_temp_heater_off(hass, setup_comp_2):
+async def test_set_target_temp_heater_off(hass: HomeAssistant, setup_comp_2) -> None:
     """Test if target temperature turn heater off."""
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 30)
@@ -475,7 +479,9 @@ async def test_set_target_temp_heater_off(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_on_within_tolerance(hass, setup_comp_2):
+async def test_temp_change_heater_on_within_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if temperature change doesn't turn on within tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -484,7 +490,9 @@ async def test_temp_change_heater_on_within_tolerance(hass, setup_comp_2):
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_on_outside_tolerance(hass, setup_comp_2):
+async def test_temp_change_heater_on_outside_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if temperature change turn heater on outside cold tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -497,7 +505,9 @@ async def test_temp_change_heater_on_outside_tolerance(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_off_within_tolerance(hass, setup_comp_2):
+async def test_temp_change_heater_off_within_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if temperature change doesn't turn off within tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -506,7 +516,9 @@ async def test_temp_change_heater_off_within_tolerance(hass, setup_comp_2):
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_off_outside_tolerance(hass, setup_comp_2):
+async def test_temp_change_heater_off_outside_tolerance(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test if temperature change turn heater off outside hot tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -519,7 +531,7 @@ async def test_temp_change_heater_off_outside_tolerance(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_hvac_mode_is_off(hass, setup_comp_2):
+async def test_running_when_hvac_mode_is_off(hass: HomeAssistant, setup_comp_2) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -531,7 +543,9 @@ async def test_running_when_hvac_mode_is_off(hass, setup_comp_2):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_no_state_change_when_hvac_mode_off(hass, setup_comp_2):
+async def test_no_state_change_when_hvac_mode_off(
+    hass: HomeAssistant, setup_comp_2
+) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -541,7 +555,7 @@ async def test_no_state_change_when_hvac_mode_off(hass, setup_comp_2):
     assert len(calls) == 0
 
 
-async def test_hvac_mode_heat(hass, setup_comp_2):
+async def test_hvac_mode_heat(hass: HomeAssistant, setup_comp_2) -> None:
     """Test change mode from OFF to HEAT.
 
     Switch turns on when temp below setpoint and mode changes.
@@ -599,7 +613,7 @@ async def setup_comp_3(hass):
     await hass.async_block_till_done()
 
 
-async def test_set_target_temp_ac_off(hass, setup_comp_3):
+async def test_set_target_temp_ac_off(hass: HomeAssistant, setup_comp_3) -> None:
     """Test if target temperature turn ac off."""
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 25)
@@ -612,7 +626,7 @@ async def test_set_target_temp_ac_off(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_turn_away_mode_on_cooling(hass, setup_comp_3):
+async def test_turn_away_mode_on_cooling(hass: HomeAssistant, setup_comp_3) -> None:
     """Test the setting away mode when cooling."""
     _setup_switch(hass, True)
     _setup_sensor(hass, 25)
@@ -623,7 +637,7 @@ async def test_turn_away_mode_on_cooling(hass, setup_comp_3):
     assert state.attributes.get("temperature") == 30
 
 
-async def test_hvac_mode_cool(hass, setup_comp_3):
+async def test_hvac_mode_cool(hass: HomeAssistant, setup_comp_3) -> None:
     """Test change mode from OFF to COOL.
 
     Switch turns on when temp below setpoint and mode changes.
@@ -641,7 +655,7 @@ async def test_hvac_mode_cool(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_temp_ac_on(hass, setup_comp_3):
+async def test_set_target_temp_ac_on(hass: HomeAssistant, setup_comp_3) -> None:
     """Test if target temperature turn ac on."""
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 30)
@@ -654,7 +668,9 @@ async def test_set_target_temp_ac_on(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_off_within_tolerance(hass, setup_comp_3):
+async def test_temp_change_ac_off_within_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if temperature change doesn't turn ac off within tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -663,7 +679,9 @@ async def test_temp_change_ac_off_within_tolerance(hass, setup_comp_3):
     assert len(calls) == 0
 
 
-async def test_set_temp_change_ac_off_outside_tolerance(hass, setup_comp_3):
+async def test_set_temp_change_ac_off_outside_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if temperature change turn ac off."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -676,7 +694,9 @@ async def test_set_temp_change_ac_off_outside_tolerance(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_on_within_tolerance(hass, setup_comp_3):
+async def test_temp_change_ac_on_within_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if temperature change doesn't turn ac on within tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -685,7 +705,9 @@ async def test_temp_change_ac_on_within_tolerance(hass, setup_comp_3):
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_on_outside_tolerance(hass, setup_comp_3):
+async def test_temp_change_ac_on_outside_tolerance(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -698,7 +720,9 @@ async def test_temp_change_ac_on_outside_tolerance(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
+async def test_running_when_operating_mode_is_off_2(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -710,7 +734,9 @@ async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_no_state_change_when_operation_mode_off_2(hass, setup_comp_3):
+async def test_no_state_change_when_operation_mode_off_2(
+    hass: HomeAssistant, setup_comp_3
+) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -744,7 +770,9 @@ async def setup_comp_4(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
+async def test_temp_change_ac_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -753,7 +781,9 @@ async def test_temp_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_trigger_on_long_enough(hass, setup_comp_4):
+async def test_temp_change_ac_trigger_on_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if temperature change turn ac on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -770,7 +800,9 @@ async def test_temp_change_ac_trigger_on_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
+async def test_temp_change_ac_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -779,7 +811,9 @@ async def test_temp_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_trigger_off_long_enough(hass, setup_comp_4):
+async def test_temp_change_ac_trigger_off_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if temperature change turn ac on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -796,7 +830,9 @@ async def test_temp_change_ac_trigger_off_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
+async def test_mode_change_ac_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if mode change turns ac off despite minimum cycle."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -811,7 +847,9 @@ async def test_mode_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
+async def test_mode_change_ac_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_4
+) -> None:
     """Test if mode change turns ac on despite minimum cycle."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -850,7 +888,9 @@ async def setup_comp_5(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
+async def test_temp_change_ac_trigger_on_not_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -859,7 +899,9 @@ async def test_temp_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_trigger_on_long_enough_2(hass, setup_comp_5):
+async def test_temp_change_ac_trigger_on_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if temperature change turn ac on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -876,7 +918,9 @@ async def test_temp_change_ac_trigger_on_long_enough_2(hass, setup_comp_5):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_trigger_off_not_long_enough_2(hass, setup_comp_5):
+async def test_temp_change_ac_trigger_off_not_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -885,7 +929,9 @@ async def test_temp_change_ac_trigger_off_not_long_enough_2(hass, setup_comp_5):
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_trigger_off_long_enough_2(hass, setup_comp_5):
+async def test_temp_change_ac_trigger_off_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if temperature change turn ac on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -902,7 +948,9 @@ async def test_temp_change_ac_trigger_off_long_enough_2(hass, setup_comp_5):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_ac_trigger_off_not_long_enough_2(hass, setup_comp_5):
+async def test_mode_change_ac_trigger_off_not_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if mode change turns ac off despite minimum cycle."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -917,7 +965,9 @@ async def test_mode_change_ac_trigger_off_not_long_enough_2(hass, setup_comp_5):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
+async def test_mode_change_ac_trigger_on_not_long_enough_2(
+    hass: HomeAssistant, setup_comp_5
+) -> None:
     """Test if mode change turns ac on despite minimum cycle."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -955,7 +1005,9 @@ async def setup_comp_6(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_heater_trigger_off_not_long_enough(hass, setup_comp_6):
+async def test_temp_change_heater_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if temp change doesn't turn heater off because of time."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 25)
@@ -964,7 +1016,9 @@ async def test_temp_change_heater_trigger_off_not_long_enough(hass, setup_comp_6
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_trigger_on_not_long_enough(hass, setup_comp_6):
+async def test_temp_change_heater_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if temp change doesn't turn heater on because of time."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -973,7 +1027,9 @@ async def test_temp_change_heater_trigger_on_not_long_enough(hass, setup_comp_6)
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_trigger_on_long_enough(hass, setup_comp_6):
+async def test_temp_change_heater_trigger_on_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if temperature change turn heater on after min cycle."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -990,7 +1046,9 @@ async def test_temp_change_heater_trigger_on_long_enough(hass, setup_comp_6):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_trigger_off_long_enough(hass, setup_comp_6):
+async def test_temp_change_heater_trigger_off_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if temperature change turn heater off after min cycle."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=dt_util.UTC)
     with patch(
@@ -1007,7 +1065,9 @@ async def test_temp_change_heater_trigger_off_long_enough(hass, setup_comp_6):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_heater_trigger_off_not_long_enough(hass, setup_comp_6):
+async def test_mode_change_heater_trigger_off_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if mode change turns heater off despite minimum cycle."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 25)
@@ -1022,7 +1082,9 @@ async def test_mode_change_heater_trigger_off_not_long_enough(hass, setup_comp_6
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_heater_trigger_on_not_long_enough(hass, setup_comp_6):
+async def test_mode_change_heater_trigger_on_not_long_enough(
+    hass: HomeAssistant, setup_comp_6
+) -> None:
     """Test if mode change turns heater on despite minimum cycle."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -1064,7 +1126,9 @@ async def setup_comp_7(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_ac_trigger_on_long_enough_3(hass, setup_comp_7):
+async def test_temp_change_ac_trigger_on_long_enough_3(
+    hass: HomeAssistant, setup_comp_7
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, True)
     await hass.async_block_till_done()
@@ -1087,7 +1151,9 @@ async def test_temp_change_ac_trigger_on_long_enough_3(hass, setup_comp_7):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_trigger_off_long_enough_3(hass, setup_comp_7):
+async def test_temp_change_ac_trigger_off_long_enough_3(
+    hass: HomeAssistant, setup_comp_7
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, False)
     await hass.async_block_till_done()
@@ -1135,7 +1201,9 @@ async def setup_comp_8(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_heater_trigger_on_long_enough_2(hass, setup_comp_8):
+async def test_temp_change_heater_trigger_on_long_enough_2(
+    hass: HomeAssistant, setup_comp_8
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, True)
     await hass.async_block_till_done()
@@ -1158,7 +1226,9 @@ async def test_temp_change_heater_trigger_on_long_enough_2(hass, setup_comp_8):
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_trigger_off_long_enough_2(hass, setup_comp_8):
+async def test_temp_change_heater_trigger_off_long_enough_2(
+    hass: HomeAssistant, setup_comp_8
+) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, False)
     await hass.async_block_till_done()
@@ -1205,7 +1275,7 @@ async def setup_comp_9(hass):
     await hass.async_block_till_done()
 
 
-async def test_precision(hass, setup_comp_9):
+async def test_precision(hass: HomeAssistant, setup_comp_9) -> None:
     """Test that setting precision to tenths works as intended."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     await common.async_set_temperature(hass, 23.27)
@@ -1243,7 +1313,7 @@ async def test_custom_setup_params(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("hvac_mode", [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL])
-async def test_restore_state(hass, hvac_mode):
+async def test_restore_state(hass: HomeAssistant, hvac_mode) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass,

--- a/tests/components/geo_location/test_trigger.py
+++ b/tests/components/geo_location/test_trigger.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, mock_component
@@ -43,7 +43,7 @@ def setup_comp(hass):
     )
 
 
-async def test_if_fires_on_zone_enter(hass, calls):
+async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone enter."""
     context = Context()
     hass.states.async_set(
@@ -124,7 +124,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_enter_on_zone_leave(hass, calls):
+async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) -> None:
     """Test for not firing on zone leave."""
     hass.states.async_set(
         "geo_location.entity",
@@ -159,7 +159,7 @@ async def test_if_not_fires_for_enter_on_zone_leave(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_leave(hass, calls):
+async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone leave."""
     hass.states.async_set(
         "geo_location.entity",
@@ -194,7 +194,7 @@ async def test_if_fires_on_zone_leave(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_zone_leave_2(hass, calls):
+async def test_if_fires_on_zone_leave_2(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone leave for unavailable entity."""
     hass.states.async_set(
         "geo_location.entity",
@@ -229,7 +229,7 @@ async def test_if_fires_on_zone_leave_2(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_for_leave_on_zone_enter(hass, calls):
+async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) -> None:
     """Test for not firing on zone enter."""
     hass.states.async_set(
         "geo_location.entity",
@@ -264,7 +264,7 @@ async def test_if_not_fires_for_leave_on_zone_enter(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_appear(hass, calls):
+async def test_if_fires_on_zone_appear(hass: HomeAssistant, calls) -> None:
     """Test for firing if entity appears in zone."""
     assert await async_setup_component(
         hass,
@@ -313,7 +313,7 @@ async def test_if_fires_on_zone_appear(hass, calls):
     )
 
 
-async def test_if_fires_on_zone_appear_2(hass, calls):
+async def test_if_fires_on_zone_appear_2(hass: HomeAssistant, calls) -> None:
     """Test for firing if entity appears in zone."""
     assert await async_setup_component(
         hass,
@@ -371,7 +371,7 @@ async def test_if_fires_on_zone_appear_2(hass, calls):
     )
 
 
-async def test_if_fires_on_zone_disappear(hass, calls):
+async def test_if_fires_on_zone_disappear(hass: HomeAssistant, calls) -> None:
     """Test for firing if entity disappears from zone."""
     hass.states.async_set(
         "geo_location.entity",
@@ -420,7 +420,9 @@ async def test_if_fires_on_zone_disappear(hass, calls):
     )
 
 
-async def test_zone_undefined(hass, calls, caplog):
+async def test_zone_undefined(
+    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for undefined zone."""
     hass.states.async_set(
         "geo_location.entity",

--- a/tests/components/geo_rss_events/test_sensor.py
+++ b/tests/components/geo_rss_events/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     EVENT_HOMEASSISTANT_START,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -55,7 +56,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass, mock_feed):
+async def test_setup(hass: HomeAssistant, mock_feed) -> None:
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -119,7 +120,7 @@ async def test_setup(hass, mock_feed):
         }
 
 
-async def test_setup_with_categories(hass, mock_feed):
+async def test_setup_with_categories(hass: HomeAssistant, mock_feed) -> None:
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
@@ -164,7 +165,7 @@ async def webhook_id(hass, geofency_client):
     return result["result"].data["webhook_id"]
 
 
-async def test_data_validation(geofency_client, webhook_id):
+async def test_data_validation(geofency_client, webhook_id) -> None:
     """Test data validation."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -182,7 +183,9 @@ async def test_data_validation(geofency_client, webhook_id):
         assert req.status == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
-async def test_gps_enter_and_exit_home(hass, geofency_client, webhook_id):
+async def test_gps_enter_and_exit_home(
+    hass: HomeAssistant, geofency_client, webhook_id
+) -> None:
     """Test GPS based zone enter and exit."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -227,7 +230,9 @@ async def test_gps_enter_and_exit_home(hass, geofency_client, webhook_id):
     assert len(ent_reg.entities) == 1
 
 
-async def test_beacon_enter_and_exit_home(hass, geofency_client, webhook_id):
+async def test_beacon_enter_and_exit_home(
+    hass: HomeAssistant, geofency_client, webhook_id
+) -> None:
     """Test iBeacon based zone enter and exit - a.k.a stationary iBeacon."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -248,7 +253,9 @@ async def test_beacon_enter_and_exit_home(hass, geofency_client, webhook_id):
     assert state_name == STATE_NOT_HOME
 
 
-async def test_beacon_enter_and_exit_car(hass, geofency_client, webhook_id):
+async def test_beacon_enter_and_exit_car(
+    hass: HomeAssistant, geofency_client, webhook_id
+) -> None:
     """Test use of mobile iBeacon."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -288,7 +295,9 @@ async def test_beacon_enter_and_exit_car(hass, geofency_client, webhook_id):
     assert state_name == STATE_HOME
 
 
-async def test_load_unload_entry(hass, geofency_client, webhook_id):
+async def test_load_unload_entry(
+    hass: HomeAssistant, geofency_client, webhook_id
+) -> None:
     """Test that the appropriate dispatch signals are added and removed."""
     url = f"/api/webhook/{webhook_id}"
 

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 
-async def test_duplicate_error(hass, config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_LATITUDE: -41.2, CONF_LONGITUDE: 174.7, CONF_RADIUS: 25}
     config_entry.add_to_hass(hass)

--- a/tests/components/geonetnz_quakes/test_init.py
+++ b/tests/components/geonetnz_quakes/test_init.py
@@ -2,9 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.geonetnz_quakes import DOMAIN, FEED
+from homeassistant.core import HomeAssistant
 
 
-async def test_component_unload_config_entry(hass, config_entry):
+async def test_component_unload_config_entry(hass: HomeAssistant, config_entry) -> None:
     """Test that loading and unloading of a config entry works."""
     config_entry.add_to_hass(hass)
     with patch(

--- a/tests/components/geonetnz_volcano/test_config_flow.py
+++ b/tests/components/geonetnz_volcano/test_config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 
-async def test_duplicate_error(hass, config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     conf = {CONF_LATITUDE: -41.2, CONF_LONGITUDE: 174.7, CONF_RADIUS: 25}
 

--- a/tests/components/geonetnz_volcano/test_init.py
+++ b/tests/components/geonetnz_volcano/test_init.py
@@ -2,9 +2,10 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.geonetnz_volcano import DOMAIN, FEED
+from homeassistant.core import HomeAssistant
 
 
-async def test_component_unload_config_entry(hass, config_entry):
+async def test_component_unload_config_entry(hass: HomeAssistant, config_entry) -> None:
     """Test that loading and unloading of a config entry works."""
     config_entry.add_to_hass(hass)
     with patch(

--- a/tests/components/goalzero/test_binary_sensor.py
+++ b/tests/components/goalzero/test_binary_sensor.py
@@ -9,7 +9,9 @@ from . import async_init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_binary_sensors(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_binary_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)
 

--- a/tests/components/goalzero/test_config_flow.py
+++ b/tests/components/goalzero/test_config_flow.py
@@ -22,7 +22,7 @@ def _patch_setup():
     return patch("homeassistant.components.goalzero.async_setup_entry")
 
 
-async def test_flow_user(hass: HomeAssistant):
+async def test_flow_user(hass: HomeAssistant) -> None:
     """Test user initialized flow."""
     mocked_yeti = await create_mocked_yeti()
     with patch_config_flow_yeti(mocked_yeti), _patch_setup():
@@ -40,7 +40,7 @@ async def test_flow_user(hass: HomeAssistant):
         assert result["result"].unique_id == MAC
 
 
-async def test_flow_user_already_configured(hass: HomeAssistant):
+async def test_flow_user_already_configured(hass: HomeAssistant) -> None:
     """Test user initialized flow with duplicate server."""
     create_entry(hass)
     result = await hass.config_entries.flow.async_init(
@@ -51,7 +51,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_flow_user_cannot_connect(hass: HomeAssistant):
+async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
     """Test user initialized flow with unreachable server."""
     with patch_config_flow_yeti(await create_mocked_yeti()) as yetimock:
         yetimock.side_effect = exceptions.ConnectError
@@ -63,7 +63,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant):
         assert result["errors"]["base"] == "cannot_connect"
 
 
-async def test_flow_user_invalid_host(hass: HomeAssistant):
+async def test_flow_user_invalid_host(hass: HomeAssistant) -> None:
     """Test user initialized flow with invalid server."""
     with patch_config_flow_yeti(await create_mocked_yeti()) as yetimock:
         yetimock.side_effect = exceptions.InvalidHost
@@ -75,7 +75,7 @@ async def test_flow_user_invalid_host(hass: HomeAssistant):
         assert result["errors"]["base"] == "invalid_host"
 
 
-async def test_flow_user_unknown_error(hass: HomeAssistant):
+async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
     """Test user initialized flow with unreachable server."""
     with patch_config_flow_yeti(await create_mocked_yeti()) as yetimock:
         yetimock.side_effect = Exception
@@ -87,7 +87,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant):
         assert result["errors"]["base"] == "unknown"
 
 
-async def test_dhcp_discovery(hass: HomeAssistant):
+async def test_dhcp_discovery(hass: HomeAssistant) -> None:
     """Test we can process the discovery from dhcp."""
 
     mocked_yeti = await create_mocked_yeti()
@@ -118,7 +118,7 @@ async def test_dhcp_discovery(hass: HomeAssistant):
         assert result["reason"] == "already_configured"
 
 
-async def test_dhcp_discovery_failed(hass: HomeAssistant):
+async def test_dhcp_discovery_failed(hass: HomeAssistant) -> None:
     """Test failed setup from dhcp."""
     mocked_yeti = await create_mocked_yeti()
     with patch_config_flow_yeti(mocked_yeti) as yetimock:

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -17,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_setup_config_and_unload(hass: HomeAssistant):
+async def test_setup_config_and_unload(hass: HomeAssistant) -> None:
     """Test Goal Zero setup and unload."""
     entry = create_entry(hass)
     mocked_yeti = await create_mocked_yeti()
@@ -35,7 +35,7 @@ async def test_setup_config_and_unload(hass: HomeAssistant):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_not_ready(hass: HomeAssistant):
+async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = create_entry(hass)
     with patch(
@@ -65,7 +65,9 @@ async def test_update_failed(
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_device_info(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_device_info(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test device info."""
     entry = await async_init_integration(hass, aioclient_mock)
     device_registry = dr.async_get(hass)

--- a/tests/components/goalzero/test_sensor.py
+++ b/tests/components/goalzero/test_sensor.py
@@ -30,7 +30,7 @@ async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     entity_registry_enabled_by_default: AsyncMock,
-):
+) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)
 

--- a/tests/components/goalzero/test_switch.py
+++ b/tests/components/goalzero/test_switch.py
@@ -18,7 +18,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 async def test_switches_states(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)
 

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -200,7 +200,7 @@ async def test_form_homekit_ip_address(hass: HomeAssistant) -> None:
 @patch("homeassistant.components.gogogate2.async_setup_entry", return_value=True)
 @patch("homeassistant.components.gogogate2.common.ISmartGateApi")
 async def test_discovered_dhcp(
-    ismartgateapi_mock, async_setup_entry_mock, hass
+    ismartgateapi_mock, async_setup_entry_mock, hass: HomeAssistant
 ) -> None:
     """Test we get the form with homekit and abort for dhcp source when we get both."""
     api: ISmartGateApi = MagicMock(spec=ISmartGateApi)

--- a/tests/components/goodwe/test_config_flow.py
+++ b/tests/components/goodwe/test_config_flow.py
@@ -26,7 +26,7 @@ def mock_inverter():
     return goodwe_inverter
 
 
-async def test_manual_setup(hass: HomeAssistant):
+async def test_manual_setup(hass: HomeAssistant) -> None:
     """Test manually setting up."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -55,7 +55,7 @@ async def test_manual_setup(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_manual_setup_already_exists(hass: HomeAssistant):
+async def test_manual_setup_already_exists(hass: HomeAssistant) -> None:
     """Test manually setting up and the device already exists."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: TEST_HOST}, unique_id=TEST_SERIAL
@@ -81,7 +81,7 @@ async def test_manual_setup_already_exists(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_manual_setup_device_offline(hass: HomeAssistant):
+async def test_manual_setup_device_offline(hass: HomeAssistant) -> None:
     """Test manually setting up, device offline."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -68,7 +68,7 @@ def test_calendar_access_role() -> str:
 
 
 @pytest.fixture
-def test_api_calendar(calendar_access_role: str):
+def test_api_calendar(calendar_access_role: str) -> None:
     """Return a test calendar object used in API responses."""
     return {
         **TEST_API_CALENDAR,

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1,5 +1,4 @@
 """The tests for the google calendar platform."""
-
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
@@ -33,6 +32,7 @@ from .conftest import (
 
 from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 TEST_ENTITY = TEST_API_ENTITY
 TEST_ENTITY_NAME = TEST_API_ENTITY_NAME
@@ -145,7 +145,9 @@ async def ws_client(
     return create_client
 
 
-async def test_all_day_event(hass, mock_events_list_items, component_setup):
+async def test_all_day_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test for an all day calendar event."""
     week_from_today = dt_util.now().date() + datetime.timedelta(days=7)
     end_event = week_from_today + datetime.timedelta(days=1)
@@ -174,7 +176,9 @@ async def test_all_day_event(hass, mock_events_list_items, component_setup):
     }
 
 
-async def test_future_event(hass, mock_events_list_items, component_setup):
+async def test_future_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test for an upcoming event."""
     one_hour_from_now = dt_util.now() + datetime.timedelta(minutes=30)
     end_event = one_hour_from_now + datetime.timedelta(minutes=60)
@@ -203,7 +207,9 @@ async def test_future_event(hass, mock_events_list_items, component_setup):
     }
 
 
-async def test_in_progress_event(hass, mock_events_list_items, component_setup):
+async def test_in_progress_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an event that is active now."""
     middle_of_event = dt_util.now() - datetime.timedelta(minutes=30)
     end_event = middle_of_event + datetime.timedelta(minutes=60)
@@ -232,7 +238,9 @@ async def test_in_progress_event(hass, mock_events_list_items, component_setup):
     }
 
 
-async def test_offset_in_progress_event(hass, mock_events_list_items, component_setup):
+async def test_offset_in_progress_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an event that is active now with an offset."""
     middle_of_event = dt_util.now() + datetime.timedelta(minutes=14)
     end_event = middle_of_event + datetime.timedelta(minutes=60)
@@ -264,8 +272,8 @@ async def test_offset_in_progress_event(hass, mock_events_list_items, component_
 
 
 async def test_all_day_offset_in_progress_event(
-    hass, mock_events_list_items, component_setup
-):
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an all day event that is currently in progress due to an offset."""
     tomorrow = dt_util.now().date() + datetime.timedelta(days=1)
     end_event = tomorrow + datetime.timedelta(days=1)
@@ -296,7 +304,9 @@ async def test_all_day_offset_in_progress_event(
     }
 
 
-async def test_all_day_offset_event(hass, mock_events_list_items, component_setup):
+async def test_all_day_offset_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an all day event that not in progress due to an offset."""
     now = dt_util.now()
     day_after_tomorrow = now.date() + datetime.timedelta(days=2)
@@ -329,7 +339,9 @@ async def test_all_day_offset_event(hass, mock_events_list_items, component_setu
     }
 
 
-async def test_missing_summary(hass, mock_events_list_items, component_setup):
+async def test_missing_summary(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test that a summary is optional."""
     start_event = dt_util.now() + datetime.timedelta(minutes=14)
     end_event = start_event + datetime.timedelta(minutes=60)
@@ -360,11 +372,11 @@ async def test_missing_summary(hass, mock_events_list_items, component_setup):
 
 
 async def test_update_error(
-    hass,
+    hass: HomeAssistant,
     component_setup,
     mock_events_list,
-    aioclient_mock,
-):
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test that the calendar update handles a server error."""
 
     now = dt_util.now()
@@ -435,8 +447,11 @@ async def test_update_error(
 
 
 async def test_calendars_api(
-    hass, hass_client, component_setup, mock_events_list_items
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    component_setup,
+    mock_events_list_items,
+) -> None:
     """Test the Rest API returns the calendar."""
     mock_events_list_items([])
     assert await component_setup()
@@ -454,13 +469,13 @@ async def test_calendars_api(
 
 
 async def test_http_event_api_failure(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     component_setup,
     mock_calendars_list,
     mock_events_list,
-    aioclient_mock,
-):
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test the Rest API response during a calendar failure."""
     mock_events_list({}, exc=ClientError())
 
@@ -478,8 +493,11 @@ async def test_http_event_api_failure(
 
 @pytest.mark.freeze_time("2022-03-27 12:05:00+00:00")
 async def test_http_api_event(
-    hass, hass_client, mock_events_list_items, component_setup
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_events_list_items,
+    component_setup,
+) -> None:
     """Test querying the API and fetching events from the server."""
     hass.config.set_time_zone("Asia/Baghdad")
     event = {
@@ -503,8 +521,11 @@ async def test_http_api_event(
 
 @pytest.mark.freeze_time("2022-03-27 12:05:00+00:00")
 async def test_http_api_all_day_event(
-    hass, hass_client, mock_events_list_items, component_setup
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_events_list_items,
+    component_setup,
+) -> None:
     """Test querying the API and fetching events from the server."""
     event = {
         **TEST_EVENT,
@@ -541,14 +562,14 @@ async def test_http_api_all_day_event(
     ],
 )
 async def test_opaque_event(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     mock_calendars_yaml,
     mock_events_list_items,
     component_setup,
     transparency,
     expect_visible_event,
-):
+) -> None:
     """Test querying the API and fetching events from the server."""
     event = {
         **TEST_EVENT,
@@ -572,11 +593,11 @@ async def test_opaque_event(
 
 @pytest.mark.parametrize("mock_test_setup", [None])
 async def test_scan_calendar_error(
-    hass,
+    hass: HomeAssistant,
     component_setup,
     mock_calendars_list,
     config_entry,
-):
+) -> None:
     """Test that the calendar update handles a server error."""
     config_entry.add_to_hass(hass)
     mock_calendars_list({}, exc=ClientError())
@@ -586,8 +607,8 @@ async def test_scan_calendar_error(
 
 
 async def test_future_event_update_behavior(
-    hass, mock_events_list_items, component_setup
-):
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
     now_utc = dt_util.utcnow()
@@ -621,8 +642,8 @@ async def test_future_event_update_behavior(
 
 
 async def test_future_event_offset_update_behavior(
-    hass, mock_events_list_items, component_setup
-):
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test an future event that becomes active."""
     now = dt_util.now()
     now_utc = dt_util.utcnow()
@@ -660,11 +681,11 @@ async def test_future_event_offset_update_behavior(
 
 
 async def test_unique_id(
-    hass,
+    hass: HomeAssistant,
     mock_events_list_items,
     component_setup,
     config_entry,
-):
+) -> None:
     """Test entity is created with a unique id based on the config entry."""
     mock_events_list_items([])
     assert await component_setup()
@@ -682,12 +703,12 @@ async def test_unique_id(
     "old_unique_id", [CALENDAR_ID, f"{CALENDAR_ID}-we_are_we_are_a_test_calendar"]
 )
 async def test_unique_id_migration(
-    hass,
+    hass: HomeAssistant,
     mock_events_list_items,
     component_setup,
     config_entry,
     old_unique_id,
-):
+) -> None:
     """Test that old unique id format is migrated to the new format that supports multiple accounts."""
     entity_registry = er.async_get(hass)
 
@@ -737,12 +758,12 @@ async def test_unique_id_migration(
     ],
 )
 async def test_invalid_unique_id_cleanup(
-    hass,
+    hass: HomeAssistant,
     mock_events_list_items,
     component_setup,
     config_entry,
     mock_calendars_yaml,
-):
+) -> None:
     """Test that old unique id format that is not actually unique is removed."""
     entity_registry = er.async_get(hass)
 
@@ -789,13 +810,13 @@ async def test_invalid_unique_id_cleanup(
     ],
 )
 async def test_all_day_iter_order(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     mock_events_list_items,
     component_setup,
     time_zone,
     event_order,
-):
+) -> None:
     """Test the sort order of an all day events depending on the time zone."""
     hass.config.set_time_zone(time_zone)
     mock_events_list_items(
@@ -921,12 +942,12 @@ async def test_websocket_create_all_day(
 
 async def test_websocket_delete(
     ws_client: ClientFixture,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     component_setup,
     mock_events_list: ApiResult,
     mock_events_list_items: ApiResult,
-    aioclient_mock,
-):
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test websocket delete command."""
     mock_events_list_items(
         [
@@ -964,12 +985,12 @@ async def test_websocket_delete(
 
 async def test_websocket_delete_recurring_event_instance(
     ws_client: ClientFixture,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     component_setup,
     mock_events_list: ApiResult,
     mock_events_list_items: ApiResult,
-    aioclient_mock,
-):
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test websocket delete command with recurring events."""
     mock_events_list_items(
         [
@@ -1159,7 +1180,9 @@ async def test_readonly_search_calendar(
 
 
 @pytest.mark.parametrize("calendar_access_role", ["reader", "freeBusyReader"])
-async def test_all_day_reader_access(hass, mock_events_list_items, component_setup):
+async def test_all_day_reader_access(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test that reader / freebusy reader access can load properly."""
     week_from_today = dt_util.now().date() + datetime.timedelta(days=7)
     end_event = week_from_today + datetime.timedelta(days=1)
@@ -1188,7 +1211,9 @@ async def test_all_day_reader_access(hass, mock_events_list_items, component_set
 
 
 @pytest.mark.parametrize("calendar_access_role", ["reader", "freeBusyReader"])
-async def test_reader_in_progress_event(hass, mock_events_list_items, component_setup):
+async def test_reader_in_progress_event(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
     """Test reader access for an event in process."""
     middle_of_event = dt_util.now() - datetime.timedelta(minutes=30)
     end_event = middle_of_event + datetime.timedelta(minutes=60)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
