### PR TITLE
Add type hints to integration tests (part 8)

### DIFF
--- a/tests/components/google_assistant/test_button.py
+++ b/tests/components/google_assistant/test_button.py
@@ -1,5 +1,4 @@
 """Test buttons."""
-
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +13,7 @@ from .test_http import DUMMY_CONFIG
 from tests.common import MockUser
 
 
-async def test_sync_button(hass: HomeAssistant, hass_owner_user: MockUser):
+async def test_sync_button(hass: HomeAssistant, hass_owner_user: MockUser) -> None:
     """Test sync button."""
 
     await async_setup_component(

--- a/tests/components/google_assistant/test_diagnostics.py
+++ b/tests/components/google_assistant/test_diagnostics.py
@@ -1,8 +1,9 @@
 """Test diagnostics."""
 from unittest.mock import ANY
 
-from homeassistant import core, setup
+from homeassistant import setup
 from homeassistant.components import google_assistant as ga, switch
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_http import DUMMY_CONFIG
@@ -12,8 +13,8 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_diagnostics(
-    hass: core.HomeAssistant, hass_client: ClientSessionGenerator
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test diagnostics v1."""
 
     await setup.async_setup_component(

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -127,8 +127,8 @@ def hass_fixture(event_loop, hass):
 
 
 async def test_sync_request(
-    hass_fixture, assistant_client, auth_header, entity_registry
-):
+    hass_fixture, assistant_client, auth_header, entity_registry: er.EntityRegistry
+) -> None:
     """Test a sync request."""
     entity_entry1 = entity_registry.async_get_or_create(
         "switch",
@@ -192,7 +192,7 @@ async def test_sync_request(
         assert dev["type"] == demo["type"]
 
 
-async def test_query_request(hass_fixture, assistant_client, auth_header):
+async def test_query_request(hass_fixture, assistant_client, auth_header) -> None:
     """Test a query request."""
     reqid = "5711642932632160984"
     data = {
@@ -233,7 +233,9 @@ async def test_query_request(hass_fixture, assistant_client, auth_header):
     assert devices["media_player.lounge_room"]["on"] is True
 
 
-async def test_query_climate_request(hass_fixture, assistant_client, auth_header):
+async def test_query_climate_request(
+    hass_fixture, assistant_client, auth_header
+) -> None:
     """Test a query request."""
     reqid = "5711642932632160984"
     data = {
@@ -285,7 +287,9 @@ async def test_query_climate_request(hass_fixture, assistant_client, auth_header
     }
 
 
-async def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
+async def test_query_climate_request_f(
+    hass_fixture, assistant_client, auth_header
+) -> None:
     """Test a query request."""
     # Mock demo devices as fahrenheit to see if we convert to celsius
     hass_fixture.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
@@ -345,7 +349,9 @@ async def test_query_climate_request_f(hass_fixture, assistant_client, auth_head
     hass_fixture.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
-async def test_query_humidifier_request(hass_fixture, assistant_client, auth_header):
+async def test_query_humidifier_request(
+    hass_fixture, assistant_client, auth_header
+) -> None:
     """Test a query request."""
     reqid = "5711642932632160984"
     data = {
@@ -391,7 +397,7 @@ async def test_query_humidifier_request(hass_fixture, assistant_client, auth_hea
     }
 
 
-async def test_execute_request(hass_fixture, assistant_client, auth_header):
+async def test_execute_request(hass_fixture, assistant_client, auth_header) -> None:
     """Test an execute request."""
     reqid = "5711642932632160985"
     data = {

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -219,7 +219,7 @@ async def test_config_local_sdk_if_ssl_enabled(
     assert await resp.read() == b""
 
 
-async def test_agent_user_id_storage(hass, hass_storage):
+async def test_agent_user_id_storage(hass: HomeAssistant, hass_storage) -> None:
     """Test a disconnect message."""
 
     hass_storage["google_assistant"] = {
@@ -302,7 +302,7 @@ async def test_agent_user_id_connect() -> None:
 
 
 @pytest.mark.parametrize("agents", [{}, {"1"}, {"1", "2"}])
-async def test_report_state_all(agents):
+async def test_report_state_all(agents) -> None:
     """Test a disconnect message."""
     config = MockConfig(agent_user_ids=agents)
     data = {}
@@ -315,7 +315,7 @@ async def test_report_state_all(agents):
     "agents, result",
     [({}, 204), ({"1": 200}, 200), ({"1": 200, "2": 300}, 300)],
 )
-async def test_sync_entities_all(agents, result):
+async def test_sync_entities_all(agents, result) -> None:
     """Test sync entities ."""
     config = MockConfig(agent_user_ids=set(agents.keys()))
     with patch.object(
@@ -328,7 +328,7 @@ async def test_sync_entities_all(agents, result):
         assert res == result
 
 
-def test_supported_features_string(caplog):
+def test_supported_features_string(caplog: pytest.LogCaptureFixture) -> None:
     """Test bad supported features."""
     entity = helpers.GoogleEntity(
         None,
@@ -353,7 +353,11 @@ def test_request_data() -> None:
     assert data.is_local_request is False
 
 
-async def test_config_local_sdk_allow_min_version(hass, hass_client, caplog):
+async def test_config_local_sdk_allow_min_version(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the local SDK."""
     version = str(helpers.LOCAL_SDK_MIN_VERSION)
     assert await async_setup_component(hass, "webhook", {})
@@ -393,7 +397,12 @@ async def test_config_local_sdk_allow_min_version(hass, hass_client, caplog):
 
 
 @pytest.mark.parametrize("version", (None, "2.1.4"))
-async def test_config_local_sdk_warn_version(hass, hass_client, caplog, version):
+async def test_config_local_sdk_warn_version(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    version,
+) -> None:
     """Test the local SDK."""
     assert await async_setup_component(hass, "webhook", {})
 

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from unittest.mock import ANY, patch
 
+import pytest
+
 from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
 from homeassistant.components.google_assistant.const import (
     DOMAIN,
@@ -23,6 +25,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, async_mock_service
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 DUMMY_CONFIG = GOOGLE_ASSISTANT_SCHEMA(
     {
@@ -109,7 +112,12 @@ async def test_update_access_token(hass: HomeAssistant) -> None:
         mock_get_token.assert_called_once()
 
 
-async def test_call_homegraph_api(hass, aioclient_mock, hass_storage, caplog):
+async def test_call_homegraph_api(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the function to call the homegraph api."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
     await config.async_initialize()
@@ -132,7 +140,9 @@ async def test_call_homegraph_api(hass, aioclient_mock, hass_storage, caplog):
         assert call[3] == MOCK_HEADER
 
 
-async def test_call_homegraph_api_retry(hass, aioclient_mock, hass_storage):
+async def test_call_homegraph_api_retry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test the that the calls get retried with new token on 401."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
     await config.async_initialize()
@@ -157,7 +167,9 @@ async def test_call_homegraph_api_retry(hass, aioclient_mock, hass_storage):
         assert call[3] == MOCK_HEADER
 
 
-async def test_report_state(hass, aioclient_mock, hass_storage):
+async def test_report_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test the report state function."""
     agent_user_id = "user"
     config = GoogleConfig(hass, DUMMY_CONFIG)
@@ -178,7 +190,9 @@ async def test_report_state(hass, aioclient_mock, hass_storage):
         )
 
 
-async def test_google_config_local_fulfillment(hass, aioclient_mock, hass_storage):
+async def test_google_config_local_fulfillment(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test the google config for local fulfillment."""
     agent_user_id = "user"
     local_webhook_id = "webhook"
@@ -270,7 +284,12 @@ async def test_missing_service_account(hass: HomeAssistant) -> None:
     assert config._access_token_renew is renew
 
 
-async def test_async_enable_local_sdk(hass, hass_client, hass_storage, caplog):
+async def test_async_enable_local_sdk(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_storage,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the google config enable and disable local sdk."""
     command_events = async_capture_events(hass, EVENT_COMMAND_RECEIVED)
     turn_on_calls = async_mock_service(hass, "light", "turn_on")

--- a/tests/components/google_assistant/test_init.py
+++ b/tests/components/google_assistant/test_init.py
@@ -8,9 +8,10 @@ from homeassistant.setup import async_setup_component
 from .test_http import DUMMY_CONFIG
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_import(hass: HomeAssistant):
+async def test_import(hass: HomeAssistant) -> None:
     """Test import."""
 
     await async_setup_component(
@@ -24,7 +25,7 @@ async def test_import(hass: HomeAssistant):
     assert entries[0].data[ga.const.CONF_PROJECT_ID] == "1234"
 
 
-async def test_import_changed(hass: HomeAssistant):
+async def test_import_changed(hass: HomeAssistant) -> None:
     """Test import with changed project id."""
 
     old_entry = MockConfigEntry(
@@ -44,7 +45,9 @@ async def test_import_changed(hass: HomeAssistant):
     assert entries[0].data[ga.const.CONF_PROJECT_ID] == "1234"
 
 
-async def test_request_sync_service(aioclient_mock, hass):
+async def test_request_sync_service(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test that it posts to the request_sync url."""
     aioclient_mock.post(
         ga.const.HOMEGRAPH_TOKEN_URL,

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -102,7 +102,7 @@ async def test_async_handle_message(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_sync_message(hass, registries):
+async def test_sync_message(hass: HomeAssistant, registries) -> None:
     """Test a sync message."""
     entity = registries.entity.async_get_or_create(
         "light",
@@ -229,7 +229,7 @@ async def test_sync_message(hass, registries):
 
 
 @pytest.mark.parametrize("area_on_device", [True, False])
-async def test_sync_in_area(area_on_device, hass, registries):
+async def test_sync_in_area(area_on_device, hass: HomeAssistant, registries) -> None:
     """Test a sync message where room hint comes from area."""
     area = registries.area.async_create("Living Room")
 
@@ -443,7 +443,9 @@ async def test_query_message(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "report_state,on,brightness,value", [(False, True, 20, 0.2), (True, ANY, ANY, ANY)]
 )
-async def test_execute(hass, report_state, on, brightness, value):
+async def test_execute(
+    hass: HomeAssistant, report_state, on, brightness, value
+) -> None:
     """Test an execute command."""
     await async_setup_component(hass, "light", {"light": {"platform": "demo"}})
     await hass.async_block_till_done()
@@ -620,7 +622,9 @@ async def test_execute(hass, report_state, on, brightness, value):
 
 
 @pytest.mark.parametrize("report_state,on,brightness,value", [(False, False, ANY, ANY)])
-async def test_execute_times_out(hass, report_state, on, brightness, value):
+async def test_execute_times_out(
+    hass: HomeAssistant, report_state, on, brightness, value
+) -> None:
     """Test an execute command which times out."""
     orig_execute_limit = sh.EXECUTE_LIMIT
     sh.EXECUTE_LIMIT = 0.02  # Decrease timeout to 20ms
@@ -1001,7 +1005,9 @@ async def test_unavailable_state_does_sync(hass: HomeAssistant) -> None:
         ("outlet", "action.devices.types.OUTLET"),
     ],
 )
-async def test_device_class_switch(hass, device_class, google_type):
+async def test_device_class_switch(
+    hass: HomeAssistant, device_class, google_type
+) -> None:
     """Test that a cover entity syncs to the correct device type."""
     sensor = DemoSwitch(
         None,
@@ -1051,7 +1057,9 @@ async def test_device_class_switch(hass, device_class, google_type):
         ("window", "action.devices.types.WINDOW"),
     ],
 )
-async def test_device_class_binary_sensor(hass, device_class, google_type):
+async def test_device_class_binary_sensor(
+    hass: HomeAssistant, device_class, google_type
+) -> None:
     """Test that a binary entity syncs to the correct device type."""
     sensor = DemoBinarySensor(
         None, "Demo Sensor", state=False, device_class=device_class
@@ -1101,7 +1109,9 @@ async def test_device_class_binary_sensor(hass, device_class, google_type):
         ("curtain", "action.devices.types.CURTAIN"),
     ],
 )
-async def test_device_class_cover(hass, device_class, google_type):
+async def test_device_class_cover(
+    hass: HomeAssistant, device_class, google_type
+) -> None:
     """Test that a cover entity syncs to the correct device type."""
     sensor = DemoCover(None, hass, "Demo Sensor", device_class=device_class)
     sensor.hass = hass
@@ -1146,7 +1156,9 @@ async def test_device_class_cover(hass, device_class, google_type):
         ("receiver", "action.devices.types.AUDIO_VIDEO_RECEIVER"),
     ],
 )
-async def test_device_media_player(hass, device_class, google_type):
+async def test_device_media_player(
+    hass: HomeAssistant, device_class, google_type
+) -> None:
     """Test that a binary entity syncs to the correct device type."""
     sensor = AbstractDemoPlayer("Demo", device_class=device_class)
     sensor.hass = hass

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -82,7 +82,7 @@ PIN_DATA = helpers.RequestData(
 @pytest.mark.parametrize(
     "supported_color_modes", [["brightness"], ["hs"], ["color_temp"]]
 )
-async def test_brightness_light(hass, supported_color_modes):
+async def test_brightness_light(hass: HomeAssistant, supported_color_modes) -> None:
     """Test brightness trait support for light domain."""
     assert helpers.get_google_type(light.DOMAIN, None) is not None
     assert trait.BrightnessTrait.supported(
@@ -563,7 +563,9 @@ async def test_startstop_cover_assumed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("supported_color_modes", [["hs"], ["rgb"], ["xy"]])
-async def test_color_setting_color_light(hass, supported_color_modes):
+async def test_color_setting_color_light(
+    hass: HomeAssistant, supported_color_modes
+) -> None:
     """Test ColorSpectrum trait support for light domain."""
     assert helpers.get_google_type(light.DOMAIN, None) is not None
     assert not trait.ColorSettingTrait.supported(light.DOMAIN, 0, None, {})
@@ -774,7 +776,7 @@ async def test_light_modes(hass: HomeAssistant) -> None:
     "component",
     [button, input_button],
 )
-async def test_scene_button(hass, component):
+async def test_scene_button(hass: HomeAssistant, component) -> None:
     """Test Scene trait support for the (input) button domain."""
     assert helpers.get_google_type(component.DOMAIN, None) is not None
     assert trait.SceneTrait.supported(component.DOMAIN, 0, None, None)
@@ -1763,7 +1765,9 @@ async def test_fan_speed_ordered(
         (None, fan.DIRECTION_FORWARD),
     ],
 )
-async def test_fan_reverse(hass, direction_state, direction_call):
+async def test_fan_reverse(
+    hass: HomeAssistant, direction_state, direction_call
+) -> None:
     """Test FanSpeed trait speed control support for fan domain."""
 
     calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_DIRECTION)
@@ -1938,7 +1942,9 @@ async def test_inputselector(hass: HomeAssistant) -> None:
         (["a", "b", "c"], "a", "b", "c"),
     ],
 )
-async def test_inputselector_nextprev(hass, sources, source, source_next, source_prev):
+async def test_inputselector_nextprev(
+    hass: HomeAssistant, sources, source, source_next, source_prev
+) -> None:
     """Test input selector trait."""
     trt = trait.InputSelectorTrait(
         hass,
@@ -1986,7 +1992,9 @@ async def test_inputselector_nextprev(hass, sources, source, source_next, source
 @pytest.mark.parametrize(
     "sources,source", [(None, "a"), (["a", "b"], None), (["a", "b"], "c")]
 )
-async def test_inputselector_nextprev_invalid(hass, sources, source):
+async def test_inputselector_nextprev_invalid(
+    hass: HomeAssistant, sources, source
+) -> None:
     """Test input selector trait."""
     trt = trait.InputSelectorTrait(
         hass,
@@ -2606,7 +2614,7 @@ async def test_openclose_cover_no_position(hass: HomeAssistant) -> None:
         cover.CoverDeviceClass.GATE,
     ),
 )
-async def test_openclose_cover_secure(hass, device_class):
+async def test_openclose_cover_secure(hass: HomeAssistant, device_class) -> None:
     """Test OpenClose trait support for cover domain."""
     assert helpers.get_google_type(cover.DOMAIN, device_class) is not None
     assert trait.OpenCloseTrait.supported(
@@ -2674,7 +2682,7 @@ async def test_openclose_cover_secure(hass, device_class):
         binary_sensor.BinarySensorDeviceClass.WINDOW,
     ),
 )
-async def test_openclose_binary_sensor(hass, device_class):
+async def test_openclose_binary_sensor(hass: HomeAssistant, device_class) -> None:
     """Test OpenClose trait support for binary_sensor domain."""
     assert helpers.get_google_type(binary_sensor.DOMAIN, device_class) is not None
     assert trait.OpenCloseTrait.supported(binary_sensor.DOMAIN, 0, device_class, None)
@@ -2916,7 +2924,9 @@ async def test_temperature_control_sensor(hass: HomeAssistant) -> None:
         (UnitOfTemperature.FAHRENHEIT, "F", "unknown", None),
     ],
 )
-async def test_temperature_control_sensor_data(hass, unit_in, unit_out, state, ambient):
+async def test_temperature_control_sensor_data(
+    hass: HomeAssistant, unit_in, unit_out, state, ambient
+) -> None:
     """Test TemperatureControl trait support for temperature sensor."""
     hass.config.units.temperature_unit = unit_in
 
@@ -2963,7 +2973,9 @@ async def test_humidity_setting_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "state,ambient", [("70", 70), ("unavailable", None), ("unknown", None)]
 )
-async def test_humidity_setting_sensor_data(hass, state, ambient):
+async def test_humidity_setting_sensor_data(
+    hass: HomeAssistant, state, ambient
+) -> None:
     """Test HumiditySetting trait support for humidity sensor."""
     trt = trait.HumiditySettingTrait(
         hass,
@@ -3116,7 +3128,7 @@ async def test_transport_control(hass: HomeAssistant) -> None:
         STATE_UNKNOWN,
     ),
 )
-async def test_media_state(hass, state):
+async def test_media_state(hass: HomeAssistant, state) -> None:
     """Test the MediaStateTrait."""
     assert helpers.get_google_type(media_player.DOMAIN, None) is not None
 

--- a/tests/components/google_assistant_sdk/test_config_flow.py
+++ b/tests/components/google_assistant_sdk/test_config_flow.py
@@ -9,6 +9,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from .conftest import CLIENT_ID, ComponentSetup
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 GOOGLE_AUTH_URI = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token"
@@ -17,9 +19,9 @@ TITLE = "Google Assistant SDK"
 
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
 ) -> None:
     """Check full flow."""
@@ -78,9 +80,9 @@ async def test_full_flow(
 
 async def test_reauth(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
 ) -> None:
     """Test the reauthentication case updates the existing config entry."""
@@ -153,9 +155,9 @@ async def test_reauth(
 
 async def test_single_instance_allowed(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
 ) -> None:
     """Test case where config flow allows a single test."""

--- a/tests/components/google_assistant_sdk/test_init.py
+++ b/tests/components/google_assistant_sdk/test_init.py
@@ -17,6 +17,7 @@ from .conftest import ComponentSetup, ExpectedCredentials
 
 from tests.common import async_fire_time_changed, async_mock_service
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def fetch_api_url(hass_client, url):
@@ -232,7 +233,9 @@ async def test_send_text_command_expired_token_refresh_failure(
 
 
 async def test_send_text_command_media_player(
-    hass: HomeAssistant, setup_integration: ComponentSetup, hass_client
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test send_text_command with media_player."""
     await setup_integration()

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -13,12 +13,13 @@ from .conftest import CLIENT_ID, GOOGLE_AUTH_URI, GOOGLE_TOKEN_URI, SCOPES, TITL
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    current_request_with_host: None,
 ) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
@@ -166,8 +167,8 @@ async def test_reauth(
 
 async def test_already_configured(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    current_request_with_host: None,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test case where config flow discovers unique id was already configured."""

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -9,7 +9,7 @@ import pytest
 import homeassistant.components.google_pubsub as google_pubsub
 from homeassistant.components.google_pubsub import DateTimeJSONEncoder as victim
 from homeassistant.const import EVENT_STATE_CHANGED
-from homeassistant.core import split_entity_id
+from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.setup import async_setup_component
 
 GOOGLE_PUBSUB_PATH = "homeassistant.components.google_pubsub"
@@ -68,7 +68,7 @@ def mock_bus_and_json(hass, monkeypatch):
     )
 
 
-async def test_minimal_config(hass, mock_client):
+async def test_minimal_config(hass: HomeAssistant, mock_client) -> None:
     """Test the minimal config and defaults of component."""
     config = {
         google_pubsub.DOMAIN: {
@@ -88,7 +88,7 @@ async def test_minimal_config(hass, mock_client):
     )
 
 
-async def test_full_config(hass, mock_client):
+async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     """Test the full config of the component."""
     config = {
         google_pubsub.DOMAIN: {
@@ -143,7 +143,7 @@ async def _setup(hass, filter_config):
     return hass.bus.listen.call_args_list[0][0][1]
 
 
-async def test_allowlist(hass, mock_client):
+async def test_allowlist(hass: HomeAssistant, mock_client) -> None:
     """Test an allowlist only config."""
     handler_method = await _setup(
         hass,
@@ -173,7 +173,7 @@ async def test_allowlist(hass, mock_client):
         publish_client.publish.reset_mock()
 
 
-async def test_denylist(hass, mock_client):
+async def test_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist only config."""
     handler_method = await _setup(
         hass,
@@ -203,7 +203,7 @@ async def test_denylist(hass, mock_client):
         publish_client.publish.reset_mock()
 
 
-async def test_filtered_allowlist(hass, mock_client):
+async def test_filtered_allowlist(hass: HomeAssistant, mock_client) -> None:
     """Test an allowlist config with a filtering denylist."""
     handler_method = await _setup(
         hass,
@@ -234,7 +234,7 @@ async def test_filtered_allowlist(hass, mock_client):
         publish_client.publish.reset_mock()
 
 
-async def test_filtered_denylist(hass, mock_client):
+async def test_filtered_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist config with a filtering allowlist."""
     handler_method = await _setup(
         hass,

--- a/tests/components/google_sheets/test_config_flow.py
+++ b/tests/components/google_sheets/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Google Sheets config flow."""
-
 from collections.abc import Generator
 from unittest.mock import Mock, patch
 
@@ -17,6 +16,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -48,9 +49,9 @@ async def mock_client() -> Generator[Mock, None, None]:
 
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
     mock_client,
 ) -> None:
@@ -115,9 +116,9 @@ async def test_full_flow(
 
 async def test_create_sheet_error(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
     mock_client,
 ) -> None:
@@ -167,9 +168,9 @@ async def test_create_sheet_error(
 
 async def test_reauth(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
     mock_client,
 ) -> None:
@@ -248,9 +249,9 @@ async def test_reauth(
 
 async def test_reauth_abort(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
     mock_client,
 ) -> None:
@@ -317,9 +318,9 @@ async def test_reauth_abort(
 
 async def test_already_configured(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
     mock_client,
 ) -> None:

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -59,7 +60,7 @@ def mock_gtts():
         yield mock_gtts
 
 
-async def test_service_say(hass, mock_gtts, calls):
+async def test_service_say(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say."""
 
     await async_setup_component(
@@ -88,7 +89,7 @@ async def test_service_say(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_german_config(hass, mock_gtts, calls):
+async def test_service_say_german_config(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say with german code in the config."""
 
     await async_setup_component(
@@ -117,7 +118,9 @@ async def test_service_say_german_config(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_german_service(hass, mock_gtts, calls):
+async def test_service_say_german_service(
+    hass: HomeAssistant, mock_gtts, calls
+) -> None:
     """Test service call say with german code in the service."""
 
     config = {
@@ -147,7 +150,7 @@ async def test_service_say_german_service(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_en_uk_config(hass, mock_gtts, calls):
+async def test_service_say_en_uk_config(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say with en-uk code in the config."""
 
     await async_setup_component(
@@ -176,7 +179,7 @@ async def test_service_say_en_uk_config(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_en_uk_service(hass, mock_gtts, calls):
+async def test_service_say_en_uk_service(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say with en-uk code in the config."""
 
     await async_setup_component(
@@ -206,7 +209,7 @@ async def test_service_say_en_uk_service(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_en_couk(hass, mock_gtts, calls):
+async def test_service_say_en_couk(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say in co.uk tld accent."""
 
     await async_setup_component(
@@ -236,7 +239,7 @@ async def test_service_say_en_couk(hass, mock_gtts, calls):
     }
 
 
-async def test_service_say_error(hass, mock_gtts, calls):
+async def test_service_say_error(hass: HomeAssistant, mock_gtts, calls) -> None:
     """Test service call say with http response 400."""
     mock_gtts.return_value.write_to_fp.side_effect = gTTSError
     await async_setup_component(

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -148,7 +148,7 @@ async def test_malformed_api_key(hass: HomeAssistant) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_options_flow(hass, mock_config):
+async def test_options_flow(hass: HomeAssistant, mock_config) -> None:
     """Test options flow."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None
@@ -209,7 +209,7 @@ async def test_options_flow(hass, mock_config):
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_options_flow_departure_time(hass, mock_config):
+async def test_options_flow_departure_time(hass: HomeAssistant, mock_config) -> None:
     """Test options flow with departure time."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None

--- a/tests/components/google_wifi/test_sensor.py
+++ b/tests/components/google_wifi/test_sensor.py
@@ -3,7 +3,10 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
+import requests_mock
+
 import homeassistant.components.google_wifi.sensor as google_wifi
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -30,7 +33,9 @@ MOCK_DATA_NEXT = (
 MOCK_DATA_MISSING = '{"software": {},' '"system": {},' '"wan": {}}'
 
 
-async def test_setup_minimum(hass, requests_mock):
+async def test_setup_minimum(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test setup with minimum configuration."""
     resource = f"http://{google_wifi.DEFAULT_HOST}{google_wifi.ENDPOINT}"
     requests_mock.get(resource, status_code=HTTPStatus.OK)
@@ -42,7 +47,9 @@ async def test_setup_minimum(hass, requests_mock):
     assert_setup_component(1, "sensor")
 
 
-async def test_setup_get(hass, requests_mock):
+async def test_setup_get(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test setup with full configuration."""
     resource = f"http://localhost{google_wifi.ENDPOINT}"
     requests_mock.get(resource, status_code=HTTPStatus.OK)
@@ -98,7 +105,7 @@ def fake_delay(hass, ha_delay):
     async_fire_time_changed(hass, shifted_time)
 
 
-def test_name(requests_mock):
+def test_name(requests_mock: requests_mock.Mocker) -> None:
     """Test the name."""
     api, sensor_dict = setup_api(None, MOCK_DATA, requests_mock)
     for name in sensor_dict:
@@ -107,7 +114,9 @@ def test_name(requests_mock):
         assert test_name == sensor.name
 
 
-def test_unit_of_measurement(hass, requests_mock):
+def test_unit_of_measurement(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test the unit of measurement."""
     api, sensor_dict = setup_api(hass, MOCK_DATA, requests_mock)
     for name in sensor_dict:
@@ -115,7 +124,7 @@ def test_unit_of_measurement(hass, requests_mock):
         assert sensor_dict[name]["units"] == sensor.unit_of_measurement
 
 
-def test_icon(requests_mock):
+def test_icon(requests_mock: requests_mock.Mocker) -> None:
     """Test the icon."""
     api, sensor_dict = setup_api(None, MOCK_DATA, requests_mock)
     for name in sensor_dict:
@@ -123,7 +132,7 @@ def test_icon(requests_mock):
         assert sensor_dict[name]["icon"] == sensor.icon
 
 
-def test_state(hass, requests_mock):
+def test_state(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test the initial state."""
     api, sensor_dict = setup_api(hass, MOCK_DATA, requests_mock)
     now = datetime(1970, month=1, day=1)
@@ -142,7 +151,9 @@ def test_state(hass, requests_mock):
                 assert sensor.state == "initial"
 
 
-def test_update_when_value_is_none(hass, requests_mock):
+def test_update_when_value_is_none(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test state gets updated to unknown when sensor returns no data."""
     api, sensor_dict = setup_api(hass, None, requests_mock)
     for name in sensor_dict:
@@ -152,7 +163,9 @@ def test_update_when_value_is_none(hass, requests_mock):
         assert sensor.state is None
 
 
-def test_update_when_value_changed(hass, requests_mock):
+def test_update_when_value_changed(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test state gets updated when sensor returns a new status."""
     api, sensor_dict = setup_api(hass, MOCK_DATA_NEXT, requests_mock)
     now = datetime(1970, month=1, day=1)
@@ -175,7 +188,9 @@ def test_update_when_value_changed(hass, requests_mock):
                 assert sensor.state == "next"
 
 
-def test_when_api_data_missing(hass, requests_mock):
+def test_when_api_data_missing(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test state logs an error when data is missing."""
     api, sensor_dict = setup_api(hass, MOCK_DATA_MISSING, requests_mock)
     now = datetime(1970, month=1, day=1)
@@ -187,7 +202,9 @@ def test_when_api_data_missing(hass, requests_mock):
             assert sensor.state is None
 
 
-def test_update_when_unavailable(hass, requests_mock):
+def test_update_when_unavailable(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test state updates when Google Wifi unavailable."""
     api, sensor_dict = setup_api(hass, None, requests_mock)
     api.update = Mock(

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOM
 from homeassistant.components.gpslogger import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
@@ -72,7 +73,7 @@ async def webhook_id(hass, gpslogger_client):
     return result["result"].data["webhook_id"]
 
 
-async def test_missing_data(hass, gpslogger_client, webhook_id):
+async def test_missing_data(hass: HomeAssistant, gpslogger_client, webhook_id) -> None:
     """Test missing data."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -98,7 +99,9 @@ async def test_missing_data(hass, gpslogger_client, webhook_id):
     assert req.status == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
-async def test_enter_and_exit(hass, gpslogger_client, webhook_id):
+async def test_enter_and_exit(
+    hass: HomeAssistant, gpslogger_client, webhook_id
+) -> None:
     """Test when there is a known zone."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -135,7 +138,9 @@ async def test_enter_and_exit(hass, gpslogger_client, webhook_id):
     assert len(ent_reg.entities) == 1
 
 
-async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
+async def test_enter_with_attrs(
+    hass: HomeAssistant, gpslogger_client, webhook_id
+) -> None:
     """Test when additional attributes are present."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -195,7 +200,9 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
 @pytest.mark.xfail(
     reason="The device_tracker component does not support unloading yet."
 )
-async def test_load_unload_entry(hass, gpslogger_client, webhook_id):
+async def test_load_unload_entry(
+    hass: HomeAssistant, gpslogger_client, webhook_id
+) -> None:
     """Test that the appropriate dispatch signals are added and removed."""
     url = f"/api/webhook/{webhook_id}"
     data = {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE, "device": "123"}

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components import graphite
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -32,14 +33,14 @@ def fixture_mock_time():
         yield mock_time
 
 
-async def test_setup(hass, mock_socket):
+async def test_setup(hass: HomeAssistant, mock_socket) -> None:
     """Test setup."""
     assert await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})
     assert mock_socket.call_count == 1
     assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_STREAM)
 
 
-async def test_setup_failure(hass, mock_socket):
+async def test_setup_failure(hass: HomeAssistant, mock_socket) -> None:
     """Test setup fails due to socket error."""
     mock_socket.return_value.connect.side_effect = OSError
     assert not await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})
@@ -49,7 +50,7 @@ async def test_setup_failure(hass, mock_socket):
     assert mock_socket.return_value.connect.call_count == 1
 
 
-async def test_full_config(hass, mock_gf, mock_socket):
+async def test_full_config(hass: HomeAssistant, mock_gf, mock_socket) -> None:
     """Test setup with full configuration."""
     config = {"graphite": {"host": "foo", "port": 123, "prefix": "me"}}
 
@@ -60,7 +61,7 @@ async def test_full_config(hass, mock_gf, mock_socket):
     assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_STREAM)
 
 
-async def test_full_udp_config(hass, mock_gf, mock_socket):
+async def test_full_udp_config(hass: HomeAssistant, mock_gf, mock_socket) -> None:
     """Test setup with full configuration and UDP protocol."""
     config = {
         "graphite": {"host": "foo", "port": 123, "protocol": "udp", "prefix": "me"}
@@ -72,7 +73,7 @@ async def test_full_udp_config(hass, mock_gf, mock_socket):
     assert mock_socket.call_count == 0
 
 
-async def test_config_port(hass, mock_gf, mock_socket):
+async def test_config_port(hass: HomeAssistant, mock_gf, mock_socket) -> None:
     """Test setup with invalid port."""
     config = {"graphite": {"host": "foo", "port": 2003}}
 
@@ -82,7 +83,7 @@ async def test_config_port(hass, mock_gf, mock_socket):
     assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_STREAM)
 
 
-async def test_start(hass, mock_socket, mock_time):
+async def test_start(hass: HomeAssistant, mock_socket, mock_time) -> None:
     """Test the start."""
     mock_time.return_value = 12345
     assert await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})
@@ -105,7 +106,7 @@ async def test_start(hass, mock_socket, mock_time):
     assert mock_socket.return_value.close.call_count == 1
 
 
-async def test_shutdown(hass, mock_socket, mock_time):
+async def test_shutdown(hass: HomeAssistant, mock_socket, mock_time) -> None:
     """Test the shutdown."""
     mock_time.return_value = 12345
     assert await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})
@@ -139,7 +140,7 @@ async def test_shutdown(hass, mock_socket, mock_time):
     assert mock_socket.return_value.sendall.call_count == 0
 
 
-async def test_report_attributes(hass, mock_socket, mock_time):
+async def test_report_attributes(hass: HomeAssistant, mock_socket, mock_time) -> None:
     """Test the reporting with attributes."""
     attrs = {"foo": 1, "bar": 2.0, "baz": True, "bat": "NaN"}
     expected = [
@@ -170,7 +171,9 @@ async def test_report_attributes(hass, mock_socket, mock_time):
     assert mock_socket.return_value.close.call_count == 1
 
 
-async def test_report_with_string_state(hass, mock_socket, mock_time):
+async def test_report_with_string_state(
+    hass: HomeAssistant, mock_socket, mock_time
+) -> None:
     """Test the reporting with strings."""
     expected = [
         "ha.test.entity.foo 1.000000 12345",
@@ -208,7 +211,9 @@ async def test_report_with_string_state(hass, mock_socket, mock_time):
     assert mock_socket.return_value.close.call_count == 0
 
 
-async def test_report_with_binary_state(hass, mock_socket, mock_time):
+async def test_report_with_binary_state(
+    hass: HomeAssistant, mock_socket, mock_time
+) -> None:
     """Test the reporting with binary state."""
     mock_time.return_value = 12345
     assert await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})
@@ -263,8 +268,13 @@ async def test_report_with_binary_state(hass, mock_socket, mock_time):
     ],
 )
 async def test_send_to_graphite_errors(
-    hass, mock_socket, mock_time, caplog, error, log_text
-):
+    hass: HomeAssistant,
+    mock_socket,
+    mock_time,
+    caplog: pytest.LogCaptureFixture,
+    error,
+    log_text,
+) -> None:
     """Test the sending with errors."""
     mock_time.return_value = 12345
     assert await async_setup_component(hass, graphite.DOMAIN, {"graphite": {}})

--- a/tests/components/gree/test_bridge.py
+++ b/tests/components/gree/test_bridge.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.climate import DOMAIN
 from homeassistant.components.gree.const import COORDINATORS, DOMAIN as GREE
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .common import async_setup_gree, build_device_mock
@@ -22,7 +23,9 @@ def mock_now():
     return dt_util.utcnow()
 
 
-async def test_discovery_after_setup(hass, discovery, device, mock_now):
+async def test_discovery_after_setup(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test gree devices don't change after multiple discoveries."""
     mock_device_1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"

--- a/tests/components/gree/test_climate.py
+++ b/tests/components/gree/test_climate.py
@@ -46,6 +46,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .common import async_setup_gree, build_device_mock
@@ -61,7 +62,7 @@ def mock_now():
     return dt_util.utcnow()
 
 
-async def test_discovery_called_once(hass, discovery, device):
+async def test_discovery_called_once(hass: HomeAssistant, discovery, device) -> None:
     """Test discovery is only ever called once."""
     await async_setup_gree(hass)
     assert discovery.call_count == 1
@@ -70,7 +71,7 @@ async def test_discovery_called_once(hass, discovery, device):
     assert discovery.call_count == 1
 
 
-async def test_discovery_setup(hass, discovery, device):
+async def test_discovery_setup(hass: HomeAssistant, discovery, device) -> None:
     """Test setup of platform."""
     MockDevice1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"
@@ -88,7 +89,9 @@ async def test_discovery_setup(hass, discovery, device):
     assert len(hass.states.async_all(DOMAIN)) == 2
 
 
-async def test_discovery_setup_connection_error(hass, discovery, device, mock_now):
+async def test_discovery_setup_connection_error(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test gree integration is setup."""
     MockDevice1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"
@@ -108,7 +111,9 @@ async def test_discovery_setup_connection_error(hass, discovery, device, mock_no
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_discovery_after_setup(hass, discovery, device, mock_now):
+async def test_discovery_after_setup(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test gree devices don't change after multiple discoveries."""
     MockDevice1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"
@@ -142,7 +147,9 @@ async def test_discovery_after_setup(hass, discovery, device, mock_now):
     assert len(hass.states.async_all(DOMAIN)) == 2
 
 
-async def test_discovery_add_device_after_setup(hass, discovery, device, mock_now):
+async def test_discovery_add_device_after_setup(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test gree devices can be added after initial setup."""
     MockDevice1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"
@@ -176,7 +183,9 @@ async def test_discovery_add_device_after_setup(hass, discovery, device, mock_no
     assert len(hass.states.async_all(DOMAIN)) == 2
 
 
-async def test_discovery_device_bind_after_setup(hass, discovery, device, mock_now):
+async def test_discovery_device_bind_after_setup(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test gree devices can be added after a late device bind."""
     MockDevice1 = build_device_mock(
         name="fake-device-1", ipAddress="1.1.1.1", mac="aabbcc112233"
@@ -208,7 +217,7 @@ async def test_discovery_device_bind_after_setup(hass, discovery, device, mock_n
     assert state.state != STATE_UNAVAILABLE
 
 
-async def test_update_connection_failure(hass, device, mock_now):
+async def test_update_connection_failure(hass: HomeAssistant, device, mock_now) -> None:
     """Testing update hvac connection failure exception."""
     device().update_state.side_effect = [
         DEFAULT_MOCK,
@@ -244,7 +253,9 @@ async def test_update_connection_failure(hass, device, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_connection_failure_recovery(hass, discovery, device, mock_now):
+async def test_update_connection_failure_recovery(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Testing update hvac connection failure recovery."""
     device().update_state.side_effect = [
         DeviceTimeoutError,
@@ -275,7 +286,9 @@ async def test_update_connection_failure_recovery(hass, discovery, device, mock_
     assert state.state != STATE_UNAVAILABLE
 
 
-async def test_update_unhandled_exception(hass, discovery, device, mock_now):
+async def test_update_unhandled_exception(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Testing update hvac connection unhandled response exception."""
     device().update_state.side_effect = [DEFAULT_MOCK, Exception]
 
@@ -295,7 +308,9 @@ async def test_update_unhandled_exception(hass, discovery, device, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_send_command_device_timeout(hass, discovery, device, mock_now):
+async def test_send_command_device_timeout(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test for sending power on command to the device with a device timeout."""
     await async_setup_gree(hass)
 
@@ -324,7 +339,7 @@ async def test_send_command_device_timeout(hass, discovery, device, mock_now):
     assert state.state != STATE_UNAVAILABLE
 
 
-async def test_send_power_on(hass, discovery, device, mock_now):
+async def test_send_power_on(hass: HomeAssistant, discovery, device, mock_now) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -340,7 +355,9 @@ async def test_send_power_on(hass, discovery, device, mock_now):
     assert state.state == HVACMode.OFF
 
 
-async def test_send_power_off_device_timeout(hass, discovery, device, mock_now):
+async def test_send_power_off_device_timeout(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test for sending power off command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -362,7 +379,9 @@ async def test_send_power_off_device_timeout(hass, discovery, device, mock_now):
     "units,temperature",
     [(UnitOfTemperature.CELSIUS, 26), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
-async def test_send_target_temperature(hass, discovery, device, units, temperature):
+async def test_send_target_temperature(
+    hass: HomeAssistant, discovery, device, units, temperature
+) -> None:
     """Test for sending target temperature command to the device."""
     hass.config.units.temperature_unit = units
 
@@ -400,8 +419,8 @@ async def test_send_target_temperature(hass, discovery, device, units, temperatu
     [(UnitOfTemperature.CELSIUS, 25), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
 async def test_send_target_temperature_device_timeout(
-    hass, discovery, device, units, temperature
-):
+    hass: HomeAssistant, discovery, device, units, temperature
+) -> None:
     """Test for sending target temperature command to the device with a device timeout."""
     hass.config.units.temperature_unit = units
     if units == UnitOfTemperature.FAHRENHEIT:
@@ -429,7 +448,9 @@ async def test_send_target_temperature_device_timeout(
     "units,temperature",
     [(UnitOfTemperature.CELSIUS, 25), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
-async def test_update_target_temperature(hass, discovery, device, units, temperature):
+async def test_update_target_temperature(
+    hass: HomeAssistant, discovery, device, units, temperature
+) -> None:
     """Test for updating target temperature from the device."""
     hass.config.units.temperature_unit = units
     if units == UnitOfTemperature.FAHRENHEIT:
@@ -449,7 +470,9 @@ async def test_update_target_temperature(hass, discovery, device, units, tempera
 @pytest.mark.parametrize(
     "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
 )
-async def test_send_preset_mode(hass, discovery, device, mock_now, preset):
+async def test_send_preset_mode(
+    hass: HomeAssistant, discovery, device, mock_now, preset
+) -> None:
     """Test for sending preset mode command to the device."""
     await async_setup_gree(hass)
 
@@ -465,7 +488,9 @@ async def test_send_preset_mode(hass, discovery, device, mock_now, preset):
     assert state.attributes.get(ATTR_PRESET_MODE) == preset
 
 
-async def test_send_invalid_preset_mode(hass, discovery, device, mock_now):
+async def test_send_invalid_preset_mode(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test for sending preset mode command to the device."""
     await async_setup_gree(hass)
 
@@ -486,8 +511,8 @@ async def test_send_invalid_preset_mode(hass, discovery, device, mock_now):
     "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
 )
 async def test_send_preset_mode_device_timeout(
-    hass, discovery, device, mock_now, preset
-):
+    hass: HomeAssistant, discovery, device, mock_now, preset
+) -> None:
     """Test for sending preset mode command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -508,7 +533,9 @@ async def test_send_preset_mode_device_timeout(
 @pytest.mark.parametrize(
     "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
 )
-async def test_update_preset_mode(hass, discovery, device, mock_now, preset):
+async def test_update_preset_mode(
+    hass: HomeAssistant, discovery, device, mock_now, preset
+) -> None:
     """Test for updating preset mode from the device."""
     device().steady_heat = preset == PRESET_AWAY
     device().power_save = preset == PRESET_ECO
@@ -533,7 +560,9 @@ async def test_update_preset_mode(hass, discovery, device, mock_now, preset):
         HVACMode.HEAT,
     ),
 )
-async def test_send_hvac_mode(hass, discovery, device, mock_now, hvac_mode):
+async def test_send_hvac_mode(
+    hass: HomeAssistant, discovery, device, mock_now, hvac_mode
+) -> None:
     """Test for sending hvac mode command to the device."""
     await async_setup_gree(hass)
 
@@ -554,8 +583,8 @@ async def test_send_hvac_mode(hass, discovery, device, mock_now, hvac_mode):
     (HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT),
 )
 async def test_send_hvac_mode_device_timeout(
-    hass, discovery, device, mock_now, hvac_mode
-):
+    hass: HomeAssistant, discovery, device, mock_now, hvac_mode
+) -> None:
     """Test for sending hvac mode command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -584,7 +613,9 @@ async def test_send_hvac_mode_device_timeout(
         HVACMode.HEAT,
     ),
 )
-async def test_update_hvac_mode(hass, discovery, device, mock_now, hvac_mode):
+async def test_update_hvac_mode(
+    hass: HomeAssistant, discovery, device, mock_now, hvac_mode
+) -> None:
     """Test for updating hvac mode from the device."""
     device().power = hvac_mode != HVACMode.OFF
     device().mode = HVAC_MODES_REVERSE.get(hvac_mode)
@@ -600,7 +631,9 @@ async def test_update_hvac_mode(hass, discovery, device, mock_now, hvac_mode):
     "fan_mode",
     (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
 )
-async def test_send_fan_mode(hass, discovery, device, mock_now, fan_mode):
+async def test_send_fan_mode(
+    hass: HomeAssistant, discovery, device, mock_now, fan_mode
+) -> None:
     """Test for sending fan mode command to the device."""
     await async_setup_gree(hass)
 
@@ -616,7 +649,9 @@ async def test_send_fan_mode(hass, discovery, device, mock_now, fan_mode):
     assert state.attributes.get(ATTR_FAN_MODE) == fan_mode
 
 
-async def test_send_invalid_fan_mode(hass, discovery, device, mock_now):
+async def test_send_invalid_fan_mode(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test for sending fan mode command to the device."""
     await async_setup_gree(hass)
 
@@ -638,8 +673,8 @@ async def test_send_invalid_fan_mode(hass, discovery, device, mock_now):
     (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
 )
 async def test_send_fan_mode_device_timeout(
-    hass, discovery, device, mock_now, fan_mode
-):
+    hass: HomeAssistant, discovery, device, mock_now, fan_mode
+) -> None:
     """Test for sending fan mode command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -661,7 +696,9 @@ async def test_send_fan_mode_device_timeout(
     "fan_mode",
     (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
 )
-async def test_update_fan_mode(hass, discovery, device, mock_now, fan_mode):
+async def test_update_fan_mode(
+    hass: HomeAssistant, discovery, device, mock_now, fan_mode
+) -> None:
     """Test for updating fan mode from the device."""
     device().fan_speed = FAN_MODES_REVERSE.get(fan_mode)
 
@@ -675,7 +712,9 @@ async def test_update_fan_mode(hass, discovery, device, mock_now, fan_mode):
 @pytest.mark.parametrize(
     "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
 )
-async def test_send_swing_mode(hass, discovery, device, mock_now, swing_mode):
+async def test_send_swing_mode(
+    hass: HomeAssistant, discovery, device, mock_now, swing_mode
+) -> None:
     """Test for sending swing mode command to the device."""
     await async_setup_gree(hass)
 
@@ -691,7 +730,9 @@ async def test_send_swing_mode(hass, discovery, device, mock_now, swing_mode):
     assert state.attributes.get(ATTR_SWING_MODE) == swing_mode
 
 
-async def test_send_invalid_swing_mode(hass, discovery, device, mock_now):
+async def test_send_invalid_swing_mode(
+    hass: HomeAssistant, discovery, device, mock_now
+) -> None:
     """Test for sending swing mode command to the device."""
     await async_setup_gree(hass)
 
@@ -712,8 +753,8 @@ async def test_send_invalid_swing_mode(hass, discovery, device, mock_now):
     "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
 )
 async def test_send_swing_mode_device_timeout(
-    hass, discovery, device, mock_now, swing_mode
-):
+    hass: HomeAssistant, discovery, device, mock_now, swing_mode
+) -> None:
     """Test for sending swing mode command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -734,7 +775,9 @@ async def test_send_swing_mode_device_timeout(
 @pytest.mark.parametrize(
     "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
 )
-async def test_update_swing_mode(hass, discovery, device, mock_now, swing_mode):
+async def test_update_swing_mode(
+    hass: HomeAssistant, discovery, device, mock_now, swing_mode
+) -> None:
     """Test for updating swing mode from the device."""
     device().horizontal_swing = (
         HorizontalSwing.FullSwing
@@ -754,14 +797,16 @@ async def test_update_swing_mode(hass, discovery, device, mock_now, swing_mode):
     assert state.attributes.get(ATTR_SWING_MODE) == swing_mode
 
 
-async def test_name(hass, discovery, device):
+async def test_name(hass: HomeAssistant, discovery, device) -> None:
     """Test for name property."""
     await async_setup_gree(hass)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake-device-1"
 
 
-async def test_supported_features_with_turnon(hass, discovery, device):
+async def test_supported_features_with_turnon(
+    hass: HomeAssistant, discovery, device
+) -> None:
     """Test for supported_features property."""
     await async_setup_gree(hass)
     state = hass.states.get(ENTITY_ID)

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -39,7 +40,7 @@ async def async_setup_gree(hass):
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_on(hass, entity):
+async def test_send_switch_on(hass: HomeAssistant, entity) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -64,7 +65,9 @@ async def test_send_switch_on(hass, entity):
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_on_device_timeout(hass, device, entity):
+async def test_send_switch_on_device_timeout(
+    hass: HomeAssistant, device, entity
+) -> None:
     """Test for sending power on command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
 
@@ -91,7 +94,7 @@ async def test_send_switch_on_device_timeout(hass, device, entity):
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_off(hass, entity):
+async def test_send_switch_off(hass: HomeAssistant, entity) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -116,7 +119,7 @@ async def test_send_switch_off(hass, entity):
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_toggle(hass, entity):
+async def test_send_switch_toggle(hass: HomeAssistant, entity) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -166,7 +169,7 @@ async def test_send_switch_toggle(hass, entity):
         (ENTITY_ID_XFAN, "XFan"),
     ],
 )
-async def test_entity_name(hass, entity, name):
+async def test_entity_name(hass: HomeAssistant, entity, name) -> None:
     """Test for name property."""
     await async_setup_gree(hass)
     state = hass.states.get(entity)

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -100,7 +100,7 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_state(hass, setup_comp):
+async def test_state(hass: HomeAssistant, setup_comp) -> None:
     """Test handling of state.
 
     The group state is unknown if all group members are unknown or unavailable.
@@ -249,7 +249,7 @@ async def test_state(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_attributes(hass, setup_comp):
+async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     """Test handling of state attributes."""
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_UNAVAILABLE
@@ -413,7 +413,9 @@ async def test_attributes(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_TILT_ONLY, 2)])
-async def test_cover_that_only_supports_tilt_removed(hass, setup_comp):
+async def test_cover_that_only_supports_tilt_removed(
+    hass: HomeAssistant, setup_comp
+) -> None:
     """Test removing a cover that support tilt."""
     hass.states.async_set(
         DEMO_COVER_TILT,
@@ -441,7 +443,7 @@ async def test_cover_that_only_supports_tilt_removed(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_open_covers(hass, setup_comp):
+async def test_open_covers(hass: HomeAssistant, setup_comp) -> None:
     """Test open cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -462,7 +464,7 @@ async def test_open_covers(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_close_covers(hass, setup_comp):
+async def test_close_covers(hass: HomeAssistant, setup_comp) -> None:
     """Test close cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -483,7 +485,7 @@ async def test_close_covers(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_toggle_covers(hass, setup_comp):
+async def test_toggle_covers(hass: HomeAssistant, setup_comp) -> None:
     """Test toggle cover function."""
     # Start covers in open state
     await hass.services.async_call(
@@ -533,7 +535,7 @@ async def test_toggle_covers(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_stop_covers(hass, setup_comp):
+async def test_stop_covers(hass: HomeAssistant, setup_comp) -> None:
     """Test stop cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -559,7 +561,7 @@ async def test_stop_covers(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_set_cover_position(hass, setup_comp):
+async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
     """Test set cover position function."""
     await hass.services.async_call(
         DOMAIN,
@@ -582,7 +584,7 @@ async def test_set_cover_position(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_open_tilts(hass, setup_comp):
+async def test_open_tilts(hass: HomeAssistant, setup_comp) -> None:
     """Test open tilt function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -602,7 +604,7 @@ async def test_open_tilts(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_close_tilts(hass, setup_comp):
+async def test_close_tilts(hass: HomeAssistant, setup_comp) -> None:
     """Test close tilt function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -620,7 +622,7 @@ async def test_close_tilts(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_toggle_tilts(hass, setup_comp):
+async def test_toggle_tilts(hass: HomeAssistant, setup_comp) -> None:
     """Test toggle tilt function."""
     # Start tilted open
     await hass.services.async_call(
@@ -673,7 +675,7 @@ async def test_toggle_tilts(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_stop_tilts(hass, setup_comp):
+async def test_stop_tilts(hass: HomeAssistant, setup_comp) -> None:
     """Test stop tilts function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -697,7 +699,7 @@ async def test_stop_tilts(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_set_tilt_positions(hass, setup_comp):
+async def test_set_tilt_positions(hass: HomeAssistant, setup_comp) -> None:
     """Test set tilt position function."""
     await hass.services.async_call(
         DOMAIN,
@@ -718,7 +720,7 @@ async def test_set_tilt_positions(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_POS, 2)])
-async def test_is_opening_closing(hass, setup_comp):
+async def test_is_opening_closing(hass: HomeAssistant, setup_comp) -> None:
     """Test is_opening property."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -112,7 +112,7 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_state(hass, setup_comp):
+async def test_state(hass: HomeAssistant, setup_comp) -> None:
     """Test handling of state.
 
     The group state is on if at least one group member is on.
@@ -208,7 +208,7 @@ async def test_state(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_attributes(hass, setup_comp):
+async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
     """Test handling of state attributes."""
     state = hass.states.get(FAN_GROUP)
     assert state.state == STATE_UNAVAILABLE
@@ -269,7 +269,7 @@ async def test_attributes(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_FULL_SUPPORT, 2)])
-async def test_direction_oscillating(hass, setup_comp):
+async def test_direction_oscillating(hass: HomeAssistant, setup_comp) -> None:
     """Test handling of direction and oscillating attributes."""
 
     hass.states.async_set(
@@ -385,7 +385,7 @@ async def test_direction_oscillating(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_MISSING_FAN, 2)])
-async def test_state_missing_entity_id(hass, setup_comp):
+async def test_state_missing_entity_id(hass: HomeAssistant, setup_comp) -> None:
     """Test we can still setup with a missing entity id."""
     state = hass.states.get(FAN_GROUP)
     await hass.async_block_till_done()
@@ -405,7 +405,7 @@ async def test_setup_before_started(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_MISSING_FAN, 2)])
-async def test_reload(hass, setup_comp):
+async def test_reload(hass: HomeAssistant, setup_comp) -> None:
     """Test the ability to reload fans."""
     await hass.async_block_till_done()
     await hass.async_start()
@@ -428,7 +428,7 @@ async def test_reload(hass, setup_comp):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_FULL_SUPPORT, 2)])
-async def test_service_calls(hass, setup_comp):
+async def test_service_calls(hass: HomeAssistant, setup_comp) -> None:
     """Test calling services."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: FAN_GROUP}, blocking=True

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -842,7 +842,7 @@ async def test_group_mixed_domains_off(hass: HomeAssistant) -> None:
         (("locked", "locked", "locked"), "locked"),
     ],
 )
-async def test_group_locks(hass, states, group_state):
+async def test_group_locks(hass: HomeAssistant, states, group_state) -> None:
     """Test group of locks."""
     hass.states.async_set("lock.one", states[0])
     hass.states.async_set("lock.two", states[1])

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -263,7 +263,9 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
     assert hass.states.get("light.light_group").state == STATE_UNAVAILABLE
 
 
-async def test_brightness(hass, enable_custom_integrations):
+async def test_brightness(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test brightness reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -333,7 +335,7 @@ async def test_brightness(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness"]
 
 
-async def test_color_hs(hass, enable_custom_integrations):
+async def test_color_hs(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test hs color reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -402,7 +404,7 @@ async def test_color_hs(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgb(hass, enable_custom_integrations):
+async def test_color_rgb(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test rgbw color reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -474,7 +476,9 @@ async def test_color_rgb(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgbw(hass, enable_custom_integrations):
+async def test_color_rgbw(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test rgbw color reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -546,7 +550,9 @@ async def test_color_rgbw(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgbww(hass, enable_custom_integrations):
+async def test_color_rgbww(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test rgbww color reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -618,7 +624,7 @@ async def test_color_rgbww(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_white(hass, enable_custom_integrations):
+async def test_white(hass: HomeAssistant, enable_custom_integrations: None) -> None:
     """Test white reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -675,7 +681,9 @@ async def test_white(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs", "white"]
 
 
-async def test_color_temp(hass, enable_custom_integrations):
+async def test_color_temp(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color temp reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -743,7 +751,9 @@ async def test_color_temp(hass, enable_custom_integrations):
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp"]
 
 
-async def test_emulated_color_temp_group(hass, enable_custom_integrations):
+async def test_emulated_color_temp_group(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test emulated color temperature in a group."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -807,7 +817,9 @@ async def test_emulated_color_temp_group(hass, enable_custom_integrations):
     assert state.attributes[ATTR_HS_COLOR] == (27.001, 19.243)
 
 
-async def test_min_max_mireds(hass, enable_custom_integrations):
+async def test_min_max_mireds(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test min/max mireds reporting.
 
     min/max mireds is reported both when light is on and off
@@ -985,7 +997,9 @@ async def test_effect(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_EFFECT] == "Random"
 
 
-async def test_supported_color_modes(hass, enable_custom_integrations):
+async def test_supported_color_modes(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test supported_color_modes reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1031,7 +1045,9 @@ async def test_supported_color_modes(hass, enable_custom_integrations):
     }
 
 
-async def test_color_mode(hass, enable_custom_integrations):
+async def test_color_mode(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color_mode reporting."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1104,7 +1120,9 @@ async def test_color_mode(hass, enable_custom_integrations):
     assert state.attributes[ATTR_COLOR_MODE] == ColorMode.HS
 
 
-async def test_color_mode2(hass, enable_custom_integrations):
+async def test_color_mode2(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test onoff color_mode and brightness are given lowest priority."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1224,7 +1242,9 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("supported_color_modes", [ColorMode.HS, ColorMode.RGB])
-async def test_service_calls(hass, enable_custom_integrations, supported_color_modes):
+async def test_service_calls(
+    hass: HomeAssistant, enable_custom_integrations: None, supported_color_modes
+) -> None:
     """Test service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)

--- a/tests/components/group/test_recorder.py
+++ b/tests/components/group/test_recorder.py
@@ -5,10 +5,11 @@ from datetime import timedelta
 
 from homeassistant.components import group
 from homeassistant.components.group import ATTR_AUTO, ATTR_ENTITY_ID, ATTR_ORDER
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -16,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test number registered attributes to be excluded."""
     hass.states.async_set("light.bowl", STATE_ON)
 

--- a/tests/components/group/test_switch.py
+++ b/tests/components/group/test_switch.py
@@ -231,7 +231,9 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
     assert hass.states.get("switch.switch_group").state == STATE_UNAVAILABLE
 
 
-async def test_service_calls(hass, enable_custom_integrations):
+async def test_service_calls(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test service calls."""
     await async_setup_component(
         hass,

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -17,7 +17,9 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_duplicate_error(hass, config, config_entry, setup_guardian):
+async def test_duplicate_error(
+    hass: HomeAssistant, config, config_entry, setup_guardian
+) -> None:
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -26,7 +28,7 @@ async def test_duplicate_error(hass, config, config_entry, setup_guardian):
     assert result["reason"] == "already_configured"
 
 
-async def test_connect_error(hass, config):
+async def test_connect_error(hass: HomeAssistant, config) -> None:
     """Test that the config entry errors out if the device cannot connect."""
     with patch(
         "aioguardian.client.Client.connect",
@@ -51,7 +53,7 @@ async def test_get_pin_from_uid() -> None:
     assert pin == "3456"
 
 
-async def test_step_user(hass, config, setup_guardian):
+async def test_step_user(hass: HomeAssistant, config, setup_guardian) -> None:
     """Test the user step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -71,7 +73,7 @@ async def test_step_user(hass, config, setup_guardian):
     }
 
 
-async def test_step_zeroconf(hass, setup_guardian):
+async def test_step_zeroconf(hass: HomeAssistant, setup_guardian) -> None:
     """Test the zeroconf step."""
     zeroconf_data = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.100",
@@ -126,7 +128,7 @@ async def test_step_zeroconf_already_in_progress(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_in_progress"
 
 
-async def test_step_dhcp(hass, setup_guardian):
+async def test_step_dhcp(hass: HomeAssistant, setup_guardian) -> None:
     """Test the dhcp step."""
     dhcp_data = dhcp.DhcpServiceInfo(
         ip="192.168.1.100",

--- a/tests/components/guardian/test_diagnostics.py
+++ b/tests/components/guardian/test_diagnostics.py
@@ -1,11 +1,18 @@
 """Test Guardian diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.guardian import DOMAIN, GuardianData
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_guardian):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_guardian,
+) -> None:
     """Test config entry diagnostics."""
     data: GuardianData = hass.data[DOMAIN][config_entry.entry_id]
 

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.components.habitica.const import (
 )
 from homeassistant.components.habitica.sensor import TASKS_TYPES
 from homeassistant.const import ATTR_NAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_capture_events
 
@@ -91,7 +92,9 @@ def common_requests(aioclient_mock):
     return aioclient_mock
 
 
-async def test_entry_setup_unload(hass, habitica_entry, common_requests):
+async def test_entry_setup_unload(
+    hass: HomeAssistant, habitica_entry, common_requests
+) -> None:
     """Test integration setup and unload."""
     assert await hass.config_entries.async_setup(habitica_entry.entry_id)
     await hass.async_block_till_done()
@@ -104,8 +107,8 @@ async def test_entry_setup_unload(hass, habitica_entry, common_requests):
 
 
 async def test_service_call(
-    hass, habitica_entry, common_requests, capture_api_call_success
-):
+    hass: HomeAssistant, habitica_entry, common_requests, capture_api_call_success
+) -> None:
     """Test integration setup, service call and unload."""
 
     assert await hass.config_entries.async_setup(habitica_entry.entry_id)

--- a/tests/components/hardkernel/test_hardware.py
+++ b/tests/components/hardkernel/test_hardware.py
@@ -7,9 +7,12 @@ from homeassistant.components.hardkernel.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.typing import WebSocketGenerator
 
 
-async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_hardware_info(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can get the board info."""
     mock_integration(hass, MockModule("hassio"))
 
@@ -58,7 +61,9 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
 
 
 @pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
-async def test_hardware_info_fail(hass: HomeAssistant, hass_ws_client, os_info) -> None:
+async def test_hardware_info_fail(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info
+) -> None:
     """Test async_info raises if os_info is not as expected."""
     mock_integration(hass, MockModule("hassio"))
 

--- a/tests/components/hardware/test_websocket_api.py
+++ b/tests/components/hardware/test_websocket_api.py
@@ -10,8 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from tests.typing import WebSocketGenerator
 
-async def test_board_info(hass: HomeAssistant, hass_ws_client) -> None:
+
+async def test_board_info(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can get the board info."""
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -28,7 +32,9 @@ async def test_board_info(hass: HomeAssistant, hass_ws_client) -> None:
 TEST_TIME_ADVANCE_INTERVAL = datetime.timedelta(seconds=5 + 1)
 
 
-async def test_system_status_subscription(hass: HomeAssistant, hass_ws_client, freezer):
+async def test_system_status_subscription(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, freezer
+) -> None:
     """Test websocket system status subscription."""
 
     mock_psutil = None

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -187,7 +187,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_options_flow(hass, mock_hc, mock_write_config):
+async def test_options_flow(hass: HomeAssistant, mock_hc, mock_write_config) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/harmony/test_init.py
+++ b/tests/components/harmony/test_init.py
@@ -1,6 +1,7 @@
 """Test init of Logitch Harmony Hub integration."""
 from homeassistant.components.harmony.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -18,7 +19,9 @@ from .const import (
 from tests.common import MockConfigEntry, mock_registry
 
 
-async def test_unique_id_migration(mock_hc, hass, mock_write_config):
+async def test_unique_id_migration(
+    mock_hc, hass: HomeAssistant, mock_write_config
+) -> None:
     """Test migration of switch unique ids to stable ones."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_remote.py
+++ b/tests/components/harmony/test_remote.py
@@ -1,5 +1,4 @@
 """Test the Logitech Harmony Hub remote."""
-
 from datetime import timedelta
 
 from aioharmony.const import SendCommandDevice
@@ -30,6 +29,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import utcnow
 
 from .conftest import ACTIVITIES_TO_IDS, TV_DEVICE_ID, TV_DEVICE_NAME
@@ -42,8 +42,8 @@ STOP_COMMAND = "Stop"
 
 
 async def test_connection_state_changes(
-    harmony_client, mock_hc, hass, mock_write_config
-):
+    harmony_client, mock_hc, hass: HomeAssistant, mock_write_config
+) -> None:
     """Ensure connection changes are reflected in the remote state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -81,7 +81,7 @@ async def test_connection_state_changes(
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
 
 
-async def test_remote_toggles(mock_hc, hass, mock_write_config):
+async def test_remote_toggles(mock_hc, hass: HomeAssistant, mock_write_config) -> None:
     """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -149,7 +149,9 @@ async def test_remote_toggles(mock_hc, hass, mock_write_config):
     assert state.attributes.get("current_activity") == "Watch TV"
 
 
-async def test_async_send_command(mock_hc, harmony_client, hass, mock_write_config):
+async def test_async_send_command(
+    mock_hc, harmony_client, hass: HomeAssistant, mock_write_config
+) -> None:
     """Ensure calls to send remote commands properly propagate to devices."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -282,8 +284,8 @@ async def test_async_send_command(mock_hc, harmony_client, hass, mock_write_conf
 
 
 async def test_async_send_command_custom_delay(
-    mock_hc, harmony_client, hass, mock_write_config
-):
+    mock_hc, harmony_client, hass: HomeAssistant, mock_write_config
+) -> None:
     """Ensure calls to send remote commands properly propagate to devices with custom delays."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -323,7 +325,9 @@ async def test_async_send_command_custom_delay(
     send_commands_mock.reset_mock()
 
 
-async def test_change_channel(mock_hc, harmony_client, hass, mock_write_config):
+async def test_change_channel(
+    mock_hc, harmony_client, hass: HomeAssistant, mock_write_config
+) -> None:
     """Test change channel commands."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -347,7 +351,9 @@ async def test_change_channel(mock_hc, harmony_client, hass, mock_write_config):
     change_channel_mock.assert_awaited_once_with(100)
 
 
-async def test_sync(mock_hc, harmony_client, mock_write_config, hass):
+async def test_sync(
+    mock_hc, harmony_client, mock_write_config, hass: HomeAssistant
+) -> None:
     """Test the sync command."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_select.py
+++ b/tests/components/harmony/test_select.py
@@ -1,5 +1,4 @@
 """Test the Logitech Harmony Hub activity select."""
-
 from datetime import timedelta
 
 from homeassistant.components.harmony.const import DOMAIN
@@ -16,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import utcnow
 
 from .const import ENTITY_REMOTE, ENTITY_SELECT, HUB_NAME
@@ -24,8 +24,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_connection_state_changes(
-    harmony_client, mock_hc, hass, mock_write_config
-):
+    harmony_client, mock_hc, hass: HomeAssistant, mock_write_config
+) -> None:
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -55,7 +55,7 @@ async def test_connection_state_changes(
     assert hass.states.is_state(ENTITY_SELECT, "Watch TV")
 
 
-async def test_options(mock_hc, hass, mock_write_config):
+async def test_options(mock_hc, hass: HomeAssistant, mock_write_config) -> None:
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -75,7 +75,7 @@ async def test_options(mock_hc, hass, mock_write_config):
     ]
 
 
-async def test_select_option(mock_hc, hass, mock_write_config):
+async def test_select_option(mock_hc, hass: HomeAssistant, mock_write_config) -> None:
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -1,5 +1,4 @@
 """Test the Logitech Harmony Hub activity switches."""
-
 from datetime import timedelta
 
 from homeassistant.components.harmony.const import DOMAIN
@@ -16,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.util import utcnow
 
@@ -25,8 +25,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_connection_state_changes(
-    harmony_client, mock_hc, hass, mock_write_config
-):
+    harmony_client, mock_hc, hass: HomeAssistant, mock_write_config
+) -> None:
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -80,7 +80,7 @@ async def test_connection_state_changes(
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_switch_toggles(mock_hc, hass, mock_write_config):
+async def test_switch_toggles(mock_hc, hass: HomeAssistant, mock_write_config) -> None:
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +23,9 @@ def mock_all(aioclient_mock):
     )
 
 
-async def test_hassio_addon_panel_startup(hass, aioclient_mock, hassio_env):
+async def test_hassio_addon_panel_startup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_env
+) -> None:
     """Test startup and panel setup after event."""
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels",
@@ -61,7 +67,12 @@ async def test_hassio_addon_panel_startup(hass, aioclient_mock, hassio_env):
         )
 
 
-async def test_hassio_addon_panel_api(hass, aioclient_mock, hassio_env, hass_client):
+async def test_hassio_addon_panel_api(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hassio_env,
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test panel api after event."""
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels",

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -1,12 +1,12 @@
 """The tests for the hassio component."""
-
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 from homeassistant.auth.providers.homeassistant import InvalidAuth
+from homeassistant.core import HomeAssistant
 
 
-async def test_auth_success(hass, hassio_client_supervisor):
+async def test_auth_success(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test no auth needed for ."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -22,7 +22,7 @@ async def test_auth_success(hass, hassio_client_supervisor):
         mock_login.assert_called_with("test", "123456")
 
 
-async def test_auth_fails_no_supervisor(hass, hassio_client):
+async def test_auth_fails_no_supervisor(hass: HomeAssistant, hassio_client) -> None:
     """Test if only supervisor can access."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -38,7 +38,7 @@ async def test_auth_fails_no_supervisor(hass, hassio_client):
         assert not mock_login.called
 
 
-async def test_auth_fails_no_auth(hass, hassio_noauth_client):
+async def test_auth_fails_no_auth(hass: HomeAssistant, hassio_noauth_client) -> None:
     """Test if only supervisor can access."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -54,7 +54,7 @@ async def test_auth_fails_no_auth(hass, hassio_noauth_client):
         assert not mock_login.called
 
 
-async def test_login_error(hass, hassio_client_supervisor):
+async def test_login_error(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test no auth needed for error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -71,7 +71,7 @@ async def test_login_error(hass, hassio_client_supervisor):
         mock_login.assert_called_with("test", "123456")
 
 
-async def test_login_no_data(hass, hassio_client_supervisor):
+async def test_login_no_data(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test auth with no data -> error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -85,7 +85,7 @@ async def test_login_no_data(hass, hassio_client_supervisor):
         assert not mock_login.called
 
 
-async def test_login_no_username(hass, hassio_client_supervisor):
+async def test_login_no_username(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test auth with no username in data -> error."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -101,7 +101,9 @@ async def test_login_no_username(hass, hassio_client_supervisor):
         assert not mock_login.called
 
 
-async def test_login_success_extra(hass, hassio_client_supervisor):
+async def test_login_success_extra(
+    hass: HomeAssistant, hassio_client_supervisor
+) -> None:
     """Test auth with extra data."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -122,7 +124,7 @@ async def test_login_success_extra(hass, hassio_client_supervisor):
         mock_login.assert_called_with("test", "123456")
 
 
-async def test_password_success(hass, hassio_client_supervisor):
+async def test_password_success(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test no auth needed for ."""
     with patch(
         "homeassistant.auth.providers.homeassistant."
@@ -138,7 +140,7 @@ async def test_password_success(hass, hassio_client_supervisor):
         mock_change.assert_called_with("test", "123456")
 
 
-async def test_password_fails_no_supervisor(hass, hassio_client):
+async def test_password_fails_no_supervisor(hass: HomeAssistant, hassio_client) -> None:
     """Test if only supervisor can access."""
     resp = await hassio_client.post(
         "/api/hassio_auth/password_reset",
@@ -149,7 +151,9 @@ async def test_password_fails_no_supervisor(hass, hassio_client):
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_password_fails_no_auth(hass, hassio_noauth_client):
+async def test_password_fails_no_auth(
+    hass: HomeAssistant, hassio_noauth_client
+) -> None:
     """Test if only supervisor can access."""
     resp = await hassio_noauth_client.post(
         "/api/hassio_auth/password_reset",
@@ -160,7 +164,7 @@ async def test_password_fails_no_auth(hass, hassio_noauth_client):
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_password_no_user(hass, hassio_client_supervisor):
+async def test_password_no_user(hass: HomeAssistant, hassio_client_supervisor) -> None:
     """Test changing password for invalid user."""
     resp = await hassio_client_supervisor.post(
         "/api/hassio_auth/password_reset",

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -1,15 +1,16 @@
 """The tests for the hassio binary sensors."""
-
 import os
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.hassio import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
@@ -155,7 +156,9 @@ def mock_all(aioclient_mock, request):
         ("binary_sensor.test2_running", "off"),
     ],
 )
-async def test_binary_sensor(hass, entity_id, expected, aioclient_mock):
+async def test_binary_sensor(
+    hass: HomeAssistant, entity_id, expected, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test hassio OS and addons binary sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -9,9 +9,11 @@ from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockModule, mock_entity_platform, mock_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture(name="mock_mqtt")
@@ -32,7 +34,9 @@ async def mock_mqtt_fixture(hass):
         yield MqttFlow
 
 
-async def test_hassio_discovery_startup(hass, aioclient_mock, hassio_client, mock_mqtt):
+async def test_hassio_discovery_startup(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_client, mock_mqtt
+) -> None:
     """Test startup and discovery after event."""
     aioclient_mock.get(
         "http://127.0.0.1/discovery",
@@ -86,8 +90,8 @@ async def test_hassio_discovery_startup(hass, aioclient_mock, hassio_client, moc
 
 
 async def test_hassio_discovery_startup_done(
-    hass, aioclient_mock, hassio_client, mock_mqtt
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_client, mock_mqtt
+) -> None:
     """Test startup and discovery with hass discovery."""
     aioclient_mock.post(
         "http://127.0.0.1/supervisor/options",
@@ -149,7 +153,9 @@ async def test_hassio_discovery_startup_done(
         )
 
 
-async def test_hassio_discovery_webhook(hass, aioclient_mock, hassio_client, mock_mqtt):
+async def test_hassio_discovery_webhook(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hassio_client, mock_mqtt
+) -> None:
     """Test discovery webhook."""
     aioclient_mock.get(
         "http://127.0.0.1/discovery/testuuid",

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -1,12 +1,13 @@
 """The tests for the hassio component."""
-
 import aiohttp
 import pytest
 
 from homeassistant.components.hassio.handler import HassioAPIError
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_api_ping(hassio_handler, aioclient_mock):
+
+async def test_api_ping(hassio_handler, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with API ping."""
     aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "ok"})
 
@@ -14,7 +15,9 @@ async def test_api_ping(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_ping_error(hassio_handler, aioclient_mock):
+async def test_api_ping_error(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API ping error."""
     aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "error"})
 
@@ -22,7 +25,9 @@ async def test_api_ping_error(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_ping_exeption(hassio_handler, aioclient_mock):
+async def test_api_ping_exeption(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API ping exception."""
     aioclient_mock.get("http://127.0.0.1/supervisor/ping", exc=aiohttp.ClientError())
 
@@ -30,7 +35,7 @@ async def test_api_ping_exeption(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_info(hassio_handler, aioclient_mock):
+async def test_api_info(hassio_handler, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with API generic info."""
     aioclient_mock.get(
         "http://127.0.0.1/info",
@@ -47,7 +52,9 @@ async def test_api_info(hassio_handler, aioclient_mock):
     assert data["supervisor"] == "222"
 
 
-async def test_api_info_error(hassio_handler, aioclient_mock):
+async def test_api_info_error(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant info error."""
     aioclient_mock.get(
         "http://127.0.0.1/info", json={"result": "error", "message": None}
@@ -59,7 +66,9 @@ async def test_api_info_error(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_host_info(hassio_handler, aioclient_mock):
+async def test_api_host_info(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Host info."""
     aioclient_mock.get(
         "http://127.0.0.1/host/info",
@@ -80,7 +89,9 @@ async def test_api_host_info(hassio_handler, aioclient_mock):
     assert data["operating_system"] == "Debian GNU/Linux 10 (buster)"
 
 
-async def test_api_supervisor_info(hassio_handler, aioclient_mock):
+async def test_api_supervisor_info(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Supervisor info."""
     aioclient_mock.get(
         "http://127.0.0.1/supervisor/info",
@@ -97,7 +108,7 @@ async def test_api_supervisor_info(hassio_handler, aioclient_mock):
     assert data["channel"] == "stable"
 
 
-async def test_api_os_info(hassio_handler, aioclient_mock):
+async def test_api_os_info(hassio_handler, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with API OS info."""
     aioclient_mock.get(
         "http://127.0.0.1/os/info",
@@ -113,7 +124,9 @@ async def test_api_os_info(hassio_handler, aioclient_mock):
     assert data["version"] == "2020.11.1"
 
 
-async def test_api_host_info_error(hassio_handler, aioclient_mock):
+async def test_api_host_info_error(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant info error."""
     aioclient_mock.get(
         "http://127.0.0.1/host/info", json={"result": "error", "message": None}
@@ -125,7 +138,9 @@ async def test_api_host_info_error(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_core_info(hassio_handler, aioclient_mock):
+async def test_api_core_info(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant Core info."""
     aioclient_mock.get(
         "http://127.0.0.1/core/info",
@@ -137,7 +152,9 @@ async def test_api_core_info(hassio_handler, aioclient_mock):
     assert data["version_latest"] == "1.0.0"
 
 
-async def test_api_core_info_error(hassio_handler, aioclient_mock):
+async def test_api_core_info_error(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant Core info error."""
     aioclient_mock.get(
         "http://127.0.0.1/core/info", json={"result": "error", "message": None}
@@ -149,7 +166,9 @@ async def test_api_core_info_error(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_homeassistant_stop(hassio_handler, aioclient_mock):
+async def test_api_homeassistant_stop(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant stop."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/stop", json={"result": "ok"})
 
@@ -157,7 +176,9 @@ async def test_api_homeassistant_stop(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_homeassistant_restart(hassio_handler, aioclient_mock):
+async def test_api_homeassistant_restart(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Home Assistant restart."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/restart", json={"result": "ok"})
 
@@ -165,7 +186,9 @@ async def test_api_homeassistant_restart(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_addon_info(hassio_handler, aioclient_mock):
+async def test_api_addon_info(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Add-on info."""
     aioclient_mock.get(
         "http://127.0.0.1/addons/test/info",
@@ -177,7 +200,9 @@ async def test_api_addon_info(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_addon_stats(hassio_handler, aioclient_mock):
+async def test_api_addon_stats(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Add-on stats."""
     aioclient_mock.get(
         "http://127.0.0.1/addons/test/stats",
@@ -189,7 +214,9 @@ async def test_api_addon_stats(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_discovery_message(hassio_handler, aioclient_mock):
+async def test_api_discovery_message(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API discovery message."""
     aioclient_mock.get(
         "http://127.0.0.1/discovery/test",
@@ -201,7 +228,9 @@ async def test_api_discovery_message(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_retrieve_discovery(hassio_handler, aioclient_mock):
+async def test_api_retrieve_discovery(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API discovery message."""
     aioclient_mock.get(
         "http://127.0.0.1/discovery",
@@ -213,7 +242,9 @@ async def test_api_retrieve_discovery(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_ingress_panels(hassio_handler, aioclient_mock):
+async def test_api_ingress_panels(
+    hassio_handler, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test setup with API Ingress panels."""
     aioclient_mock.get(
         "http://127.0.0.1/ingress/panels",

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -8,8 +8,13 @@ import pytest
 from homeassistant.components.hassio.http import _need_auth
 from homeassistant.core import HomeAssistant
 
+from tests.common import MockUser
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-async def test_forward_request(hassio_client, aioclient_mock):
+
+async def test_forward_request(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test fetching normal path."""
     aioclient_mock.post("http://127.0.0.1/beer", text="response")
 
@@ -27,7 +32,7 @@ async def test_forward_request(hassio_client, aioclient_mock):
 @pytest.mark.parametrize(
     "build_type", ["supervisor/info", "homeassistant/update", "host/info"]
 )
-async def test_auth_required_forward_request(hassio_noauth_client, build_type):
+async def test_auth_required_forward_request(hassio_noauth_client, build_type) -> None:
     """Test auth required for normal request."""
     resp = await hassio_noauth_client.post(f"/api/hassio/{build_type}")
 
@@ -47,8 +52,8 @@ async def test_auth_required_forward_request(hassio_noauth_client, build_type):
     ],
 )
 async def test_forward_request_no_auth_for_panel(
-    hassio_client, build_type, aioclient_mock
-):
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.get(f"http://127.0.0.1/{build_type}", text="response")
 
@@ -63,7 +68,9 @@ async def test_forward_request_no_auth_for_panel(
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
+async def test_forward_request_no_auth_for_logo(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for logo."""
     aioclient_mock.get("http://127.0.0.1/addons/bl_b392/logo", text="response")
 
@@ -78,7 +85,9 @@ async def test_forward_request_no_auth_for_logo(hassio_client, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_forward_request_no_auth_for_icon(hassio_client, aioclient_mock):
+async def test_forward_request_no_auth_for_icon(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for icon."""
     aioclient_mock.get("http://127.0.0.1/addons/bl_b392/icon", text="response")
 
@@ -93,7 +102,9 @@ async def test_forward_request_no_auth_for_icon(hassio_client, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_forward_log_request(hassio_client, aioclient_mock):
+async def test_forward_log_request(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test fetching normal log path doesn't remove ANSI color escape codes."""
     aioclient_mock.get("http://127.0.0.1/beer/logs", text="\033[32mresponse\033[0m")
 
@@ -108,7 +119,9 @@ async def test_forward_log_request(hassio_client, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_bad_gateway_when_cannot_find_supervisor(hassio_client, aioclient_mock):
+async def test_bad_gateway_when_cannot_find_supervisor(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test we get a bad gateway error if we can't find supervisor."""
     aioclient_mock.get("http://127.0.0.1/addons/test/info", exc=asyncio.TimeoutError)
 
@@ -116,7 +129,9 @@ async def test_bad_gateway_when_cannot_find_supervisor(hassio_client, aioclient_
     assert resp.status == HTTPStatus.BAD_GATEWAY
 
 
-async def test_forwarding_user_info(hassio_client, hass_admin_user, aioclient_mock):
+async def test_forwarding_user_info(
+    hassio_client, hass_admin_user: MockUser, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that we forward user info correctly."""
     aioclient_mock.get("http://127.0.0.1/hello")
 
@@ -132,7 +147,9 @@ async def test_forwarding_user_info(hassio_client, hass_admin_user, aioclient_mo
     assert req_headers["X-Hass-Is-Admin"] == "1"
 
 
-async def test_backup_upload_headers(hassio_client, aioclient_mock, caplog):
+async def test_backup_upload_headers(
+    hassio_client, aioclient_mock: AiohttpClientMocker, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we forward the full header for backup upload."""
     content_type = "multipart/form-data; boundary='--webkit'"
     aioclient_mock.get("http://127.0.0.1/backups/new/upload")
@@ -150,7 +167,9 @@ async def test_backup_upload_headers(hassio_client, aioclient_mock, caplog):
     assert req_headers["Content-Type"] == content_type
 
 
-async def test_backup_download_headers(hassio_client, aioclient_mock):
+async def test_backup_download_headers(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that we forward the full header for backup download."""
     content_disposition = "attachment; filename=test.tar"
     aioclient_mock.get(
@@ -182,14 +201,16 @@ def test_need_auth(hass: HomeAssistant) -> None:
     assert not _need_auth(hass, "supervisor/logs")
 
 
-async def test_stream(hassio_client, aioclient_mock):
+async def test_stream(hassio_client, aioclient_mock: AiohttpClientMocker) -> None:
     """Verify that the request is a stream."""
     aioclient_mock.get("http://127.0.0.1/test")
     await hassio_client.get("/api/hassio/test", data="test")
     assert isinstance(aioclient_mock.mock_calls[-1][2], StreamReader)
 
 
-async def test_entrypoint_cache_control(hassio_client, aioclient_mock):
+async def test_entrypoint_cache_control(
+    hassio_client, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that we return cache control for requests to the entrypoint only."""
     aioclient_mock.get("http://127.0.0.1/app/entrypoint.js")
     aioclient_mock.get("http://127.0.0.1/app/entrypoint.fdhkusd8y43r.js")

--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -7,6 +7,8 @@ import pytest
 
 from homeassistant.components.hassio.const import X_AUTH_TOKEN
 
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 
 @pytest.mark.parametrize(
     "build_type",
@@ -18,7 +20,9 @@ from homeassistant.components.hassio.const import X_AUTH_TOKEN
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_get(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_get(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.get(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -58,7 +62,9 @@ async def test_ingress_request_get(hassio_client, build_type, aioclient_mock):
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_post(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_post(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.post(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -98,7 +104,9 @@ async def test_ingress_request_post(hassio_client, build_type, aioclient_mock):
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_put(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_put(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.put(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -138,7 +146,9 @@ async def test_ingress_request_put(hassio_client, build_type, aioclient_mock):
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_delete(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_delete(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.delete(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -178,7 +188,9 @@ async def test_ingress_request_delete(hassio_client, build_type, aioclient_mock)
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_patch(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_patch(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.patch(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -218,7 +230,9 @@ async def test_ingress_request_patch(hassio_client, build_type, aioclient_mock):
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_options(hassio_client, build_type, aioclient_mock):
+async def test_ingress_request_options(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.options(
         f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
@@ -258,7 +272,9 @@ async def test_ingress_request_options(hassio_client, build_type, aioclient_mock
         ("demo", "ws/connection?id=9&token=SJAKWS283"),
     ],
 )
-async def test_ingress_websocket(hassio_client, build_type, aioclient_mock):
+async def test_ingress_websocket(
+    hassio_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test no auth needed for ."""
     aioclient_mock.get(f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}")
 
@@ -281,7 +297,9 @@ async def test_ingress_websocket(hassio_client, build_type, aioclient_mock):
     assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
 
 
-async def test_ingress_missing_peername(hassio_client, aioclient_mock, caplog):
+async def test_ingress_missing_peername(
+    hassio_client, aioclient_mock: AiohttpClientMocker, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test hadnling of missing peername."""
     aioclient_mock.get(
         "http://127.0.0.1/ingress/lorem/ipsum",

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -278,7 +278,9 @@ async def test_setup_api_push_api_data_server_host(
     assert not aioclient_mock.mock_calls[1][2]["watchdog"]
 
 
-async def test_setup_api_push_api_data_default(hass, aioclient_mock, hass_storage):
+async def test_setup_api_push_api_data_default(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test setup with API push default data."""
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
@@ -304,7 +306,9 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock, hass_storag
         pytest.fail("refresh token not found")
 
 
-async def test_setup_adds_admin_group_to_user(hass, aioclient_mock, hass_storage):
+async def test_setup_adds_admin_group_to_user(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test setup with API push default data."""
     # Create user without admin
     user = await hass.auth.async_create_system_user("Hass.io")
@@ -324,7 +328,9 @@ async def test_setup_adds_admin_group_to_user(hass, aioclient_mock, hass_storage
     assert user.is_admin
 
 
-async def test_setup_migrate_user_name(hass, aioclient_mock, hass_storage):
+async def test_setup_migrate_user_name(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test setup with migrating the user name."""
     # Create user with old name
     user = await hass.auth.async_create_system_user("Hass.io")
@@ -343,7 +349,9 @@ async def test_setup_migrate_user_name(hass, aioclient_mock, hass_storage):
     assert user.name == "Supervisor"
 
 
-async def test_setup_api_existing_hassio_user(hass, aioclient_mock, hass_storage):
+async def test_setup_api_existing_hassio_user(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+) -> None:
     """Test setup with API push default data."""
     user = await hass.auth.async_create_system_user("Hass.io test")
     token = await hass.auth.async_create_refresh_token(user)
@@ -416,7 +424,7 @@ async def test_warn_when_cannot_connect(
     assert "Not connected with the supervisor / system too busy!" in caplog.text
 
 
-async def test_service_register(hassio_env, hass):
+async def test_service_register(hassio_env, hass: HomeAssistant) -> None:
     """Check if service will be setup."""
     assert await async_setup_component(hass, "hassio", {})
     assert hass.services.has_service("hassio", "addon_start")
@@ -433,7 +441,12 @@ async def test_service_register(hassio_env, hass):
     assert hass.services.has_service("hassio", "restore_partial")
 
 
-async def test_service_calls(hassio_env, hass, aioclient_mock, caplog):
+async def test_service_calls(
+    hassio_env,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Call service and check the API calls behind that."""
     assert await async_setup_component(hass, "hassio", {})
 
@@ -517,7 +530,9 @@ async def test_service_calls(hassio_env, hass, aioclient_mock, caplog):
     }
 
 
-async def test_service_calls_core(hassio_env, hass, aioclient_mock):
+async def test_service_calls_core(
+    hassio_env, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Call core service and check the API calls behind that."""
     assert await async_setup_component(hass, "hassio", {})
 
@@ -785,7 +800,9 @@ async def test_coordinator_updates(
         ({"board": "yellow"}, "homeassistant_yellow"),
     ],
 )
-async def test_setup_hardware_integration(hass, aioclient_mock, integration):
+async def test_setup_hardware_integration(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, integration
+) -> None:
     """Test setup initiates hardware integration."""
 
     with patch.dict(os.environ, MOCK_ENVIRON), patch(
@@ -800,7 +817,9 @@ async def test_setup_hardware_integration(hass, aioclient_mock, integration):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_get_store_addon_info(hass, hassio_stubs, aioclient_mock):
+async def test_get_store_addon_info(
+    hass: HomeAssistant, hassio_stubs, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test get store add-on info from Supervisor API."""
     aioclient_mock.clear_requests()
     aioclient_mock.get(

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -1,5 +1,4 @@
 """Test repairs from supervisor issues."""
-
 from __future__ import annotations
 
 import os
@@ -15,6 +14,7 @@ from homeassistant.setup import async_setup_component
 from .test_init import MOCK_ENVIRON
 
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -148,8 +148,8 @@ def assert_repair_in_list(issues: list[dict[str, Any]], unhealthy: bool, reason:
 async def test_unhealthy_repairs(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test repairs added for unhealthy systems."""
     mock_resolution_info(aioclient_mock, unhealthy=["docker", "setup"])
 
@@ -169,8 +169,8 @@ async def test_unhealthy_repairs(
 async def test_unsupported_repairs(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test repairs added for unsupported systems."""
     mock_resolution_info(aioclient_mock, unsupported=["content_trust", "os"])
 
@@ -192,8 +192,8 @@ async def test_unsupported_repairs(
 async def test_unhealthy_repairs_add_remove(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test unhealthy repairs added and removed from dispatches."""
     mock_resolution_info(aioclient_mock)
 
@@ -248,8 +248,8 @@ async def test_unhealthy_repairs_add_remove(
 async def test_unsupported_repairs_add_remove(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test unsupported repairs added and removed from dispatches."""
     mock_resolution_info(aioclient_mock)
 
@@ -304,8 +304,8 @@ async def test_unsupported_repairs_add_remove(
 async def test_reset_repairs_supervisor_restart(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Unsupported/unhealthy repairs reset on supervisor restart."""
     mock_resolution_info(aioclient_mock, unsupported=["os"], unhealthy=["docker"])
 
@@ -347,8 +347,8 @@ async def test_reset_repairs_supervisor_restart(
 async def test_reasons_added_and_removed(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test an unsupported/unhealthy reasons being added and removed at same time."""
     mock_resolution_info(aioclient_mock, unsupported=["os"], unhealthy=["docker"])
 
@@ -396,8 +396,8 @@ async def test_reasons_added_and_removed(
 async def test_ignored_unsupported_skipped(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Unsupported reasons which have an identical unhealthy reason are ignored."""
     mock_resolution_info(
         aioclient_mock, unsupported=["privileged"], unhealthy=["privileged"]
@@ -418,8 +418,8 @@ async def test_ignored_unsupported_skipped(
 async def test_new_unsupported_unhealthy_reason(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """New unsupported/unhealthy reasons result in a generic repair until next core update."""
     mock_resolution_info(
         aioclient_mock, unsupported=["fake_unsupported"], unhealthy=["fake_unhealthy"]

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -1,15 +1,16 @@
 """The tests for the hassio sensors."""
-
 import os
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.hassio import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
@@ -156,7 +157,9 @@ def mock_all(aioclient_mock, request):
         ("sensor.test2_memory_percent", "unavailable"),
     ],
 )
-async def test_sensor(hass, entity_id, expected, aioclient_mock):
+async def test_sensor(
+    hass: HomeAssistant, entity_id, expected, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test hassio OS and addons sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -12,6 +12,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
@@ -166,12 +167,12 @@ def mock_all(aioclient_mock, request):
     ],
 )
 async def test_update_entities(
-    hass,
+    hass: HomeAssistant,
     entity_id,
     expected_state,
     auto_update,
-    aioclient_mock,
-):
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test update entities."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -425,7 +426,11 @@ async def test_update_core_with_error(
         )
 
 
-async def test_release_notes_between_versions(hass, aioclient_mock, hass_ws_client):
+async def test_release_notes_between_versions(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test release notes between versions."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -457,7 +462,11 @@ async def test_release_notes_between_versions(hass, aioclient_mock, hass_ws_clie
     assert "New updates" in result["result"]
 
 
-async def test_release_notes_full(hass, aioclient_mock, hass_ws_client):
+async def test_release_notes_full(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test release notes no match."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -489,7 +498,11 @@ async def test_release_notes_full(hass, aioclient_mock, hass_ws_client):
     assert "New updates" in result["result"]
 
 
-async def test_not_release_notes(hass, aioclient_mock, hass_ws_client):
+async def test_not_release_notes(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test handling where there are no release notes."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -16,7 +16,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_signal
+from tests.common import MockUser, async_mock_signal
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +78,9 @@ def mock_all(aioclient_mock):
     )
 
 
-async def test_ws_subscription(hassio_env, hass: HomeAssistant, hass_ws_client):
+async def test_ws_subscription(
+    hassio_env, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test websocket subscription."""
     assert await async_setup_component(hass, "hassio", {})
     client = await hass_ws_client(hass)
@@ -112,8 +116,11 @@ async def test_ws_subscription(hassio_env, hass: HomeAssistant, hass_ws_client):
 
 
 async def test_websocket_supervisor_api(
-    hassio_env, hass: HomeAssistant, hass_ws_client, aioclient_mock
-):
+    hassio_env,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test Supervisor websocket api."""
     assert await async_setup_component(hass, "hassio", {})
     websocket_client = await hass_ws_client(hass)
@@ -148,8 +155,11 @@ async def test_websocket_supervisor_api(
 
 
 async def test_websocket_supervisor_api_error(
-    hassio_env, hass: HomeAssistant, hass_ws_client, aioclient_mock
-):
+    hassio_env,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test Supervisor websocket api error."""
     assert await async_setup_component(hass, "hassio", {})
     websocket_client = await hass_ws_client(hass)
@@ -172,8 +182,12 @@ async def test_websocket_supervisor_api_error(
 
 
 async def test_websocket_non_admin_user(
-    hassio_env, hass: HomeAssistant, hass_ws_client, aioclient_mock, hass_admin_user
-):
+    hassio_env,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    hass_admin_user: MockUser,
+) -> None:
     """Test Supervisor websocket api error."""
     hass_admin_user.groups = []
     assert await async_setup_component(hass, "hassio", {})

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 VALID_CONFIG_MINIMAL = {"sensor": {"platform": "hddtemp"}}
@@ -87,7 +88,7 @@ def telnetmock():
         yield
 
 
-async def test_hddtemp_min_config(hass, telnetmock):
+async def test_hddtemp_min_config(hass: HomeAssistant, telnetmock) -> None:
     """Test minimal hddtemp configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
     await hass.async_block_till_done()
@@ -108,7 +109,7 @@ async def test_hddtemp_min_config(hass, telnetmock):
     )
 
 
-async def test_hddtemp_rename_config(hass, telnetmock):
+async def test_hddtemp_rename_config(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp configuration with different name."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_NAME)
     await hass.async_block_till_done()
@@ -121,7 +122,7 @@ async def test_hddtemp_rename_config(hass, telnetmock):
     assert state.attributes.get("friendly_name") == f"FooBar {reference['device']}"
 
 
-async def test_hddtemp_one_disk(hass, telnetmock):
+async def test_hddtemp_one_disk(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp one disk configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_ONE_DISK)
     await hass.async_block_till_done()
@@ -141,7 +142,7 @@ async def test_hddtemp_one_disk(hass, telnetmock):
     )
 
 
-async def test_hddtemp_wrong_disk(hass, telnetmock):
+async def test_hddtemp_wrong_disk(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp wrong disk configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_WRONG_DISK)
     await hass.async_block_till_done()
@@ -151,7 +152,7 @@ async def test_hddtemp_wrong_disk(hass, telnetmock):
     assert state.attributes.get("friendly_name") == "HD Temperature /dev/sdx1"
 
 
-async def test_hddtemp_multiple_disks(hass, telnetmock):
+async def test_hddtemp_multiple_disks(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp multiple disk configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_MULTIPLE_DISKS)
     await hass.async_block_till_done()
@@ -178,14 +179,14 @@ async def test_hddtemp_multiple_disks(hass, telnetmock):
         )
 
 
-async def test_hddtemp_host_refused(hass, telnetmock):
+async def test_hddtemp_host_refused(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp if host is refused."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_HOST_REFUSED)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_hddtemp_host_unreachable(hass, telnetmock):
+async def test_hddtemp_host_unreachable(hass: HomeAssistant, telnetmock) -> None:
     """Test hddtemp if host unreachable."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_HOST_UNREACHABLE)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
