### PR TITLE
Add type hints to integration tests (part 9)

### DIFF
--- a/tests/components/hdmi_cec/test_init.py
+++ b/tests/components/hdmi_cec/test_init.py
@@ -22,6 +22,7 @@ from homeassistant.components.hdmi_cec import (
     parse_mapping,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -86,7 +87,7 @@ def mock_tcp_adapter_fixture():
         ),
     ],
 )
-def test_parse_mapping_physical_address(mapping, expected):
+def test_parse_mapping_physical_address(mapping, expected) -> None:
     """Test the device config mapping function."""
     result = parse_mapping(mapping)
     result = [
@@ -98,7 +99,9 @@ def test_parse_mapping_physical_address(mapping, expected):
 # Test Setup
 
 
-async def test_setup_cec_adapter(hass, mock_cec_adapter, mock_hdmi_network):
+async def test_setup_cec_adapter(
+    hass: HomeAssistant, mock_cec_adapter, mock_hdmi_network
+) -> None:
     """Test the general setup of this component."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -120,14 +123,18 @@ async def test_setup_cec_adapter(hass, mock_cec_adapter, mock_hdmi_network):
 
 
 @pytest.mark.parametrize("osd_name", ["test", "test_a_long_name"])
-async def test_setup_set_osd_name(hass, osd_name, mock_cec_adapter):
+async def test_setup_set_osd_name(
+    hass: HomeAssistant, osd_name, mock_cec_adapter
+) -> None:
     """Test the setup of this component with the `osd_name` config setting."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"osd_name": osd_name}})
 
     mock_cec_adapter.assert_called_once_with(name=osd_name[:12], activate_source=False)
 
 
-async def test_setup_tcp_adapter(hass, mock_tcp_adapter, mock_hdmi_network):
+async def test_setup_tcp_adapter(
+    hass: HomeAssistant, mock_tcp_adapter, mock_hdmi_network
+) -> None:
     """Test the setup of this component with the TcpAdapter (`host` config setting)."""
     host = "0.0.0.0"
 
@@ -153,7 +160,7 @@ async def test_setup_tcp_adapter(hass, mock_tcp_adapter, mock_hdmi_network):
 # Test services
 
 
-async def test_service_power_on(hass, create_hdmi_network):
+async def test_service_power_on(hass: HomeAssistant, create_hdmi_network) -> None:
     """Test the power on service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -167,7 +174,7 @@ async def test_service_power_on(hass, create_hdmi_network):
     mock_hdmi_network_instance.power_on.assert_called_once_with()
 
 
-async def test_service_standby(hass, create_hdmi_network):
+async def test_service_standby(hass: HomeAssistant, create_hdmi_network) -> None:
     """Test the standby service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -181,7 +188,9 @@ async def test_service_standby(hass, create_hdmi_network):
     mock_hdmi_network_instance.standby.assert_called_once_with()
 
 
-async def test_service_select_device_alias(hass, create_hdmi_network):
+async def test_service_select_device_alias(
+    hass: HomeAssistant, create_hdmi_network
+) -> None:
     """Test the select device service call with a known alias."""
     mock_hdmi_network_instance = await create_hdmi_network(
         {"devices": {"Chromecast": "1.0.0.0"}}
@@ -209,7 +218,9 @@ class MockCecEntity(MockEntity):
         return {"physical_address": self._values["physical_address"]}
 
 
-async def test_service_select_device_entity(hass, create_hdmi_network):
+async def test_service_select_device_entity(
+    hass: HomeAssistant, create_hdmi_network
+) -> None:
     """Test the select device service call with an existing entity."""
     platform = MockEntityPlatform(hass)
     await platform.async_add_entities(
@@ -231,7 +242,9 @@ async def test_service_select_device_entity(hass, create_hdmi_network):
     assert str(physical_address) == "3.0.0.0"
 
 
-async def test_service_select_device_physical_address(hass, create_hdmi_network):
+async def test_service_select_device_physical_address(
+    hass: HomeAssistant, create_hdmi_network
+) -> None:
     """Test the select device service call with a raw physical address."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -248,7 +261,7 @@ async def test_service_select_device_physical_address(hass, create_hdmi_network)
     assert str(physical_address) == "1.1.0.0"
 
 
-async def test_service_update_devices(hass, create_hdmi_network):
+async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) -> None:
     """Test the update devices service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -280,8 +293,8 @@ async def test_service_update_devices(hass, create_hdmi_network):
 )
 @pytest.mark.parametrize("direction,key", [("up", 65), ("down", 66)])
 async def test_service_volume_x_times(
-    hass, create_hdmi_network, count, calls, direction, key
-):
+    hass: HomeAssistant, create_hdmi_network, count, calls, direction, key
+) -> None:
     """Test the volume service call with steps."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -300,7 +313,9 @@ async def test_service_volume_x_times(
 
 
 @pytest.mark.parametrize("direction,key", [("up", 65), ("down", 66)])
-async def test_service_volume_press(hass, create_hdmi_network, direction, key):
+async def test_service_volume_press(
+    hass: HomeAssistant, create_hdmi_network, direction, key
+) -> None:
     """Test the volume service call with press attribute."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -319,7 +334,9 @@ async def test_service_volume_press(hass, create_hdmi_network, direction, key):
 
 
 @pytest.mark.parametrize("direction,key", [("up", 65), ("down", 66)])
-async def test_service_volume_release(hass, create_hdmi_network, direction, key):
+async def test_service_volume_release(
+    hass: HomeAssistant, create_hdmi_network, direction, key
+) -> None:
     """Test the volume service call with release attribute."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -352,7 +369,9 @@ async def test_service_volume_release(hass, create_hdmi_network, direction, key)
         ),
     ],
 )
-async def test_service_volume_mute(hass, create_hdmi_network, attr, key):
+async def test_service_volume_mute(
+    hass: HomeAssistant, create_hdmi_network, attr, key
+) -> None:
     """Test the volume service call with mute."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -421,7 +440,9 @@ async def test_service_volume_mute(hass, create_hdmi_network, attr, key):
         ),
     ],
 )
-async def test_service_send_command(hass, create_hdmi_network, data, expected):
+async def test_service_send_command(
+    hass: HomeAssistant, create_hdmi_network, data, expected
+) -> None:
     """Test the send command service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -442,12 +463,12 @@ async def test_service_send_command(hass, create_hdmi_network, data, expected):
     "adapter_initialized_value, watchdog_actions", [(False, 1), (True, 0)]
 )
 async def test_watchdog(
-    hass,
+    hass: HomeAssistant,
     create_hdmi_network,
     mock_cec_adapter,
     adapter_initialized_value,
     watchdog_actions,
-):
+) -> None:
     """Test the watchdog when adapter is down/up."""
     adapter_initialized = PropertyMock(return_value=adapter_initialized_value)
     events = async_capture_events(hass, EVENT_HDMI_CEC_UNAVAILABLE)

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -49,6 +49,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice, assert_key_press_release
 
@@ -84,7 +85,9 @@ def assert_state_fixture(hass, request):
     return test_state
 
 
-async def test_load_platform(hass, create_hdmi_network, create_cec_entity):
+async def test_load_platform(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test that media_player entity is loaded."""
     hdmi_network = await create_hdmi_network(config={"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3)
@@ -98,7 +101,9 @@ async def test_load_platform(hass, create_hdmi_network, create_cec_entity):
 
 
 @pytest.mark.parametrize("platform", [{}, {"platform": "switch"}])
-async def test_load_types(hass, create_hdmi_network, create_cec_entity, platform):
+async def test_load_types(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, platform
+) -> None:
     """Test that media_player entity is loaded when types is set."""
     config = platform | {"types": {"hdmi_cec.hdmi_4": "media_player"}}
     hdmi_network = await create_hdmi_network(config=config)
@@ -121,7 +126,9 @@ async def test_load_types(hass, create_hdmi_network, create_cec_entity, platform
     assert state is None
 
 
-async def test_service_on(hass, create_hdmi_network, create_cec_entity, assert_state):
+async def test_service_on(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, assert_state
+) -> None:
     """Test that media_player triggers on `on` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3)
@@ -143,7 +150,9 @@ async def test_service_on(hass, create_hdmi_network, create_cec_entity, assert_s
     assert_state(state.state, STATE_ON)
 
 
-async def test_service_off(hass, create_hdmi_network, create_cec_entity, assert_state):
+async def test_service_off(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, assert_state
+) -> None:
     """Test that media_player triggers on `off` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3)
@@ -239,8 +248,12 @@ async def test_service_off(hass, create_hdmi_network, create_cec_entity, assert_
     ],
 )
 async def test_supported_features(
-    hass, create_hdmi_network, create_cec_entity, type_id, expected_features
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    type_id,
+    expected_features,
+) -> None:
     """Test that features load as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(
@@ -264,8 +277,13 @@ async def test_supported_features(
     ],
 )
 async def test_volume_services(
-    hass, create_hdmi_network, create_cec_entity, service, extra_data, key
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    service,
+    extra_data,
+    key,
+) -> None:
     """Test volume related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3, type=TYPE_AUDIO)
@@ -295,8 +313,8 @@ async def test_volume_services(
     ],
 )
 async def test_track_change_services(
-    hass, create_hdmi_network, create_cec_entity, service, key
-):
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, service, key
+) -> None:
     """Test track change related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3, type=TYPE_RECORDER)
@@ -330,14 +348,14 @@ async def test_track_change_services(
     ],
 )
 async def test_playback_services(
-    hass,
+    hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
     assert_state,
     service,
     key,
     expected_state,
-):
+) -> None:
     """Test playback related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3, type=TYPE_RECORDER)
@@ -360,11 +378,11 @@ async def test_playback_services(
 
 @pytest.mark.xfail(reason="PLAY feature isn't enabled")
 async def test_play_pause_service(
-    hass,
+    hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
     assert_state,
-):
+) -> None:
     """Test play pause service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(
@@ -422,8 +440,13 @@ async def test_play_pause_service(
     ],
 )
 async def test_update_state(
-    hass, create_hdmi_network, create_cec_entity, type_id, update_data, expected_state
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    type_id,
+    update_data,
+    expected_state,
+) -> None:
     """Test state updates work as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3, type=type_id)
@@ -468,8 +491,8 @@ async def test_update_state(
     ],
 )
 async def test_starting_state(
-    hass, create_hdmi_network, create_cec_entity, data, expected_state
-):
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, data, expected_state
+) -> None:
     """Test starting states are set as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3, **data)
@@ -481,7 +504,9 @@ async def test_starting_state(
 @pytest.mark.xfail(
     reason="The code only sets the state to unavailable, doesn't set the `_attr_available` to false."
 )
-async def test_unavailable_status(hass, create_hdmi_network, create_cec_entity):
+async def test_unavailable_status(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test entity goes into unavailable status when expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
     mock_hdmi_device = MockHDMIDevice(logical_address=3)

--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -13,12 +13,15 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice
 
 
 @pytest.mark.parametrize("config", [{}, {"platform": "switch"}])
-async def test_load_platform(hass, create_hdmi_network, create_cec_entity, config):
+async def test_load_platform(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, config
+) -> None:
     """Test that switch entity is loaded."""
     hdmi_network = await create_hdmi_network(config=config)
     mock_hdmi_device = MockHDMIDevice(logical_address=3)
@@ -31,7 +34,9 @@ async def test_load_platform(hass, create_hdmi_network, create_cec_entity, confi
     assert state is not None
 
 
-async def test_load_types(hass, create_hdmi_network, create_cec_entity):
+async def test_load_types(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test that switch entity is loaded when types is set."""
     config = {"platform": "media_player", "types": {"hdmi_cec.hdmi_3": "switch"}}
     hdmi_network = await create_hdmi_network(config=config)
@@ -54,7 +59,9 @@ async def test_load_types(hass, create_hdmi_network, create_cec_entity):
     assert state is None
 
 
-async def test_service_on(hass, create_hdmi_network, create_cec_entity):
+async def test_service_on(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test that switch triggers on `on` service."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, power_status=3)
@@ -72,7 +79,9 @@ async def test_service_on(hass, create_hdmi_network, create_cec_entity):
     assert state.state == STATE_ON
 
 
-async def test_service_off(hass, create_hdmi_network, create_cec_entity):
+async def test_service_off(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test that switch triggers on `off` service."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, power_status=4)
@@ -107,8 +116,13 @@ async def test_service_off(hass, create_hdmi_network, create_cec_entity):
     ],
 )
 async def test_device_status_change(
-    hass, create_hdmi_network, create_cec_entity, power_status, expected_state, status
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    power_status,
+    expected_state,
+    status,
+) -> None:
     """Test state change on device status change."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, status=status)
@@ -139,8 +153,8 @@ async def test_device_status_change(
     ],
 )
 async def test_friendly_name(
-    hass, create_hdmi_network, create_cec_entity, device_values, expected
-):
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity, device_values, expected
+) -> None:
     """Test friendly name setup."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, **device_values)
@@ -191,8 +205,12 @@ async def test_friendly_name(
     ],
 )
 async def test_extra_state_attributes(
-    hass, create_hdmi_network, create_cec_entity, device_values, expected_attributes
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    device_values,
+    expected_attributes,
+) -> None:
     """Test extra state attributes."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, **device_values)
@@ -219,8 +237,12 @@ async def test_extra_state_attributes(
     ],
 )
 async def test_icon(
-    hass, create_hdmi_network, create_cec_entity, device_type, expected_icon
-):
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    device_type,
+    expected_icon,
+) -> None:
     """Test icon selection."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3, type=device_type)
@@ -230,7 +252,9 @@ async def test_icon(
     assert state.attributes["icon"] == expected_icon
 
 
-async def test_unavailable_status(hass, create_hdmi_network, create_cec_entity):
+async def test_unavailable_status(
+    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+) -> None:
     """Test entity goes into unavailable status when expected."""
     hdmi_network = await create_hdmi_network()
     mock_hdmi_device = MockHDMIDevice(logical_address=3)

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 
-async def test_flow_aborts_already_setup(hass, config_entry):
+async def test_flow_aborts_already_setup(hass: HomeAssistant, config_entry) -> None:
     """Test flow aborts when entry already setup."""
     config_entry.add_to_hass(hass)
     flow = HeosFlowHandler()
@@ -33,7 +33,7 @@ async def test_no_host_shows_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_cannot_connect_shows_error_form(hass, controller):
+async def test_cannot_connect_shows_error_form(hass: HomeAssistant, controller) -> None:
     """Test form is shown with error when cannot connect."""
     controller.connect.side_effect = HeosError()
     result = await hass.config_entries.flow.async_init(
@@ -48,7 +48,7 @@ async def test_cannot_connect_shows_error_form(hass, controller):
     controller.disconnect.reset_mock()
 
 
-async def test_create_entry_when_host_valid(hass, controller):
+async def test_create_entry_when_host_valid(hass: HomeAssistant, controller) -> None:
     """Test result type is create entry when host is valid."""
     data = {CONF_HOST: "127.0.0.1"}
     with patch("homeassistant.components.heos.async_setup_entry", return_value=True):
@@ -63,7 +63,9 @@ async def test_create_entry_when_host_valid(hass, controller):
         assert controller.disconnect.call_count == 1
 
 
-async def test_create_entry_when_friendly_name_valid(hass, controller):
+async def test_create_entry_when_friendly_name_valid(
+    hass: HomeAssistant, controller
+) -> None:
     """Test result type is create entry when friendly name is valid."""
     hass.data[DATA_DISCOVERED_HOSTS] = {"Office (127.0.0.1)": "127.0.0.1"}
     data = {CONF_HOST: "Office (127.0.0.1)"}
@@ -81,8 +83,8 @@ async def test_create_entry_when_friendly_name_valid(hass, controller):
 
 
 async def test_discovery_shows_create_form(
-    hass, controller, discovery_data: ssdp.SsdpServiceInfo
-):
+    hass: HomeAssistant, controller, discovery_data: ssdp.SsdpServiceInfo
+) -> None:
     """Test discovery shows form to confirm setup and subsequent abort."""
 
     await hass.config_entries.flow.async_init(
@@ -112,8 +114,8 @@ async def test_discovery_shows_create_form(
 
 
 async def test_discovery_flow_aborts_already_setup(
-    hass, controller, discovery_data: ssdp.SsdpServiceInfo, config_entry
-):
+    hass: HomeAssistant, controller, discovery_data: ssdp.SsdpServiceInfo, config_entry
+) -> None:
     """Test discovery flow aborts when entry already setup."""
     config_entry.add_to_hass(hass)
     flow = HeosFlowHandler()
@@ -124,8 +126,8 @@ async def test_discovery_flow_aborts_already_setup(
 
 
 async def test_discovery_sets_the_unique_id(
-    hass, controller, discovery_data: ssdp.SsdpServiceInfo
-):
+    hass: HomeAssistant, controller, discovery_data: ssdp.SsdpServiceInfo
+) -> None:
     """Test discovery sets the unique id."""
 
     port = urlparse(discovery_data.ssdp_location).port
@@ -142,7 +144,7 @@ async def test_discovery_sets_the_unique_id(
     assert hass.data[DATA_DISCOVERED_HOSTS] == {"Bedroom (127.0.0.2)": "127.0.0.2"}
 
 
-async def test_import_sets_the_unique_id(hass, controller):
+async def test_import_sets_the_unique_id(hass: HomeAssistant, controller) -> None:
     """Test import sets the unique id."""
 
     with patch("homeassistant.components.heos.async_setup_entry", return_value=True):

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -17,11 +17,12 @@ from homeassistant.components.heos.const import (
 )
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 
 
-async def test_async_setup_creates_entry(hass, config):
+async def test_async_setup_creates_entry(hass: HomeAssistant, config) -> None:
     """Test component setup creates entry from config."""
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
@@ -33,7 +34,9 @@ async def test_async_setup_creates_entry(hass, config):
     assert entry.unique_id == DOMAIN
 
 
-async def test_async_setup_updates_entry(hass, config_entry, config, controller):
+async def test_async_setup_updates_entry(
+    hass: HomeAssistant, config_entry, config, controller
+) -> None:
     """Test component setup updates entry from config."""
     config[DOMAIN][CONF_HOST] = "127.0.0.2"
     config_entry.add_to_hass(hass)
@@ -47,7 +50,9 @@ async def test_async_setup_updates_entry(hass, config_entry, config, controller)
     assert entry.unique_id == DOMAIN
 
 
-async def test_async_setup_returns_true(hass, config_entry, config):
+async def test_async_setup_returns_true(
+    hass: HomeAssistant, config_entry, config
+) -> None:
     """Test component setup from config."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, config)
@@ -57,7 +62,9 @@ async def test_async_setup_returns_true(hass, config_entry, config):
     assert entries[0] == config_entry
 
 
-async def test_async_setup_no_config_returns_true(hass, config_entry):
+async def test_async_setup_no_config_returns_true(
+    hass: HomeAssistant, config_entry
+) -> None:
     """Test component setup from entry only."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
@@ -68,8 +75,8 @@ async def test_async_setup_no_config_returns_true(hass, config_entry):
 
 
 async def test_async_setup_entry_loads_platforms(
-    hass, config_entry, controller, input_sources, favorites
-):
+    hass: HomeAssistant, config_entry, controller, input_sources, favorites
+) -> None:
     """Test load connects to heos, retrieves players, and loads platforms."""
     config_entry.add_to_hass(hass)
     with patch.object(hass.config_entries, "async_forward_entry_setup") as forward_mock:
@@ -89,8 +96,12 @@ async def test_async_setup_entry_loads_platforms(
 
 
 async def test_async_setup_entry_not_signed_in_loads_platforms(
-    hass, config_entry, controller, input_sources, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    controller,
+    input_sources,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test setup does not retrieve favorites when not logged in."""
     config_entry.add_to_hass(hass)
     controller.is_signed_in = False
@@ -116,7 +127,9 @@ async def test_async_setup_entry_not_signed_in_loads_platforms(
     )
 
 
-async def test_async_setup_entry_connect_failure(hass, config_entry, controller):
+async def test_async_setup_entry_connect_failure(
+    hass: HomeAssistant, config_entry, controller
+) -> None:
     """Connection failure raises ConfigEntryNotReady."""
     config_entry.add_to_hass(hass)
     controller.connect.side_effect = HeosError()
@@ -129,7 +142,9 @@ async def test_async_setup_entry_connect_failure(hass, config_entry, controller)
     controller.disconnect.reset_mock()
 
 
-async def test_async_setup_entry_player_failure(hass, config_entry, controller):
+async def test_async_setup_entry_player_failure(
+    hass: HomeAssistant, config_entry, controller
+) -> None:
     """Failure to retrieve players/sources raises ConfigEntryNotReady."""
     config_entry.add_to_hass(hass)
     controller.get_players.side_effect = HeosError()
@@ -142,7 +157,7 @@ async def test_async_setup_entry_player_failure(hass, config_entry, controller):
     controller.disconnect.reset_mock()
 
 
-async def test_unload_entry(hass, config_entry, controller):
+async def test_unload_entry(hass: HomeAssistant, config_entry, controller) -> None:
     """Test entries are unloaded correctly."""
     controller_manager = Mock(ControllerManager)
     hass.data[DOMAIN] = {DATA_CONTROLLER_MANAGER: controller_manager}
@@ -156,7 +171,13 @@ async def test_unload_entry(hass, config_entry, controller):
     assert DOMAIN not in hass.data
 
 
-async def test_update_sources_retry(hass, config_entry, config, controller, caplog):
+async def test_update_sources_retry(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test update sources retries on failures to max attempts."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -3,6 +3,7 @@ import asyncio
 
 from pyheos import CommandFailedError, const
 from pyheos.error import HeosError
+import pytest
 
 from homeassistant.components.heos import media_player
 from homeassistant.components.heos.const import (
@@ -51,6 +52,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
@@ -63,7 +65,9 @@ async def setup_platform(hass, config_entry, config):
     await hass.async_block_till_done()
 
 
-async def test_state_attributes(hass, config_entry, config, controller):
+async def test_state_attributes(
+    hass: HomeAssistant, config_entry, config, controller
+) -> None:
     """Tests the state attributes."""
     await setup_platform(hass, config_entry, config)
     state = hass.states.get("media_player.test_player")
@@ -100,7 +104,9 @@ async def test_state_attributes(hass, config_entry, config, controller):
     )
 
 
-async def test_updates_from_signals(hass, config_entry, config, controller, favorites):
+async def test_updates_from_signals(
+    hass: HomeAssistant, config_entry, config, controller, favorites
+) -> None:
     """Tests dispatched signals update player."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -140,8 +146,12 @@ async def test_updates_from_signals(hass, config_entry, config, controller, favo
 
 
 async def test_updates_from_connection_event(
-    hass, config_entry, config, controller, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Tests player updates from connection event after connection failure."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -186,8 +196,8 @@ async def test_updates_from_connection_event(
 
 
 async def test_updates_from_sources_updated(
-    hass, config_entry, config, controller, input_sources
-):
+    hass: HomeAssistant, config_entry, config, controller, input_sources
+) -> None:
     """Tests player updates from changes in sources list."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -210,8 +220,13 @@ async def test_updates_from_sources_updated(
 
 
 async def test_updates_from_players_changed(
-    hass, config_entry, config, controller, change_data, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    change_data,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test player updates from changes to available players."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -233,8 +248,13 @@ async def test_updates_from_players_changed(
 
 
 async def test_updates_from_players_changed_new_ids(
-    hass, config_entry, config, controller, change_data_mapped_ids, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    change_data_mapped_ids,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test player updates from changes to available players."""
     await setup_platform(hass, config_entry, config)
     device_registry = dr.async_get(hass)
@@ -273,7 +293,9 @@ async def test_updates_from_players_changed_new_ids(
     )
 
 
-async def test_updates_from_user_changed(hass, config_entry, config, controller):
+async def test_updates_from_user_changed(
+    hass: HomeAssistant, config_entry, config, controller
+) -> None:
     """Tests player updates from changes in user."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -296,7 +318,13 @@ async def test_updates_from_user_changed(hass, config_entry, config, controller)
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == source_list
 
 
-async def test_clear_playlist(hass, config_entry, config, controller, caplog):
+async def test_clear_playlist(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the clear playlist service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -314,7 +342,13 @@ async def test_clear_playlist(hass, config_entry, config, controller, caplog):
     assert "Unable to clear playlist: Failure (1)" in caplog.text
 
 
-async def test_pause(hass, config_entry, config, controller, caplog):
+async def test_pause(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the pause service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -332,7 +366,13 @@ async def test_pause(hass, config_entry, config, controller, caplog):
     assert "Unable to pause: Failure (1)" in caplog.text
 
 
-async def test_play(hass, config_entry, config, controller, caplog):
+async def test_play(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the play service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -350,7 +390,13 @@ async def test_play(hass, config_entry, config, controller, caplog):
     assert "Unable to play: Failure (1)" in caplog.text
 
 
-async def test_previous_track(hass, config_entry, config, controller, caplog):
+async def test_previous_track(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the previous track service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -368,7 +414,13 @@ async def test_previous_track(hass, config_entry, config, controller, caplog):
     assert "Unable to move to previous track: Failure (1)" in caplog.text
 
 
-async def test_next_track(hass, config_entry, config, controller, caplog):
+async def test_next_track(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the next track service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -386,7 +438,13 @@ async def test_next_track(hass, config_entry, config, controller, caplog):
     assert "Unable to move to next track: Failure (1)" in caplog.text
 
 
-async def test_stop(hass, config_entry, config, controller, caplog):
+async def test_stop(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the stop service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -404,7 +462,13 @@ async def test_stop(hass, config_entry, config, controller, caplog):
     assert "Unable to stop: Failure (1)" in caplog.text
 
 
-async def test_volume_mute(hass, config_entry, config, controller, caplog):
+async def test_volume_mute(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the volume mute service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -422,7 +486,13 @@ async def test_volume_mute(hass, config_entry, config, controller, caplog):
     assert "Unable to set mute: Failure (1)" in caplog.text
 
 
-async def test_shuffle_set(hass, config_entry, config, controller, caplog):
+async def test_shuffle_set(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the shuffle set service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -440,7 +510,13 @@ async def test_shuffle_set(hass, config_entry, config, controller, caplog):
     assert "Unable to set shuffle: Failure (1)" in caplog.text
 
 
-async def test_volume_set(hass, config_entry, config, controller, caplog):
+async def test_volume_set(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the volume set service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -458,7 +534,9 @@ async def test_volume_set(hass, config_entry, config, controller, caplog):
     assert "Unable to set volume level: Failure (1)" in caplog.text
 
 
-async def test_select_favorite(hass, config_entry, config, controller, favorites):
+async def test_select_favorite(
+    hass: HomeAssistant, config_entry, config, controller, favorites
+) -> None:
     """Tests selecting a music service favorite and state."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -481,7 +559,9 @@ async def test_select_favorite(hass, config_entry, config, controller, favorites
     assert state.attributes[ATTR_INPUT_SOURCE] == favorite.name
 
 
-async def test_select_radio_favorite(hass, config_entry, config, controller, favorites):
+async def test_select_radio_favorite(
+    hass: HomeAssistant, config_entry, config, controller, favorites
+) -> None:
     """Tests selecting a radio favorite and state."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -506,8 +586,13 @@ async def test_select_radio_favorite(hass, config_entry, config, controller, fav
 
 
 async def test_select_radio_favorite_command_error(
-    hass, config_entry, config, controller, favorites, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    favorites,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Tests command error logged when playing favorite."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -525,8 +610,8 @@ async def test_select_radio_favorite_command_error(
 
 
 async def test_select_input_source(
-    hass, config_entry, config, controller, input_sources
-):
+    hass: HomeAssistant, config_entry, config, controller, input_sources
+) -> None:
     """Tests selecting input source and state."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -553,7 +638,13 @@ async def test_select_input_source(
     assert state.attributes[ATTR_INPUT_SOURCE] == input_source.name
 
 
-async def test_select_input_unknown(hass, config_entry, config, controller, caplog):
+async def test_select_input_unknown(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Tests selecting an unknown input."""
     await setup_platform(hass, config_entry, config)
     await hass.services.async_call(
@@ -566,8 +657,13 @@ async def test_select_input_unknown(hass, config_entry, config, controller, capl
 
 
 async def test_select_input_command_error(
-    hass, config_entry, config, controller, caplog, input_sources
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+    input_sources,
+) -> None:
     """Tests selecting an unknown input."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -586,14 +682,22 @@ async def test_select_input_command_error(
     assert "Unable to select source: Failure (1)" in caplog.text
 
 
-async def test_unload_config_entry(hass, config_entry, config, controller):
+async def test_unload_config_entry(
+    hass: HomeAssistant, config_entry, config, controller
+) -> None:
     """Test the player is set unavailable when the config entry is unloaded."""
     await setup_platform(hass, config_entry, config)
     await config_entry.async_unload(hass)
     assert hass.states.get("media_player.test_player").state == STATE_UNAVAILABLE
 
 
-async def test_play_media_url(hass, config_entry, config, controller, caplog):
+async def test_play_media_url(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the play media service with type url."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -616,7 +720,13 @@ async def test_play_media_url(hass, config_entry, config, controller, caplog):
     assert "Unable to play media: Failure (1)" in caplog.text
 
 
-async def test_play_media_music(hass, config_entry, config, controller, caplog):
+async def test_play_media_music(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the play media service with type music."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -640,8 +750,13 @@ async def test_play_media_music(hass, config_entry, config, controller, caplog):
 
 
 async def test_play_media_quick_select(
-    hass, config_entry, config, controller, caplog, quick_selects
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+    quick_selects,
+) -> None:
     """Test the play media service with type quick_select."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -690,8 +805,13 @@ async def test_play_media_quick_select(
 
 
 async def test_play_media_playlist(
-    hass, config_entry, config, controller, caplog, playlists
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+    playlists,
+) -> None:
     """Test the play media service with type playlist."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -741,8 +861,13 @@ async def test_play_media_playlist(
 
 
 async def test_play_media_favorite(
-    hass, config_entry, config, controller, caplog, favorites
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+    favorites,
+) -> None:
     """Test the play media service with type favorite."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -790,7 +915,13 @@ async def test_play_media_favorite(
     assert "Unable to play media: Invalid favorite 'Invalid'" in caplog.text
 
 
-async def test_play_media_invalid_type(hass, config_entry, config, controller, caplog):
+async def test_play_media_invalid_type(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the play media service with an invalid type."""
     await setup_platform(hass, config_entry, config)
     await hass.services.async_call(
@@ -806,7 +937,13 @@ async def test_play_media_invalid_type(hass, config_entry, config, controller, c
     assert "Unable to play media: Unsupported media type 'Other'" in caplog.text
 
 
-async def test_media_player_join_group(hass, config_entry, config, controller, caplog):
+async def test_media_player_join_group(
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test grouping of media players through the join service."""
     await setup_platform(hass, config_entry, config)
     await hass.services.async_call(
@@ -840,8 +977,12 @@ async def test_media_player_join_group(hass, config_entry, config, controller, c
 
 
 async def test_media_player_group_members(
-    hass, config_entry, config, controller, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test group_members attribute."""
     await setup_platform(hass, config_entry, config)
     await hass.async_block_till_done()
@@ -855,8 +996,12 @@ async def test_media_player_group_members(
 
 
 async def test_media_player_group_members_error(
-    hass, config_entry, config, controller, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test error in HEOS API."""
     controller.get_groups.side_effect = HeosError("error")
     await setup_platform(hass, config_entry, config)
@@ -867,8 +1012,12 @@ async def test_media_player_group_members_error(
 
 
 async def test_media_player_unjoin_group(
-    hass, config_entry, config, controller, caplog
-):
+    hass: HomeAssistant,
+    config_entry,
+    config,
+    controller,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test ungrouping of media players through the join service."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]

--- a/tests/components/heos/test_services.py
+++ b/tests/components/heos/test_services.py
@@ -1,5 +1,6 @@
 """Tests for the services module."""
 from pyheos import CommandFailedError, HeosError, const
+import pytest
 
 from homeassistant.components.heos.const import (
     ATTR_PASSWORD,
@@ -8,6 +9,7 @@ from homeassistant.components.heos.const import (
     SERVICE_SIGN_IN,
     SERVICE_SIGN_OUT,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -18,7 +20,7 @@ async def setup_component(hass, config_entry):
     await hass.async_block_till_done()
 
 
-async def test_sign_in(hass, config_entry, controller):
+async def test_sign_in(hass: HomeAssistant, config_entry, controller) -> None:
     """Test the sign-in service."""
     await setup_component(hass, config_entry)
 
@@ -32,7 +34,9 @@ async def test_sign_in(hass, config_entry, controller):
     controller.sign_in.assert_called_once_with("test@test.com", "password")
 
 
-async def test_sign_in_not_connected(hass, config_entry, controller, caplog):
+async def test_sign_in_not_connected(
+    hass: HomeAssistant, config_entry, controller, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test sign-in service logs error when not connected."""
     await setup_component(hass, config_entry)
     controller.connection_state = const.STATE_RECONNECTING
@@ -48,7 +52,9 @@ async def test_sign_in_not_connected(hass, config_entry, controller, caplog):
     assert "Unable to sign in because HEOS is not connected" in caplog.text
 
 
-async def test_sign_in_failed(hass, config_entry, controller, caplog):
+async def test_sign_in_failed(
+    hass: HomeAssistant, config_entry, controller, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test sign-in service logs error when not connected."""
     await setup_component(hass, config_entry)
     controller.sign_in.side_effect = CommandFailedError("", "Invalid credentials", 6)
@@ -64,7 +70,9 @@ async def test_sign_in_failed(hass, config_entry, controller, caplog):
     assert "Sign in failed: Invalid credentials (6)" in caplog.text
 
 
-async def test_sign_in_unknown_error(hass, config_entry, controller, caplog):
+async def test_sign_in_unknown_error(
+    hass: HomeAssistant, config_entry, controller, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test sign-in service logs error for failure."""
     await setup_component(hass, config_entry)
     controller.sign_in.side_effect = HeosError()
@@ -80,7 +88,7 @@ async def test_sign_in_unknown_error(hass, config_entry, controller, caplog):
     assert "Unable to sign in" in caplog.text
 
 
-async def test_sign_out(hass, config_entry, controller):
+async def test_sign_out(hass: HomeAssistant, config_entry, controller) -> None:
     """Test the sign-out service."""
     await setup_component(hass, config_entry)
 
@@ -89,7 +97,9 @@ async def test_sign_out(hass, config_entry, controller):
     assert controller.sign_out.call_count == 1
 
 
-async def test_sign_out_not_connected(hass, config_entry, controller, caplog):
+async def test_sign_out_not_connected(
+    hass: HomeAssistant, config_entry, controller, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the sign-out service."""
     await setup_component(hass, config_entry)
     controller.connection_state = const.STATE_RECONNECTING
@@ -100,7 +110,9 @@ async def test_sign_out_not_connected(hass, config_entry, controller, caplog):
     assert "Unable to sign out because HEOS is not connected" in caplog.text
 
 
-async def test_sign_out_unknown_error(hass, config_entry, controller, caplog):
+async def test_sign_out_unknown_error(
+    hass: HomeAssistant, config_entry, controller, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the sign-out service."""
     await setup_component(hass, config_entry)
     controller.sign_out.side_effect = HeosError()

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -119,7 +119,7 @@ async def test_sensor(
     icon,
     arrival_time,
     departure_time,
-):
+) -> None:
     """Test that sensor works."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -174,7 +174,9 @@ async def test_sensor(
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_circular_ref(hass: HomeAssistant, caplog):
+async def test_circular_ref(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that a circular ref is handled."""
     hass.states.async_set(
         "test.first",
@@ -205,7 +207,7 @@ async def test_circular_ref(hass: HomeAssistant, caplog):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_public_transport(hass: HomeAssistant):
+async def test_public_transport(hass: HomeAssistant) -> None:
     """Test that public transport mode is handled."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -240,7 +242,7 @@ async def test_public_transport(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("no_attribution_response")
-async def test_no_attribution_response(hass: HomeAssistant):
+async def test_no_attribution_response(hass: HomeAssistant) -> None:
     """Test that no_attribution is handled."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -268,7 +270,7 @@ async def test_no_attribution_response(hass: HomeAssistant):
     )
 
 
-async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock):
+async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> None:
     """Test that origin/destination supplied by entities works."""
     zone_config = {
         "zone": [
@@ -324,7 +326,9 @@ async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_destination_entity_not_found(hass: HomeAssistant, caplog):
+async def test_destination_entity_not_found(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that a not existing destination_entity_id is caught."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -350,7 +354,9 @@ async def test_destination_entity_not_found(hass: HomeAssistant, caplog):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_origin_entity_not_found(hass: HomeAssistant, caplog):
+async def test_origin_entity_not_found(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that a not existing origin_entity_id is caught."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -376,7 +382,9 @@ async def test_origin_entity_not_found(hass: HomeAssistant, caplog):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_invalid_destination_entity_state(hass: HomeAssistant, caplog):
+async def test_invalid_destination_entity_state(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an invalid state of the destination_entity_id is caught."""
     hass.states.async_set(
         "device_tracker.test",
@@ -408,7 +416,9 @@ async def test_invalid_destination_entity_state(hass: HomeAssistant, caplog):
 
 
 @pytest.mark.usefixtures("valid_response")
-async def test_invalid_origin_entity_state(hass: HomeAssistant, caplog):
+async def test_invalid_origin_entity_state(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an invalid state of the origin_entity_id is caught."""
     hass.states.async_set(
         "device_tracker.test",
@@ -439,7 +449,9 @@ async def test_invalid_origin_entity_state(hass: HomeAssistant, caplog):
     )
 
 
-async def test_route_not_found(hass: HomeAssistant, caplog):
+async def test_route_not_found(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that route not found error is correctly handled."""
     with patch(
         "here_routing.HERERoutingApi.route",
@@ -618,7 +630,9 @@ async def test_restore_state(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_transit_errors(hass: HomeAssistant, caplog, exception, expected_message):
+async def test_transit_errors(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, exception, expected_message
+) -> None:
     """Test that transit errors are correctly handled."""
     with patch(
         "here_transit.HERETransitApi.route",
@@ -647,7 +661,9 @@ async def test_transit_errors(hass: HomeAssistant, caplog, exception, expected_m
         assert expected_message in caplog.text
 
 
-async def test_routing_rate_limit(hass: HomeAssistant, caplog):
+async def test_routing_rate_limit(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that rate limiting is applied when encountering HTTP 429."""
     with patch(
         "here_routing.HERERoutingApi.route",
@@ -695,7 +711,9 @@ async def test_routing_rate_limit(hass: HomeAssistant, caplog):
         assert "Resetting update interval to" in caplog.text
 
 
-async def test_transit_rate_limit(hass: HomeAssistant, caplog):
+async def test_transit_rate_limit(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that rate limiting is applied when encountering HTTP 429."""
     with patch(
         "here_transit.HERETransitApi.route",
@@ -754,7 +772,7 @@ async def test_transit_rate_limit(hass: HomeAssistant, caplog):
 @pytest.mark.usefixtures("bike_response")
 async def test_multiple_sections(
     hass: HomeAssistant,
-):
+) -> None:
     """Test that multiple sections are handled correctly."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, sentinel
 import pytest
 
 from homeassistant.components import history
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.models import process_timestamp
 from homeassistant.const import (
@@ -18,6 +19,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_FINAL_WRITE,
 )
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -30,6 +32,7 @@ from tests.components.recorder.common import (
     async_wait_recording_done,
     wait_recording_done,
 )
+from tests.typing import ClientSessionGenerator
 
 
 def listeners_without_writes(listeners: dict[str, int]) -> dict[str, int]:
@@ -47,7 +50,7 @@ def test_setup() -> None:
     # Verification occurs in the fixture
 
 
-def test_get_significant_states(hass_history):
+def test_get_significant_states(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -60,7 +63,7 @@ def test_get_significant_states(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_minimal_response(hass_history):
+def test_get_significant_states_minimal_response(hass_history) -> None:
     """Test that only significant states are returned.
 
     When minimal responses is set only the first and
@@ -125,7 +128,7 @@ def test_get_significant_states_minimal_response(hass_history):
     )
 
 
-def test_get_significant_states_with_initial(hass_history):
+def test_get_significant_states_with_initial(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -153,7 +156,7 @@ def test_get_significant_states_with_initial(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_without_initial(hass_history):
+def test_get_significant_states_without_initial(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -180,7 +183,7 @@ def test_get_significant_states_without_initial(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_entity_id(hass_history):
+def test_get_significant_states_entity_id(hass_history) -> None:
     """Test that only significant states are returned for one entity."""
     hass = hass_history
     zero, four, states = record_states(hass)
@@ -196,7 +199,7 @@ def test_get_significant_states_entity_id(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_multiple_entity_ids(hass_history):
+def test_get_significant_states_multiple_entity_ids(hass_history) -> None:
     """Test that only significant states are returned for one entity."""
     hass = hass_history
     zero, four, states = record_states(hass)
@@ -215,7 +218,7 @@ def test_get_significant_states_multiple_entity_ids(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_exclude_domain(hass_history):
+def test_get_significant_states_exclude_domain(hass_history) -> None:
     """Test if significant states are returned when excluding domains.
 
     We should get back every thermostat change that includes an attribute
@@ -236,7 +239,7 @@ def test_get_significant_states_exclude_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude_entity(hass_history):
+def test_get_significant_states_exclude_entity(hass_history) -> None:
     """Test if significant states are returned when excluding entities.
 
     We should get back every thermostat and script changes, but no media
@@ -255,7 +258,7 @@ def test_get_significant_states_exclude_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude(hass_history):
+def test_get_significant_states_exclude(hass_history) -> None:
     """Test significant states when excluding entities and domains.
 
     We should not get back every thermostat and media player test changes.
@@ -280,7 +283,7 @@ def test_get_significant_states_exclude(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude_include_entity(hass_history):
+def test_get_significant_states_exclude_include_entity(hass_history) -> None:
     """Test significant states when excluding domains and include entities.
 
     We should not get back every thermostat change unless its specifically included
@@ -301,7 +304,7 @@ def test_get_significant_states_exclude_include_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_domain(hass_history):
+def test_get_significant_states_include_domain(hass_history) -> None:
     """Test if significant states are returned when including domains.
 
     We should get back every thermostat and script changes, but no media
@@ -322,7 +325,7 @@ def test_get_significant_states_include_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_entity(hass_history):
+def test_get_significant_states_include_entity(hass_history) -> None:
     """Test if significant states are returned when including entities.
 
     We should only get back changes of the media_player.test entity.
@@ -344,7 +347,7 @@ def test_get_significant_states_include_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include(hass_history):
+def test_get_significant_states_include(hass_history) -> None:
     """Test significant states when including domains and entities.
 
     We should only get back changes of the media_player.test entity and the
@@ -370,7 +373,7 @@ def test_get_significant_states_include(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude_domain(hass_history):
+def test_get_significant_states_include_exclude_domain(hass_history) -> None:
     """Test if significant states when excluding and including domains.
 
     We should get back all the media_player domain changes
@@ -395,7 +398,7 @@ def test_get_significant_states_include_exclude_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude_entity(hass_history):
+def test_get_significant_states_include_exclude_entity(hass_history) -> None:
     """Test if significant states when excluding and including domains.
 
     We should not get back any changes since we include only
@@ -421,7 +424,7 @@ def test_get_significant_states_include_exclude_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude(hass_history):
+def test_get_significant_states_include_exclude(hass_history) -> None:
     """Test if significant states when in/excluding domains and entities.
 
     We should get back changes of the media_player.test2, media_player.test3,
@@ -451,7 +454,7 @@ def test_get_significant_states_include_exclude(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_are_ordered(hass_history):
+def test_get_significant_states_are_ordered(hass_history) -> None:
     """Test order of results from get_significant_states.
 
     When entity ids are given, the results should be returned with the data
@@ -471,7 +474,7 @@ def test_get_significant_states_are_ordered(hass_history):
     assert list(hist.keys()) == entity_ids
 
 
-def test_get_significant_states_only(hass_history):
+def test_get_significant_states_only(hass_history) -> None:
     """Test significant states when significant_states_only is set."""
     hass = hass_history
     entity_id = "sensor.test"
@@ -631,7 +634,9 @@ def record_states(hass):
     return zero, four, states
 
 
-async def test_fetch_period_api(recorder_mock, hass, hass_client):
+async def test_fetch_period_api(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(hass, "history", {})
     client = await hass_client()
@@ -640,8 +645,8 @@ async def test_fetch_period_api(recorder_mock, hass, hass_client):
 
 
 async def test_fetch_period_api_with_use_include_order(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with include order."""
     await async_setup_component(
         hass, "history", {history.DOMAIN: {history.CONF_ORDER: True}}
@@ -651,7 +656,9 @@ async def test_fetch_period_api_with_use_include_order(
     assert response.status == HTTPStatus.OK
 
 
-async def test_fetch_period_api_with_minimal_response(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_minimal_response(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with minimal_response."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "history", {})
@@ -691,7 +698,9 @@ async def test_fetch_period_api_with_minimal_response(recorder_mock, hass, hass_
     ).replace('"', "")
 
 
-async def test_fetch_period_api_with_no_timestamp(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_no_timestamp(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with no timestamp."""
     await async_setup_component(hass, "history", {})
     client = await hass_client()
@@ -699,7 +708,9 @@ async def test_fetch_period_api_with_no_timestamp(recorder_mock, hass, hass_clie
     assert response.status == HTTPStatus.OK
 
 
-async def test_fetch_period_api_with_include_order(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_include_order(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -720,8 +731,8 @@ async def test_fetch_period_api_with_include_order(recorder_mock, hass, hass_cli
 
 
 async def test_fetch_period_api_with_entity_glob_include(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -748,8 +759,8 @@ async def test_fetch_period_api_with_entity_glob_include(
 
 
 async def test_fetch_period_api_with_entity_glob_exclude(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -787,8 +798,8 @@ async def test_fetch_period_api_with_entity_glob_exclude(
 
 
 async def test_fetch_period_api_with_entity_glob_include_and_exclude(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -832,7 +843,9 @@ async def test_fetch_period_api_with_entity_glob_include_and_exclude(
     }
 
 
-async def test_entity_ids_limit_via_api(recorder_mock, hass, hass_client):
+async def test_entity_ids_limit_via_api(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test limiting history to entity_ids."""
     await async_setup_component(
         hass,
@@ -857,8 +870,8 @@ async def test_entity_ids_limit_via_api(recorder_mock, hass, hass_client):
 
 
 async def test_entity_ids_limit_via_api_with_skip_initial_state(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test limiting history to entity_ids with skip_initial_state."""
     await async_setup_component(
         hass,

--- a/tests/components/history/test_init_db_schema_30.py
+++ b/tests/components/history/test_init_db_schema_30.py
@@ -14,11 +14,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from homeassistant.components import history, recorder
-from homeassistant.components.recorder import core, statistics
+from homeassistant.components.recorder import Recorder, core, statistics
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.models import process_timestamp
 from homeassistant.const import CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -32,6 +33,7 @@ from tests.components.recorder.common import (
     async_wait_recording_done,
     wait_recording_done,
 )
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 CREATE_ENGINE_TARGET = "homeassistant.components.recorder.core.create_engine"
 SCHEMA_MODULE = "tests.components.recorder.db_schema_30"
@@ -85,7 +87,7 @@ def test_setup() -> None:
     # Verification occurs in the fixture
 
 
-def test_get_significant_states(hass_history):
+def test_get_significant_states(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -98,7 +100,7 @@ def test_get_significant_states(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_minimal_response(hass_history):
+def test_get_significant_states_minimal_response(hass_history) -> None:
     """Test that only significant states are returned.
 
     When minimal responses is set only the first and
@@ -164,7 +166,7 @@ def test_get_significant_states_minimal_response(hass_history):
     )
 
 
-def test_get_significant_states_with_initial(hass_history):
+def test_get_significant_states_with_initial(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -193,7 +195,7 @@ def test_get_significant_states_with_initial(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_without_initial(hass_history):
+def test_get_significant_states_without_initial(hass_history) -> None:
     """Test that only significant states are returned.
 
     We should get back every thermostat change that
@@ -220,7 +222,7 @@ def test_get_significant_states_without_initial(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_entity_id(hass_history):
+def test_get_significant_states_entity_id(hass_history) -> None:
     """Test that only significant states are returned for one entity."""
     hass = hass_history
     zero, four, states = record_states(hass)
@@ -236,7 +238,7 @@ def test_get_significant_states_entity_id(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_multiple_entity_ids(hass_history):
+def test_get_significant_states_multiple_entity_ids(hass_history) -> None:
     """Test that only significant states are returned for one entity."""
     hass = hass_history
     zero, four, states = record_states(hass)
@@ -255,7 +257,7 @@ def test_get_significant_states_multiple_entity_ids(hass_history):
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
-def test_get_significant_states_exclude_domain(hass_history):
+def test_get_significant_states_exclude_domain(hass_history) -> None:
     """Test if significant states are returned when excluding domains.
 
     We should get back every thermostat change that includes an attribute
@@ -276,7 +278,7 @@ def test_get_significant_states_exclude_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude_entity(hass_history):
+def test_get_significant_states_exclude_entity(hass_history) -> None:
     """Test if significant states are returned when excluding entities.
 
     We should get back every thermostat and script changes, but no media
@@ -295,7 +297,7 @@ def test_get_significant_states_exclude_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude(hass_history):
+def test_get_significant_states_exclude(hass_history) -> None:
     """Test significant states when excluding entities and domains.
 
     We should not get back every thermostat and media player test changes.
@@ -320,7 +322,7 @@ def test_get_significant_states_exclude(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_exclude_include_entity(hass_history):
+def test_get_significant_states_exclude_include_entity(hass_history) -> None:
     """Test significant states when excluding domains and include entities.
 
     We should not get back every thermostat change unless its specifically included
@@ -341,7 +343,7 @@ def test_get_significant_states_exclude_include_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_domain(hass_history):
+def test_get_significant_states_include_domain(hass_history) -> None:
     """Test if significant states are returned when including domains.
 
     We should get back every thermostat and script changes, but no media
@@ -362,7 +364,7 @@ def test_get_significant_states_include_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_entity(hass_history):
+def test_get_significant_states_include_entity(hass_history) -> None:
     """Test if significant states are returned when including entities.
 
     We should only get back changes of the media_player.test entity.
@@ -384,7 +386,7 @@ def test_get_significant_states_include_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include(hass_history):
+def test_get_significant_states_include(hass_history) -> None:
     """Test significant states when including domains and entities.
 
     We should only get back changes of the media_player.test entity and the
@@ -410,7 +412,7 @@ def test_get_significant_states_include(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude_domain(hass_history):
+def test_get_significant_states_include_exclude_domain(hass_history) -> None:
     """Test if significant states when excluding and including domains.
 
     We should get back all the media_player domain changes
@@ -435,7 +437,7 @@ def test_get_significant_states_include_exclude_domain(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude_entity(hass_history):
+def test_get_significant_states_include_exclude_entity(hass_history) -> None:
     """Test if significant states when excluding and including domains.
 
     We should not get back any changes since we include only
@@ -461,7 +463,7 @@ def test_get_significant_states_include_exclude_entity(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_include_exclude(hass_history):
+def test_get_significant_states_include_exclude(hass_history) -> None:
     """Test if significant states when in/excluding domains and entities.
 
     We should get back changes of the media_player.test2, media_player.test3,
@@ -491,7 +493,7 @@ def test_get_significant_states_include_exclude(hass_history):
     check_significant_states(hass, zero, four, states, config)
 
 
-def test_get_significant_states_are_ordered(hass_history):
+def test_get_significant_states_are_ordered(hass_history) -> None:
     """Test order of results from get_significant_states.
 
     When entity ids are given, the results should be returned with the data
@@ -511,7 +513,7 @@ def test_get_significant_states_are_ordered(hass_history):
     assert list(hist.keys()) == entity_ids
 
 
-def test_get_significant_states_only(hass_history):
+def test_get_significant_states_only(hass_history) -> None:
     """Test significant states when significant_states_only is set."""
     hass = hass_history
     entity_id = "sensor.test"
@@ -671,7 +673,9 @@ def record_states(hass):
     return zero, four, states
 
 
-async def test_fetch_period_api(recorder_mock, hass, hass_client):
+async def test_fetch_period_api(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(hass, "history", {})
     client = await hass_client()
@@ -680,8 +684,8 @@ async def test_fetch_period_api(recorder_mock, hass, hass_client):
 
 
 async def test_fetch_period_api_with_use_include_order(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with include order."""
     await async_setup_component(
         hass, "history", {history.DOMAIN: {history.CONF_ORDER: True}}
@@ -691,7 +695,9 @@ async def test_fetch_period_api_with_use_include_order(
     assert response.status == HTTPStatus.OK
 
 
-async def test_fetch_period_api_with_minimal_response(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_minimal_response(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with minimal_response."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "history", {})
@@ -731,7 +737,9 @@ async def test_fetch_period_api_with_minimal_response(recorder_mock, hass, hass_
     ).replace('"', "")
 
 
-async def test_fetch_period_api_with_no_timestamp(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_no_timestamp(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history with no timestamp."""
     await async_setup_component(hass, "history", {})
     client = await hass_client()
@@ -739,7 +747,9 @@ async def test_fetch_period_api_with_no_timestamp(recorder_mock, hass, hass_clie
     assert response.status == HTTPStatus.OK
 
 
-async def test_fetch_period_api_with_include_order(recorder_mock, hass, hass_client):
+async def test_fetch_period_api_with_include_order(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -760,8 +770,8 @@ async def test_fetch_period_api_with_include_order(recorder_mock, hass, hass_cli
 
 
 async def test_fetch_period_api_with_entity_glob_include(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -788,8 +798,8 @@ async def test_fetch_period_api_with_entity_glob_include(
 
 
 async def test_fetch_period_api_with_entity_glob_exclude(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -827,8 +837,8 @@ async def test_fetch_period_api_with_entity_glob_exclude(
 
 
 async def test_fetch_period_api_with_entity_glob_include_and_exclude(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the fetch period view for history."""
     await async_setup_component(
         hass,
@@ -872,7 +882,9 @@ async def test_fetch_period_api_with_entity_glob_include_and_exclude(
     }
 
 
-async def test_entity_ids_limit_via_api(recorder_mock, hass, hass_client):
+async def test_entity_ids_limit_via_api(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test limiting history to entity_ids."""
     await async_setup_component(
         hass,
@@ -897,8 +909,8 @@ async def test_entity_ids_limit_via_api(recorder_mock, hass, hass_client):
 
 
 async def test_entity_ids_limit_via_api_with_skip_initial_state(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test limiting history to entity_ids with skip_initial_state."""
     await async_setup_component(
         hass,
@@ -930,7 +942,9 @@ async def test_entity_ids_limit_via_api_with_skip_initial_state(
     assert response_json[1][0]["entity_id"] == "light.cow"
 
 
-async def test_history_during_period(recorder_mock, hass, hass_ws_client):
+async def test_history_during_period(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period."""
     now = dt_util.utcnow()
 
@@ -1063,8 +1077,8 @@ async def test_history_during_period(recorder_mock, hass, hass_ws_client):
 
 
 async def test_history_during_period_impossible_conditions(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period returns when condition cannot be true."""
     await async_setup_component(hass, "history", {})
     await async_setup_component(hass, "sensor", {})
@@ -1125,8 +1139,11 @@ async def test_history_during_period_impossible_conditions(
     "time_zone", ["UTC", "Europe/Berlin", "America/Chicago", "US/Hawaii"]
 )
 async def test_history_during_period_significant_domain(
-    time_zone, recorder_mock, hass, hass_ws_client
-):
+    time_zone,
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test history_during_period with climate domain."""
     hass.config.set_time_zone(time_zone)
     now = dt_util.utcnow()
@@ -1290,8 +1307,8 @@ async def test_history_during_period_significant_domain(
 
 
 async def test_history_during_period_bad_start_time(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period bad state time."""
     await async_setup_component(
         hass,
@@ -1312,7 +1329,9 @@ async def test_history_during_period_bad_start_time(
     assert response["error"]["code"] == "invalid_start_time"
 
 
-async def test_history_during_period_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_history_during_period_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period bad end time."""
     now = dt_util.utcnow()
 

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -9,12 +9,14 @@ import pytest
 
 from homeassistant.components import history
 from homeassistant.components.history import websocket_api
+from homeassistant.components.recorder import Recorder
 from homeassistant.const import (
     CONF_DOMAINS,
     CONF_ENTITIES,
     CONF_INCLUDE,
     EVENT_HOMEASSISTANT_FINAL_WRITE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -23,6 +25,7 @@ from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
 )
+from tests.typing import WebSocketGenerator
 
 
 def listeners_without_writes(listeners: dict[str, int]) -> dict[str, int]:
@@ -40,7 +43,9 @@ def test_setup() -> None:
     # Verification occurs in the fixture
 
 
-async def test_history_during_period(recorder_mock, hass, hass_ws_client):
+async def test_history_during_period(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period."""
     now = dt_util.utcnow()
 
@@ -173,8 +178,8 @@ async def test_history_during_period(recorder_mock, hass, hass_ws_client):
 
 
 async def test_history_during_period_impossible_conditions(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period returns when condition cannot be true."""
     await async_setup_component(hass, "history", {})
     await async_setup_component(hass, "sensor", {})
@@ -235,8 +240,11 @@ async def test_history_during_period_impossible_conditions(
     "time_zone", ["UTC", "Europe/Berlin", "America/Chicago", "US/Hawaii"]
 )
 async def test_history_during_period_significant_domain(
-    time_zone, recorder_mock, hass, hass_ws_client
-):
+    time_zone,
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test history_during_period with climate domain."""
     hass.config.set_time_zone(time_zone)
     now = dt_util.utcnow()
@@ -400,8 +408,8 @@ async def test_history_during_period_significant_domain(
 
 
 async def test_history_during_period_bad_start_time(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period bad state time."""
     await async_setup_component(
         hass,
@@ -422,7 +430,9 @@ async def test_history_during_period_bad_start_time(
     assert response["error"]["code"] == "invalid_start_time"
 
 
-async def test_history_during_period_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_history_during_period_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history_during_period bad end time."""
     now = dt_util.utcnow()
 
@@ -446,7 +456,9 @@ async def test_history_during_period_bad_end_time(recorder_mock, hass, hass_ws_c
     assert response["error"]["code"] == "invalid_end_time"
 
 
-async def test_history_stream_historical_only(recorder_mock, hass, hass_ws_client):
+async def test_history_stream_historical_only(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream."""
     now = dt_util.utcnow()
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
@@ -528,8 +540,8 @@ async def test_history_stream_historical_only(recorder_mock, hass, hass_ws_clien
 
 
 async def test_history_stream_significant_domain_historical_only(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the stream with climate domain with historical states only."""
     now = dt_util.utcnow()
 
@@ -728,7 +740,9 @@ async def test_history_stream_significant_domain_historical_only(
     assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
 
-async def test_history_stream_bad_start_time(recorder_mock, hass, hass_ws_client):
+async def test_history_stream_bad_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream bad state time."""
     await async_setup_component(
         hass,
@@ -750,8 +764,8 @@ async def test_history_stream_bad_start_time(recorder_mock, hass, hass_ws_client
 
 
 async def test_history_stream_end_time_before_start_time(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with an end_time before the start_time."""
     end_time = dt_util.utcnow() - timedelta(seconds=2)
     start_time = dt_util.utcnow() - timedelta(seconds=1)
@@ -776,7 +790,9 @@ async def test_history_stream_end_time_before_start_time(
     assert response["error"]["code"] == "invalid_end_time"
 
 
-async def test_history_stream_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_history_stream_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream bad end time."""
     now = dt_util.utcnow()
 
@@ -801,8 +817,8 @@ async def test_history_stream_bad_end_time(recorder_mock, hass, hass_ws_client):
 
 
 async def test_history_stream_live_no_attributes_minimal_response(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data and no_attributes and minimal_response."""
     now = dt_util.utcnow()
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
@@ -889,7 +905,9 @@ async def test_history_stream_live_no_attributes_minimal_response(
     }
 
 
-async def test_history_stream_live(recorder_mock, hass, hass_ws_client):
+async def test_history_stream_live(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data."""
     now = dt_util.utcnow()
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
@@ -999,8 +1017,8 @@ async def test_history_stream_live(recorder_mock, hass, hass_ws_client):
 
 
 async def test_history_stream_live_minimal_response(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data and minimal_response."""
     now = dt_util.utcnow()
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
@@ -1103,7 +1121,9 @@ async def test_history_stream_live_minimal_response(
     }
 
 
-async def test_history_stream_live_no_attributes(recorder_mock, hass, hass_ws_client):
+async def test_history_stream_live_no_attributes(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data and no_attributes."""
     now = dt_util.utcnow()
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
@@ -1191,8 +1211,8 @@ async def test_history_stream_live_no_attributes(recorder_mock, hass, hass_ws_cl
 
 
 async def test_history_stream_live_no_attributes_minimal_response_specific_entities(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data and no_attributes and minimal_response with specific entities."""
     now = dt_util.utcnow()
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]
@@ -1273,8 +1293,8 @@ async def test_history_stream_live_no_attributes_minimal_response_specific_entit
 
 
 async def test_history_stream_live_with_future_end_time(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream with history and live data with future end time."""
     now = dt_util.utcnow()
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]
@@ -1370,8 +1390,11 @@ async def test_history_stream_live_with_future_end_time(
 
 @pytest.mark.parametrize("include_start_time_state", (True, False))
 async def test_history_stream_before_history_starts(
-    recorder_mock, hass, hass_ws_client, include_start_time_state
-):
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    include_start_time_state,
+) -> None:
     """Test history stream before we have history."""
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
     await async_setup_component(
@@ -1427,8 +1450,8 @@ async def test_history_stream_before_history_starts(
 
 
 async def test_history_stream_for_entity_with_no_possible_changes(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test history stream for future with no possible changes where end time is less than or equal to now."""
     sort_order = ["sensor.two", "sensor.four", "sensor.one"]
     await async_setup_component(
@@ -1486,7 +1509,9 @@ async def test_history_stream_for_entity_with_no_possible_changes(
         }
 
 
-async def test_overflow_queue(recorder_mock, hass, hass_ws_client):
+async def test_overflow_queue(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test overflowing the history stream queue."""
     now = dt_util.utcnow()
     wanted_entities = ["sensor.two", "sensor.four", "sensor.one"]

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1,5 +1,4 @@
 """The test for the History Statistics sensor platform."""
-
 from datetime import timedelta
 import unittest
 from unittest.mock import patch
@@ -9,8 +8,10 @@ import pytest
 
 from homeassistant import config as hass_config
 from homeassistant.components.history_stats import DOMAIN
+from homeassistant.components.recorder import Recorder
 from homeassistant.const import ATTR_DEVICE_CLASS, SERVICE_RELOAD, STATE_UNKNOWN
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component, setup_component
 import homeassistant.util.dt as dt_util
@@ -136,7 +137,9 @@ class TestHistoryStatsSensor(unittest.TestCase):
         self.hass.start()
 
 
-async def test_invalid_date_for_start(recorder_mock, hass):
+async def test_invalid_date_for_start(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Verify with an invalid date for start."""
     await async_setup_component(
         hass,
@@ -161,7 +164,9 @@ async def test_invalid_date_for_start(recorder_mock, hass):
     assert hass.states.get("sensor.test") is None
 
 
-async def test_invalid_date_for_end(recorder_mock, hass):
+async def test_invalid_date_for_end(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Verify with an invalid date for end."""
     await async_setup_component(
         hass,
@@ -186,7 +191,9 @@ async def test_invalid_date_for_end(recorder_mock, hass):
     assert hass.states.get("sensor.test") is None
 
 
-async def test_invalid_entity_in_template(recorder_mock, hass):
+async def test_invalid_entity_in_template(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Verify with an invalid entity in the template."""
     await async_setup_component(
         hass,
@@ -211,7 +218,9 @@ async def test_invalid_entity_in_template(recorder_mock, hass):
     assert hass.states.get("sensor.test") is None
 
 
-async def test_invalid_entity_returning_none_in_template(recorder_mock, hass):
+async def test_invalid_entity_returning_none_in_template(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Verify with an invalid entity returning none in the template."""
     await async_setup_component(
         hass,
@@ -236,7 +245,7 @@ async def test_invalid_entity_returning_none_in_template(recorder_mock, hass):
     assert hass.states.get("sensor.test") is None
 
 
-async def test_reload(recorder_mock, hass):
+async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload history_stats sensors."""
     hass.state = ha.CoreState.not_running
     hass.states.async_set("binary_sensor.test_id", "on")
@@ -279,7 +288,7 @@ async def test_reload(recorder_mock, hass):
     assert hass.states.get("sensor.second_test")
 
 
-async def test_measure_multiple(recorder_mock, hass):
+async def test_measure_multiple(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor measure for multiple ."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -361,7 +370,7 @@ async def test_measure_multiple(recorder_mock, hass):
     assert hass.states.get("sensor.sensor4").state == "50.0"
 
 
-async def test_measure(recorder_mock, hass):
+async def test_measure(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor measure."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -440,7 +449,9 @@ async def test_measure(recorder_mock, hass):
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
-async def test_async_on_entire_period(recorder_mock, hass):
+async def test_async_on_entire_period(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor measuring as on the entire period."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -520,7 +531,9 @@ async def test_async_on_entire_period(recorder_mock, hass):
     assert hass.states.get("sensor.on_sensor4").state == "100.0"
 
 
-async def test_async_off_entire_period(recorder_mock, hass):
+async def test_async_off_entire_period(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor measuring as off the entire period."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -602,9 +615,9 @@ async def test_async_off_entire_period(recorder_mock, hass):
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_single(
-    recorder_mock,
-    hass,
-):
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+) -> None:
     """Test we startup from history and switch to watching state changes."""
     hass.config.set_time_zone("UTC")
     utcnow = dt_util.utcnow()
@@ -700,9 +713,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_single_expanding_window(
-    recorder_mock,
-    hass,
-):
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+) -> None:
     """Test we startup from history and switch to watching state changes with an expanding end time."""
     hass.config.set_time_zone("UTC")
     utcnow = dt_util.utcnow()
@@ -797,9 +810,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_multiple(
-    recorder_mock,
-    hass,
-):
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+) -> None:
     """Test we startup from history and switch to watching state changes."""
     hass.config.set_time_zone("UTC")
     utcnow = dt_util.utcnow()
@@ -932,7 +945,9 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor4").state == "87.5"
 
 
-async def test_does_not_work_into_the_future(recorder_mock, hass):
+async def test_does_not_work_into_the_future(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test history cannot tell the future.
 
     Verifies we do not regress https://github.com/home-assistant/core/pull/20589
@@ -1071,7 +1086,9 @@ async def test_does_not_work_into_the_future(recorder_mock, hass):
     assert hass.states.get("sensor.sensor1").state == "0.0"
 
 
-async def test_reload_before_start_event(recorder_mock, hass):
+async def test_reload_before_start_event(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Verify we can reload history_stats sensors before the start event."""
     hass.state = ha.CoreState.not_running
     hass.states.async_set("binary_sensor.test_id", "on")
@@ -1112,7 +1129,9 @@ async def test_reload_before_start_event(recorder_mock, hass):
     assert hass.states.get("sensor.second_test")
 
 
-async def test_measure_sliding_window(recorder_mock, hass):
+async def test_measure_sliding_window(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor with a moving end and a moving start."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -1205,7 +1224,9 @@ async def test_measure_sliding_window(recorder_mock, hass):
     assert hass.states.get("sensor.sensor4").state == "41.7"
 
 
-async def test_measure_from_end_going_backwards(recorder_mock, hass):
+async def test_measure_from_end_going_backwards(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor with a moving end and a duration to find the start."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -1297,7 +1318,7 @@ async def test_measure_from_end_going_backwards(recorder_mock, hass):
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
-async def test_measure_cet(recorder_mock, hass):
+async def test_measure_cet(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor measure with a non-UTC timezone."""
     hass.config.set_time_zone("Europe/Berlin")
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -1378,7 +1399,9 @@ async def test_measure_cet(recorder_mock, hass):
 
 
 @pytest.mark.parametrize("time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii"])
-async def test_end_time_with_microseconds_zeroed(time_zone, recorder_mock, hass):
+async def test_end_time_with_microseconds_zeroed(
+    time_zone, recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor that has the end time microseconds zeroed out."""
     hass.config.set_time_zone(time_zone)
     start_of_today = dt_util.now().replace(
@@ -1493,7 +1516,7 @@ async def test_end_time_with_microseconds_zeroed(time_zone, recorder_mock, hass)
         assert hass.states.get("sensor.heatpump_compressor_today").state == "16.0"
 
 
-async def test_device_classes(recorder_mock, hass):
+async def test_device_classes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the device classes."""
     await async_setup_component(
         hass,

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -9,15 +9,22 @@ from homeassistant.components.home_connect.const import (
     OAUTH2_TOKEN,
 )
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/home_plus_control/test_config_flow.py
+++ b/tests/components/home_plus_control/test_config_flow.py
@@ -10,16 +10,22 @@ from homeassistant.components.home_plus_control.const import (
     OAUTH2_TOKEN,
 )
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .conftest import CLIENT_ID, CLIENT_SECRET, SUBSCRIPTION_KEY
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,
@@ -83,7 +89,9 @@ async def test_full_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_abort_if_entry_in_progress(hass, current_request_with_host):
+async def test_abort_if_entry_in_progress(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Check flow abort when an entry is already in progress."""
     assert await setup.async_setup_component(
         hass,
@@ -110,7 +118,9 @@ async def test_abort_if_entry_in_progress(hass, current_request_with_host):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_abort_if_entry_exists(hass, current_request_with_host):
+async def test_abort_if_entry_exists(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Check flow abort when an entry already exists."""
     existing_entry = MockConfigEntry(domain=DOMAIN)
     existing_entry.add_to_hass(hass)
@@ -136,8 +146,11 @@ async def test_abort_if_entry_exists(hass, current_request_with_host):
 
 
 async def test_abort_if_invalid_token(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check flow abort when the token has an invalid value."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/home_plus_control/test_init.py
+++ b/tests/components/home_plus_control/test_init.py
@@ -7,11 +7,12 @@ from homeassistant.components.home_plus_control.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 
 from .conftest import CLIENT_ID, CLIENT_SECRET, SUBSCRIPTION_KEY
 
 
-async def test_loading(hass, mock_config_entry):
+async def test_loading(hass: HomeAssistant, mock_config_entry) -> None:
     """Test component loading."""
     mock_config_entry.add_to_hass(hass)
     with patch(
@@ -35,7 +36,7 @@ async def test_loading(hass, mock_config_entry):
     assert mock_config_entry.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_loading_with_no_config(hass, mock_config_entry):
+async def test_loading_with_no_config(hass: HomeAssistant, mock_config_entry) -> None:
     """Test component loading failure when it has not configuration."""
     mock_config_entry.add_to_hass(hass)
     await setup.async_setup_component(hass, DOMAIN, {})
@@ -43,7 +44,7 @@ async def test_loading_with_no_config(hass, mock_config_entry):
     assert mock_config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
 
-async def test_unloading(hass, mock_config_entry):
+async def test_unloading(hass: HomeAssistant, mock_config_entry) -> None:
     """Test component unloading."""
     mock_config_entry.add_to_hass(hass)
     with patch(

--- a/tests/components/home_plus_control/test_switch.py
+++ b/tests/components/home_plus_control/test_switch.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import CLIENT_ID, CLIENT_SECRET, SUBSCRIPTION_KEY
@@ -63,10 +64,10 @@ def one_entity_state(hass, device_uid):
 
 
 async def test_plant_update(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test entity and device loading."""
     # Load the entry
     mock_config_entry.add_to_hass(hass)
@@ -100,10 +101,10 @@ async def test_plant_update(
 
 
 async def test_plant_topology_reduction_change(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test an entity leaving the plant topology."""
     # Load the entry
     mock_config_entry.add_to_hass(hass)
@@ -159,10 +160,10 @@ async def test_plant_topology_reduction_change(
 
 
 async def test_plant_topology_increase_change(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test an entity entering the plant topology."""
     # Remove one module initially
     new_module = mock_modules.pop("0000000987654321fedcba")
@@ -219,7 +220,9 @@ async def test_plant_topology_increase_change(
     )
 
 
-async def test_module_status_unavailable(hass, mock_config_entry, mock_modules):
+async def test_module_status_unavailable(
+    hass: HomeAssistant, mock_config_entry, mock_modules
+) -> None:
     """Test a module becoming unreachable in the plant."""
     # Load the entry
     mock_config_entry.add_to_hass(hass)
@@ -285,10 +288,10 @@ async def test_module_status_unavailable(hass, mock_config_entry, mock_modules):
 
 
 async def test_module_status_available(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test a module becoming reachable in the plant."""
     # Set the module initially unreachable
     mock_modules["0000000987654321fedcba"].reachable = False
@@ -357,10 +360,10 @@ async def test_module_status_available(
 
 
 async def test_initial_api_error(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test an API error on initial call."""
     # Load the entry
     mock_config_entry.add_to_hass(hass)
@@ -391,10 +394,10 @@ async def test_initial_api_error(
 
 
 async def test_update_with_api_error(
-    hass,
+    hass: HomeAssistant,
     mock_config_entry,
     mock_modules,
-):
+) -> None:
     """Test an API timeout when updating the module data."""
     # Load the entry
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -37,6 +37,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
+    MockUser,
     async_capture_events,
     async_mock_service,
     get_test_home_assistant,
@@ -313,7 +314,9 @@ async def test_setting_location(hass: HomeAssistant) -> None:
     assert hass.config.longitude == 40
 
 
-async def test_require_admin(hass, hass_read_only_user):
+async def test_require_admin(
+    hass: HomeAssistant, hass_read_only_user: MockUser
+) -> None:
     """Test services requiring admin."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -343,7 +346,9 @@ async def test_require_admin(hass, hass_read_only_user):
         )
 
 
-async def test_turn_on_off_toggle_schema(hass, hass_read_only_user):
+async def test_turn_on_off_toggle_schema(
+    hass: HomeAssistant, hass_read_only_user: MockUser
+) -> None:
     """Test the schemas for the turn on/off/toggle services."""
     await async_setup_component(hass, "homeassistant", {})
 
@@ -441,7 +446,9 @@ async def test_reload_config_entry_by_entry_id(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "service", [SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP]
 )
-async def test_raises_when_db_upgrade_in_progress(hass, service, caplog):
+async def test_raises_when_db_upgrade_in_progress(
+    hass: HomeAssistant, service, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test an exception is raised when the database migration is in progress."""
     await async_setup_component(hass, "homeassistant", {})
 

--- a/tests/components/homeassistant_alerts/test_init.py
+++ b/tests/components/homeassistant_alerts/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import assert_lists_same, async_fire_time_changed, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 
 def stub_alert(aioclient_mock, alert_id):
@@ -88,7 +89,7 @@ async def setup_repairs(hass):
 )
 async def test_alerts(
     hass: HomeAssistant,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     aioclient_mock: AiohttpClientMocker,
     ha_version,
     supervisor_info,
@@ -186,7 +187,7 @@ async def test_alerts(
 )
 async def test_bad_alerts(
     hass: HomeAssistant,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     aioclient_mock: AiohttpClientMocker,
     ha_version,
     fixture,
@@ -247,7 +248,7 @@ async def test_bad_alerts(
 
 async def test_no_alerts(
     hass: HomeAssistant,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test creating issues based on alerts."""

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -6,6 +6,7 @@ from homeassistant.core import EVENT_HOMEASSISTANT_STARTED, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 CONFIG_ENTRY_DATA = {
     "device": "bla_device",
@@ -27,7 +28,7 @@ CONFIG_ENTRY_DATA_2 = {
 
 
 async def test_hardware_info(
-    hass: HomeAssistant, hass_ws_client, addon_store_info
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
 ) -> None:
     """Test we can get the board info."""
     assert await async_setup_component(hass, "usb", {})

--- a/tests/components/homeassistant_yellow/test_hardware.py
+++ b/tests/components/homeassistant_yellow/test_hardware.py
@@ -7,10 +7,11 @@ from homeassistant.components.homeassistant_yellow.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.typing import WebSocketGenerator
 
 
 async def test_hardware_info(
-    hass: HomeAssistant, hass_ws_client, addon_store_info
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
 ) -> None:
     """Test we can get the board info."""
     mock_integration(hass, MockModule("hassio"))
@@ -61,7 +62,7 @@ async def test_hardware_info(
 
 @pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
 async def test_hardware_info_fail(
-    hass: HomeAssistant, hass_ws_client, os_info, addon_store_info
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info, addon_store_info
 ) -> None:
     """Test async_info raises if os_info is not as expected."""
     mock_integration(hass, MockModule("hassio"))

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -45,12 +45,15 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     __version__ as hass_version,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import TRACK_STATE_CHANGE_CALLBACKS
 
 from tests.common import async_mock_service
 
 
-async def test_accessory_cancels_track_state_change_on_stop(hass, hk_driver):
+async def test_accessory_cancels_track_state_change_on_stop(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Ensure homekit state changed listeners are unsubscribed on reload."""
     entity_id = "sensor.accessory"
     hass.states.async_set(entity_id, None)
@@ -66,7 +69,7 @@ async def test_accessory_cancels_track_state_change_on_stop(hass, hk_driver):
     assert entity_id not in hass.data[TRACK_STATE_CHANGE_CALLBACKS]
 
 
-async def test_home_accessory(hass, hk_driver):
+async def test_home_accessory(hass: HomeAssistant, hk_driver) -> None:
     """Test HomeAccessory class."""
     entity_id = "sensor.accessory"
     entity_id2 = "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum_maximum_maximum_maximum_allowed_length"
@@ -196,7 +199,9 @@ async def test_home_accessory(hass, hk_driver):
     assert serv.get_characteristic(CHAR_MODEL).value == "Test Model"
 
 
-async def test_accessory_with_missing_basic_service_info(hass, hk_driver):
+async def test_accessory_with_missing_basic_service_info(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test HomeAccessory class."""
     entity_id = "sensor.accessory"
     hass.states.async_set(entity_id, "on")
@@ -224,7 +229,7 @@ async def test_accessory_with_missing_basic_service_info(hass, hk_driver):
     assert isinstance(acc.to_HAP(), dict)
 
 
-async def test_accessory_with_hardware_revision(hass, hk_driver):
+async def test_accessory_with_hardware_revision(hass: HomeAssistant, hk_driver) -> None:
     """Test HomeAccessory class with hardware revision."""
     entity_id = "sensor.accessory"
     hass.states.async_set(entity_id, "on")
@@ -255,7 +260,9 @@ async def test_accessory_with_hardware_revision(hass, hk_driver):
     assert isinstance(acc.to_HAP(), dict)
 
 
-async def test_battery_service(hass, hk_driver, caplog):
+async def test_battery_service(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service."""
     entity_id = "homekit.accessory"
     hass.states.async_set(entity_id, None, {ATTR_BATTERY_LEVEL: 50})
@@ -345,7 +352,9 @@ async def test_battery_service(hass, hk_driver, caplog):
     assert acc._char_charging.value == 0
 
 
-async def test_linked_battery_sensor(hass, hk_driver, caplog):
+async def test_linked_battery_sensor(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service with linked_battery_sensor."""
     entity_id = "homekit.accessory"
     linked_battery = "sensor.battery"
@@ -432,7 +441,9 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
     assert acc._char_charging.value == 0
 
 
-async def test_linked_battery_charging_sensor(hass, hk_driver, caplog):
+async def test_linked_battery_charging_sensor(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service with linked_battery_charging_sensor."""
     entity_id = "homekit.accessory"
     linked_battery_charging_sensor = "binary_sensor.battery_charging"
@@ -491,8 +502,8 @@ async def test_linked_battery_charging_sensor(hass, hk_driver, caplog):
 
 
 async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
-    hass, hk_driver, caplog
-):
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service with linked_battery_sensor and a linked_battery_charging_sensor."""
     entity_id = "homekit.accessory"
     linked_battery = "sensor.battery"
@@ -539,7 +550,9 @@ async def test_linked_battery_sensor_and_linked_battery_charging_sensor(
     assert acc._char_charging.value == 0
 
 
-async def test_missing_linked_battery_charging_sensor(hass, hk_driver, caplog):
+async def test_missing_linked_battery_charging_sensor(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service with linked_battery_charging_sensor that is mapping to a missing entity."""
     entity_id = "homekit.accessory"
     linked_battery_charging_sensor = "binary_sensor.battery_charging"
@@ -575,7 +588,9 @@ async def test_missing_linked_battery_charging_sensor(hass, hk_driver, caplog):
         await hass.async_block_till_done()
 
 
-async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
+async def test_missing_linked_battery_sensor(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery service with missing linked_battery_sensor."""
     entity_id = "homekit.accessory"
     linked_battery = "sensor.battery"
@@ -618,7 +633,9 @@ async def test_missing_linked_battery_sensor(hass, hk_driver, caplog):
     assert acc._char_charging is None
 
 
-async def test_battery_appears_after_startup(hass, hk_driver, caplog):
+async def test_battery_appears_after_startup(
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test battery level appears after homekit is started."""
     entity_id = "homekit.accessory"
     hass.states.async_set(entity_id, None, {})
@@ -651,7 +668,7 @@ async def test_battery_appears_after_startup(hass, hk_driver, caplog):
     assert acc._char_battery is None
 
 
-async def test_call_service(hass, hk_driver, events):
+async def test_call_service(hass: HomeAssistant, hk_driver, events) -> None:
     """Test call_service method."""
     entity_id = "homekit.accessory"
     hass.states.async_set(entity_id, None)
@@ -683,7 +700,7 @@ async def test_call_service(hass, hk_driver, events):
     assert call_service[0].data == {ATTR_ENTITY_ID: entity_id}
 
 
-def test_home_bridge(hk_driver):
+def test_home_bridge(hk_driver) -> None:
     """Test HomeBridge class."""
     bridge = HomeBridge("hass", hk_driver, BRIDGE_NAME)
     assert bridge.hass == "hass"
@@ -701,7 +718,7 @@ def test_home_bridge(hk_driver):
     assert serv.get_characteristic(CHAR_SERIAL_NUMBER).value == BRIDGE_SERIAL_NUMBER
 
 
-def test_home_bridge_setup_message(hk_driver):
+def test_home_bridge_setup_message(hk_driver) -> None:
     """Test HomeBridge setup message."""
     bridge = HomeBridge("hass", hk_driver, "test_name")
     assert bridge.display_name == "test_name"
@@ -710,7 +727,7 @@ def test_home_bridge_setup_message(hk_driver):
     bridge.setup_message()
 
 
-def test_home_driver(iid_storage):
+def test_home_driver(iid_storage) -> None:
     """Test HomeDriver class."""
     ip_address = "127.0.0.1"
     port = 51826

--- a/tests/components/homekit/test_aidmanager.py
+++ b/tests/components/homekit/test_aidmanager.py
@@ -10,6 +10,7 @@ from homeassistant.components.homekit.aidmanager import (
     get_aid_storage_filename_for_entry_id,
     get_system_unique_id,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.storage import STORAGE_DIR
 
@@ -28,7 +29,7 @@ def entity_reg(hass):
     return mock_registry(hass)
 
 
-async def test_aid_generation(hass, device_reg, entity_reg):
+async def test_aid_generation(hass: HomeAssistant, device_reg, entity_reg) -> None:
     """Test generating aids."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -98,7 +99,7 @@ async def test_aid_generation(hass, device_reg, entity_reg):
         )
 
 
-async def test_no_aid_collision(hass, device_reg, entity_reg):
+async def test_no_aid_collision(hass: HomeAssistant, device_reg, entity_reg) -> None:
     """Test generating aids."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -126,8 +127,8 @@ async def test_no_aid_collision(hass, device_reg, entity_reg):
 
 
 async def test_aid_generation_no_unique_ids_handles_collision(
-    hass, device_reg, entity_reg
-):
+    hass: HomeAssistant, device_reg, entity_reg
+) -> None:
     """Test colliding aids is stable."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.homekit.const import (
 )
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT, EntityCategory
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import RegistryEntry, RegistryEntryHider
 from homeassistant.helpers.entityfilter import CONF_INCLUDE_DOMAINS
 from homeassistant.setup import async_setup_component
@@ -42,7 +43,7 @@ def _mock_config_entry_with_options_populated():
     )
 
 
-async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
+async def test_setup_in_bridge_mode(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test we can setup a new instance in bridge mode."""
 
     result = await hass.config_entries.flow.async_init(
@@ -92,7 +93,9 @@ async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
+async def test_setup_in_bridge_mode_name_taken(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test we can setup a new instance in bridge mode when the name is taken."""
 
     entry = MockConfigEntry(
@@ -150,8 +153,8 @@ async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
 
 
 async def test_setup_creates_entries_for_accessory_mode_devices(
-    hass, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test we can setup a new instance and we create entries for accessory mode devices."""
     hass.states.async_set("camera.one", "on")
     hass.states.async_set("camera.existing", "on")
@@ -240,7 +243,7 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
     assert len(mock_setup_entry.mock_calls) == 7
 
 
-async def test_import(hass, mock_get_source_ip):
+async def test_import(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test we can import instance."""
 
     ignored_entry = MockConfigEntry(domain=DOMAIN, data={}, source=SOURCE_IGNORE)
@@ -282,7 +285,9 @@ async def test_import(hass, mock_get_source_ip):
     assert len(mock_setup_entry.mock_calls) == 2
 
 
-async def test_options_flow_exclude_mode_advanced(hass, mock_get_source_ip):
+async def test_options_flow_exclude_mode_advanced(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in exclude mode with advanced options."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -335,7 +340,9 @@ async def test_options_flow_exclude_mode_advanced(hass, mock_get_source_ip):
     }
 
 
-async def test_options_flow_exclude_mode_basic(hass, mock_get_source_ip):
+async def test_options_flow_exclude_mode_basic(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in exclude mode."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -389,13 +396,13 @@ async def test_options_flow_exclude_mode_basic(hass, mock_get_source_ip):
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_devices(
     port_mock,
-    hass,
+    hass: HomeAssistant,
     demo_cleanup,
     device_reg,
     entity_reg,
     mock_get_source_ip,
-    mock_async_zeroconf,
-):
+    mock_async_zeroconf: None,
+) -> None:
     """Test devices can be bridged."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -479,8 +486,8 @@ async def test_options_flow_devices(
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_devices_preserved_when_advanced_off(
-    port_mock, hass, mock_get_source_ip, mock_async_zeroconf
-):
+    port_mock, hass: HomeAssistant, mock_get_source_ip, mock_async_zeroconf: None
+) -> None:
     """Test devices are preserved if they were added in advanced mode but it was turned off."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -551,8 +558,8 @@ async def test_options_flow_devices_preserved_when_advanced_off(
 
 
 async def test_options_flow_include_mode_with_non_existant_entity(
-    hass, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in include mode with a non-existent entity."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -611,8 +618,8 @@ async def test_options_flow_include_mode_with_non_existant_entity(
 
 
 async def test_options_flow_exclude_mode_with_non_existant_entity(
-    hass, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in exclude mode with a non-existent entity."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -671,7 +678,9 @@ async def test_options_flow_exclude_mode_with_non_existant_entity(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_include_mode_basic(hass, mock_get_source_ip):
+async def test_options_flow_include_mode_basic(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in include mode."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -717,7 +726,9 @@ async def test_options_flow_include_mode_basic(hass, mock_get_source_ip):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
+async def test_options_flow_exclude_mode_with_cameras(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in exclude mode with cameras."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -824,7 +835,9 @@ async def test_options_flow_exclude_mode_with_cameras(hass, mock_get_source_ip):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
+async def test_options_flow_include_mode_with_cameras(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options in include mode with cameras."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -958,7 +971,9 @@ async def test_options_flow_include_mode_with_cameras(hass, mock_get_source_ip):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
+async def test_options_flow_with_camera_audio(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options with cameras that support audio."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -1092,7 +1107,9 @@ async def test_options_flow_with_camera_audio(hass, mock_get_source_ip):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_blocked_when_from_yaml(hass, mock_get_source_ip):
+async def test_options_flow_blocked_when_from_yaml(
+    hass: HomeAssistant, mock_get_source_ip
+) -> None:
     """Test config flow options."""
 
     config_entry = MockConfigEntry(
@@ -1134,8 +1151,12 @@ async def test_options_flow_blocked_when_from_yaml(hass, mock_get_source_ip):
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_include_mode_basic_accessory(
-    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf
-):
+    port_mock,
+    hass: HomeAssistant,
+    mock_get_source_ip,
+    hk_driver,
+    mock_async_zeroconf: None,
+) -> None:
     """Test config flow options in include mode with a single accessory."""
     config_entry = _mock_config_entry_with_options_populated()
     await async_init_entry(hass, config_entry)
@@ -1233,7 +1254,9 @@ async def test_options_flow_include_mode_basic_accessory(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_source_ip):
+async def test_converting_bridge_to_accessory_mode(
+    hass: HomeAssistant, hk_driver, mock_get_source_ip
+) -> None:
     """Test we can convert a bridge to accessory mode."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1351,8 +1374,13 @@ def _get_schema_default(schema, key_name):
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_exclude_mode_skips_category_entities(
-    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf, entity_reg
-):
+    port_mock,
+    hass: HomeAssistant,
+    mock_get_source_ip,
+    hk_driver,
+    mock_async_zeroconf: None,
+    entity_reg,
+) -> None:
     """Ensure exclude mode does not offer category entities."""
     config_entry = _mock_config_entry_with_options_populated()
     await async_init_entry(hass, config_entry)
@@ -1451,8 +1479,13 @@ async def test_options_flow_exclude_mode_skips_category_entities(
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_exclude_mode_skips_hidden_entities(
-    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf, entity_reg
-):
+    port_mock,
+    hass: HomeAssistant,
+    mock_get_source_ip,
+    hk_driver,
+    mock_async_zeroconf: None,
+    entity_reg,
+) -> None:
     """Ensure exclude mode does not offer hidden entities."""
     config_entry = _mock_config_entry_with_options_populated()
     await async_init_entry(hass, config_entry)
@@ -1531,8 +1564,13 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_include_mode_allows_hidden_entities(
-    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf, entity_reg
-):
+    port_mock,
+    hass: HomeAssistant,
+    mock_get_source_ip,
+    hk_driver,
+    mock_async_zeroconf: None,
+    entity_reg,
+) -> None:
     """Ensure include mode does not offer hidden entities."""
     config_entry = _mock_config_entry_with_options_populated()
     await async_init_entry(hass, config_entry)

--- a/tests/components/homekit/test_diagnostics.py
+++ b/tests/components/homekit/test_diagnostics.py
@@ -8,17 +8,22 @@ from homeassistant.components.homekit.const import (
     HOMEKIT_MODE_ACCESSORY,
 )
 from homeassistant.const import CONF_NAME, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .util import async_init_integration
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 async def test_config_entry_not_running(
-    hass, hass_client, hk_driver, mock_async_zeroconf
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hk_driver,
+    mock_async_zeroconf: None,
+) -> None:
     """Test generating diagnostics for a config entry."""
     entry = await async_init_integration(hass)
     diag = await get_diagnostics_for_config_entry(hass, hass_client, entry)
@@ -33,7 +38,12 @@ async def test_config_entry_not_running(
     }
 
 
-async def test_config_entry_running(hass, hass_client, hk_driver, mock_async_zeroconf):
+async def test_config_entry_running(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hk_driver,
+    mock_async_zeroconf: None,
+) -> None:
     """Test generating diagnostics for a bridge config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
@@ -139,8 +149,11 @@ async def test_config_entry_running(hass, hass_client, hk_driver, mock_async_zer
 
 
 async def test_config_entry_accessory(
-    hass, hass_client, hk_driver, mock_async_zeroconf
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hk_driver,
+    mock_async_zeroconf: None,
+) -> None:
     """Test generating diagnostics for an accessory config entry."""
     hass.states.async_set("light.demo", "on")
 
@@ -295,15 +308,15 @@ async def test_config_entry_accessory(
 
 
 async def test_config_entry_with_trigger_accessory(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     hk_driver,
-    mock_async_zeroconf,
+    mock_async_zeroconf: None,
     events,
     demo_cleanup,
     device_reg,
     entity_reg,
-):
+) -> None:
     """Test generating diagnostics for a bridge config entry with a trigger accessory."""
     assert await async_setup_component(hass, "demo", {"demo": {}})
     hk_driver.publish = MagicMock()

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
 from homeassistant.core import State
 
 
-def test_not_supported(caplog):
+def test_not_supported(caplog: pytest.LogCaptureFixture) -> None:
     """Test if none is returned if entity isn't supported."""
     # not supported entity
     assert get_accessory(None, None, State("demo.demo", "on"), 2, {}) is None
@@ -61,7 +61,7 @@ def test_not_supported_media_player() -> None:
 @pytest.mark.parametrize(
     "config, name", [({CONF_NAME: "Customize Name"}, "Customize Name")]
 )
-def test_customize_options(config, name):
+def test_customize_options(config, name) -> None:
     """Test with customized options."""
     mock_type = Mock()
     conf = config.copy()
@@ -97,7 +97,7 @@ def test_customize_options(config, name):
         ("WaterHeater", "water_heater.test", "auto", {}, {}),
     ],
 )
-def test_types(type_name, entity_id, state, attrs, config):
+def test_types(type_name, entity_id, state, attrs, config) -> None:
     """Test if types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -162,7 +162,7 @@ def test_types(type_name, entity_id, state, attrs, config):
         ),
     ],
 )
-def test_type_covers(type_name, entity_id, state, attrs):
+def test_type_covers(type_name, entity_id, state, attrs) -> None:
     """Test if cover types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -193,7 +193,7 @@ def test_type_covers(type_name, entity_id, state, attrs):
         ),
     ],
 )
-def test_type_media_player(type_name, entity_id, state, attrs, config):
+def test_type_media_player(type_name, entity_id, state, attrs, config) -> None:
     """Test if media_player types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -278,7 +278,7 @@ def test_type_media_player(type_name, entity_id, state, attrs, config):
         ),
     ],
 )
-def test_type_sensors(type_name, entity_id, state, attrs):
+def test_type_sensors(type_name, entity_id, state, attrs) -> None:
     """Test if sensor types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -308,7 +308,7 @@ def test_type_sensors(type_name, entity_id, state, attrs):
         ("Valve", "switch.test", "on", {}, {CONF_TYPE: TYPE_SPRINKLER}),
     ],
 )
-def test_type_switches(type_name, entity_id, state, attrs, config):
+def test_type_switches(type_name, entity_id, state, attrs, config) -> None:
     """Test if switch types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -332,7 +332,7 @@ def test_type_switches(type_name, entity_id, state, attrs, config):
         ("Vacuum", "vacuum.basic_vacuum", "off", {}),
     ],
 )
-def test_type_vacuum(type_name, entity_id, state, attrs):
+def test_type_vacuum(type_name, entity_id, state, attrs) -> None:
     """Test if vacuum types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):
@@ -345,7 +345,7 @@ def test_type_vacuum(type_name, entity_id, state, attrs):
     "type_name, entity_id, state, attrs",
     [("Camera", "camera.basic", "on", {})],
 )
-def test_type_camera(type_name, entity_id, state, attrs):
+def test_type_camera(type_name, entity_id, state, attrs) -> None:
     """Test if camera types are associated correctly."""
     mock_type = Mock()
     with patch.dict(TYPES, {type_name: mock_type}):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -137,7 +137,7 @@ def _mock_pyhap_bridge():
     )
 
 
-async def test_setup_min(hass, mock_async_zeroconf):
+async def test_setup_min(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test async_setup with min config options."""
 
     entry = MockConfigEntry(
@@ -177,7 +177,9 @@ async def test_setup_min(hass, mock_async_zeroconf):
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
-async def test_removing_entry(port_mock, hass, mock_async_zeroconf):
+async def test_removing_entry(
+    port_mock, hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test removing a config entry."""
 
     entry = MockConfigEntry(
@@ -219,7 +221,9 @@ async def test_removing_entry(port_mock, hass, mock_async_zeroconf):
     await hass.async_block_till_done()
 
 
-async def test_homekit_setup(hass, hk_driver, mock_async_zeroconf):
+async def test_homekit_setup(
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+) -> None:
     """Test setup of bridge and driver."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -267,7 +271,9 @@ async def test_homekit_setup(hass, hk_driver, mock_async_zeroconf):
     assert homekit.driver.safe_mode is False
 
 
-async def test_homekit_setup_ip_address(hass, hk_driver, mock_async_zeroconf):
+async def test_homekit_setup_ip_address(
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+) -> None:
     """Test setup with given IP address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -310,7 +316,9 @@ async def test_homekit_setup_ip_address(hass, hk_driver, mock_async_zeroconf):
     )
 
 
-async def test_homekit_setup_advertise_ip(hass, hk_driver, mock_async_zeroconf):
+async def test_homekit_setup_advertise_ip(
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+) -> None:
     """Test setup with given IP address to advertise."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -354,7 +362,9 @@ async def test_homekit_setup_advertise_ip(hass, hk_driver, mock_async_zeroconf):
     )
 
 
-async def test_homekit_add_accessory(hass, mock_async_zeroconf, mock_hap):
+async def test_homekit_add_accessory(
+    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
+) -> None:
     """Add accessory if config exists and get_acc returns an accessory."""
 
     entry = MockConfigEntry(
@@ -393,8 +403,12 @@ async def test_homekit_add_accessory(hass, mock_async_zeroconf, mock_hap):
 
 @pytest.mark.parametrize("acc_category", [CATEGORY_TELEVISION, CATEGORY_CAMERA])
 async def test_homekit_warn_add_accessory_bridge(
-    hass, acc_category, mock_async_zeroconf, mock_hap, caplog
-):
+    hass: HomeAssistant,
+    acc_category,
+    mock_async_zeroconf: None,
+    mock_hap,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we warn when adding cameras or tvs to a bridge."""
 
     entry = MockConfigEntry(
@@ -422,7 +436,9 @@ async def test_homekit_warn_add_accessory_bridge(
     assert "accessory mode" in caplog.text
 
 
-async def test_homekit_remove_accessory(hass, mock_async_zeroconf):
+async def test_homekit_remove_accessory(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Remove accessory from bridge."""
     entry = await async_init_integration(hass)
 
@@ -439,7 +455,9 @@ async def test_homekit_remove_accessory(hass, mock_async_zeroconf):
     assert len(homekit.bridge.accessories) == 0
 
 
-async def test_homekit_entity_filter(hass, mock_async_zeroconf):
+async def test_homekit_entity_filter(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test the entity filter."""
     entry = await async_init_integration(hass)
 
@@ -458,7 +476,9 @@ async def test_homekit_entity_filter(hass, mock_async_zeroconf):
     assert hass.states.get("light.demo") not in filtered_states
 
 
-async def test_homekit_entity_glob_filter(hass, mock_async_zeroconf):
+async def test_homekit_entity_glob_filter(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test the entity filter."""
     entry = await async_init_integration(hass)
 
@@ -483,8 +503,8 @@ async def test_homekit_entity_glob_filter(hass, mock_async_zeroconf):
 
 
 async def test_homekit_entity_glob_filter_with_config_entities(
-    hass, mock_async_zeroconf, entity_reg
-):
+    hass: HomeAssistant, mock_async_zeroconf: None, entity_reg
+) -> None:
     """Test the entity filter with configuration entities."""
     entry = await async_init_integration(hass)
 
@@ -539,8 +559,8 @@ async def test_homekit_entity_glob_filter_with_config_entities(
 
 
 async def test_homekit_entity_glob_filter_with_hidden_entities(
-    hass, mock_async_zeroconf, entity_reg
-):
+    hass: HomeAssistant, mock_async_zeroconf: None, entity_reg
+) -> None:
     """Test the entity filter with hidden entities."""
     entry = await async_init_integration(hass)
 
@@ -593,7 +613,9 @@ async def test_homekit_entity_glob_filter_with_hidden_entities(
     assert hass.states.get("select.keep") in filtered_states
 
 
-async def test_homekit_start(hass, hk_driver, mock_async_zeroconf, device_reg):
+async def test_homekit_start(
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None, device_reg
+) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
 
@@ -669,8 +691,8 @@ async def test_homekit_start(hass, hk_driver, mock_async_zeroconf, device_reg):
 
 
 async def test_homekit_start_with_a_broken_accessory(
-    hass, hk_driver, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit start method."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
@@ -710,8 +732,13 @@ async def test_homekit_start_with_a_broken_accessory(
 
 
 async def test_homekit_start_with_a_device(
-    hass, hk_driver, mock_async_zeroconf, demo_cleanup, device_reg, entity_reg
-):
+    hass: HomeAssistant,
+    hk_driver,
+    mock_async_zeroconf: None,
+    demo_cleanup,
+    device_reg,
+    entity_reg,
+) -> None:
     """Test HomeKit start method with a device."""
 
     entry = MockConfigEntry(
@@ -772,7 +799,9 @@ async def test_homekit_stop(hass: HomeAssistant) -> None:
     assert homekit.driver.async_stop.called is True
 
 
-async def test_homekit_reset_accessories(hass, mock_async_zeroconf, mock_hap):
+async def test_homekit_reset_accessories(
+    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
+) -> None:
     """Test resetting HomeKit accessories."""
 
     entry = MockConfigEntry(
@@ -811,7 +840,9 @@ async def test_homekit_reset_accessories(hass, mock_async_zeroconf, mock_hap):
         await homekit.async_stop()
 
 
-async def test_homekit_unpair(hass, device_reg, mock_async_zeroconf):
+async def test_homekit_unpair(
+    hass: HomeAssistant, device_reg, mock_async_zeroconf: None
+) -> None:
     """Test unpairing HomeKit accessories."""
 
     entry = MockConfigEntry(
@@ -858,7 +889,9 @@ async def test_homekit_unpair(hass, device_reg, mock_async_zeroconf):
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_async_zeroconf):
+async def test_homekit_unpair_missing_device_id(
+    hass: HomeAssistant, device_reg, mock_async_zeroconf: None
+) -> None:
     """Test unpairing HomeKit accessories with invalid device id."""
 
     entry = MockConfigEntry(
@@ -896,7 +929,9 @@ async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_async_zer
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_async_zeroconf):
+async def test_homekit_unpair_not_homekit_device(
+    hass: HomeAssistant, device_reg, mock_async_zeroconf: None
+) -> None:
     """Test unpairing HomeKit accessories with a non-homekit device id."""
 
     entry = MockConfigEntry(
@@ -944,7 +979,9 @@ async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_async_ze
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_not_supported(hass, mock_async_zeroconf):
+async def test_homekit_reset_accessories_not_supported(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit accessories with an unsupported entity."""
 
     entry = MockConfigEntry(
@@ -988,7 +1025,9 @@ async def test_homekit_reset_accessories_not_supported(hass, mock_async_zeroconf
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_state_missing(hass, mock_async_zeroconf):
+async def test_homekit_reset_accessories_state_missing(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit accessories when the state goes missing."""
 
     entry = MockConfigEntry(
@@ -1030,7 +1069,9 @@ async def test_homekit_reset_accessories_state_missing(hass, mock_async_zeroconf
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_not_bridged(hass, mock_async_zeroconf):
+async def test_homekit_reset_accessories_not_bridged(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit accessories when the state is not bridged."""
 
     entry = MockConfigEntry(
@@ -1072,7 +1113,9 @@ async def test_homekit_reset_accessories_not_bridged(hass, mock_async_zeroconf):
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_single_accessory(hass, mock_hap, mock_async_zeroconf):
+async def test_homekit_reset_single_accessory(
+    hass: HomeAssistant, mock_hap, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit single accessory."""
 
     entry = MockConfigEntry(
@@ -1106,7 +1149,9 @@ async def test_homekit_reset_single_accessory(hass, mock_hap, mock_async_zerocon
         await homekit.async_stop()
 
 
-async def test_homekit_reset_single_accessory_unsupported(hass, mock_async_zeroconf):
+async def test_homekit_reset_single_accessory_unsupported(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit single accessory with an unsupported entity."""
 
     entry = MockConfigEntry(
@@ -1143,7 +1188,9 @@ async def test_homekit_reset_single_accessory_unsupported(hass, mock_async_zeroc
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_single_accessory_state_missing(hass, mock_async_zeroconf):
+async def test_homekit_reset_single_accessory_state_missing(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit single accessory when the state goes missing."""
 
     entry = MockConfigEntry(
@@ -1179,7 +1226,9 @@ async def test_homekit_reset_single_accessory_state_missing(hass, mock_async_zer
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_single_accessory_no_match(hass, mock_async_zeroconf):
+async def test_homekit_reset_single_accessory_no_match(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test resetting HomeKit single accessory when the entity id does not match."""
 
     entry = MockConfigEntry(
@@ -1216,8 +1265,11 @@ async def test_homekit_reset_single_accessory_no_match(hass, mock_async_zeroconf
 
 
 async def test_homekit_too_many_accessories(
-    hass, hk_driver, caplog, mock_async_zeroconf
-):
+    hass: HomeAssistant,
+    hk_driver,
+    caplog: pytest.LogCaptureFixture,
+    mock_async_zeroconf: None,
+) -> None:
     """Test adding too many accessories to HomeKit."""
     entry = await async_init_integration(hass)
 
@@ -1247,8 +1299,8 @@ async def test_homekit_too_many_accessories(
 
 
 async def test_homekit_finds_linked_batteries(
-    hass, hk_driver, device_reg, entity_reg, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, device_reg, entity_reg, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
 
@@ -1320,8 +1372,8 @@ async def test_homekit_finds_linked_batteries(
 
 
 async def test_homekit_async_get_integration_fails(
-    hass, hk_driver, device_reg, entity_reg, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, device_reg, entity_reg, mock_async_zeroconf: None
+) -> None:
     """Test that we continue if async_get_integration fails."""
     entry = await async_init_integration(hass)
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
@@ -1389,7 +1441,9 @@ async def test_homekit_async_get_integration_fails(
     )
 
 
-async def test_yaml_updates_update_config_entry_for_name(hass, mock_async_zeroconf):
+async def test_yaml_updates_update_config_entry_for_name(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test async_setup with imported config."""
 
     entry = MockConfigEntry(
@@ -1433,7 +1487,9 @@ async def test_yaml_updates_update_config_entry_for_name(hass, mock_async_zeroco
     mock_homekit().async_start.assert_called()
 
 
-async def test_yaml_can_link_with_default_name(hass, mock_async_zeroconf):
+async def test_yaml_can_link_with_default_name(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test async_setup with imported config linked by default name."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1461,7 +1517,9 @@ async def test_yaml_can_link_with_default_name(hass, mock_async_zeroconf):
     assert entry.options["entity_config"]["camera.back_camera"]["stream_count"] == 3
 
 
-async def test_yaml_can_link_with_port(hass, mock_async_zeroconf):
+async def test_yaml_can_link_with_port(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test async_setup with imported config linked by port."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1509,7 +1567,9 @@ async def test_yaml_can_link_with_port(hass, mock_async_zeroconf):
     assert entry3.options == {}
 
 
-async def test_homekit_uses_system_zeroconf(hass, hk_driver, mock_async_zeroconf):
+async def test_homekit_uses_system_zeroconf(
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit uses system zeroconf."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1534,8 +1594,8 @@ async def test_homekit_uses_system_zeroconf(hass, hk_driver, mock_async_zeroconf
 
 
 async def test_homekit_ignored_missing_devices(
-    hass, hk_driver, device_reg, entity_reg, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, device_reg, entity_reg, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit handles a device in the entity registry but missing from the device registry."""
 
     entry = await async_init_integration(hass)
@@ -1604,8 +1664,8 @@ async def test_homekit_ignored_missing_devices(
 
 
 async def test_homekit_finds_linked_motion_sensors(
-    hass, hk_driver, device_reg, entity_reg, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, device_reg, entity_reg, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
 
@@ -1666,8 +1726,8 @@ async def test_homekit_finds_linked_motion_sensors(
 
 
 async def test_homekit_finds_linked_humidity_sensors(
-    hass, hk_driver, device_reg, entity_reg, mock_async_zeroconf
-):
+    hass: HomeAssistant, hk_driver, device_reg, entity_reg, mock_async_zeroconf: None
+) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
 
@@ -1730,7 +1790,7 @@ async def test_homekit_finds_linked_humidity_sensors(
     )
 
 
-async def test_reload(hass, mock_async_zeroconf):
+async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test we can reload from yaml."""
 
     entry = MockConfigEntry(
@@ -1802,8 +1862,8 @@ async def test_reload(hass, mock_async_zeroconf):
 
 
 async def test_homekit_start_in_accessory_mode(
-    hass, hk_driver, mock_async_zeroconf, device_reg
-):
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None, device_reg
+) -> None:
     """Test HomeKit start method in accessory mode."""
     entry = await async_init_integration(hass)
 
@@ -1833,8 +1893,12 @@ async def test_homekit_start_in_accessory_mode(
 
 
 async def test_homekit_start_in_accessory_mode_unsupported_entity(
-    hass, hk_driver, mock_async_zeroconf, device_reg, caplog
-):
+    hass: HomeAssistant,
+    hk_driver,
+    mock_async_zeroconf: None,
+    device_reg,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test HomeKit start method in accessory mode with an unsupported entity."""
     entry = await async_init_integration(hass)
 
@@ -1863,8 +1927,12 @@ async def test_homekit_start_in_accessory_mode_unsupported_entity(
 
 
 async def test_homekit_start_in_accessory_mode_missing_entity(
-    hass, hk_driver, mock_async_zeroconf, device_reg, caplog
-):
+    hass: HomeAssistant,
+    hk_driver,
+    mock_async_zeroconf: None,
+    device_reg,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test HomeKit start method in accessory mode when entity is not available."""
     entry = await async_init_integration(hass)
 
@@ -1887,7 +1955,12 @@ async def test_homekit_start_in_accessory_mode_missing_entity(
     assert "entity not available" in caplog.text
 
 
-async def test_wait_for_port_to_free(hass, hk_driver, mock_async_zeroconf, caplog):
+async def test_wait_for_port_to_free(
+    hass: HomeAssistant,
+    hk_driver,
+    mock_async_zeroconf: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we wait for the port to free before declaring unload success."""
 
     entry = MockConfigEntry(

--- a/tests/components/homekit/test_iidmanager.py
+++ b/tests/components/homekit/test_iidmanager.py
@@ -1,5 +1,4 @@
 """Tests for the HomeKit IID manager."""
-
 from uuid import UUID
 
 from homeassistant.components.homekit.const import DOMAIN
@@ -7,13 +6,16 @@ from homeassistant.components.homekit.iidmanager import (
     AccessoryIIDStorage,
     get_iid_storage_filename_for_entry_id,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_loads
 from homeassistant.util.uuid import random_uuid_hex
 
 from tests.common import MockConfigEntry, load_fixture
 
 
-async def test_iid_generation_and_restore(hass, iid_storage, hass_storage):
+async def test_iid_generation_and_restore(
+    hass: HomeAssistant, iid_storage, hass_storage
+) -> None:
     """Test generating iids and restoring them from storage."""
     entry = MockConfigEntry(domain=DOMAIN)
 
@@ -87,7 +89,9 @@ async def test_iid_generation_and_restore(hass, iid_storage, hass_storage):
     assert iid3 == iid1
 
 
-async def test_iid_storage_filename(hass, iid_storage, hass_storage):
+async def test_iid_storage_filename(
+    hass: HomeAssistant, iid_storage, hass_storage
+) -> None:
     """Test iid storage uses the expected filename."""
     entry = MockConfigEntry(domain=DOMAIN)
 
@@ -98,7 +102,9 @@ async def test_iid_storage_filename(hass, iid_storage, hass_storage):
     )
 
 
-async def test_iid_migration_to_v2(hass, iid_storage, hass_storage):
+async def test_iid_migration_to_v2(
+    hass: HomeAssistant, iid_storage, hass_storage
+) -> None:
     """Test iid storage migration."""
     v1_iids = json_loads(load_fixture("iids_v1", DOMAIN))
     v2_iids = json_loads(load_fixture("iids_v2", DOMAIN))
@@ -120,7 +126,9 @@ async def test_iid_migration_to_v2(hass, iid_storage, hass_storage):
         assert allocations["3E___"] == 1
 
 
-async def test_iid_migration_to_v2_with_underscore(hass, iid_storage, hass_storage):
+async def test_iid_migration_to_v2_with_underscore(
+    hass: HomeAssistant, iid_storage, hass_storage
+) -> None:
     """Test iid storage migration with underscore."""
     v1_iids = json_loads(load_fixture("iids_v1_with_underscore", DOMAIN))
     v2_iids = json_loads(load_fixture("iids_v2_with_underscore", DOMAIN))
@@ -142,7 +150,9 @@ async def test_iid_migration_to_v2_with_underscore(hass, iid_storage, hass_stora
         assert allocations["3E___"] == 1
 
 
-async def test_iid_generation_and_restore_v2(hass, iid_storage, hass_storage):
+async def test_iid_generation_and_restore_v2(
+    hass: HomeAssistant, iid_storage, hass_storage
+) -> None:
     """Test generating iids and restoring them from storage."""
     entry = MockConfigEntry(domain=DOMAIN)
 

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -1,6 +1,8 @@
 """Test HomeKit initialization."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.homekit.const import (
     ATTR_DISPLAY_NAME,
     ATTR_VALUE,
@@ -13,6 +15,7 @@ from homeassistant.const import (
     ATTR_SERVICE,
     EVENT_HOMEASSISTANT_STARTED,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .util import PATH_HOMEKIT
@@ -21,7 +24,9 @@ from tests.common import MockConfigEntry
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_homekit_changed_event(hass, hk_driver, mock_get_source_ip):
+async def test_humanify_homekit_changed_event(
+    hass: HomeAssistant, hk_driver, mock_get_source_ip
+) -> None:
     """Test humanifying HomeKit changed event."""
     hass.config.components.add("recorder")
     with patch("homeassistant.components.homekit.HomeKit"):
@@ -63,8 +68,12 @@ async def test_humanify_homekit_changed_event(hass, hk_driver, mock_get_source_i
 
 
 async def test_bridge_with_triggers(
-    hass, hk_driver, mock_async_zeroconf, entity_reg, caplog
-):
+    hass: HomeAssistant,
+    hk_driver,
+    mock_async_zeroconf: None,
+    entity_reg,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we can setup a bridge with triggers and we ignore numeric states.
 
     Since numeric states are not supported by HomeKit as they require

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Camera."""
-
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from uuid import UUID
@@ -29,6 +28,7 @@ from homeassistant.components.homekit.const import (
 from homeassistant.components.homekit.type_cameras import Camera
 from homeassistant.components.homekit.type_switches import Switch
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -121,7 +121,9 @@ def _get_failing_mock_ffmpeg():
     return ffmpeg
 
 
-async def test_camera_stream_source_configured(hass, run_driver, events):
+async def test_camera_stream_source_configured(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -235,8 +237,8 @@ async def test_camera_stream_source_configured(hass, run_driver, events):
 
 
 async def test_camera_stream_source_configured_with_failing_ffmpeg(
-    hass, run_driver, events
-):
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream with a configured source with ffmpeg failing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -288,7 +290,9 @@ async def test_camera_stream_source_configured_with_failing_ffmpeg(
         await _async_stop_all_streams(hass, acc)
 
 
-async def test_camera_stream_source_found(hass, run_driver, events):
+async def test_camera_stream_source_found(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream and we get the source from the entity."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -368,7 +372,9 @@ async def test_camera_stream_source_found(hass, run_driver, events):
     )
 
 
-async def test_camera_stream_source_fails(hass, run_driver, events):
+async def test_camera_stream_source_fails(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream and we cannot get the source from the entity."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -406,7 +412,7 @@ async def test_camera_stream_source_fails(hass, run_driver, events):
         await _async_stop_all_streams(hass, acc)
 
 
-async def test_camera_with_no_stream(hass, run_driver, events):
+async def test_camera_with_no_stream(hass: HomeAssistant, run_driver, events) -> None:
     """Test a camera that cannot stream."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(hass, camera.DOMAIN, {camera.DOMAIN: {}})
@@ -438,7 +444,9 @@ async def test_camera_with_no_stream(hass, run_driver, events):
         )
 
 
-async def test_camera_stream_source_configured_and_copy_codec(hass, run_driver, events):
+async def test_camera_stream_source_configured_and_copy_codec(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -508,7 +516,9 @@ async def test_camera_stream_source_configured_and_copy_codec(hass, run_driver, 
     )
 
 
-async def test_camera_streaming_fails_after_starting_ffmpeg(hass, run_driver, events):
+async def test_camera_streaming_fails_after_starting_ffmpeg(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -580,7 +590,9 @@ async def test_camera_streaming_fails_after_starting_ffmpeg(hass, run_driver, ev
     )
 
 
-async def test_camera_with_linked_motion_sensor(hass, run_driver, events):
+async def test_camera_with_linked_motion_sensor(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera with a linked motion sensor can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -672,7 +684,9 @@ async def test_camera_with_linked_motion_sensor(hass, run_driver, events):
     assert char.value is True
 
 
-async def test_camera_with_a_missing_linked_motion_sensor(hass, run_driver, events):
+async def test_camera_with_a_missing_linked_motion_sensor(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera with a configured linked motion sensor that is missing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -702,7 +716,9 @@ async def test_camera_with_a_missing_linked_motion_sensor(hass, run_driver, even
     assert not acc.get_service(SERV_MOTION_SENSOR)
 
 
-async def test_camera_with_linked_doorbell_sensor(hass, run_driver, events):
+async def test_camera_with_linked_doorbell_sensor(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera with a linked doorbell sensor can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -816,7 +832,9 @@ async def test_camera_with_linked_doorbell_sensor(hass, run_driver, events):
     assert char2.value is None
 
 
-async def test_camera_with_a_missing_linked_doorbell_sensor(hass, run_driver, events):
+async def test_camera_with_a_missing_linked_doorbell_sensor(
+    hass: HomeAssistant, run_driver, events
+) -> None:
     """Test a camera with a configured linked doorbell sensor that is missing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Covers."""
-
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
@@ -39,13 +38,13 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_garage_door_open_close(hass, hk_driver, events):
+async def test_garage_door_open_close(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.garage_door"
 
@@ -129,7 +128,9 @@ async def test_garage_door_open_close(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_windowcovering_set_cover_position(hass, hk_driver, events):
+async def test_windowcovering_set_cover_position(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
 
@@ -238,7 +239,9 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == 75
 
 
-async def test_window_instantiate_set_position(hass, hk_driver, events):
+async def test_window_instantiate_set_position(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if Window accessory is instantiated correctly and can set position."""
     entity_id = "cover.window"
 
@@ -288,7 +291,9 @@ async def test_window_instantiate_set_position(hass, hk_driver, events):
     assert acc.char_position_state.value == 2
 
 
-async def test_windowcovering_cover_set_tilt(hass, hk_driver, events):
+async def test_windowcovering_cover_set_tilt(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA update slat tilt accordingly."""
     entity_id = "cover.window"
 
@@ -357,7 +362,7 @@ async def test_windowcovering_cover_set_tilt(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == 75
 
 
-async def test_windowcovering_tilt_only(hass, hk_driver, events):
+async def test_windowcovering_tilt_only(hass: HomeAssistant, hk_driver, events) -> None:
     """Test we lock the window covering closed when its tilt only."""
     entity_id = "cover.window"
 
@@ -380,7 +385,9 @@ async def test_windowcovering_tilt_only(hass, hk_driver, events):
     assert acc.char_target_position.properties[PROP_MAX_VALUE] == 0
 
 
-async def test_windowcovering_open_close(hass, hk_driver, events):
+async def test_windowcovering_open_close(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
 
@@ -461,7 +468,9 @@ async def test_windowcovering_open_close(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_windowcovering_open_close_stop(hass, hk_driver, events):
+async def test_windowcovering_open_close_stop(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
 
@@ -509,8 +518,8 @@ async def test_windowcovering_open_close_stop(hass, hk_driver, events):
 
 
 async def test_windowcovering_open_close_with_position_and_stop(
-    hass, hk_driver, events
-):
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.stop_window"
 
@@ -542,7 +551,9 @@ async def test_windowcovering_open_close_with_position_and_stop(
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_windowcovering_basic_restore(hass, hk_driver, events):
+async def test_windowcovering_basic_restore(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -580,7 +591,7 @@ async def test_windowcovering_basic_restore(hass, hk_driver, events):
     assert acc.char_position_state is not None
 
 
-async def test_windowcovering_restore(hass, hk_driver, events):
+async def test_windowcovering_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -618,7 +629,9 @@ async def test_windowcovering_restore(hass, hk_driver, events):
     assert acc.char_position_state is not None
 
 
-async def test_garage_door_with_linked_obstruction_sensor(hass, hk_driver, events):
+async def test_garage_door_with_linked_obstruction_sensor(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly with a linked obstruction sensor."""
     linked_obstruction_sensor_entity_id = "binary_sensor.obstruction"
     entity_id = "cover.garage_door"

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Fans."""
-
 from pyhap.const import HAP_REPR_AID, HAP_REPR_CHARS, HAP_REPR_IID, HAP_REPR_VALUE
 
 from homeassistant.components.fan import (
@@ -24,13 +23,13 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_fan_basic(hass, hk_driver, events):
+async def test_fan_basic(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with char state."""
     entity_id = "fan.demo"
 
@@ -108,7 +107,7 @@ async def test_fan_basic(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_fan_direction(hass, hk_driver, events):
+async def test_fan_direction(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with direction."""
     entity_id = "fan.demo"
 
@@ -179,7 +178,7 @@ async def test_fan_direction(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == DIRECTION_REVERSE
 
 
-async def test_fan_oscillate(hass, hk_driver, events):
+async def test_fan_oscillate(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with oscillate."""
     entity_id = "fan.demo"
 
@@ -248,7 +247,7 @@ async def test_fan_oscillate(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is True
 
 
-async def test_fan_speed(hass, hk_driver, events):
+async def test_fan_speed(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with speed."""
     entity_id = "fan.demo"
 
@@ -334,7 +333,7 @@ async def test_fan_speed(hass, hk_driver, events):
     assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
 
 
-async def test_fan_set_all_one_shot(hass, hk_driver, events):
+async def test_fan_set_all_one_shot(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with speed."""
     entity_id = "fan.demo"
 
@@ -527,7 +526,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, events):
     assert len(call_set_direction) == 2
 
 
-async def test_fan_restore(hass, hk_driver, events):
+async def test_fan_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -569,7 +568,9 @@ async def test_fan_restore(hass, hk_driver, events):
     assert acc.char_swing is not None
 
 
-async def test_fan_multiple_preset_modes(hass, hk_driver, events):
+async def test_fan_multiple_preset_modes(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test fan with multiple preset modes."""
     entity_id = "fan.demo"
 
@@ -649,7 +650,7 @@ async def test_fan_multiple_preset_modes(hass, hk_driver, events):
     assert len(events) == 2
 
 
-async def test_fan_single_preset_mode(hass, hk_driver, events):
+async def test_fan_single_preset_mode(hass: HomeAssistant, hk_driver, events) -> None:
     """Test fan with a single preset mode."""
     entity_id = "fan.demo"
 

--- a/tests/components/homekit/test_type_humidifiers.py
+++ b/tests/components/homekit/test_type_humidifiers.py
@@ -6,6 +6,7 @@ from pyhap.const import (
     HAP_REPR_IID,
     HAP_REPR_VALUE,
 )
+import pytest
 
 from homeassistant.components.homekit.const import (
     ATTR_VALUE,
@@ -38,11 +39,12 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_humidifier(hass, hk_driver, events):
+async def test_humidifier(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if humidifier accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -121,7 +123,7 @@ async def test_humidifier(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "RelativeHumidityHumidifierThreshold to 39.0%"
 
 
-async def test_dehumidifier(hass, hk_driver, events):
+async def test_dehumidifier(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if dehumidifier accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -204,7 +206,7 @@ async def test_dehumidifier(hass, hk_driver, events):
     )
 
 
-async def test_hygrostat_power_state(hass, hk_driver, events):
+async def test_hygrostat_power_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -284,7 +286,7 @@ async def test_hygrostat_power_state(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "Active to 0"
 
 
-async def test_hygrostat_get_humidity_range(hass, hk_driver):
+async def test_hygrostat_get_humidity_range(hass: HomeAssistant, hk_driver) -> None:
     """Test if humidity range is evaluated correctly."""
     entity_id = "humidifier.test"
 
@@ -304,7 +306,9 @@ async def test_hygrostat_get_humidity_range(hass, hk_driver):
     assert acc.char_target_humidity.properties[PROP_MIN_VALUE] == 40
 
 
-async def test_humidifier_with_linked_humidity_sensor(hass, hk_driver):
+async def test_humidifier_with_linked_humidity_sensor(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test a humidifier with a linked humidity sensor can update."""
     humidity_sensor_entity_id = "sensor.bedroom_humidity"
 
@@ -366,7 +370,9 @@ async def test_humidifier_with_linked_humidity_sensor(hass, hk_driver):
     assert acc.char_current_humidity.value == 43.0
 
 
-async def test_humidifier_with_a_missing_linked_humidity_sensor(hass, hk_driver):
+async def test_humidifier_with_a_missing_linked_humidity_sensor(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test a humidifier with a configured linked motion sensor that is missing."""
     humidity_sensor_entity_id = "sensor.bedroom_humidity"
     entity_id = "humidifier.test"
@@ -389,7 +395,9 @@ async def test_humidifier_with_a_missing_linked_humidity_sensor(hass, hk_driver)
     assert acc.char_current_humidity.value == 0
 
 
-async def test_humidifier_as_dehumidifier(hass, hk_driver, events, caplog):
+async def test_humidifier_as_dehumidifier(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test an invalid char_target_humidifier_dehumidifier from HomeKit."""
     entity_id = "humidifier.test"
 
@@ -430,7 +438,9 @@ async def test_humidifier_as_dehumidifier(hass, hk_driver, events, caplog):
     assert len(events) == 0
 
 
-async def test_dehumidifier_as_humidifier(hass, hk_driver, events, caplog):
+async def test_dehumidifier_as_humidifier(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test an invalid char_target_humidifier_dehumidifier from HomeKit."""
     entity_id = "humidifier.test"
 

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Lights."""
-
 from datetime import timedelta
 
 from pyhap.const import HAP_REPR_AID, HAP_REPR_CHARS, HAP_REPR_IID, HAP_REPR_VALUE
@@ -39,7 +38,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -53,7 +52,7 @@ async def _wait_for_light_coalesce(hass):
     await hass.async_block_till_done()
 
 
-async def test_light_basic(hass, hk_driver, events):
+async def test_light_basic(hass: HomeAssistant, hk_driver, events) -> None:
     """Test light with char state."""
     entity_id = "light.demo"
 
@@ -125,7 +124,9 @@ async def test_light_basic(hass, hk_driver, events):
 @pytest.mark.parametrize(
     "supported_color_modes", [["brightness"], ["hs"], ["color_temp"]]
 )
-async def test_light_brightness(hass, hk_driver, events, supported_color_modes):
+async def test_light_brightness(
+    hass: HomeAssistant, hk_driver, events, supported_color_modes
+) -> None:
     """Test light with brightness."""
     entity_id = "light.demo"
 
@@ -243,7 +244,7 @@ async def test_light_brightness(hass, hk_driver, events, supported_color_modes):
     assert acc.char_brightness.value == 1
 
 
-async def test_light_color_temperature(hass, hk_driver, events):
+async def test_light_color_temperature(hass: HomeAssistant, hk_driver, events) -> None:
     """Test light with color temperature."""
     entity_id = "light.demo"
 
@@ -292,8 +293,8 @@ async def test_light_color_temperature(hass, hk_driver, events):
     [["color_temp", "hs"], ["color_temp", "rgb"], ["color_temp", "xy"]],
 )
 async def test_light_color_temperature_and_rgb_color(
-    hass, hk_driver, events, supported_color_modes
-):
+    hass: HomeAssistant, hk_driver, events, supported_color_modes
+) -> None:
     """Test light with color temperature and rgb color not exposing temperature."""
     entity_id = "light.demo"
 
@@ -490,7 +491,9 @@ async def test_light_color_temperature_and_rgb_color(
 
 
 @pytest.mark.parametrize("supported_color_modes", [["hs"], ["rgb"], ["xy"]])
-async def test_light_rgb_color(hass, hk_driver, events, supported_color_modes):
+async def test_light_rgb_color(
+    hass: HomeAssistant, hk_driver, events, supported_color_modes
+) -> None:
     """Test light with rgb_color."""
     entity_id = "light.demo"
 
@@ -542,7 +545,7 @@ async def test_light_rgb_color(hass, hk_driver, events, supported_color_modes):
     assert events[-1].data[ATTR_VALUE] == "set color at (145, 75)"
 
 
-async def test_light_restore(hass, hk_driver, events):
+async def test_light_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -603,13 +606,13 @@ async def test_light_restore(hass, hk_driver, events):
     ],
 )
 async def test_light_rgb_with_color_temp(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
     supported_color_modes,
     state_props,
     turn_on_props_with_brightness,
-):
+) -> None:
     """Test lights with RGBW/RGBWW with color temp support."""
     entity_id = "light.demo"
 
@@ -723,13 +726,13 @@ async def test_light_rgb_with_color_temp(
     ],
 )
 async def test_light_rgbwx_with_color_temp_and_brightness(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
     supported_color_modes,
     state_props,
     turn_on_props_with_brightness,
-):
+) -> None:
     """Test lights with RGBW/RGBWW with color temp support and setting brightness."""
     entity_id = "light.demo"
 
@@ -785,10 +788,10 @@ async def test_light_rgbwx_with_color_temp_and_brightness(
 
 
 async def test_light_rgb_or_w_lights(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
-):
+) -> None:
     """Test lights with RGB or W lights."""
     entity_id = "light.demo"
 
@@ -918,12 +921,12 @@ async def test_light_rgb_or_w_lights(
     ],
 )
 async def test_light_rgb_with_white_switch_to_temp(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
     supported_color_modes,
     state_props,
-):
+) -> None:
     """Test lights with RGBW/RGBWW that preserves brightness when switching to color temp."""
     entity_id = "light.demo"
 
@@ -998,10 +1001,10 @@ async def test_light_rgb_with_white_switch_to_temp(
 
 
 async def test_light_rgbww_with_color_temp_conversion(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
-):
+) -> None:
     """Test lights with RGBWW convert color temp as expected."""
     entity_id = "light.demo"
 
@@ -1119,10 +1122,10 @@ async def test_light_rgbww_with_color_temp_conversion(
 
 
 async def test_light_rgbw_with_color_temp_conversion(
-    hass,
+    hass: HomeAssistant,
     hk_driver,
     events,
-):
+) -> None:
     """Test lights with RGBW convert color temp as expected."""
     entity_id = "light.demo"
 
@@ -1208,7 +1211,9 @@ async def test_light_rgbw_with_color_temp_conversion(
     assert acc.char_brightness.value == 100
 
 
-async def test_light_set_brightness_and_color(hass, hk_driver, events):
+async def test_light_set_brightness_and_color(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test light with all chars in one go."""
     entity_id = "light.demo"
 
@@ -1284,7 +1289,7 @@ async def test_light_set_brightness_and_color(hass, hk_driver, events):
     )
 
 
-async def test_light_min_max_mireds(hass, hk_driver, events):
+async def test_light_min_max_mireds(hass: HomeAssistant, hk_driver, events) -> None:
     """Test mireds are forced to ints."""
     entity_id = "light.demo"
 
@@ -1304,7 +1309,9 @@ async def test_light_min_max_mireds(hass, hk_driver, events):
     acc.char_color_temp.properties["minValue"] == 100
 
 
-async def test_light_set_brightness_and_color_temp(hass, hk_driver, events):
+async def test_light_set_brightness_and_color_temp(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test light with all chars in one go."""
     entity_id = "light.demo"
 

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -16,11 +16,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_lock_unlock(hass, hk_driver, events):
+async def test_lock_unlock(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     code = "1234"
     config = {ATTR_CODE: code}
@@ -96,7 +97,7 @@ async def test_lock_unlock(hass, hk_driver, events):
 
 
 @pytest.mark.parametrize("config", [{}, {ATTR_CODE: None}])
-async def test_no_code(hass, hk_driver, config, events):
+async def test_no_code(hass: HomeAssistant, hk_driver, config, events) -> None:
     """Test accessory if lock doesn't require a code."""
     entity_id = "lock.kitchen_door"
 

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Media Players."""
-
 import pytest
 
 from homeassistant.components.homekit.const import (
@@ -38,13 +37,13 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_STANDBY,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_media_player_set_state(hass, hk_driver, events):
+async def test_media_player_set_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     config = {
         CONF_FEATURE_LIST: {
@@ -171,7 +170,9 @@ async def test_media_player_set_state(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_media_player_television(hass, hk_driver, events, caplog):
+async def test_media_player_television(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if television accessory and HA are updated accordingly."""
     entity_id = "media_player.television"
 
@@ -350,7 +351,9 @@ async def test_media_player_television(hass, hk_driver, events, caplog):
     assert events[0].data[ATTR_KEY_NAME] == KEY_ARROW_RIGHT
 
 
-async def test_media_player_television_basic(hass, hk_driver, events, caplog):
+async def test_media_player_television_basic(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if basic television accessory and HA are updated accordingly."""
     entity_id = "media_player.television"
 
@@ -385,8 +388,8 @@ async def test_media_player_television_basic(hass, hk_driver, events, caplog):
 
 
 async def test_media_player_television_supports_source_select_no_sources(
-    hass, hk_driver, events, caplog
-):
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if basic tv that supports source select but is missing a source list."""
     entity_id = "media_player.television"
 
@@ -404,7 +407,7 @@ async def test_media_player_television_supports_source_select_no_sources(
     assert acc.support_select_source is False
 
 
-async def test_tv_restore(hass, hk_driver, events):
+async def test_tv_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -457,7 +460,9 @@ async def test_tv_restore(hass, hk_driver, events):
     assert acc.char_input_source is not None
 
 
-async def test_media_player_television_max_sources(hass, hk_driver, events, caplog):
+async def test_media_player_television_max_sources(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if television accessory that reaches the maximum number of sources."""
     entity_id = "media_player.television"
     sources = [f"HDMI {i}" for i in range(1, 101)]
@@ -515,8 +520,8 @@ async def test_media_player_television_max_sources(hass, hk_driver, events, capl
 
 
 async def test_media_player_television_duplicate_sources(
-    hass, hk_driver, events, caplog
-):
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if television accessory with duplicate sources."""
     entity_id = "media_player.television"
     sources = ["MUSIC", "HDMI", "SCREEN MIRRORING", "HDMI", "MUSIC"]

--- a/tests/components/homekit/test_type_remote.py
+++ b/tests/components/homekit/test_type_remote.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Remotes."""
-
 import pytest
 
 from homeassistant.components.homekit.const import (
@@ -25,11 +24,14 @@ from homeassistant.const import (
     STATE_ON,
     STATE_STANDBY,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_activity_remote(hass, hk_driver, events, caplog):
+async def test_activity_remote(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if remote accessory and HA are updated accordingly."""
     entity_id = "remote.harmony"
     hass.states.async_set(
@@ -169,7 +171,9 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
     assert call_reset_accessory[0].data[ATTR_ENTITY_ID] == entity_id
 
 
-async def test_activity_remote_bad_names(hass, hk_driver, events, caplog):
+async def test_activity_remote_bad_names(
+    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if remote accessory with invalid names works as expected."""
     entity_id = "remote.harmony"
     hass.states.async_set(

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -20,11 +20,12 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_switch_set_state(hass, hk_driver, events):
+async def test_switch_set_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     code = "1234"
     config = {ATTR_CODE: code}
@@ -116,7 +117,7 @@ async def test_switch_set_state(hass, hk_driver, events):
 
 
 @pytest.mark.parametrize("config", [{}, {ATTR_CODE: None}])
-async def test_no_alarm_code(hass, hk_driver, config, events):
+async def test_no_alarm_code(hass: HomeAssistant, hk_driver, config, events) -> None:
     """Test accessory if security_system doesn't require an alarm_code."""
     entity_id = "alarm_control_panel.test"
 
@@ -137,7 +138,7 @@ async def test_no_alarm_code(hass, hk_driver, config, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_arming(hass, hk_driver, events):
+async def test_arming(hass: HomeAssistant, hk_driver, events) -> None:
     """Test to make sure arming sets the right state."""
     entity_id = "alarm_control_panel.test"
 
@@ -188,7 +189,7 @@ async def test_arming(hass, hk_driver, events):
     assert acc.char_current_state.value == 4
 
 
-async def test_supported_states(hass, hk_driver, events):
+async def test_supported_states(hass: HomeAssistant, hk_driver, events) -> None:
     """Test different supported states."""
     code = "1234"
     config = {ATTR_CODE: code}

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -1,5 +1,4 @@
 """Test different accessory types: Sensors."""
-
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.homekit import get_accessory
 from homeassistant.components.homekit.const import (
@@ -33,11 +32,11 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
-async def test_temperature(hass, hk_driver):
+async def test_temperature(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.temperature"
 
@@ -79,7 +78,7 @@ async def test_temperature(hass, hk_driver):
     assert acc.char_temp.value == 24
 
 
-async def test_humidity(hass, hk_driver):
+async def test_humidity(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.humidity"
 
@@ -107,7 +106,7 @@ async def test_humidity(hass, hk_driver):
     assert acc.char_humidity.value == 0
 
 
-async def test_air_quality(hass, hk_driver):
+async def test_air_quality(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.air_quality"
 
@@ -139,7 +138,7 @@ async def test_air_quality(hass, hk_driver):
     assert acc.char_quality.value == 5
 
 
-async def test_pm10(hass, hk_driver):
+async def test_pm10(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.air_quality_pm10"
 
@@ -186,7 +185,7 @@ async def test_pm10(hass, hk_driver):
     assert acc.char_quality.value == 5
 
 
-async def test_pm25(hass, hk_driver):
+async def test_pm25(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.air_quality_pm25"
 
@@ -233,7 +232,7 @@ async def test_pm25(hass, hk_driver):
     assert acc.char_quality.value == 5
 
 
-async def test_no2(hass, hk_driver):
+async def test_no2(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.air_quality_nitrogen_dioxide"
 
@@ -282,7 +281,7 @@ async def test_no2(hass, hk_driver):
     assert acc.char_quality.value == 5
 
 
-async def test_voc(hass, hk_driver):
+async def test_voc(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.air_quality_volatile_organic_compounds"
 
@@ -331,7 +330,7 @@ async def test_voc(hass, hk_driver):
     assert acc.char_quality.value == 5
 
 
-async def test_co(hass, hk_driver):
+async def test_co(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.co"
 
@@ -371,7 +370,7 @@ async def test_co(hass, hk_driver):
     assert acc.char_detected.value == 0
 
 
-async def test_co2(hass, hk_driver):
+async def test_co2(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.co2"
 
@@ -411,7 +410,7 @@ async def test_co2(hass, hk_driver):
     assert acc.char_detected.value == 0
 
 
-async def test_light(hass, hk_driver):
+async def test_light(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "sensor.light"
 
@@ -439,7 +438,7 @@ async def test_light(hass, hk_driver):
     assert acc.char_light.value == 0.0001
 
 
-async def test_binary(hass, hk_driver):
+async def test_binary(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "binary_sensor.opening"
 
@@ -476,7 +475,7 @@ async def test_binary(hass, hk_driver):
     assert acc.char_detected.value == 0
 
 
-async def test_motion_uses_bool(hass, hk_driver):
+async def test_motion_uses_bool(hass: HomeAssistant, hk_driver) -> None:
     """Test if accessory is updated after state change."""
     entity_id = "binary_sensor.motion"
 
@@ -523,7 +522,7 @@ async def test_motion_uses_bool(hass, hk_driver):
     assert acc.char_detected.value is False
 
 
-async def test_binary_device_classes(hass, hk_driver):
+async def test_binary_device_classes(hass: HomeAssistant, hk_driver) -> None:
     """Test if services and characteristics are assigned correctly."""
     entity_id = "binary_sensor.demo"
     aid = 1
@@ -538,7 +537,7 @@ async def test_binary_device_classes(hass, hk_driver):
         assert acc.char_detected.display_name == char
 
 
-async def test_sensor_restore(hass, hk_driver, events):
+async def test_sensor_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -569,7 +568,7 @@ async def test_sensor_restore(hass, hk_driver, events):
     assert acc.category == 10
 
 
-async def test_bad_name(hass, hk_driver):
+async def test_bad_name(hass: HomeAssistant, hk_driver) -> None:
     """Test an entity with a bad name."""
     entity_id = "sensor.humidity"
 
@@ -586,7 +585,7 @@ async def test_bad_name(hass, hk_driver):
     assert acc.display_name == "--Humid--"
 
 
-async def test_empty_name(hass, hk_driver):
+async def test_empty_name(hass: HomeAssistant, hk_driver) -> None:
     """Test an entity with a empty name."""
     entity_id = "sensor.humidity"
 

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -36,13 +36,13 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import split_entity_id
+from homeassistant.core import HomeAssistant, split_entity_id
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed, async_mock_service
 
 
-async def test_outlet_set_state(hass, hk_driver, events):
+async def test_outlet_set_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if Outlet accessory and HA are updated accordingly."""
     entity_id = "switch.outlet_test"
 
@@ -94,7 +94,9 @@ async def test_outlet_set_state(hass, hk_driver, events):
         ("switch.test", {}),
     ],
 )
-async def test_switch_set_state(hass, hk_driver, entity_id, attrs, events):
+async def test_switch_set_state(
+    hass: HomeAssistant, hk_driver, entity_id, attrs, events
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     domain = split_entity_id(entity_id)[0]
 
@@ -137,7 +139,7 @@ async def test_switch_set_state(hass, hk_driver, entity_id, attrs, events):
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_valve_set_state(hass, hk_driver, events):
+async def test_valve_set_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if Valve accessory and HA are updated accordingly."""
     entity_id = "switch.valve_test"
 
@@ -205,8 +207,8 @@ async def test_valve_set_state(hass, hk_driver, events):
 
 
 async def test_vacuum_set_state_with_returnhome_and_start_support(
-    hass, hk_driver, events
-):
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if Vacuum accessory and HA are updated accordingly."""
     entity_id = "vacuum.roomba"
 
@@ -274,8 +276,8 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
 
 
 async def test_vacuum_set_state_without_returnhome_and_start_support(
-    hass, hk_driver, events
-):
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if Vacuum accessory and HA are updated accordingly."""
     entity_id = "vacuum.roomba"
 
@@ -319,7 +321,7 @@ async def test_vacuum_set_state_without_returnhome_and_start_support(
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_reset_switch(hass, hk_driver, events):
+async def test_reset_switch(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if switch accessory is reset correctly."""
     domain = "scene"
     entity_id = "scene.test"
@@ -363,7 +365,7 @@ async def test_reset_switch(hass, hk_driver, events):
     assert len(events) == 1
 
 
-async def test_script_switch(hass, hk_driver, events):
+async def test_script_switch(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if script switch accessory is reset correctly."""
     domain = "script"
     entity_id = "script.test"
@@ -411,7 +413,9 @@ async def test_script_switch(hass, hk_driver, events):
     "domain",
     ["input_select", "select"],
 )
-async def test_input_select_switch(hass, hk_driver, events, domain):
+async def test_input_select_switch(
+    hass: HomeAssistant, hk_driver, events, domain
+) -> None:
     """Test if select switch accessory is handled correctly."""
     entity_id = f"{domain}.test"
 
@@ -465,7 +469,7 @@ async def test_input_select_switch(hass, hk_driver, events, domain):
     "domain",
     ["button", "input_button"],
 )
-async def test_button_switch(hass, hk_driver, events, domain):
+async def test_button_switch(hass: HomeAssistant, hk_driver, events, domain) -> None:
     """Test switch accessory from a (input) button entity."""
     entity_id = f"{domain}.test"
 

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -70,13 +70,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     UnitOfTemperature,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_thermostat(hass, hk_driver, events):
+async def test_thermostat(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
 
@@ -416,7 +416,7 @@ async def test_thermostat(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "TargetHeatingCoolingState to 3"
 
 
-async def test_thermostat_auto(hass, hk_driver, events):
+async def test_thermostat_auto(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
 
@@ -570,7 +570,9 @@ async def test_thermostat_auto(hass, hk_driver, events):
     )
 
 
-async def test_thermostat_mode_and_temp_change(hass, hk_driver, events):
+async def test_thermostat_mode_and_temp_change(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory where the mode and temp change in the same call."""
     entity_id = "climate.test"
 
@@ -683,7 +685,7 @@ async def test_thermostat_mode_and_temp_change(hass, hk_driver, events):
     )
 
 
-async def test_thermostat_humidity(hass, hk_driver, events):
+async def test_thermostat_humidity(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly with humidity."""
     entity_id = "climate.test"
 
@@ -742,7 +744,9 @@ async def test_thermostat_humidity(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "35%"
 
 
-async def test_thermostat_humidity_with_target_humidity(hass, hk_driver, events):
+async def test_thermostat_humidity_with_target_humidity(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if accessory and HA are updated accordingly with humidity without target hudmidity.
 
     This test is for thermostats that do not support target humidity but
@@ -765,7 +769,7 @@ async def test_thermostat_humidity_with_target_humidity(hass, hk_driver, events)
     assert acc.char_current_humidity.value == 65
 
 
-async def test_thermostat_power_state(hass, hk_driver, events):
+async def test_thermostat_power_state(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
 
@@ -885,7 +889,7 @@ async def test_thermostat_power_state(hass, hk_driver, events):
     assert acc.char_target_heat_cool.value == 2
 
 
-async def test_thermostat_fahrenheit(hass, hk_driver, events):
+async def test_thermostat_fahrenheit(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
 
@@ -996,7 +1000,7 @@ async def test_thermostat_fahrenheit(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "TargetTemperature to 24.0°C"
 
 
-async def test_thermostat_get_temperature_range(hass, hk_driver):
+async def test_thermostat_get_temperature_range(hass: HomeAssistant, hk_driver) -> None:
     """Test if temperature range is evaluated correctly."""
     entity_id = "climate.test"
 
@@ -1018,7 +1022,9 @@ async def test_thermostat_get_temperature_range(hass, hk_driver):
     assert acc.get_temperature_range() == (15.5, 21.0)
 
 
-async def test_thermostat_temperature_step_whole(hass, hk_driver):
+async def test_thermostat_temperature_step_whole(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test climate device with single digit precision."""
     entity_id = "climate.test"
 
@@ -1033,7 +1039,7 @@ async def test_thermostat_temperature_step_whole(hass, hk_driver):
     assert acc.char_target_temp.properties[PROP_MIN_STEP] == 0.1
 
 
-async def test_thermostat_restore(hass, hk_driver, events):
+async def test_thermostat_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -1078,7 +1084,7 @@ async def test_thermostat_restore(hass, hk_driver, events):
     }
 
 
-async def test_thermostat_hvac_modes(hass, hk_driver):
+async def test_thermostat_hvac_modes(hass: HomeAssistant, hk_driver) -> None:
     """Test if unsupported HVAC modes are deactivated in HomeKit."""
     entity_id = "climate.test"
 
@@ -1111,7 +1117,9 @@ async def test_thermostat_hvac_modes(hass, hk_driver):
     assert acc.char_target_heat_cool.value == 1
 
 
-async def test_thermostat_hvac_modes_with_auto_heat_cool(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_auto_heat_cool(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test we get heat cool over auto."""
     entity_id = "climate.test"
 
@@ -1174,7 +1182,9 @@ async def test_thermostat_hvac_modes_with_auto_heat_cool(hass, hk_driver):
     assert acc.char_target_heat_cool.value == 3
 
 
-async def test_thermostat_hvac_modes_with_auto_no_heat_cool(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_auto_no_heat_cool(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test we get auto when there is no heat cool."""
     entity_id = "climate.test"
 
@@ -1231,7 +1241,9 @@ async def test_thermostat_hvac_modes_with_auto_no_heat_cool(hass, hk_driver):
     assert acc.char_target_heat_cool.value == 3
 
 
-async def test_thermostat_hvac_modes_with_auto_only(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_auto_only(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test if unsupported HVAC modes are deactivated in HomeKit."""
     entity_id = "climate.test"
 
@@ -1285,7 +1297,9 @@ async def test_thermostat_hvac_modes_with_auto_only(hass, hk_driver):
     assert call_set_hvac_mode[0].data[ATTR_HVAC_MODE] == HVACMode.AUTO
 
 
-async def test_thermostat_hvac_modes_with_heat_only(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_heat_only(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to heat."""
     entity_id = "climate.test"
 
@@ -1363,7 +1377,9 @@ async def test_thermostat_hvac_modes_with_heat_only(hass, hk_driver):
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
 
 
-async def test_thermostat_hvac_modes_with_cool_only(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_cool_only(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to cool."""
     entity_id = "climate.test"
 
@@ -1416,7 +1432,9 @@ async def test_thermostat_hvac_modes_with_cool_only(hass, hk_driver):
     assert call_set_hvac_mode[0].data[ATTR_HVAC_MODE] == HVACMode.COOL
 
 
-async def test_thermostat_hvac_modes_with_heat_cool_only(hass, hk_driver):
+async def test_thermostat_hvac_modes_with_heat_cool_only(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test if unsupported HVAC modes are deactivated in HomeKit and siri calls get converted to heat or cool."""
     entity_id = "climate.test"
 
@@ -1504,7 +1522,9 @@ async def test_thermostat_hvac_modes_with_heat_cool_only(hass, hk_driver):
     assert call_set_hvac_mode[1].data[ATTR_HVAC_MODE] == HVACMode.HEAT
 
 
-async def test_thermostat_hvac_modes_without_off(hass, hk_driver):
+async def test_thermostat_hvac_modes_without_off(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test a thermostat that has no off."""
     entity_id = "climate.test"
 
@@ -1541,7 +1561,9 @@ async def test_thermostat_hvac_modes_without_off(hass, hk_driver):
     assert acc.char_target_heat_cool.value == 1
 
 
-async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events):
+async def test_thermostat_without_target_temp_only_range(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostat that only supports a range."""
     entity_id = "climate.test"
 
@@ -1723,7 +1745,7 @@ async def test_thermostat_without_target_temp_only_range(hass, hk_driver, events
     assert events[-1].data[ATTR_VALUE] == "HeatingThresholdTemperature to 27.0°C"
 
 
-async def test_water_heater(hass, hk_driver, events):
+async def test_water_heater(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "water_heater.test"
 
@@ -1797,7 +1819,7 @@ async def test_water_heater(hass, hk_driver, events):
     assert acc.char_target_heat_cool.value == 1
 
 
-async def test_water_heater_fahrenheit(hass, hk_driver, events):
+async def test_water_heater_fahrenheit(hass: HomeAssistant, hk_driver, events) -> None:
     """Test if accessory and HA are update accordingly."""
     entity_id = "water_heater.test"
 
@@ -1831,7 +1853,9 @@ async def test_water_heater_fahrenheit(hass, hk_driver, events):
     assert events[-1].data[ATTR_VALUE] == "140.0°F"
 
 
-async def test_water_heater_get_temperature_range(hass, hk_driver):
+async def test_water_heater_get_temperature_range(
+    hass: HomeAssistant, hk_driver
+) -> None:
     """Test if temperature range is evaluated correctly."""
     entity_id = "water_heater.test"
 
@@ -1853,7 +1877,7 @@ async def test_water_heater_get_temperature_range(hass, hk_driver):
     assert acc.get_temperature_range() == (15.5, 21.0)
 
 
-async def test_water_heater_restore(hass, hk_driver, events):
+async def test_water_heater_restore(hass: HomeAssistant, hk_driver, events) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -1896,7 +1920,9 @@ async def test_water_heater_restore(hass, hk_driver, events):
     }
 
 
-async def test_thermostat_with_no_modes_when_we_first_see(hass, hk_driver, events):
+async def test_thermostat_with_no_modes_when_we_first_see(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if a thermostat that is not ready when we first see it."""
     entity_id = "climate.test"
 
@@ -1949,7 +1975,9 @@ async def test_thermostat_with_no_modes_when_we_first_see(hass, hk_driver, event
     assert acc.char_display_units.value == 0
 
 
-async def test_thermostat_with_no_off_after_recheck(hass, hk_driver, events):
+async def test_thermostat_with_no_off_after_recheck(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test if a thermostat that is not ready when we first see it that actually does not have off."""
     entity_id = "climate.test"
 
@@ -2002,7 +2030,9 @@ async def test_thermostat_with_no_off_after_recheck(hass, hk_driver, events):
     assert acc.char_display_units.value == 0
 
 
-async def test_thermostat_with_temp_clamps(hass, hk_driver, events):
+async def test_thermostat_with_temp_clamps(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test that tempatures are clamped to valid values to prevent homekit crash."""
     entity_id = "climate.test"
 
@@ -2056,7 +2086,9 @@ async def test_thermostat_with_temp_clamps(hass, hk_driver, events):
     assert acc.char_display_units.value == 0
 
 
-async def test_thermostat_with_fan_modes_with_auto(hass, hk_driver, events):
+async def test_thermostat_with_fan_modes_with_auto(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostate with fan modes with an auto fan mode."""
     entity_id = "climate.test"
     hass.states.async_set(
@@ -2260,7 +2292,9 @@ async def test_thermostat_with_fan_modes_with_auto(hass, hk_driver, events):
     assert call_set_fan_mode[-1].data[ATTR_FAN_MODE] == FAN_MEDIUM
 
 
-async def test_thermostat_with_fan_modes_with_off(hass, hk_driver, events):
+async def test_thermostat_with_fan_modes_with_off(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostate with fan modes that can turn off."""
     entity_id = "climate.test"
     hass.states.async_set(
@@ -2367,7 +2401,9 @@ async def test_thermostat_with_fan_modes_with_off(hass, hk_driver, events):
     assert call_set_fan_mode[-1].data[ATTR_FAN_MODE] == FAN_OFF
 
 
-async def test_thermostat_with_fan_modes_set_to_none(hass, hk_driver, events):
+async def test_thermostat_with_fan_modes_set_to_none(
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostate with fan modes set to None."""
     entity_id = "climate.test"
     hass.states.async_set(
@@ -2410,8 +2446,8 @@ async def test_thermostat_with_fan_modes_set_to_none(hass, hk_driver, events):
 
 
 async def test_thermostat_with_fan_modes_set_to_none_not_supported(
-    hass, hk_driver, events
-):
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostate with fan modes set to None and supported feature missing."""
     entity_id = "climate.test"
     hass.states.async_set(
@@ -2453,8 +2489,8 @@ async def test_thermostat_with_fan_modes_set_to_none_not_supported(
 
 
 async def test_thermostat_with_supported_features_target_temp_but_fan_mode_set(
-    hass, hk_driver, events
-):
+    hass: HomeAssistant, hk_driver, events
+) -> None:
     """Test a thermostate with fan mode and supported feature missing."""
     entity_id = "climate.test"
     hass.states.async_set(

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -1,19 +1,19 @@
 """Test different accessory types: Triggers (Programmable Switches)."""
-
 from unittest.mock import MagicMock
 
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.homekit.const import CHAR_PROGRAMMABLE_SWITCH_EVENT
 from homeassistant.components.homekit.type_triggers import DeviceTriggerAccessory
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_programmable_switch_button_fires_on_trigger(
-    hass, hk_driver, events, demo_cleanup, device_reg, entity_reg
-):
+    hass: HomeAssistant, hk_driver, events, demo_cleanup, device_reg, entity_reg
+) -> None:
     """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""
     hk_driver.publish = MagicMock()
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -234,7 +234,9 @@ def test_density_to_air_quality() -> None:
     assert density_to_air_quality(200) == 5
 
 
-async def test_async_show_setup_msg(hass, hk_driver, mock_get_source_ip):
+async def test_async_show_setup_msg(
+    hass: HomeAssistant, hk_driver, mock_get_source_ip
+) -> None:
     """Test show setup message as persistence notification."""
     pincode = b"123-45-678"
 

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -25,7 +26,7 @@ def create_security_system_service(accessory):
     targ_state.value = 50
 
 
-async def test_switch_change_alarm_state(hass, utcnow):
+async def test_switch_change_alarm_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit alarm on and off again."""
     helper = await setup_test_component(hass, create_security_system_service)
 
@@ -82,7 +83,7 @@ async def test_switch_change_alarm_state(hass, utcnow):
     )
 
 
-async def test_switch_read_alarm_state(hass, utcnow):
+async def test_switch_read_alarm_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit alarm accessory."""
     helper = await setup_test_component(hass, create_security_system_service)
 
@@ -123,7 +124,7 @@ async def test_switch_read_alarm_state(hass, utcnow):
     assert state.state == "triggered"
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a alarm_control_panel unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -3,6 +3,7 @@ from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -16,7 +17,7 @@ def create_motion_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_motion_sensor_read_state(hass, utcnow):
+async def test_motion_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit motion sensor accessory."""
     helper = await setup_test_component(hass, create_motion_sensor_service)
 
@@ -43,7 +44,7 @@ def create_contact_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_contact_sensor_read_state(hass, utcnow):
+async def test_contact_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_contact_sensor_service)
 
@@ -70,7 +71,7 @@ def create_smoke_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_smoke_sensor_read_state(hass, utcnow):
+async def test_smoke_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_smoke_sensor_service)
 
@@ -97,7 +98,7 @@ def create_carbon_monoxide_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_carbon_monoxide_sensor_read_state(hass, utcnow):
+async def test_carbon_monoxide_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit contact accessory."""
     helper = await setup_test_component(hass, create_carbon_monoxide_sensor_service)
 
@@ -126,7 +127,7 @@ def create_occupancy_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_occupancy_sensor_read_state(hass, utcnow):
+async def test_occupancy_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit occupancy sensor accessory."""
     helper = await setup_test_component(hass, create_occupancy_sensor_service)
 
@@ -153,7 +154,7 @@ def create_leak_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_leak_sensor_read_state(hass, utcnow):
+async def test_leak_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit leak sensor accessory."""
     helper = await setup_test_component(hass, create_leak_sensor_service)
 
@@ -172,7 +173,7 @@ async def test_leak_sensor_read_state(hass, utcnow):
     assert state.attributes["device_class"] == BinarySensorDeviceClass.MOISTURE
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a binary_sensor unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -94,7 +94,7 @@ async def test_ecobee_clear_hold_press_button(hass: HomeAssistant) -> None:
     )
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a button unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_camera.py
+++ b/tests/components/homekit_controller/test_camera.py
@@ -5,6 +5,7 @@ from aiohomekit.model.services import ServicesTypes
 from aiohomekit.testing import FAKE_CAMERA_IMAGE
 
 from homeassistant.components import camera
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -15,7 +16,7 @@ def create_camera(accessory):
     accessory.add_service(ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT)
 
 
-async def test_migrate_unique_ids(hass, utcnow):
+async def test_migrate_unique_ids(hass: HomeAssistant, utcnow) -> None:
     """Test migrating entity unique ids."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()
@@ -31,7 +32,7 @@ async def test_migrate_unique_ids(hass, utcnow):
     )
 
 
-async def test_read_state(hass, utcnow):
+async def test_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit camera."""
     helper = await setup_test_component(hass, create_camera)
 
@@ -39,7 +40,7 @@ async def test_read_state(hass, utcnow):
     assert state.state == "idle"
 
 
-async def test_get_image(hass, utcnow):
+async def test_get_image(hass: HomeAssistant, utcnow) -> None:
     """Test getting a JPEG from a camera."""
     helper = await setup_test_component(hass, create_camera)
     image = await camera.async_get_image(hass, helper.entity_id)

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -71,7 +72,9 @@ def create_thermostat_service_min_max(accessory):
     char.maxValue = 1
 
 
-async def test_climate_respect_supported_op_modes_1(hass, utcnow):
+async def test_climate_respect_supported_op_modes_1(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that climate respects minValue/maxValue hints."""
     helper = await setup_test_component(hass, create_thermostat_service_min_max)
     state = await helper.poll_and_get_state()
@@ -86,14 +89,16 @@ def create_thermostat_service_valid_vals(accessory):
     char.valid_values = [0, 1, 2]
 
 
-async def test_climate_respect_supported_op_modes_2(hass, utcnow):
+async def test_climate_respect_supported_op_modes_2(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that climate respects validValue hints."""
     helper = await setup_test_component(hass, create_thermostat_service_valid_vals)
     state = await helper.poll_and_get_state()
     assert state.attributes["hvac_modes"] == ["off", "heat", "cool"]
 
 
-async def test_climate_change_thermostat_state(hass, utcnow):
+async def test_climate_change_thermostat_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -176,7 +181,9 @@ async def test_climate_change_thermostat_state(hass, utcnow):
     )
 
 
-async def test_climate_check_min_max_values_per_mode(hass, utcnow):
+async def test_climate_check_min_max_values_per_mode(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we we get the appropriate min/max values for each mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -211,7 +218,9 @@ async def test_climate_check_min_max_values_per_mode(hass, utcnow):
     assert climate_state.attributes["max_temp"] == 40
 
 
-async def test_climate_change_thermostat_temperature(hass, utcnow):
+async def test_climate_change_thermostat_temperature(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -242,7 +251,9 @@ async def test_climate_change_thermostat_temperature(hass, utcnow):
     )
 
 
-async def test_climate_change_thermostat_temperature_range(hass, utcnow):
+async def test_climate_change_thermostat_temperature_range(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can set separate heat and cool setpoints in heat_cool mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -275,7 +286,9 @@ async def test_climate_change_thermostat_temperature_range(hass, utcnow):
     )
 
 
-async def test_climate_change_thermostat_temperature_range_iphone(hass, utcnow):
+async def test_climate_change_thermostat_temperature_range_iphone(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can set all three set points at once (iPhone heat_cool mode support)."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -308,7 +321,9 @@ async def test_climate_change_thermostat_temperature_range_iphone(hass, utcnow):
     )
 
 
-async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(hass, utcnow):
+async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we cannot set range values when not in heat_cool mode."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -365,7 +380,9 @@ def create_thermostat_single_set_point_auto(accessory):
     char.value = 0
 
 
-async def test_climate_check_min_max_values_per_mode_sspa_device(hass, utcnow):
+async def test_climate_check_min_max_values_per_mode_sspa_device(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test appropriate min/max values for each mode on sspa devices."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
@@ -400,7 +417,9 @@ async def test_climate_check_min_max_values_per_mode_sspa_device(hass, utcnow):
     assert climate_state.attributes["max_temp"] == 35
 
 
-async def test_climate_set_thermostat_temp_on_sspa_device(hass, utcnow):
+async def test_climate_set_thermostat_temp_on_sspa_device(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test setting temperature in different modes on device with single set point in auto."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
@@ -454,7 +473,7 @@ async def test_climate_set_thermostat_temp_on_sspa_device(hass, utcnow):
     )
 
 
-async def test_climate_set_mode_via_temp(hass, utcnow):
+async def test_climate_set_mode_via_temp(hass: HomeAssistant, utcnow) -> None:
     """Test setting temperature and mode at same tims."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
@@ -495,7 +514,7 @@ async def test_climate_set_mode_via_temp(hass, utcnow):
     )
 
 
-async def test_climate_change_thermostat_humidity(hass, utcnow):
+async def test_climate_change_thermostat_humidity(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -526,7 +545,7 @@ async def test_climate_change_thermostat_humidity(hass, utcnow):
     )
 
 
-async def test_climate_read_thermostat_state(hass, utcnow):
+async def test_climate_read_thermostat_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit thermostat accessory."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -583,7 +602,7 @@ async def test_climate_read_thermostat_state(hass, utcnow):
     assert state.state == HVACMode.HEAT_COOL
 
 
-async def test_hvac_mode_vs_hvac_action(hass, utcnow):
+async def test_hvac_mode_vs_hvac_action(hass: HomeAssistant, utcnow) -> None:
     """Check that we haven't conflated hvac_mode and hvac_action."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -620,7 +639,9 @@ async def test_hvac_mode_vs_hvac_action(hass, utcnow):
     assert state.attributes["hvac_action"] == "heating"
 
 
-async def test_hvac_mode_vs_hvac_action_current_mode_wrong(hass, utcnow):
+async def test_hvac_mode_vs_hvac_action_current_mode_wrong(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Check that we cope with buggy HEATING_COOLING_CURRENT."""
     helper = await setup_test_component(hass, create_thermostat_service)
 
@@ -681,7 +702,9 @@ def create_heater_cooler_service_min_max(accessory):
     char.maxValue = 2
 
 
-async def test_heater_cooler_respect_supported_op_modes_1(hass, utcnow):
+async def test_heater_cooler_respect_supported_op_modes_1(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that climate respects minValue/maxValue hints."""
     helper = await setup_test_component(hass, create_heater_cooler_service_min_max)
     state = await helper.poll_and_get_state()
@@ -696,14 +719,18 @@ def create_theater_cooler_service_valid_vals(accessory):
     char.valid_values = [1, 2]
 
 
-async def test_heater_cooler_respect_supported_op_modes_2(hass, utcnow):
+async def test_heater_cooler_respect_supported_op_modes_2(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that climate respects validValue hints."""
     helper = await setup_test_component(hass, create_theater_cooler_service_valid_vals)
     state = await helper.poll_and_get_state()
     assert state.attributes["hvac_modes"] == ["heat", "cool", "off"]
 
 
-async def test_heater_cooler_change_thermostat_state(hass, utcnow):
+async def test_heater_cooler_change_thermostat_state(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can change the operational mode."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -760,7 +787,7 @@ async def test_heater_cooler_change_thermostat_state(hass, utcnow):
     )
 
 
-async def test_can_turn_on_after_off(hass, utcnow):
+async def test_can_turn_on_after_off(hass: HomeAssistant, utcnow) -> None:
     """Test that we always force device from inactive to active when setting mode.
 
     This is a regression test for #81863.
@@ -795,7 +822,9 @@ async def test_can_turn_on_after_off(hass, utcnow):
     )
 
 
-async def test_heater_cooler_change_thermostat_temperature(hass, utcnow):
+async def test_heater_cooler_change_thermostat_temperature(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can change the target temperature."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -838,7 +867,7 @@ async def test_heater_cooler_change_thermostat_temperature(hass, utcnow):
     )
 
 
-async def test_heater_cooler_read_thermostat_state(hass, utcnow):
+async def test_heater_cooler_read_thermostat_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit thermostat accessory."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -892,7 +921,9 @@ async def test_heater_cooler_read_thermostat_state(hass, utcnow):
     assert state.state == HVACMode.HEAT_COOL
 
 
-async def test_heater_cooler_hvac_mode_vs_hvac_action(hass, utcnow):
+async def test_heater_cooler_hvac_mode_vs_hvac_action(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Check that we haven't conflated hvac_mode and hvac_action."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -931,7 +962,7 @@ async def test_heater_cooler_hvac_mode_vs_hvac_action(hass, utcnow):
     assert state.attributes["hvac_action"] == "heating"
 
 
-async def test_heater_cooler_change_swing_mode(hass, utcnow):
+async def test_heater_cooler_change_swing_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that we can change the swing mode."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -962,7 +993,7 @@ async def test_heater_cooler_change_swing_mode(hass, utcnow):
     )
 
 
-async def test_heater_cooler_turn_off(hass, utcnow):
+async def test_heater_cooler_turn_off(hass: HomeAssistant, utcnow) -> None:
     """Test that both hvac_action and hvac_mode return "off" when turned off."""
     helper = await setup_test_component(hass, create_heater_cooler_service)
 
@@ -981,7 +1012,7 @@ async def test_heater_cooler_turn_off(hass, utcnow):
     assert state.attributes["hvac_action"] == "off"
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a switch unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.components.homekit_controller.storage import async_get_entity_storage
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
@@ -132,14 +133,14 @@ HK_BLUETOOTH_SERVICE_INFO_DISCOVERED_PAIRED = BluetoothServiceInfo(
 
 
 @pytest.mark.parametrize("pairing_code", INVALID_PAIRING_CODES)
-def test_invalid_pairing_codes(pairing_code):
+def test_invalid_pairing_codes(pairing_code) -> None:
     """Test ensure_pin_format raises for an invalid pin code."""
     with pytest.raises(aiohomekit.exceptions.MalformedPinError):
         config_flow.ensure_pin_format(pairing_code)
 
 
 @pytest.mark.parametrize("pairing_code", INSECURE_PAIRING_CODES)
-def test_insecure_pairing_codes(pairing_code):
+def test_insecure_pairing_codes(pairing_code) -> None:
     """Test ensure_pin_format raises for an invalid setup code."""
     with pytest.raises(config_flow.InsecureSetupCode):
         config_flow.ensure_pin_format(pairing_code)
@@ -148,7 +149,7 @@ def test_insecure_pairing_codes(pairing_code):
 
 
 @pytest.mark.parametrize("pairing_code", VALID_PAIRING_CODES)
-def test_valid_pairing_codes(pairing_code):
+def test_valid_pairing_codes(pairing_code) -> None:
     """Test ensure_pin_format corrects format for a valid pin in an alternative format."""
     valid_pin = config_flow.ensure_pin_format(pairing_code).split("-")
     assert len(valid_pin) == 3
@@ -227,7 +228,9 @@ def setup_mock_accessory(controller):
 
 @pytest.mark.parametrize("upper_case_props", [True, False])
 @pytest.mark.parametrize("missing_csharp", [True, False])
-async def test_discovery_works(hass, controller, upper_case_props, missing_csharp):
+async def test_discovery_works(
+    hass: HomeAssistant, controller, upper_case_props, missing_csharp
+) -> None:
     """Test a device being discovered."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device, upper_case_props, missing_csharp)
@@ -260,7 +263,7 @@ async def test_discovery_works(hass, controller, upper_case_props, missing_cshar
     assert result["data"] == {}
 
 
-async def test_abort_duplicate_flow(hass, controller):
+async def test_abort_duplicate_flow(hass: HomeAssistant, controller) -> None:
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -283,7 +286,7 @@ async def test_abort_duplicate_flow(hass, controller):
     assert result["reason"] == "already_in_progress"
 
 
-async def test_pair_already_paired_1(hass, controller):
+async def test_pair_already_paired_1(hass: HomeAssistant, controller) -> None:
     """Already paired."""
     device = setup_mock_accessory(controller)
     # Flag device as already paired
@@ -299,7 +302,7 @@ async def test_pair_already_paired_1(hass, controller):
     assert result["reason"] == "already_paired"
 
 
-async def test_unknown_domain_type(hass, controller):
+async def test_unknown_domain_type(hass: HomeAssistant, controller) -> None:
     """Test that aiohomekit can reject discoveries it doesn't support."""
     device = setup_mock_accessory(controller)
     # Flag device as already paired
@@ -316,7 +319,7 @@ async def test_unknown_domain_type(hass, controller):
     assert result["reason"] == "ignored_model"
 
 
-async def test_id_missing(hass, controller):
+async def test_id_missing(hass: HomeAssistant, controller) -> None:
     """Test id is missing."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -334,7 +337,7 @@ async def test_id_missing(hass, controller):
     assert result["reason"] == "invalid_properties"
 
 
-async def test_discovery_ignored_model(hass, controller):
+async def test_discovery_ignored_model(hass: HomeAssistant, controller) -> None:
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -351,7 +354,9 @@ async def test_discovery_ignored_model(hass, controller):
     assert result["reason"] == "ignored_model"
 
 
-async def test_discovery_ignored_hk_bridge(hass, controller, device_registry):
+async def test_discovery_ignored_hk_bridge(
+    hass: HomeAssistant, controller, device_registry: dr.DeviceRegistry
+) -> None:
     """Ensure we ignore homekit bridges and accessories created by the homekit integration."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -377,7 +382,9 @@ async def test_discovery_ignored_hk_bridge(hass, controller, device_registry):
     assert result["reason"] == "ignored_model"
 
 
-async def test_discovery_does_not_ignore_non_homekit(hass, controller, device_registry):
+async def test_discovery_does_not_ignore_non_homekit(
+    hass: HomeAssistant, controller, device_registry: dr.DeviceRegistry
+) -> None:
     """Do not ignore devices that are not from the homekit integration."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -402,7 +409,7 @@ async def test_discovery_does_not_ignore_non_homekit(hass, controller, device_re
     assert result["type"] == "form"
 
 
-async def test_discovery_broken_pairing_flag(hass, controller):
+async def test_discovery_broken_pairing_flag(hass: HomeAssistant, controller) -> None:
     """There is already a config entry for the pairing and its pairing flag is wrong in zeroconf.
 
     We have seen this particular implementation error in 2 different devices.
@@ -439,7 +446,7 @@ async def test_discovery_broken_pairing_flag(hass, controller):
     assert result["reason"] == "already_paired"
 
 
-async def test_discovery_invalid_config_entry(hass, controller):
+async def test_discovery_invalid_config_entry(hass: HomeAssistant, controller) -> None:
     """There is already a config entry for the pairing id but it's invalid."""
     pairing = await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
 
@@ -477,7 +484,7 @@ async def test_discovery_invalid_config_entry(hass, controller):
     assert result["type"] == "form"
 
 
-async def test_discovery_already_configured(hass, controller):
+async def test_discovery_already_configured(hass: HomeAssistant, controller) -> None:
     """Already configured."""
     entry = MockConfigEntry(
         domain="homekit_controller",
@@ -508,7 +515,9 @@ async def test_discovery_already_configured(hass, controller):
     assert entry.data["AccessoryPort"] == discovery_info.port
 
 
-async def test_discovery_already_configured_update_csharp(hass, controller):
+async def test_discovery_already_configured_update_csharp(
+    hass: HomeAssistant, controller
+) -> None:
     """Already configured and csharp changes."""
     entry = MockConfigEntry(
         domain="homekit_controller",
@@ -547,7 +556,9 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)
-async def test_pair_abort_errors_on_start(hass, controller, exception, expected):
+async def test_pair_abort_errors_on_start(
+    hass: HomeAssistant, controller, exception, expected
+) -> None:
     """Test various pairing errors."""
 
     device = setup_mock_accessory(controller)
@@ -569,7 +580,9 @@ async def test_pair_abort_errors_on_start(hass, controller, exception, expected)
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_TRY_LATER_ERRORS)
-async def test_pair_try_later_errors_on_start(hass, controller, exception, expected):
+async def test_pair_try_later_errors_on_start(
+    hass: HomeAssistant, controller, exception, expected
+) -> None:
     """Test various pairing errors."""
 
     device = setup_mock_accessory(controller)
@@ -606,7 +619,9 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_START_FORM_ERRORS)
-async def test_pair_form_errors_on_start(hass, controller, exception, expected):
+async def test_pair_form_errors_on_start(
+    hass: HomeAssistant, controller, exception, expected
+) -> None:
     """Test various pairing errors."""
 
     device = setup_mock_accessory(controller)
@@ -655,7 +670,9 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_FINISH_ABORT_ERRORS)
-async def test_pair_abort_errors_on_finish(hass, controller, exception, expected):
+async def test_pair_abort_errors_on_finish(
+    hass: HomeAssistant, controller, exception, expected
+) -> None:
     """Test various pairing errors."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -695,7 +712,9 @@ async def test_pair_abort_errors_on_finish(hass, controller, exception, expected
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_FINISH_FORM_ERRORS)
-async def test_pair_form_errors_on_finish(hass, controller, exception, expected):
+async def test_pair_form_errors_on_finish(
+    hass: HomeAssistant, controller, exception, expected
+) -> None:
     """Test various pairing errors."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -741,7 +760,7 @@ async def test_pair_form_errors_on_finish(hass, controller, exception, expected)
     }
 
 
-async def test_pair_unknown_errors(hass, controller):
+async def test_pair_unknown_errors(hass: HomeAssistant, controller) -> None:
     """Test describing unknown errors."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -792,7 +811,7 @@ async def test_pair_unknown_errors(hass, controller):
     }
 
 
-async def test_user_works(hass, controller):
+async def test_user_works(hass: HomeAssistant, controller) -> None:
     """Test user initiated disovers devices."""
     setup_mock_accessory(controller)
 
@@ -826,7 +845,9 @@ async def test_user_works(hass, controller):
     assert result["title"] == "Koogeek-LS1-20833F"
 
 
-async def test_user_pairing_with_insecure_setup_code(hass, controller):
+async def test_user_pairing_with_insecure_setup_code(
+    hass: HomeAssistant, controller
+) -> None:
     """Test user initiated disovers devices."""
     device = setup_mock_accessory(controller)
     device.pairing_code = "123-45-678"
@@ -869,7 +890,7 @@ async def test_user_pairing_with_insecure_setup_code(hass, controller):
     assert result["title"] == "Koogeek-LS1-20833F"
 
 
-async def test_user_no_devices(hass, controller):
+async def test_user_no_devices(hass: HomeAssistant, controller) -> None:
     """Test user initiated pairing where no devices discovered."""
     result = await hass.config_entries.flow.async_init(
         "homekit_controller", context={"source": config_entries.SOURCE_USER}
@@ -878,7 +899,7 @@ async def test_user_no_devices(hass, controller):
     assert result["reason"] == "no_devices"
 
 
-async def test_user_no_unpaired_devices(hass, controller):
+async def test_user_no_unpaired_devices(hass: HomeAssistant, controller) -> None:
     """Test user initiated pairing where no unpaired devices discovered."""
     device = setup_mock_accessory(controller)
 
@@ -895,7 +916,7 @@ async def test_user_no_unpaired_devices(hass, controller):
     assert result["reason"] == "no_devices"
 
 
-async def test_unignore_works(hass, controller):
+async def test_unignore_works(hass: HomeAssistant, controller) -> None:
     """Test rediscovery triggered disovers work."""
     device = setup_mock_accessory(controller)
 
@@ -926,7 +947,9 @@ async def test_unignore_works(hass, controller):
     assert result["title"] == "Koogeek-LS1-20833F"
 
 
-async def test_unignore_ignores_missing_devices(hass, controller):
+async def test_unignore_ignores_missing_devices(
+    hass: HomeAssistant, controller
+) -> None:
     """Test rediscovery triggered disovers handle devices that have gone away."""
     setup_mock_accessory(controller)
 
@@ -941,7 +964,9 @@ async def test_unignore_ignores_missing_devices(hass, controller):
     assert result["reason"] == "accessory_not_found_error"
 
 
-async def test_discovery_dismiss_existing_flow_on_paired(hass, controller):
+async def test_discovery_dismiss_existing_flow_on_paired(
+    hass: HomeAssistant, controller
+) -> None:
     """Test that existing flows get dismissed once paired to something else."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -982,7 +1007,9 @@ async def test_discovery_dismiss_existing_flow_on_paired(hass, controller):
     )
 
 
-async def test_mdns_update_to_paired_during_pairing(hass, controller):
+async def test_mdns_update_to_paired_during_pairing(
+    hass: HomeAssistant, controller
+) -> None:
     """Test we do not abort pairing if mdns is updated to reflect paired during pairing."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -1048,7 +1075,7 @@ async def test_mdns_update_to_paired_during_pairing(hass, controller):
     assert result["data"] == {}
 
 
-async def test_discovery_no_bluetooth_support(hass, controller):
+async def test_discovery_no_bluetooth_support(hass: HomeAssistant, controller) -> None:
     """Test discovery with bluetooth support not available."""
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
@@ -1063,7 +1090,7 @@ async def test_discovery_no_bluetooth_support(hass, controller):
     assert result["reason"] == "ignored_model"
 
 
-async def test_bluetooth_not_homekit(hass, controller):
+async def test_bluetooth_not_homekit(hass: HomeAssistant, controller) -> None:
     """Test bluetooth discovery with a non-homekit device."""
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
@@ -1078,7 +1105,9 @@ async def test_bluetooth_not_homekit(hass, controller):
     assert result["reason"] == "ignored_model"
 
 
-async def test_bluetooth_valid_device_no_discovery(hass, controller):
+async def test_bluetooth_valid_device_no_discovery(
+    hass: HomeAssistant, controller
+) -> None:
     """Test bluetooth discovery  with a homekit device and discovery fails."""
     with patch(
         "homeassistant.components.homekit_controller.config_flow.aiohomekit_const.BLE_TRANSPORT_SUPPORTED",
@@ -1093,7 +1122,9 @@ async def test_bluetooth_valid_device_no_discovery(hass, controller):
     assert result["reason"] == "accessory_not_found_error"
 
 
-async def test_bluetooth_valid_device_discovery_paired(hass, controller):
+async def test_bluetooth_valid_device_discovery_paired(
+    hass: HomeAssistant, controller
+) -> None:
     """Test bluetooth discovery  with a homekit device and discovery works."""
     setup_mock_accessory(controller)
 
@@ -1111,7 +1142,9 @@ async def test_bluetooth_valid_device_discovery_paired(hass, controller):
     assert result["reason"] == "already_paired"
 
 
-async def test_bluetooth_valid_device_discovery_unpaired(hass, controller):
+async def test_bluetooth_valid_device_discovery_unpaired(
+    hass: HomeAssistant, controller
+) -> None:
     """Test bluetooth discovery with a homekit device and discovery works."""
     setup_mock_accessory(controller)
     storage = await async_get_entity_storage(hass)

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -88,7 +88,7 @@ DEVICE_MIGRATION_TESTS = [
 @pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
 async def test_migrate_device_id_no_serial_skip_if_other_owner(
     hass: HomeAssistant, variant: DeviceMigrationTest
-):
+) -> None:
     """Don't migrate unrelated devices.
 
     Create a device registry entry that needs migrate, but belongs to a different
@@ -118,7 +118,7 @@ async def test_migrate_device_id_no_serial_skip_if_other_owner(
 @pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
 async def test_migrate_device_id_no_serial(
     hass: HomeAssistant, variant: DeviceMigrationTest
-):
+) -> None:
     """Test that a Ryse smart bridge with four shades can be migrated correctly in HA."""
     device_registry = dr.async_get(hass)
 
@@ -154,7 +154,7 @@ async def test_migrate_device_id_no_serial(
     assert device.manufacturer == variant.manufacturer
 
 
-async def test_migrate_ble_unique_id(hass: HomeAssistant):
+async def test_migrate_ble_unique_id(hass: HomeAssistant) -> None:
     """Test that a config entry with incorrect unique_id is repaired."""
     accessories = await setup_accessories_from_file(hass, "anker_eufycam.json")
 

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -54,7 +55,7 @@ def create_window_covering_service_with_v_tilt(accessory):
     tilt_target.value = 0
 
 
-async def test_change_window_cover_state(hass, utcnow):
+async def test_change_window_cover_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit alarm on and off again."""
     helper = await setup_test_component(hass, create_window_covering_service)
 
@@ -79,7 +80,7 @@ async def test_change_window_cover_state(hass, utcnow):
     )
 
 
-async def test_read_window_cover_state(hass, utcnow):
+async def test_read_window_cover_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit alarm accessory."""
     helper = await setup_test_component(hass, create_window_covering_service)
 
@@ -112,7 +113,7 @@ async def test_read_window_cover_state(hass, utcnow):
     assert state.attributes["obstruction-detected"] is True
 
 
-async def test_read_window_cover_tilt_horizontal(hass, utcnow):
+async def test_read_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) -> None:
     """Test that horizontal tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt
@@ -126,7 +127,7 @@ async def test_read_window_cover_tilt_horizontal(hass, utcnow):
     assert state.attributes["current_tilt_position"] == 75
 
 
-async def test_read_window_cover_tilt_vertical(hass, utcnow):
+async def test_read_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> None:
     """Test that vertical tilt is handled correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -140,7 +141,7 @@ async def test_read_window_cover_tilt_vertical(hass, utcnow):
     assert state.attributes["current_tilt_position"] == 75
 
 
-async def test_write_window_cover_tilt_horizontal(hass, utcnow):
+async def test_write_window_cover_tilt_horizontal(hass: HomeAssistant, utcnow) -> None:
     """Test that horizontal tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_h_tilt
@@ -160,7 +161,7 @@ async def test_write_window_cover_tilt_horizontal(hass, utcnow):
     )
 
 
-async def test_write_window_cover_tilt_vertical(hass, utcnow):
+async def test_write_window_cover_tilt_vertical(hass: HomeAssistant, utcnow) -> None:
     """Test that vertical tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -180,7 +181,7 @@ async def test_write_window_cover_tilt_vertical(hass, utcnow):
     )
 
 
-async def test_window_cover_stop(hass, utcnow):
+async def test_window_cover_stop(hass: HomeAssistant, utcnow) -> None:
     """Test that vertical tilt is written correctly."""
     helper = await setup_test_component(
         hass, create_window_covering_service_with_v_tilt
@@ -216,7 +217,7 @@ def create_garage_door_opener_service(accessory):
     return service
 
 
-async def test_change_door_state(hass, utcnow):
+async def test_change_door_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn open and close a HomeKit garage door."""
     helper = await setup_test_component(hass, create_garage_door_opener_service)
 
@@ -241,7 +242,7 @@ async def test_change_door_state(hass, utcnow):
     )
 
 
-async def test_read_door_state(hass, utcnow):
+async def test_read_door_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit garage door."""
     helper = await setup_test_component(hass, create_garage_door_opener_service)
 
@@ -281,7 +282,7 @@ async def test_read_door_state(hass, utcnow):
     assert state.attributes["obstruction-detected"] is True
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a cover unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -7,6 +7,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.homekit_controller.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -81,7 +82,7 @@ def create_doorbell(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-async def test_enumerate_remote(hass, utcnow):
+async def test_enumerate_remote(hass: HomeAssistant, utcnow) -> None:
     """Test that remote is correctly enumerated."""
     await setup_test_component(hass, create_remote)
 
@@ -129,7 +130,7 @@ async def test_enumerate_remote(hass, utcnow):
     assert_lists_same(triggers, expected)
 
 
-async def test_enumerate_button(hass, utcnow):
+async def test_enumerate_button(hass: HomeAssistant, utcnow) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_button)
 
@@ -176,7 +177,7 @@ async def test_enumerate_button(hass, utcnow):
     assert_lists_same(triggers, expected)
 
 
-async def test_enumerate_doorbell(hass, utcnow):
+async def test_enumerate_doorbell(hass: HomeAssistant, utcnow) -> None:
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_doorbell)
 
@@ -223,7 +224,7 @@ async def test_enumerate_doorbell(hass, utcnow):
     assert_lists_same(triggers, expected)
 
 
-async def test_handle_events(hass, utcnow, calls):
+async def test_handle_events(hass: HomeAssistant, utcnow, calls) -> None:
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
 
@@ -340,7 +341,7 @@ async def test_handle_events(hass, utcnow, calls):
     assert len(calls) == 2
 
 
-async def test_handle_events_late_setup(hass, utcnow, calls):
+async def test_handle_events_late_setup(hass: HomeAssistant, utcnow, calls) -> None:
     """Test that events are handled when setup happens after startup."""
     helper = await setup_test_component(hass, create_remote)
 

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -16,7 +16,7 @@ from tests.typing import ClientSessionGenerator
 
 async def test_config_entry(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, utcnow
-):
+) -> None:
     """Test generating diagnostics for a config entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
     config_entry, _ = await setup_test_accessories(hass, accessories)
@@ -284,7 +284,9 @@ async def test_config_entry(
     }
 
 
-async def test_device(hass: HomeAssistant, hass_client: ClientSessionGenerator, utcnow):
+async def test_device(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, utcnow
+) -> None:
     """Test generating diagnostics for a device entry."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
     config_entry, _ = await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/test_fan.py
+++ b/tests/components/homekit_controller/test_fan.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -88,7 +89,7 @@ def create_fanv2_service_without_rotation_speed(accessory):
     swing_mode.value = 0
 
 
-async def test_fan_read_state(hass, utcnow):
+async def test_fan_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -103,7 +104,7 @@ async def test_fan_read_state(hass, utcnow):
     assert state.state == "on"
 
 
-async def test_turn_on(hass, utcnow):
+async def test_turn_on(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -150,7 +151,7 @@ async def test_turn_on(hass, utcnow):
     )
 
 
-async def test_turn_on_off_without_rotation_speed(hass, utcnow):
+async def test_turn_on_off_without_rotation_speed(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(
         hass, create_fanv2_service_without_rotation_speed
@@ -183,7 +184,7 @@ async def test_turn_on_off_without_rotation_speed(hass, utcnow):
     )
 
 
-async def test_turn_off(hass, utcnow):
+async def test_turn_off(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a fan off."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -203,7 +204,7 @@ async def test_turn_off(hass, utcnow):
     )
 
 
-async def test_set_speed(hass, utcnow):
+async def test_set_speed(hass: HomeAssistant, utcnow) -> None:
     """Test that we set fan speed."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -262,7 +263,7 @@ async def test_set_speed(hass, utcnow):
     )
 
 
-async def test_set_percentage(hass, utcnow):
+async def test_set_percentage(hass: HomeAssistant, utcnow) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -295,7 +296,7 @@ async def test_set_percentage(hass, utcnow):
     )
 
 
-async def test_speed_read(hass, utcnow):
+async def test_speed_read(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -335,7 +336,7 @@ async def test_speed_read(hass, utcnow):
     assert state.attributes["percentage"] == 0
 
 
-async def test_set_direction(hass, utcnow):
+async def test_set_direction(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set fan spin direction."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -366,7 +367,7 @@ async def test_set_direction(hass, utcnow):
     )
 
 
-async def test_direction_read(hass, utcnow):
+async def test_direction_read(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fan_service)
 
@@ -381,7 +382,7 @@ async def test_direction_read(hass, utcnow):
     assert state.attributes["direction"] == "reverse"
 
 
-async def test_fanv2_read_state(hass, utcnow):
+async def test_fanv2_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -396,7 +397,7 @@ async def test_fanv2_read_state(hass, utcnow):
     assert state.state == "on"
 
 
-async def test_v2_turn_on(hass, utcnow):
+async def test_v2_turn_on(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a fan on."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -471,7 +472,7 @@ async def test_v2_turn_on(hass, utcnow):
     )
 
 
-async def test_v2_turn_off(hass, utcnow):
+async def test_v2_turn_off(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a fan off."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -491,7 +492,7 @@ async def test_v2_turn_off(hass, utcnow):
     )
 
 
-async def test_v2_set_speed(hass, utcnow):
+async def test_v2_set_speed(hass: HomeAssistant, utcnow) -> None:
     """Test that we set fan speed."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -550,7 +551,7 @@ async def test_v2_set_speed(hass, utcnow):
     )
 
 
-async def test_v2_set_percentage(hass, utcnow):
+async def test_v2_set_percentage(hass: HomeAssistant, utcnow) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -583,7 +584,7 @@ async def test_v2_set_percentage(hass, utcnow):
     )
 
 
-async def test_v2_set_percentage_with_min_step(hass, utcnow):
+async def test_v2_set_percentage_with_min_step(hass: HomeAssistant, utcnow) -> None:
     """Test that we set fan speed by percentage."""
     helper = await setup_test_component(hass, create_fanv2_service_with_min_step)
 
@@ -616,7 +617,7 @@ async def test_v2_set_percentage_with_min_step(hass, utcnow):
     )
 
 
-async def test_v2_speed_read(hass, utcnow):
+async def test_v2_speed_read(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -655,7 +656,7 @@ async def test_v2_speed_read(hass, utcnow):
     assert state.attributes["percentage"] == 0
 
 
-async def test_v2_set_direction(hass, utcnow):
+async def test_v2_set_direction(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set fan spin direction."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -686,7 +687,7 @@ async def test_v2_set_direction(hass, utcnow):
     )
 
 
-async def test_v2_direction_read(hass, utcnow):
+async def test_v2_direction_read(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -701,7 +702,7 @@ async def test_v2_direction_read(hass, utcnow):
     assert state.attributes["direction"] == "reverse"
 
 
-async def test_v2_oscillate(hass, utcnow):
+async def test_v2_oscillate(hass: HomeAssistant, utcnow) -> None:
     """Test that we can control a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -732,7 +733,7 @@ async def test_v2_oscillate(hass, utcnow):
     )
 
 
-async def test_v2_oscillate_read(hass, utcnow):
+async def test_v2_oscillate_read(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read a fans oscillation."""
     helper = await setup_test_component(hass, create_fanv2_service)
 
@@ -747,7 +748,9 @@ async def test_v2_oscillate_read(hass, utcnow):
     assert state.attributes["oscillating"] is True
 
 
-async def test_v2_set_percentage_non_standard_rotation_range(hass, utcnow):
+async def test_v2_set_percentage_non_standard_rotation_range(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we set fan speed with a non-standard rotation range."""
     helper = await setup_test_component(
         hass, create_fanv2_service_non_standard_rotation_range
@@ -808,7 +811,7 @@ async def test_v2_set_percentage_non_standard_rotation_range(hass, utcnow):
     )
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a fan unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_humidifier.py
+++ b/tests/components/homekit_controller/test_humidifier.py
@@ -3,6 +3,7 @@ from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.humidifier import DOMAIN, MODE_AUTO, MODE_NORMAL
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -62,7 +63,7 @@ def create_dehumidifier_service(accessory):
     return service
 
 
-async def test_humidifier_active_state(hass, utcnow):
+async def test_humidifier_active_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit humidifier on and off again."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -85,7 +86,7 @@ async def test_humidifier_active_state(hass, utcnow):
     )
 
 
-async def test_dehumidifier_active_state(hass, utcnow):
+async def test_dehumidifier_active_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit dehumidifier on and off again."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -108,7 +109,7 @@ async def test_dehumidifier_active_state(hass, utcnow):
     )
 
 
-async def test_humidifier_read_humidity(hass, utcnow):
+async def test_humidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -142,7 +143,7 @@ async def test_humidifier_read_humidity(hass, utcnow):
     assert state.state == "off"
 
 
-async def test_dehumidifier_read_humidity(hass, utcnow):
+async def test_dehumidifier_read_humidity(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -175,7 +176,7 @@ async def test_dehumidifier_read_humidity(hass, utcnow):
     assert state.attributes["humidity"] == 40
 
 
-async def test_humidifier_set_humidity(hass, utcnow):
+async def test_humidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -191,7 +192,7 @@ async def test_humidifier_set_humidity(hass, utcnow):
     )
 
 
-async def test_dehumidifier_set_humidity(hass, utcnow):
+async def test_dehumidifier_set_humidity(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -207,7 +208,7 @@ async def test_dehumidifier_set_humidity(hass, utcnow):
     )
 
 
-async def test_humidifier_set_mode(hass, utcnow):
+async def test_humidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the mode of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -240,7 +241,7 @@ async def test_humidifier_set_mode(hass, utcnow):
     )
 
 
-async def test_dehumidifier_set_mode(hass, utcnow):
+async def test_dehumidifier_set_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the mode of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -273,7 +274,7 @@ async def test_dehumidifier_set_mode(hass, utcnow):
     )
 
 
-async def test_humidifier_read_only_mode(hass, utcnow):
+async def test_humidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -313,7 +314,7 @@ async def test_humidifier_read_only_mode(hass, utcnow):
     assert state.attributes["mode"] == "normal"
 
 
-async def test_dehumidifier_read_only_mode(hass, utcnow):
+async def test_dehumidifier_read_only_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -353,7 +354,7 @@ async def test_dehumidifier_read_only_mode(hass, utcnow):
     assert state.attributes["mode"] == "normal"
 
 
-async def test_humidifier_target_humidity_modes(hass, utcnow):
+async def test_humidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit humidifier accessory."""
     helper = await setup_test_component(hass, create_humidifier_service)
 
@@ -396,7 +397,7 @@ async def test_humidifier_target_humidity_modes(hass, utcnow):
     assert state.attributes["humidity"] == 37
 
 
-async def test_dehumidifier_target_humidity_modes(hass, utcnow):
+async def test_dehumidifier_target_humidity_modes(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit dehumidifier accessory."""
     helper = await setup_test_component(hass, create_dehumidifier_service)
 
@@ -439,7 +440,7 @@ async def test_dehumidifier_target_humidity_modes(hass, utcnow):
     assert state.attributes["humidity"] == 73
 
 
-async def test_migrate_entity_ids(hass, utcnow):
+async def test_migrate_entity_ids(hass: HomeAssistant, utcnow) -> None:
     """Test that we can migrate humidifier entity ids."""
     aid = get_next_aid()
 

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -38,7 +38,7 @@ def create_motion_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_unload_on_stop(hass, utcnow):
+async def test_unload_on_stop(hass: HomeAssistant, utcnow) -> None:
     """Test async_unload is called on stop."""
     await setup_test_component(hass, create_motion_sensor_service)
     with patch(
@@ -50,7 +50,7 @@ async def test_unload_on_stop(hass, utcnow):
     assert async_unlock_mock.called
 
 
-async def test_async_remove_entry(hass: HomeAssistant):
+async def test_async_remove_entry(hass: HomeAssistant) -> None:
     """Test unpairing a component."""
     helper = await setup_test_component(hass, create_motion_sensor_service)
     controller = helper.pairing.controller
@@ -104,7 +104,7 @@ async def test_device_remove_devices(
     )
 
 
-async def test_offline_device_raises(hass, controller):
+async def test_offline_device_raises(hass: HomeAssistant, controller) -> None:
     """Test an offline device raises ConfigEntryNotReady."""
 
     is_connected = False
@@ -155,7 +155,9 @@ async def test_offline_device_raises(hass, controller):
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
 
-async def test_ble_device_only_checks_is_available(hass, controller):
+async def test_ble_device_only_checks_is_available(
+    hass: HomeAssistant, controller
+) -> None:
     """Test a BLE device only checks is_available."""
 
     is_available = False

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -9,6 +9,7 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -53,7 +54,7 @@ def create_lightbulb_service_with_color_temp(accessory):
     return service
 
 
-async def test_switch_change_light_state(hass, utcnow):
+async def test_switch_change_light_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit light on and off again."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -84,7 +85,9 @@ async def test_switch_change_light_state(hass, utcnow):
     )
 
 
-async def test_switch_change_light_state_color_temp(hass, utcnow):
+async def test_switch_change_light_state_color_temp(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test that we can turn change color_temp."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -104,7 +107,7 @@ async def test_switch_change_light_state_color_temp(hass, utcnow):
     )
 
 
-async def test_switch_read_light_state_dimmer(hass, utcnow):
+async def test_switch_read_light_state_dimmer(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service)
 
@@ -139,7 +142,7 @@ async def test_switch_read_light_state_dimmer(hass, utcnow):
     assert state.state == "off"
 
 
-async def test_switch_push_light_state_dimmer(hass, utcnow):
+async def test_switch_push_light_state_dimmer(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service)
 
@@ -167,7 +170,7 @@ async def test_switch_push_light_state_dimmer(hass, utcnow):
     assert state.state == "off"
 
 
-async def test_switch_read_light_state_hs(hass, utcnow):
+async def test_switch_read_light_state_hs(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -205,7 +208,7 @@ async def test_switch_read_light_state_hs(hass, utcnow):
     assert state.state == "off"
 
 
-async def test_switch_push_light_state_hs(hass, utcnow):
+async def test_switch_push_light_state_hs(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_hs)
 
@@ -236,7 +239,7 @@ async def test_switch_push_light_state_hs(hass, utcnow):
     assert state.state == "off"
 
 
-async def test_switch_read_light_state_color_temp(hass, utcnow):
+async def test_switch_read_light_state_color_temp(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the color_temp of a  light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -264,7 +267,7 @@ async def test_switch_read_light_state_color_temp(hass, utcnow):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_switch_push_light_state_color_temp(hass, utcnow):
+async def test_switch_push_light_state_color_temp(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit light accessory."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -285,7 +288,9 @@ async def test_switch_push_light_state_color_temp(hass, utcnow):
     assert state.attributes["color_temp"] == 400
 
 
-async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
+async def test_light_becomes_unavailable_but_recovers(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test transition to and from unavailable state."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -313,7 +318,7 @@ async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
     assert state.attributes["color_temp"] == 400
 
 
-async def test_light_unloaded_removed(hass, utcnow):
+async def test_light_unloaded_removed(hass: HomeAssistant, utcnow) -> None:
     """Test entity and HKDevice are correctly unloaded and removed."""
     helper = await setup_test_component(hass, create_lightbulb_service_with_color_temp)
 
@@ -338,7 +343,7 @@ async def test_light_unloaded_removed(hass, utcnow):
     assert hass.states.get(helper.entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a light unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()
@@ -355,7 +360,7 @@ async def test_migrate_unique_id(hass, utcnow):
     )
 
 
-async def test_only_migrate_once(hass, utcnow):
+async def test_only_migrate_once(hass: HomeAssistant, utcnow) -> None:
     """Test a we handle migration happening after an upgrade and than a downgrade and then an upgrade."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -27,7 +28,7 @@ def create_lock_service(accessory):
     return service
 
 
-async def test_switch_change_lock_state(hass, utcnow):
+async def test_switch_change_lock_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit lock on and off again."""
     helper = await setup_test_component(hass, create_lock_service)
 
@@ -52,7 +53,7 @@ async def test_switch_change_lock_state(hass, utcnow):
     )
 
 
-async def test_switch_read_lock_state(hass, utcnow):
+async def test_switch_read_lock_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit lock accessory."""
     helper = await setup_test_component(hass, create_lock_service)
 
@@ -116,7 +117,7 @@ async def test_switch_read_lock_state(hass, utcnow):
     assert state.state == "unlocking"
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a lock unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_media_player.py
+++ b/tests/components/homekit_controller/test_media_player.py
@@ -6,6 +6,7 @@ from aiohomekit.model.characteristics import (
 from aiohomekit.model.services import ServicesTypes
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -60,7 +61,7 @@ def create_tv_service_with_target_media_state(accessory):
     return service
 
 
-async def test_tv_read_state(hass, utcnow):
+async def test_tv_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit fan accessory."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -89,7 +90,7 @@ async def test_tv_read_state(hass, utcnow):
     assert state.state == "idle"
 
 
-async def test_tv_read_sources(hass, utcnow):
+async def test_tv_read_sources(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -98,7 +99,7 @@ async def test_tv_read_sources(hass, utcnow):
     assert state.attributes["source_list"] == ["HDMI 1", "HDMI 2"]
 
 
-async def test_play_remote_key(hass, utcnow):
+async def test_play_remote_key(hass: HomeAssistant, utcnow) -> None:
     """Test that we can play media on a media player."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -145,7 +146,7 @@ async def test_play_remote_key(hass, utcnow):
     )
 
 
-async def test_pause_remote_key(hass, utcnow):
+async def test_pause_remote_key(hass: HomeAssistant, utcnow) -> None:
     """Test that we can pause a media player."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -192,7 +193,7 @@ async def test_pause_remote_key(hass, utcnow):
     )
 
 
-async def test_play(hass, utcnow):
+async def test_play(hass: HomeAssistant, utcnow) -> None:
     """Test that we can play media on a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -241,7 +242,7 @@ async def test_play(hass, utcnow):
     )
 
 
-async def test_pause(hass, utcnow):
+async def test_pause(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn pause a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -289,7 +290,7 @@ async def test_pause(hass, utcnow):
     )
 
 
-async def test_stop(hass, utcnow):
+async def test_stop(hass: HomeAssistant, utcnow) -> None:
     """Test that we can  stop a media player."""
     helper = await setup_test_component(hass, create_tv_service_with_target_media_state)
 
@@ -330,7 +331,7 @@ async def test_stop(hass, utcnow):
     )
 
 
-async def test_tv_set_source(hass, utcnow):
+async def test_tv_set_source(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -351,7 +352,7 @@ async def test_tv_set_source(hass, utcnow):
     assert state.attributes["source"] == "HDMI 2"
 
 
-async def test_tv_set_source_fail(hass, utcnow):
+async def test_tv_set_source_fail(hass: HomeAssistant, utcnow) -> None:
     """Test that we can set the input source of a HomeKit TV."""
     helper = await setup_test_component(hass, create_tv_service)
 
@@ -367,7 +368,7 @@ async def test_tv_set_source_fail(hass, utcnow):
     assert state.attributes["source"] == "HDMI 1"
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a media_player unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -2,6 +2,7 @@
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import Helper, get_next_aid, setup_test_component
@@ -28,7 +29,7 @@ def create_switch_with_spray_level(accessory):
     return service
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a number unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()
@@ -46,7 +47,7 @@ async def test_migrate_unique_id(hass, utcnow):
     )
 
 
-async def test_read_number(hass, utcnow):
+async def test_read_number(hass: HomeAssistant, utcnow) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_spray_level)
 
@@ -72,7 +73,7 @@ async def test_read_number(hass, utcnow):
     assert state.state == "5"
 
 
-async def test_write_number(hass, utcnow):
+async def test_write_number(hass: HomeAssistant, utcnow) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_spray_level)
 

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -3,6 +3,7 @@ from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import Helper, get_next_aid, setup_test_component
@@ -21,7 +22,7 @@ def create_service_with_ecobee_mode(accessory: Accessory):
     return service
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test we can migrate a select unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()
@@ -40,7 +41,7 @@ async def test_migrate_unique_id(hass, utcnow):
     )
 
 
-async def test_read_current_mode(hass, utcnow):
+async def test_read_current_mode(hass: HomeAssistant, utcnow) -> None:
     """Test that Ecobee mode can be correctly read and show as human readable text."""
     helper = await setup_test_component(hass, create_service_with_ecobee_mode)
 
@@ -78,7 +79,7 @@ async def test_read_current_mode(hass, utcnow):
     assert state.state == "away"
 
 
-async def test_write_current_mode(hass, utcnow):
+async def test_write_current_mode(hass: HomeAssistant, utcnow) -> None:
     """Test can set a specific mode."""
     helper = await setup_test_component(hass, create_service_with_ecobee_mode)
     helper.accessory.services.first(service_type=ServicesTypes.THERMOSTAT)

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.homekit_controller.sensor import (
     thread_status_to_str,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import TEST_DEVICE_SERVICE_INFO, Helper, setup_test_component
@@ -68,7 +69,7 @@ def create_battery_level_sensor(accessory):
     return service
 
 
-async def test_temperature_sensor_read_state(hass, utcnow):
+async def test_temperature_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit temperature sensor accessory."""
     helper = await setup_test_component(
         hass, create_temperature_sensor_service, suffix="temperature"
@@ -94,7 +95,7 @@ async def test_temperature_sensor_read_state(hass, utcnow):
     assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
 
-async def test_temperature_sensor_not_added_twice(hass, utcnow):
+async def test_temperature_sensor_not_added_twice(hass: HomeAssistant, utcnow) -> None:
     """A standalone temperature sensor should not get a characteristic AND a service entity."""
     helper = await setup_test_component(
         hass, create_temperature_sensor_service, suffix="temperature"
@@ -108,7 +109,7 @@ async def test_temperature_sensor_not_added_twice(hass, utcnow):
     assert created_sensors == {helper.entity_id}
 
 
-async def test_humidity_sensor_read_state(hass, utcnow):
+async def test_humidity_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit humidity sensor accessory."""
     helper = await setup_test_component(
         hass, create_humidity_sensor_service, suffix="humidity"
@@ -133,7 +134,7 @@ async def test_humidity_sensor_read_state(hass, utcnow):
     assert state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
 
 
-async def test_light_level_sensor_read_state(hass, utcnow):
+async def test_light_level_sensor_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit temperature sensor accessory."""
     helper = await setup_test_component(
         hass, create_light_level_sensor_service, suffix="light_level"
@@ -158,7 +159,9 @@ async def test_light_level_sensor_read_state(hass, utcnow):
     assert state.attributes["device_class"] == SensorDeviceClass.ILLUMINANCE
 
 
-async def test_carbon_dioxide_level_sensor_read_state(hass, utcnow):
+async def test_carbon_dioxide_level_sensor_read_state(
+    hass: HomeAssistant, utcnow
+) -> None:
     """Test reading the state of a HomeKit carbon dioxide sensor accessory."""
     helper = await setup_test_component(
         hass, create_carbon_dioxide_level_sensor_service, suffix="carbon_dioxide"
@@ -181,7 +184,7 @@ async def test_carbon_dioxide_level_sensor_read_state(hass, utcnow):
     assert state.state == "20"
 
 
-async def test_battery_level_sensor(hass, utcnow):
+async def test_battery_level_sensor(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit battery level sensor."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -208,7 +211,7 @@ async def test_battery_level_sensor(hass, utcnow):
     assert state.attributes["device_class"] == SensorDeviceClass.BATTERY
 
 
-async def test_battery_charging(hass, utcnow):
+async def test_battery_charging(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit battery's charging state."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -232,7 +235,7 @@ async def test_battery_charging(hass, utcnow):
     assert state.attributes["icon"] == "mdi:battery-charging-20"
 
 
-async def test_battery_low(hass, utcnow):
+async def test_battery_low(hass: HomeAssistant, utcnow) -> None:
     """Test reading the state of a HomeKit battery's low state."""
     helper = await setup_test_component(
         hass, create_battery_level_sensor, suffix="battery"
@@ -274,7 +277,7 @@ def create_switch_with_sensor(accessory):
     return service
 
 
-async def test_switch_with_sensor(hass, utcnow):
+async def test_switch_with_sensor(hass: HomeAssistant, utcnow) -> None:
     """Test a switch service that has a sensor characteristic is correctly handled."""
     helper = await setup_test_component(hass, create_switch_with_sensor)
 
@@ -304,7 +307,7 @@ async def test_switch_with_sensor(hass, utcnow):
     assert state.state == "50"
 
 
-async def test_sensor_unavailable(hass, utcnow):
+async def test_sensor_unavailable(hass: HomeAssistant, utcnow) -> None:
     """Test a sensor becoming unavailable."""
     helper = await setup_test_component(hass, create_switch_with_sensor)
 
@@ -359,8 +362,11 @@ def test_thread_status_to_str() -> None:
 
 
 async def test_rssi_sensor(
-    hass, utcnow, entity_registry_enabled_by_default, enable_bluetooth
-):
+    hass: HomeAssistant,
+    utcnow,
+    entity_registry_enabled_by_default,
+    enable_bluetooth: None,
+) -> None:
     """Test an rssi sensor."""
     inject_bluetooth_service_info(hass, TEST_DEVICE_SERVICE_INFO)
 
@@ -381,8 +387,11 @@ async def test_rssi_sensor(
 
 
 async def test_migrate_rssi_sensor_unique_id(
-    hass, utcnow, entity_registry_enabled_by_default, enable_bluetooth
-):
+    hass: HomeAssistant,
+    utcnow,
+    entity_registry_enabled_by_default,
+    enable_bluetooth: None,
+) -> None:
     """Test an rssi sensor unique id migration."""
     entity_registry = er.async_get(hass)
     rssi_sensor = entity_registry.async_get_or_create(

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -11,7 +11,7 @@ from .common import setup_platform, setup_test_component
 from tests.common import flush_store
 
 
-async def test_load_from_storage(hass, hass_storage):
+async def test_load_from_storage(hass: HomeAssistant, hass_storage) -> None:
     """Test that entity map can be correctly loaded from cache."""
     hkid = "00:00:00:00:00:00"
 
@@ -24,7 +24,7 @@ async def test_load_from_storage(hass, hass_storage):
     assert hkid in hass.data[ENTITY_MAP].storage_data
 
 
-async def test_storage_is_removed(hass, hass_storage):
+async def test_storage_is_removed(hass: HomeAssistant, hass_storage) -> None:
     """Test entity map storage removal is idempotent."""
     await setup_platform(hass)
 
@@ -64,7 +64,9 @@ def create_lightbulb_service(accessory):
     on_char.value = 0
 
 
-async def test_storage_is_updated_on_add(hass, hass_storage, utcnow):
+async def test_storage_is_updated_on_add(
+    hass: HomeAssistant, hass_storage, utcnow
+) -> None:
     """Test entity map storage is cleaned up on adding an accessory."""
     await setup_test_component(hass, create_lightbulb_service)
 

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -1,5 +1,4 @@
 """Basic checks for HomeKitSwitch."""
-
 from aiohomekit.model.characteristics import (
     CharacteristicsTypes,
     InUseValues,
@@ -7,6 +6,7 @@ from aiohomekit.model.characteristics import (
 )
 from aiohomekit.model.services import ServicesTypes
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import get_next_aid, setup_test_component
@@ -49,7 +49,7 @@ def create_char_switch_service(accessory):
     on_char.value = False
 
 
-async def test_switch_change_outlet_state(hass, utcnow):
+async def test_switch_change_outlet_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a HomeKit outlet on and off again."""
     helper = await setup_test_component(hass, create_switch_service)
 
@@ -74,7 +74,7 @@ async def test_switch_change_outlet_state(hass, utcnow):
     )
 
 
-async def test_switch_read_outlet_state(hass, utcnow):
+async def test_switch_read_outlet_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit outlet accessory."""
     helper = await setup_test_component(hass, create_switch_service)
 
@@ -107,7 +107,7 @@ async def test_switch_read_outlet_state(hass, utcnow):
     assert switch_1.attributes["outlet_in_use"] is True
 
 
-async def test_valve_change_active_state(hass, utcnow):
+async def test_valve_change_active_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a valve on and off again."""
     helper = await setup_test_component(hass, create_valve_service)
 
@@ -132,7 +132,7 @@ async def test_valve_change_active_state(hass, utcnow):
     )
 
 
-async def test_valve_read_state(hass, utcnow):
+async def test_valve_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a valve accessory."""
     helper = await setup_test_component(hass, create_valve_service)
 
@@ -165,7 +165,7 @@ async def test_valve_read_state(hass, utcnow):
     assert switch_1.attributes["in_use"] is False
 
 
-async def test_char_switch_change_state(hass, utcnow):
+async def test_char_switch_change_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can turn a characteristic on and off again."""
     helper = await setup_test_component(
         hass, create_char_switch_service, suffix="pairing_mode"
@@ -198,7 +198,7 @@ async def test_char_switch_change_state(hass, utcnow):
     )
 
 
-async def test_char_switch_read_state(hass, utcnow):
+async def test_char_switch_read_state(hass: HomeAssistant, utcnow) -> None:
     """Test that we can read the state of a HomeKit characteristic switch."""
     helper = await setup_test_component(
         hass, create_char_switch_service, suffix="pairing_mode"
@@ -219,7 +219,7 @@ async def test_char_switch_read_state(hass, utcnow):
     assert switch_1.state == "off"
 
 
-async def test_migrate_unique_id(hass, utcnow):
+async def test_migrate_unique_id(hass: HomeAssistant, utcnow) -> None:
     """Test a we can migrate a switch unique id."""
     entity_registry = er.async_get(hass)
     aid = get_next_aid()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
