### PR TITLE
Add type hints to integration tests (part 10)

### DIFF
--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -48,7 +48,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_alarm_control_panel(hass, default_mock_hap_factory):
+async def test_hmip_alarm_control_panel(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipAlarmControlPanel."""
     entity_id = "alarm_control_panel.hmip_alarm_control_panel"
     entity_name = "HmIP Alarm Control Panel"

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -39,7 +39,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_home_cloud_connection_sensor(hass, default_mock_hap_factory):
+async def test_hmip_home_cloud_connection_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCloudConnectionSensor."""
     entity_id = "binary_sensor.cloud_connection"
     entity_name = "Cloud Connection"
@@ -60,7 +62,9 @@ async def test_hmip_home_cloud_connection_sensor(hass, default_mock_hap_factory)
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_acceleration_sensor(hass, default_mock_hap_factory):
+async def test_hmip_acceleration_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipAccelerationSensor."""
     entity_id = "binary_sensor.garagentor"
     entity_name = "Garagentor"
@@ -97,7 +101,9 @@ async def test_hmip_acceleration_sensor(hass, default_mock_hap_factory):
     assert len(hmip_device.mock_calls) == service_call_counter + 2
 
 
-async def test_hmip_tilt_vibration_sensor(hass, default_mock_hap_factory):
+async def test_hmip_tilt_vibration_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTiltVibrationSensor."""
     entity_id = "binary_sensor.garage_neigungs_und_erschutterungssensor"
     entity_name = "Garage Neigungs- und Erschütterungssensor"
@@ -133,7 +139,9 @@ async def test_hmip_tilt_vibration_sensor(hass, default_mock_hap_factory):
     assert len(hmip_device.mock_calls) == service_call_counter + 2
 
 
-async def test_hmip_contact_interface(hass, default_mock_hap_factory):
+async def test_hmip_contact_interface(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipContactInterface."""
     entity_id = "binary_sensor.kontakt_schnittstelle_unterputz_1_fach"
     entity_name = "Kontakt-Schnittstelle Unterputz – 1-fach"
@@ -156,7 +164,9 @@ async def test_hmip_contact_interface(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_shutter_contact(hass, default_mock_hap_factory):
+async def test_hmip_shutter_contact(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipShutterContact."""
     entity_id = "binary_sensor.fenstergriffsensor"
     entity_name = "Fenstergriffsensor"
@@ -196,7 +206,9 @@ async def test_hmip_shutter_contact(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_SABOTAGE]
 
 
-async def test_hmip_shutter_contact_optical(hass, default_mock_hap_factory):
+async def test_hmip_shutter_contact_optical(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipShutterContact."""
     entity_id = "binary_sensor.sitzplatzture"
     entity_name = "Sitzplatzt\u00fcre"
@@ -226,7 +238,9 @@ async def test_hmip_shutter_contact_optical(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_SABOTAGE]
 
 
-async def test_hmip_motion_detector(hass, default_mock_hap_factory):
+async def test_hmip_motion_detector(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipMotionDetector."""
     entity_id = "binary_sensor.bewegungsmelder_fur_55er_rahmen_innen"
     entity_name = "Bewegungsmelder für 55er Rahmen – innen"
@@ -245,7 +259,9 @@ async def test_hmip_motion_detector(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_presence_detector(hass, default_mock_hap_factory):
+async def test_hmip_presence_detector(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.spi_1"
     entity_name = "SPI_1"
@@ -270,8 +286,8 @@ async def test_hmip_presence_detector(hass, default_mock_hap_factory):
 
 
 async def test_hmip_pluggable_mains_failure_surveillance_sensor(
-    hass, default_mock_hap_factory
-):
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.netzausfalluberwachung"
     entity_name = "Netzausfallüberwachung"
@@ -290,7 +306,9 @@ async def test_hmip_pluggable_mains_failure_surveillance_sensor(
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_smoke_detector(hass, default_mock_hap_factory):
+async def test_hmip_smoke_detector(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSmokeDetector."""
     entity_id = "binary_sensor.rauchwarnmelder"
     entity_name = "Rauchwarnmelder"
@@ -322,7 +340,9 @@ async def test_hmip_smoke_detector(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_water_detector(hass, default_mock_hap_factory):
+async def test_hmip_water_detector(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipWaterDetector."""
     entity_id = "binary_sensor.wassersensor"
     entity_name = "Wassersensor"
@@ -357,7 +377,7 @@ async def test_hmip_water_detector(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_storm_sensor(hass, default_mock_hap_factory):
+async def test_hmip_storm_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipStormSensor."""
     entity_id = "binary_sensor.weather_sensor_plus_storm"
     entity_name = "Weather Sensor – plus Storm"
@@ -376,7 +396,7 @@ async def test_hmip_storm_sensor(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_rain_sensor(hass, default_mock_hap_factory):
+async def test_hmip_rain_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipRainSensor."""
     entity_id = "binary_sensor.wettersensor_pro_raining"
     entity_name = "Wettersensor - pro Raining"
@@ -395,7 +415,9 @@ async def test_hmip_rain_sensor(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_sunshine_sensor(hass, default_mock_hap_factory):
+async def test_hmip_sunshine_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wettersensor_pro_sunshine"
     entity_name = "Wettersensor - pro Sunshine"
@@ -415,7 +437,9 @@ async def test_hmip_sunshine_sensor(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_battery_sensor(hass, default_mock_hap_factory):
+async def test_hmip_battery_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wohnungsture_battery"
     entity_name = "Wohnungstüre Battery"
@@ -434,7 +458,9 @@ async def test_hmip_battery_sensor(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_security_zone_sensor_group(hass, default_mock_hap_factory):
+async def test_hmip_security_zone_sensor_group(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSecurityZoneSensorGroup."""
     entity_id = "binary_sensor.internal_securityzone"
     entity_name = "INTERNAL SecurityZone"
@@ -469,7 +495,9 @@ async def test_hmip_security_zone_sensor_group(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_WINDOW_STATE] == WindowState.OPEN
 
 
-async def test_hmip_security_sensor_group(hass, default_mock_hap_factory):
+async def test_hmip_security_sensor_group(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSecuritySensorGroup."""
     entity_id = "binary_sensor.buro_sensors"
     entity_name = "Büro Sensors"
@@ -541,7 +569,9 @@ async def test_hmip_security_sensor_group(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_multi_contact_interface(hass, default_mock_hap_factory):
+async def test_hmip_multi_contact_interface(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipMultiContactInterface."""
     entity_id = "binary_sensor.wired_eingangsmodul_32_fach_channel5"
     entity_name = "Wired Eingangsmodul – 32-fach Channel5"

--- a/tests/components/homematicip_cloud/test_button.py
+++ b/tests/components/homematicip_cloud/test_button.py
@@ -1,16 +1,18 @@
 """Tests for HomematicIP Cloud button."""
-
 from unittest.mock import patch
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.button.const import SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .helper import get_and_check_entity_basics
 
 
-async def test_hmip_garage_door_controller_button(hass, default_mock_hap_factory):
+async def test_hmip_garage_door_controller_button(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipGarageDoorControllerButton."""
     entity_id = "button.garagentor"
     entity_name = "Garagentor"

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -36,7 +36,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_heating_group_heat(hass, default_mock_hap_factory):
+async def test_hmip_heating_group_heat(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"
@@ -229,7 +231,9 @@ async def test_hmip_heating_group_heat(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
 
 
-async def test_hmip_heating_group_cool(hass, default_mock_hap_factory):
+async def test_hmip_heating_group_cool(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"
@@ -349,7 +353,9 @@ async def test_hmip_heating_group_cool(hass, default_mock_hap_factory):
     assert hmip_device.mock_calls[-1][1] == (4,)
 
 
-async def test_hmip_heating_group_heat_with_switch(hass, default_mock_hap_factory):
+async def test_hmip_heating_group_heat_with_switch(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.schlafzimmer"
     entity_name = "Schlafzimmer"
@@ -373,7 +379,9 @@ async def test_hmip_heating_group_heat_with_switch(hass, default_mock_hap_factor
     assert ha_state.attributes[ATTR_PRESET_MODES] == [PRESET_BOOST, "STD", "P2"]
 
 
-async def test_hmip_heating_group_heat_with_radiator(hass, default_mock_hap_factory):
+async def test_hmip_heating_group_heat_with_radiator(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.vorzimmer"
     entity_name = "Vorzimmer"
@@ -396,7 +404,9 @@ async def test_hmip_heating_group_heat_with_radiator(hass, default_mock_hap_fact
     assert ha_state.attributes[ATTR_PRESET_MODES] == [PRESET_NONE, PRESET_BOOST]
 
 
-async def test_hmip_climate_services(hass, mock_hap_with_service):
+async def test_hmip_climate_services(
+    hass: HomeAssistant, mock_hap_with_service
+) -> None:
     """Test HomematicipHeatingGroup."""
 
     home = mock_hap_with_service.home
@@ -508,7 +518,9 @@ async def test_hmip_climate_services(hass, mock_hap_with_service):
     assert len(home._connection.mock_calls) == 10
 
 
-async def test_hmip_heating_group_services(hass, default_mock_hap_factory):
+async def test_hmip_heating_group_services(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingGroup services."""
     entity_id = "climate.badezimmer"
     entity_name = "Badezimmer"

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -18,7 +18,7 @@ DEFAULT_CONFIG = {HMIPC_HAPID: "ABC123", HMIPC_PIN: "123", HMIPC_NAME: "hmip"}
 IMPORT_CONFIG = {HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "123", HMIPC_NAME: "hmip"}
 
 
-async def test_flow_works(hass, simple_mock_home):
+async def test_flow_works(hass: HomeAssistant, simple_mock_home) -> None:
     """Test config flow."""
 
     with patch(
@@ -152,7 +152,7 @@ async def test_init_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_import_config(hass, simple_mock_home):
+async def test_import_config(hass: HomeAssistant, simple_mock_home) -> None:
     """Test importing a host with an existing config file."""
     with patch(
         "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -22,7 +22,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_cover_shutter(hass, default_mock_hap_factory):
+async def test_hmip_cover_shutter(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.broll_1"
     entity_name = "BROLL_1"
@@ -87,7 +89,7 @@ async def test_hmip_cover_shutter(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_cover_slats(hass, default_mock_hap_factory):
+async def test_hmip_cover_slats(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipCoverSlats."""
     entity_id = "cover.sofa_links"
     entity_name = "Sofa links"
@@ -161,7 +163,9 @@ async def test_hmip_cover_slats(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_multi_cover_slats(hass, default_mock_hap_factory):
+async def test_hmip_multi_cover_slats(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCoverSlats."""
     entity_id = "cover.wohnzimmer_fenster"
     entity_name = "Wohnzimmer Fenster"
@@ -239,7 +243,7 @@ async def test_hmip_multi_cover_slats(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_blind_module(hass, default_mock_hap_factory):
+async def test_hmip_blind_module(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipBlindModule."""
     entity_id = "cover.sonnenschutz_balkontur"
     entity_name = "Sonnenschutz Balkontür"
@@ -349,7 +353,9 @@ async def test_hmip_blind_module(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_garage_door_tormatic(hass, default_mock_hap_factory):
+async def test_hmip_garage_door_tormatic(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.garage_door_module"
     entity_name = "Garage Door Module"
@@ -396,7 +402,9 @@ async def test_hmip_garage_door_tormatic(hass, default_mock_hap_factory):
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.STOP,)
 
 
-async def test_hmip_garage_door_hoermann(hass, default_mock_hap_factory):
+async def test_hmip_garage_door_hoermann(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.garage_door"
     entity_name = "Garage door"
@@ -443,7 +451,9 @@ async def test_hmip_garage_door_hoermann(hass, default_mock_hap_factory):
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.STOP,)
 
 
-async def test_hmip_cover_shutter_group(hass, default_mock_hap_factory):
+async def test_hmip_cover_shutter_group(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipCoverShutteGroup."""
     entity_id = "cover.rollos_shuttergroup"
     entity_name = "Rollos ShutterGroup"
@@ -506,7 +516,9 @@ async def test_hmip_cover_shutter_group(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_cover_slats_group(hass, default_mock_hap_factory):
+async def test_hmip_cover_slats_group(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test slats with HomematicipCoverShutteGroup."""
     entity_id = "cover.rollos_shuttergroup"
     entity_name = "Rollos ShutterGroup"

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -6,6 +6,7 @@ from homematicip.base.enums import EventType
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .helper import (
@@ -16,7 +17,9 @@ from .helper import (
 )
 
 
-async def test_hmip_load_all_supported_devices(hass, default_mock_hap_factory):
+async def test_hmip_load_all_supported_devices(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Ensure that all supported devices could be loaded."""
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
         test_devices=None, test_groups=None
@@ -25,7 +28,9 @@ async def test_hmip_load_all_supported_devices(hass, default_mock_hap_factory):
     assert len(mock_hap.hmip_device_by_entity_id) == 270
 
 
-async def test_hmip_remove_device(hass, default_mock_hap_factory):
+async def test_hmip_remove_device(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -57,7 +62,9 @@ async def test_hmip_remove_device(hass, default_mock_hap_factory):
     assert len(mock_hap.hmip_device_by_entity_id) == pre_mapping_count - 3
 
 
-async def test_hmip_add_device(hass, default_mock_hap_factory, hmip_config_entry):
+async def test_hmip_add_device(
+    hass: HomeAssistant, default_mock_hap_factory, hmip_config_entry
+) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -105,7 +112,7 @@ async def test_hmip_add_device(hass, default_mock_hap_factory, hmip_config_entry
     assert len(new_hap.hmip_device_by_entity_id) == pre_mapping_count
 
 
-async def test_hmip_remove_group(hass, default_mock_hap_factory):
+async def test_hmip_remove_group(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test Remove of hmip group."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
@@ -135,8 +142,8 @@ async def test_hmip_remove_group(hass, default_mock_hap_factory):
 
 
 async def test_all_devices_unavailable_when_hap_not_connected(
-    hass, default_mock_hap_factory
-):
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test make all devices unavaulable when hap is not connected."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -160,7 +167,7 @@ async def test_all_devices_unavailable_when_hap_not_connected(
     assert ha_state.state == STATE_UNAVAILABLE
 
 
-async def test_hap_reconnected(hass, default_mock_hap_factory):
+async def test_hap_reconnected(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test reconnect hap."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -190,7 +197,9 @@ async def test_hap_reconnected(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
+async def test_hap_with_name(
+    hass: HomeAssistant, mock_connection, hmip_config_entry
+) -> None:
     """Test hap with name."""
     home_name = "TestName"
     entity_id = f"light.{home_name.lower()}_treppe_ch"
@@ -212,7 +221,9 @@ async def test_hap_with_name(hass, mock_connection, hmip_config_entry):
     assert ha_state.attributes["friendly_name"] == entity_name
 
 
-async def test_hmip_reset_energy_counter_services(hass, default_mock_hap_factory):
+async def test_hmip_reset_energy_counter_services(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test reset_energy_counter service."""
     entity_id = "switch.pc"
     entity_name = "Pc"
@@ -242,7 +253,9 @@ async def test_hmip_reset_energy_counter_services(hass, default_mock_hap_factory
     assert len(hmip_device._connection.mock_calls) == 4  # pylint: disable=W0212
 
 
-async def test_hmip_multi_area_device(hass, default_mock_hap_factory):
+async def test_hmip_multi_area_device(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test multi area device. Check if devices are created and referenced."""
     entity_id = "binary_sensor.wired_eingangsmodul_32_fach_channel5"
     entity_name = "Wired Eingangsmodul – 32-fach Channel5"

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -103,7 +103,9 @@ async def test_hap_setup_connection_error() -> None:
     assert not hass.config_entries.flow.async_init.mock_calls
 
 
-async def test_hap_reset_unloads_entry_if_setup(hass, default_mock_hap_factory):
+async def test_hap_reset_unloads_entry_if_setup(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test calling reset while the entry has been setup."""
     mock_hap = await default_mock_hap_factory.async_get_mock_hap()
     assert hass.data[HMIPC_DOMAIN][HAPID] == mock_hap
@@ -116,7 +118,9 @@ async def test_hap_reset_unloads_entry_if_setup(hass, default_mock_hap_factory):
     assert hass.data[HMIPC_DOMAIN] == {}
 
 
-async def test_hap_create(hass, hmip_config_entry, simple_mock_home):
+async def test_hap_create(
+    hass: HomeAssistant, hmip_config_entry, simple_mock_home
+) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)
     hap = HomematicipHAP(hass, hmip_config_entry)
@@ -125,7 +129,9 @@ async def test_hap_create(hass, hmip_config_entry, simple_mock_home):
         assert await hap.async_setup()
 
 
-async def test_hap_create_exception(hass, hmip_config_entry, mock_connection_init):
+async def test_hap_create_exception(
+    hass: HomeAssistant, hmip_config_entry, mock_connection_init
+) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)
 
@@ -145,7 +151,7 @@ async def test_hap_create_exception(hass, hmip_config_entry, mock_connection_ini
         await hap.async_setup()
 
 
-async def test_auth_create(hass, simple_mock_auth):
+async def test_auth_create(hass: HomeAssistant, simple_mock_auth) -> None:
     """Mock AsyncAuth to execute get_auth."""
     config = {HMIPC_HAPID: HAPID, HMIPC_PIN: HAPPIN, HMIPC_NAME: "hmip"}
     hmip_auth = HomematicipAuth(hass, config)
@@ -160,7 +166,7 @@ async def test_auth_create(hass, simple_mock_auth):
         assert hmip_auth.auth.pin == HAPPIN
 
 
-async def test_auth_create_exception(hass, simple_mock_auth):
+async def test_auth_create_exception(hass: HomeAssistant, simple_mock_auth) -> None:
     """Mock AsyncAuth to execute get_auth."""
     config = {HMIPC_HAPID: HAPID, HMIPC_PIN: HAPPIN, HMIPC_NAME: "hmip"}
     hmip_auth = HomematicipAuth(hass, config)

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -21,8 +21,8 @@ from tests.common import MockConfigEntry
 
 
 async def test_config_with_accesspoint_passed_to_config_entry(
-    hass, mock_connection, simple_mock_home
-):
+    hass: HomeAssistant, mock_connection, simple_mock_home
+) -> None:
     """Test that config for a accesspoint are loaded via config entry."""
 
     entry_config = {
@@ -55,8 +55,8 @@ async def test_config_with_accesspoint_passed_to_config_entry(
 
 
 async def test_config_already_registered_not_passed_to_config_entry(
-    hass, simple_mock_home
-):
+    hass: HomeAssistant, simple_mock_home
+) -> None:
     """Test that an already registered accesspoint does not get imported."""
 
     mock_config = {HMIPC_AUTHTOKEN: "123", HMIPC_HAPID: "ABC123", HMIPC_NAME: "name"}
@@ -99,8 +99,8 @@ async def test_config_already_registered_not_passed_to_config_entry(
 
 
 async def test_load_entry_fails_due_to_connection_error(
-    hass, hmip_config_entry, mock_connection_init
-):
+    hass: HomeAssistant, hmip_config_entry, mock_connection_init
+) -> None:
     """Test load entry fails due to connection error."""
     hmip_config_entry.add_to_hass(hass)
 
@@ -114,7 +114,9 @@ async def test_load_entry_fails_due_to_connection_error(
     assert hmip_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_load_entry_fails_due_to_generic_exception(hass, hmip_config_entry):
+async def test_load_entry_fails_due_to_generic_exception(
+    hass: HomeAssistant, hmip_config_entry
+) -> None:
     """Test load entry fails due to generic exception."""
     hmip_config_entry.add_to_hass(hass)
 
@@ -160,7 +162,9 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     assert hass.data[HMIPC_DOMAIN] == {}
 
 
-async def test_hmip_dump_hap_config_services(hass, mock_hap_with_service):
+async def test_hmip_dump_hap_config_services(
+    hass: HomeAssistant, mock_hap_with_service
+) -> None:
     """Test dump configuration services."""
 
     with patch("pathlib.Path.write_text", return_value=Mock()) as write_mock:

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -26,7 +26,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_light(hass, default_mock_hap_factory):
+async def test_hmip_light(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipLight."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -71,7 +71,9 @@ async def test_hmip_light(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_notification_light(hass, default_mock_hap_factory):
+async def test_hmip_notification_light(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipNotificationLight."""
     entity_id = "light.alarm_status"
     entity_name = "Alarm Status"
@@ -168,7 +170,7 @@ async def test_hmip_notification_light(hass, default_mock_hap_factory):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_dimmer(hass, default_mock_hap_factory):
+async def test_hmip_dimmer(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipDimmer."""
     entity_id = "light.schlafzimmerlicht"
     entity_name = "Schlafzimmerlicht"
@@ -226,7 +228,9 @@ async def test_hmip_dimmer(hass, default_mock_hap_factory):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_light_measuring(hass, default_mock_hap_factory):
+async def test_hmip_light_measuring(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipLightMeasuring."""
     entity_id = "light.flur_oben"
     entity_name = "Flur oben"
@@ -270,7 +274,9 @@ async def test_hmip_light_measuring(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_wired_multi_dimmer(hass, default_mock_hap_factory):
+async def test_hmip_wired_multi_dimmer(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipMultiDimmer."""
     entity_id = "light.raumlich_kuche"
     entity_name = "Raumlich (Küche)"
@@ -328,7 +334,9 @@ async def test_hmip_wired_multi_dimmer(hass, default_mock_hap_factory):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_din_rail_dimmer_3_channel1(hass, default_mock_hap_factory):
+async def test_hmip_din_rail_dimmer_3_channel1(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 1."""
     entity_id = "light.3_dimmer_channel1"
     entity_name = "3-Dimmer Channel1"
@@ -385,7 +393,9 @@ async def test_hmip_din_rail_dimmer_3_channel1(hass, default_mock_hap_factory):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_din_rail_dimmer_3_channel2(hass, default_mock_hap_factory):
+async def test_hmip_din_rail_dimmer_3_channel2(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 2."""
     entity_id = "light.3_dimmer_channel2"
     entity_name = "3-Dimmer Channel2"
@@ -442,7 +452,9 @@ async def test_hmip_din_rail_dimmer_3_channel2(hass, default_mock_hap_factory):
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_din_rail_dimmer_3_channel3(hass, default_mock_hap_factory):
+async def test_hmip_din_rail_dimmer_3_channel3(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 3."""
     entity_id = "light.esstisch"
     entity_name = "Esstisch"

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -46,7 +46,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_accesspoint_status(hass, default_mock_hap_factory):
+async def test_hmip_accesspoint_status(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSwitch."""
     entity_id = "sensor.home_control_access_point_duty_cycle"
     entity_name = "HOME_CONTROL_ACCESS_POINT Duty Cycle"
@@ -63,7 +65,9 @@ async def test_hmip_accesspoint_status(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
-async def test_hmip_heating_thermostat(hass, default_mock_hap_factory):
+async def test_hmip_heating_thermostat(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingThermostat."""
     entity_id = "sensor.heizkorperthermostat_heating"
     entity_name = "Heizkörperthermostat Heating"
@@ -97,7 +101,9 @@ async def test_hmip_heating_thermostat(hass, default_mock_hap_factory):
     assert ha_state.attributes["icon"] == "mdi:battery-outline"
 
 
-async def test_hmip_humidity_sensor(hass, default_mock_hap_factory):
+async def test_hmip_humidity_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHumiditySensor."""
     entity_id = "sensor.bwth_1_humidity"
     entity_name = "BWTH 1 Humidity"
@@ -120,7 +126,9 @@ async def test_hmip_humidity_sensor(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_RSSI_PEER] == -77
 
 
-async def test_hmip_temperature_sensor1(hass, default_mock_hap_factory):
+async def test_hmip_temperature_sensor1(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.bwth_1_temperature"
     entity_name = "BWTH 1 Temperature"
@@ -145,7 +153,9 @@ async def test_hmip_temperature_sensor1(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 10
 
 
-async def test_hmip_temperature_sensor2(hass, default_mock_hap_factory):
+async def test_hmip_temperature_sensor2(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.heizkorperthermostat_temperature"
     entity_name = "Heizkörperthermostat Temperature"
@@ -170,7 +180,9 @@ async def test_hmip_temperature_sensor2(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 10
 
 
-async def test_hmip_temperature_sensor3(hass, default_mock_hap_factory):
+async def test_hmip_temperature_sensor3(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.raumbediengerat_analog_temperature"
     entity_name = "Raumbediengerät Analog Temperature"
@@ -195,7 +207,9 @@ async def test_hmip_temperature_sensor3(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 10
 
 
-async def test_hmip_thermostat_evo_heating(hass, default_mock_hap_factory):
+async def test_hmip_thermostat_evo_heating(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipHeatingThermostat for HmIP-eTRV-E."""
     entity_id = "sensor.thermostat_evo_heating"
     entity_name = "thermostat_evo Heating"
@@ -215,7 +229,9 @@ async def test_hmip_thermostat_evo_heating(hass, default_mock_hap_factory):
     assert ha_state.state == "40"
 
 
-async def test_hmip_thermostat_evo_temperature(hass, default_mock_hap_factory):
+async def test_hmip_thermostat_evo_temperature(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.thermostat_evo_temperature"
     entity_name = "thermostat_evo Temperature"
@@ -239,7 +255,7 @@ async def test_hmip_thermostat_evo_temperature(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 0.7
 
 
-async def test_hmip_power_sensor(hass, default_mock_hap_factory):
+async def test_hmip_power_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipPowerSensor."""
     entity_id = "sensor.flur_oben_power"
     entity_name = "Flur oben Power"
@@ -276,7 +292,9 @@ async def test_hmip_power_sensor(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_CONFIG_PENDING]
 
 
-async def test_hmip_illuminance_sensor1(hass, default_mock_hap_factory):
+async def test_hmip_illuminance_sensor1(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.wettersensor_illuminance"
     entity_name = "Wettersensor Illuminance"
@@ -296,7 +314,9 @@ async def test_hmip_illuminance_sensor1(hass, default_mock_hap_factory):
     assert ha_state.state == "231"
 
 
-async def test_hmip_illuminance_sensor2(hass, default_mock_hap_factory):
+async def test_hmip_illuminance_sensor2(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.lichtsensor_nord_illuminance"
     entity_name = "Lichtsensor Nord Illuminance"
@@ -319,7 +339,9 @@ async def test_hmip_illuminance_sensor2(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_LOWEST_ILLUMINATION] == 785.2
 
 
-async def test_hmip_windspeed_sensor(hass, default_mock_hap_factory):
+async def test_hmip_windspeed_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipWindspeedSensor."""
     entity_id = "sensor.wettersensor_pro_windspeed"
     entity_name = "Wettersensor - pro Windspeed"
@@ -368,7 +390,9 @@ async def test_hmip_windspeed_sensor(hass, default_mock_hap_factory):
         assert ha_state.attributes[ATTR_WIND_DIRECTION] == txt
 
 
-async def test_hmip_today_rain_sensor(hass, default_mock_hap_factory):
+async def test_hmip_today_rain_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTodayRainSensor."""
     entity_id = "sensor.weather_sensor_plus_today_rain"
     entity_name = "Weather Sensor – plus Today Rain"
@@ -389,8 +413,8 @@ async def test_hmip_today_rain_sensor(hass, default_mock_hap_factory):
 
 
 async def test_hmip_temperature_external_sensor_channel_1(
-    hass, default_mock_hap_factory
-):
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureDifferenceSensor Channel 1 HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_channel_1_temperature"
     entity_name = "STE2 Channel 1 Temperature"
@@ -414,8 +438,8 @@ async def test_hmip_temperature_external_sensor_channel_1(
 
 
 async def test_hmip_temperature_external_sensor_channel_2(
-    hass, default_mock_hap_factory
-):
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureDifferenceSensor Channel 2 HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_channel_2_temperature"
     entity_name = "STE2 Channel 2 Temperature"
@@ -438,7 +462,9 @@ async def test_hmip_temperature_external_sensor_channel_2(
     assert ha_state.state == "23.4"
 
 
-async def test_hmip_temperature_external_sensor_delta(hass, default_mock_hap_factory):
+async def test_hmip_temperature_external_sensor_delta(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipTemperatureDifferenceSensor Delta HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_delta_temperature"
     entity_name = "STE2 Delta Temperature"
@@ -463,7 +489,9 @@ async def test_hmip_temperature_external_sensor_delta(hass, default_mock_hap_fac
     assert ha_state.state == "-0.5"
 
 
-async def test_hmip_passage_detector_delta_counter(hass, default_mock_hap_factory):
+async def test_hmip_passage_detector_delta_counter(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipPassageDetectorDeltaCounter."""
     entity_id = "sensor.spdr_1"
     entity_name = "SPDR_1"

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -19,7 +19,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_switch(hass, default_mock_hap_factory):
+async def test_hmip_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipSwitch."""
     entity_id = "switch.schrank"
     entity_name = "Schrank"
@@ -56,7 +56,7 @@ async def test_hmip_switch(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_switch_input(hass, default_mock_hap_factory):
+async def test_hmip_switch_input(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipSwitch."""
     entity_id = "switch.wohnzimmer_beleuchtung"
     entity_name = "Wohnzimmer Beleuchtung"
@@ -93,7 +93,9 @@ async def test_hmip_switch_input(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_switch_measuring(hass, default_mock_hap_factory):
+async def test_hmip_switch_measuring(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipSwitchMeasuring."""
     entity_id = "switch.pc"
     entity_name = "Pc"
@@ -131,7 +133,7 @@ async def test_hmip_switch_measuring(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_group_switch(hass, default_mock_hap_factory):
+async def test_hmip_group_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipGroupSwitch."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
@@ -171,7 +173,7 @@ async def test_hmip_group_switch(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_GROUP_MEMBER_UNREACHABLE]
 
 
-async def test_hmip_multi_switch(hass, default_mock_hap_factory):
+async def test_hmip_multi_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipMultiSwitch."""
     entity_id = "switch.jalousien_1_kizi_2_schlazi_channel1"
     entity_name = "Jalousien - 1 KiZi, 2 SchlaZi Channel1"
@@ -224,7 +226,9 @@ async def test_hmip_multi_switch(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_wired_multi_switch(hass, default_mock_hap_factory):
+async def test_hmip_wired_multi_switch(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipMultiSwitch."""
     entity_id = "switch.fernseher_wohnzimmer"
     entity_name = "Fernseher (Wohnzimmer)"

--- a/tests/components/homematicip_cloud/test_weather.py
+++ b/tests/components/homematicip_cloud/test_weather.py
@@ -22,7 +22,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_weather_sensor(hass, default_mock_hap_factory):
+async def test_hmip_weather_sensor(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipWeatherSensor."""
     entity_id = "weather.weather_sensor_plus"
     entity_name = "Weather Sensor – plus"
@@ -46,7 +48,9 @@ async def test_hmip_weather_sensor(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_WEATHER_TEMPERATURE] == 12.1
 
 
-async def test_hmip_weather_sensor_pro(hass, default_mock_hap_factory):
+async def test_hmip_weather_sensor_pro(
+    hass: HomeAssistant, default_mock_hap_factory
+) -> None:
     """Test HomematicipWeatherSensorPro."""
     entity_id = "weather.wettersensor_pro"
     entity_name = "Wettersensor - pro"
@@ -71,7 +75,7 @@ async def test_hmip_weather_sensor_pro(hass, default_mock_hap_factory):
     assert ha_state.attributes[ATTR_WEATHER_TEMPERATURE] == 12.1
 
 
-async def test_hmip_home_weather(hass, default_mock_hap_factory):
+async def test_hmip_home_weather(hass: HomeAssistant, default_mock_hap_factory) -> None:
     """Test HomematicipHomeWeather."""
     entity_id = "weather.weather_1010_wien_osterreich"
     entity_name = "Weather 1010  Wien, Österreich"

--- a/tests/components/homewizard/test_button.py
+++ b/tests/components/homewizard/test_button.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components import button
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -13,8 +14,8 @@ from .generator import get_mock_device
 
 
 async def test_identify_button_entity_not_loaded_when_not_available(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Does not load button when device has no support for it."""
 
     api = get_mock_device(product_type="HWE-P1")
@@ -34,8 +35,8 @@ async def test_identify_button_entity_not_loaded_when_not_available(
 
 
 async def test_identify_button_is_loaded(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Loads button when device has support."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -64,7 +65,9 @@ async def test_identify_button_is_loaded(
     assert entry.unique_id == "aabbccddeeff_identify"
 
 
-async def test_identify_press(hass, mock_config_entry_data, mock_config_entry):
+async def test_identify_press(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test button press is handled correctly."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -96,8 +99,8 @@ async def test_identify_press(hass, mock_config_entry_data, mock_config_entry):
 
 
 async def test_identify_press_catches_requesterror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test button press is handled RequestError correctly."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -134,8 +137,8 @@ async def test_identify_press_catches_requesterror(
 
 
 async def test_identify_press_catches_disablederror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test button press is handled DisabledError correctly."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -116,7 +116,7 @@ async def test_discovery_flow_works(
 
 
 async def test_discovery_flow_during_onboarding(
-    hass, aioclient_mock: AiohttpClientMocker, mock_onboarding: MagicMock
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_onboarding: MagicMock
 ) -> None:
     """Test discovery setup flow during onboarding."""
 
@@ -159,7 +159,7 @@ async def test_discovery_flow_during_onboarding(
 
 
 async def test_discovery_flow_during_onboarding_disabled_api(
-    hass, aioclient_mock: AiohttpClientMocker, mock_onboarding: MagicMock
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_onboarding: MagicMock
 ) -> None:
     """Test discovery setup flow during onboarding with a disabled API."""
 

--- a/tests/components/homewizard/test_diagnostics.py
+++ b/tests/components/homewizard/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -7,13 +7,17 @@ from homewizard_energy.errors import DisabledError, HomeWizardEnergyException
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
 
 from .generator import get_mock_device
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_load_unload(aioclient_mock, hass):
+async def test_load_unload(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test loading and unloading of integration."""
 
     device = get_mock_device()
@@ -41,7 +45,9 @@ async def test_load_unload(aioclient_mock, hass):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_load_failed_host_unavailable(aioclient_mock, hass):
+async def test_load_failed_host_unavailable(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test setup handles unreachable host."""
 
     def MockInitialize():
@@ -68,7 +74,9 @@ async def test_load_failed_host_unavailable(aioclient_mock, hass):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_load_detect_api_disabled(aioclient_mock, hass):
+async def test_load_detect_api_disabled(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test setup detects disabled API."""
 
     def MockInitialize():
@@ -106,7 +114,9 @@ async def test_load_detect_api_disabled(aioclient_mock, hass):
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_load_removes_reauth_flow(aioclient_mock, hass):
+async def test_load_removes_reauth_flow(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test setup removes reauth flow when API is enabled."""
 
     device = get_mock_device()
@@ -141,7 +151,9 @@ async def test_load_removes_reauth_flow(aioclient_mock, hass):
     assert len(flows) == 0
 
 
-async def test_load_handles_homewizardenergy_exception(aioclient_mock, hass):
+async def test_load_handles_homewizardenergy_exception(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test setup handles exception from API."""
 
     def MockInitialize():
@@ -168,7 +180,9 @@ async def test_load_handles_homewizardenergy_exception(aioclient_mock, hass):
     assert entry.state is ConfigEntryState.SETUP_RETRY or ConfigEntryState.SETUP_ERROR
 
 
-async def test_load_handles_generic_exception(aioclient_mock, hass):
+async def test_load_handles_generic_exception(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test setup handles global exception."""
 
     def MockInitialize():
@@ -195,7 +209,9 @@ async def test_load_handles_generic_exception(aioclient_mock, hass):
     assert entry.state is ConfigEntryState.SETUP_RETRY or ConfigEntryState.SETUP_ERROR
 
 
-async def test_load_handles_initialization_error(aioclient_mock, hass):
+async def test_load_handles_initialization_error(
+    aioclient_mock: AiohttpClientMocker, hass: HomeAssistant
+) -> None:
     """Test handles non-exception error."""
 
     device = get_mock_device()

--- a/tests/components/homewizard/test_number.py
+++ b/tests/components/homewizard/test_number.py
@@ -1,5 +1,4 @@
 """Test the update coordinator for HomeWizard."""
-
 from unittest.mock import AsyncMock, patch
 
 from homewizard_energy.errors import DisabledError, RequestError
@@ -9,6 +8,7 @@ import pytest
 from homeassistant.components import number
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -16,8 +16,8 @@ from .generator import get_mock_device
 
 
 async def test_number_entity_not_loaded_when_not_available(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity does not load number when brightness is not available."""
 
     api = get_mock_device()
@@ -39,7 +39,9 @@ async def test_number_entity_not_loaded_when_not_available(
     )
 
 
-async def test_number_loads_entities(hass, mock_config_entry_data, mock_config_entry):
+async def test_number_loads_entities(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity does load number when brightness is available."""
 
     api = get_mock_device()
@@ -74,7 +76,9 @@ async def test_number_loads_entities(hass, mock_config_entry_data, mock_config_e
     assert not entry.disabled
 
 
-async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_entry):
+async def test_brightness_level_set(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity turns sets light level."""
 
     api = get_mock_device()
@@ -149,8 +153,8 @@ async def test_brightness_level_set(hass, mock_config_entry_data, mock_config_en
 
 
 async def test_brightness_level_set_catches_requesterror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity raises HomeAssistantError when RequestError was raised."""
 
     api = get_mock_device()
@@ -185,8 +189,8 @@ async def test_brightness_level_set_catches_requesterror(
 
 
 async def test_brightness_level_set_catches_disablederror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity raises HomeAssistantError when DisabledError was raised."""
 
     api = get_mock_device()
@@ -221,8 +225,8 @@ async def test_brightness_level_set_catches_disablederror(
 
 
 async def test_brightness_level_set_catches_invalid_value(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity raises ValueError when value was invalid."""
 
     api = get_mock_device()

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -1,5 +1,4 @@
 """Test the update coordinator for HomeWizard."""
-
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -24,6 +23,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfVolume,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -33,8 +33,8 @@ from tests.common import async_fire_time_changed
 
 
 async def test_sensor_entity_smr_version(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads smr version."""
 
     api = get_mock_device()
@@ -71,8 +71,8 @@ async def test_sensor_entity_smr_version(
 
 
 async def test_sensor_entity_meter_model(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads meter model."""
 
     api = get_mock_device()
@@ -111,8 +111,8 @@ async def test_sensor_entity_meter_model(
 
 
 async def test_sensor_entity_unique_meter_id(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads unique meter id."""
 
     api = get_mock_device()
@@ -150,7 +150,9 @@ async def test_sensor_entity_unique_meter_id(
     assert state.attributes.get(ATTR_ICON) == "mdi:alphabetical-variant"
 
 
-async def test_sensor_entity_wifi_ssid(hass, mock_config_entry_data, mock_config_entry):
+async def test_sensor_entity_wifi_ssid(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads wifi ssid."""
 
     api = get_mock_device()
@@ -187,8 +189,8 @@ async def test_sensor_entity_wifi_ssid(hass, mock_config_entry_data, mock_config
 
 
 async def test_sensor_entity_active_tariff(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active_tariff."""
 
     api = get_mock_device()
@@ -226,8 +228,8 @@ async def test_sensor_entity_active_tariff(
 
 
 async def test_sensor_entity_wifi_strength(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads wifi strength."""
 
     api = get_mock_device()
@@ -253,8 +255,8 @@ async def test_sensor_entity_wifi_strength(
 
 
 async def test_sensor_entity_total_power_import_t1_kwh(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total power import t1."""
 
     api = get_mock_device()
@@ -295,8 +297,8 @@ async def test_sensor_entity_total_power_import_t1_kwh(
 
 
 async def test_sensor_entity_total_power_import_t2_kwh(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total power import t2."""
 
     api = get_mock_device()
@@ -337,8 +339,8 @@ async def test_sensor_entity_total_power_import_t2_kwh(
 
 
 async def test_sensor_entity_total_power_export_t1_kwh(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total power export t1."""
 
     api = get_mock_device()
@@ -379,8 +381,8 @@ async def test_sensor_entity_total_power_export_t1_kwh(
 
 
 async def test_sensor_entity_total_power_export_t2_kwh(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total power export t2."""
 
     api = get_mock_device()
@@ -421,8 +423,8 @@ async def test_sensor_entity_total_power_export_t2_kwh(
 
 
 async def test_sensor_entity_active_power(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active power."""
 
     api = get_mock_device()
@@ -459,8 +461,8 @@ async def test_sensor_entity_active_power(
 
 
 async def test_sensor_entity_active_power_l1(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active power l1."""
 
     api = get_mock_device()
@@ -499,8 +501,8 @@ async def test_sensor_entity_active_power_l1(
 
 
 async def test_sensor_entity_active_power_l2(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active power l2."""
 
     api = get_mock_device()
@@ -539,8 +541,8 @@ async def test_sensor_entity_active_power_l2(
 
 
 async def test_sensor_entity_active_power_l3(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active power l3."""
 
     api = get_mock_device()
@@ -578,7 +580,9 @@ async def test_sensor_entity_active_power_l3(
     assert ATTR_ICON not in state.attributes
 
 
-async def test_sensor_entity_total_gas(hass, mock_config_entry_data, mock_config_entry):
+async def test_sensor_entity_total_gas(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total gas."""
 
     api = get_mock_device()
@@ -615,8 +619,8 @@ async def test_sensor_entity_total_gas(hass, mock_config_entry_data, mock_config
 
 
 async def test_sensor_entity_unique_gas_meter_id(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads unique gas meter id."""
 
     api = get_mock_device()
@@ -655,8 +659,8 @@ async def test_sensor_entity_unique_gas_meter_id(
 
 
 async def test_sensor_entity_active_voltage_l1(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active voltage l1."""
 
     api = get_mock_device()
@@ -714,8 +718,8 @@ async def test_sensor_entity_active_voltage_l1(
 
 
 async def test_sensor_entity_active_voltage_l2(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active voltage l2."""
 
     api = get_mock_device()
@@ -773,8 +777,8 @@ async def test_sensor_entity_active_voltage_l2(
 
 
 async def test_sensor_entity_active_voltage_l3(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active voltage l3."""
 
     api = get_mock_device()
@@ -832,8 +836,8 @@ async def test_sensor_entity_active_voltage_l3(
 
 
 async def test_sensor_entity_active_current_l1(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active current l1."""
 
     api = get_mock_device()
@@ -891,8 +895,8 @@ async def test_sensor_entity_active_current_l1(
 
 
 async def test_sensor_entity_active_current_l2(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active current l2."""
 
     api = get_mock_device()
@@ -950,8 +954,8 @@ async def test_sensor_entity_active_current_l2(
 
 
 async def test_sensor_entity_active_current_l3(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active current l3."""
 
     api = get_mock_device()
@@ -1009,8 +1013,8 @@ async def test_sensor_entity_active_current_l3(
 
 
 async def test_sensor_entity_active_frequency(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active frequency."""
 
     api = get_mock_device()
@@ -1065,8 +1069,8 @@ async def test_sensor_entity_active_frequency(
 
 
 async def test_sensor_entity_voltage_sag_count_l1(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_sag_count_l1."""
 
     api = get_mock_device()
@@ -1104,8 +1108,8 @@ async def test_sensor_entity_voltage_sag_count_l1(
 
 
 async def test_sensor_entity_voltage_sag_count_l2(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_sag_count_l2."""
 
     api = get_mock_device()
@@ -1143,8 +1147,8 @@ async def test_sensor_entity_voltage_sag_count_l2(
 
 
 async def test_sensor_entity_voltage_sag_count_l3(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_sag_count_l3."""
 
     api = get_mock_device()
@@ -1182,8 +1186,8 @@ async def test_sensor_entity_voltage_sag_count_l3(
 
 
 async def test_sensor_entity_voltage_swell_count_l1(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_swell_count_l1."""
 
     api = get_mock_device()
@@ -1223,8 +1227,8 @@ async def test_sensor_entity_voltage_swell_count_l1(
 
 
 async def test_sensor_entity_voltage_swell_count_l2(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_swell_count_l2."""
 
     api = get_mock_device()
@@ -1264,8 +1268,8 @@ async def test_sensor_entity_voltage_swell_count_l2(
 
 
 async def test_sensor_entity_voltage_swell_count_l3(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads voltage_swell_count_l3."""
 
     api = get_mock_device()
@@ -1305,8 +1309,8 @@ async def test_sensor_entity_voltage_swell_count_l3(
 
 
 async def test_sensor_entity_any_power_fail_count(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads any power fail count."""
 
     api = get_mock_device()
@@ -1344,8 +1348,8 @@ async def test_sensor_entity_any_power_fail_count(
 
 
 async def test_sensor_entity_long_power_fail_count(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads long power fail count."""
 
     api = get_mock_device()
@@ -1385,8 +1389,8 @@ async def test_sensor_entity_long_power_fail_count(
 
 
 async def test_sensor_entity_active_power_average(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active power average."""
 
     api = get_mock_device()
@@ -1428,8 +1432,8 @@ async def test_sensor_entity_active_power_average(
 
 
 async def test_sensor_entity_monthly_power_peak(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads monthly power peak."""
 
     api = get_mock_device()
@@ -1471,8 +1475,8 @@ async def test_sensor_entity_monthly_power_peak(
 
 
 async def test_sensor_entity_active_liters(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads active liters (watermeter)."""
 
     api = get_mock_device()
@@ -1512,8 +1516,8 @@ async def test_sensor_entity_active_liters(
 
 
 async def test_sensor_entity_total_liters(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads total liters (watermeter)."""
 
     api = get_mock_device()
@@ -1553,8 +1557,8 @@ async def test_sensor_entity_total_liters(
 
 
 async def test_sensor_entity_disabled_when_null(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test sensor disables data with null by default."""
 
     api = get_mock_device()
@@ -1592,8 +1596,8 @@ async def test_sensor_entity_disabled_when_null(
 
 
 async def test_sensor_entity_export_disabled_when_unused(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test sensor disables export if value is 0."""
 
     api = get_mock_device()
@@ -1641,7 +1645,9 @@ async def test_sensor_entity_export_disabled_when_unused(
     assert entry.disabled
 
 
-async def test_sensors_unreachable(hass, mock_config_entry_data, mock_config_entry):
+async def test_sensors_unreachable(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test sensor handles api unreachable."""
 
     api = get_mock_device()
@@ -1689,7 +1695,9 @@ async def test_sensors_unreachable(hass, mock_config_entry_data, mock_config_ent
         )
 
 
-async def test_api_disabled(hass, mock_config_entry_data, mock_config_entry):
+async def test_api_disabled(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test sensor handles api unreachable."""
 
     api = get_mock_device()

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -1,5 +1,4 @@
 """Test the update coordinator for HomeWizard."""
-
 from unittest.mock import AsyncMock, patch
 
 from homewizard_energy.errors import DisabledError, RequestError
@@ -18,6 +17,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -25,8 +25,8 @@ from .generator import get_mock_device
 
 
 async def test_switch_entity_not_loaded_when_not_available(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads smr version."""
 
     api = get_mock_device()
@@ -49,7 +49,9 @@ async def test_switch_entity_not_loaded_when_not_available(
     assert state_switch_lock is None
 
 
-async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_entry):
+async def test_switch_loads_entities(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity loads smr version."""
 
     api = get_mock_device()
@@ -102,7 +104,9 @@ async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_e
     assert ATTR_DEVICE_CLASS not in state_switch_lock.attributes
 
 
-async def test_switch_power_on_off(hass, mock_config_entry_data, mock_config_entry):
+async def test_switch_power_on_off(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity turns switch on and off."""
 
     api = get_mock_device()
@@ -156,8 +160,8 @@ async def test_switch_power_on_off(hass, mock_config_entry_data, mock_config_ent
 
 
 async def test_switch_lock_power_on_off(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity turns switch on and off."""
 
     api = get_mock_device()
@@ -220,8 +224,8 @@ async def test_switch_lock_power_on_off(
 
 
 async def test_switch_lock_sets_power_on_unavailable(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity turns switch on and off."""
 
     api = get_mock_device()
@@ -289,7 +293,9 @@ async def test_switch_lock_sets_power_on_unavailable(
         assert len(api.state_set.mock_calls) == 2
 
 
-async def test_cloud_connection_on_off(hass, mock_config_entry_data, mock_config_entry):
+async def test_cloud_connection_on_off(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity turns switch on and off."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -350,8 +356,8 @@ async def test_cloud_connection_on_off(hass, mock_config_entry_data, mock_config
 
 
 async def test_switch_handles_requesterror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity raises HomeAssistantError when RequestError was raised."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")
@@ -427,8 +433,8 @@ async def test_switch_handles_requesterror(
 
 
 async def test_switch_handles_disablederror(
-    hass, mock_config_entry_data, mock_config_entry
-):
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry
+) -> None:
     """Test entity raises HomeAssistantError when Disabled was raised."""
 
     api = get_mock_device(product_type="HWE-SKT", firmware_version="3.02")

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -1,8 +1,8 @@
 """Test honeywell setup process."""
-
 from unittest.mock import create_autospec, patch
 
 import aiosomecomfort
+import pytest
 
 from homeassistant.components.honeywell.const import (
     CONF_COOL_AWAY_TEMPERATURE,
@@ -19,7 +19,7 @@ MIGRATE_OPTIONS_KEYS = {CONF_COOL_AWAY_TEMPERATURE, CONF_HEAT_AWAY_TEMPERATURE}
 
 
 @patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 0)
-async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry):
+async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Initialize the config entry."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -43,7 +43,11 @@ async def test_setup_multiple_thermostats(
 
 @patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 0)
 async def test_setup_multiple_thermostats_with_same_deviceid(
-    hass: HomeAssistant, caplog, config_entry: MockConfigEntry, device, client
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    config_entry: MockConfigEntry,
+    device,
+    client,
 ) -> None:
     """Test Honeywell TCC API returning duplicate device IDs."""
     mock_location2 = create_autospec(aiosomecomfort.Location, instance=True)

--- a/tests/components/honeywell/test_sensor.py
+++ b/tests/components/honeywell/test_sensor.py
@@ -16,7 +16,7 @@ async def test_outdoor_sensor(
     device_with_outdoor_sensor: Device,
     unit,
     temp,
-):
+) -> None:
     """Test outdoor temperature sensor."""
     device_with_outdoor_sensor.temperature_unit = unit
     location.devices_by_id[

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -13,6 +13,9 @@ import yarl
 from homeassistant.auth.const import GROUP_ID_READ_ONLY
 from homeassistant.auth.models import User
 from homeassistant.auth.providers import trusted_networks
+from homeassistant.auth.providers.legacy_api_password import (
+    LegacyApiPasswordAuthProvider,
+)
 from homeassistant.components import websocket_api
 from homeassistant.components.http.auth import (
     CONTENT_USER_NAME,
@@ -33,6 +36,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from . import HTTP_HEADER_HA_AUTH, mock_real_ip
+
+from tests.common import MockUser
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 API_PASSWORD = "test-password"
 
@@ -107,8 +113,11 @@ async def test_auth_middleware_loaded_by_default(hass: HomeAssistant) -> None:
 
 
 async def test_cant_access_with_password_in_header(
-    app, aiohttp_client, legacy_auth, hass
-):
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+    hass: HomeAssistant,
+) -> None:
     """Test access with password in header."""
     await async_setup_auth(hass, app)
     client = await aiohttp_client(app)
@@ -121,8 +130,11 @@ async def test_cant_access_with_password_in_header(
 
 
 async def test_cant_access_with_password_in_query(
-    app, aiohttp_client, legacy_auth, hass
-):
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+    hass: HomeAssistant,
+) -> None:
     """Test access with password in URL."""
     await async_setup_auth(hass, app)
     client = await aiohttp_client(app)
@@ -137,7 +149,12 @@ async def test_cant_access_with_password_in_query(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_basic_auth_does_not_work(app, aiohttp_client, hass, legacy_auth):
+async def test_basic_auth_does_not_work(
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass: HomeAssistant,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+) -> None:
     """Test access with basic authentication."""
     await async_setup_auth(hass, app)
     client = await aiohttp_client(app)
@@ -156,8 +173,12 @@ async def test_basic_auth_does_not_work(app, aiohttp_client, hass, legacy_auth):
 
 
 async def test_cannot_access_with_trusted_ip(
-    hass, app2, trusted_networks_auth, aiohttp_client, hass_owner_user
-):
+    hass: HomeAssistant,
+    app2,
+    trusted_networks_auth,
+    aiohttp_client: ClientSessionGenerator,
+    hass_owner_user: MockUser,
+) -> None:
     """Test access with an untrusted ip address."""
     await async_setup_auth(hass, app2)
 
@@ -180,8 +201,11 @@ async def test_cannot_access_with_trusted_ip(
 
 
 async def test_auth_active_access_with_access_token_in_header(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with access token in header."""
     token = hass_access_token
     await async_setup_auth(hass, app)
@@ -213,8 +237,12 @@ async def test_auth_active_access_with_access_token_in_header(
 
 
 async def test_auth_active_access_with_trusted_ip(
-    hass, app2, trusted_networks_auth, aiohttp_client, hass_owner_user
-):
+    hass: HomeAssistant,
+    app2,
+    trusted_networks_auth,
+    aiohttp_client: ClientSessionGenerator,
+    hass_owner_user: MockUser,
+) -> None:
     """Test access with an untrusted ip address."""
     await async_setup_auth(hass, app2)
 
@@ -237,8 +265,11 @@ async def test_auth_active_access_with_trusted_ip(
 
 
 async def test_auth_legacy_support_api_password_cannot_access(
-    app, aiohttp_client, legacy_auth, hass
-):
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+    hass: HomeAssistant,
+) -> None:
     """Test access using api_password if auth.support_legacy."""
     await async_setup_auth(hass, app)
     client = await aiohttp_client(app)
@@ -254,8 +285,11 @@ async def test_auth_legacy_support_api_password_cannot_access(
 
 
 async def test_auth_access_signed_path_with_refresh_token(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with signed url."""
     app.router.add_post("/", mock_handler)
     app.router.add_get("/another_path", mock_handler)
@@ -296,8 +330,11 @@ async def test_auth_access_signed_path_with_refresh_token(
 
 
 async def test_auth_access_signed_path_with_query_param(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with signed url and query params."""
     app.router.add_post("/", mock_handler)
     app.router.add_get("/another_path", mock_handler)
@@ -317,8 +354,11 @@ async def test_auth_access_signed_path_with_query_param(
 
 
 async def test_auth_access_signed_path_with_query_param_order(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with signed url and query params different order."""
     app.router.add_post("/", mock_handler)
     app.router.add_get("/another_path", mock_handler)
@@ -343,8 +383,11 @@ async def test_auth_access_signed_path_with_query_param_order(
 
 
 async def test_auth_access_signed_path_with_query_param_safe_param(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with signed url and changing a safe param."""
     app.router.add_post("/", mock_handler)
     app.router.add_get("/another_path", mock_handler)
@@ -377,8 +420,13 @@ async def test_auth_access_signed_path_with_query_param_safe_param(
     ],
 )
 async def test_auth_access_signed_path_with_query_param_tamper(
-    hass, app, aiohttp_client, hass_access_token, base_url: str, test_url: str
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+    base_url: str,
+    test_url: str,
+) -> None:
     """Test access with signed url and query params that have been tampered with."""
     app.router.add_post("/", mock_handler)
     app.router.add_get("/another_path", mock_handler)
@@ -398,8 +446,11 @@ async def test_auth_access_signed_path_with_query_param_tamper(
 
 
 async def test_auth_access_signed_path_via_websocket(
-    hass, app, hass_ws_client, hass_read_only_access_token
-):
+    hass: HomeAssistant,
+    app,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
     """Test signed url via websockets uses connection user."""
 
     @websocket_api.websocket_command({"type": "diagnostics/list"})
@@ -435,8 +486,11 @@ async def test_auth_access_signed_path_via_websocket(
 
 
 async def test_auth_access_signed_path_with_http(
-    hass, app, aiohttp_client, hass_access_token
-):
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test signed url via HTTP uses HTTP user."""
     setup_request_context(app, current_request)
 
@@ -467,7 +521,9 @@ async def test_auth_access_signed_path_with_http(
     assert claims["iss"] == refresh_token.id
 
 
-async def test_auth_access_signed_path_with_content_user(hass, app, aiohttp_client):
+async def test_auth_access_signed_path_with_content_user(
+    hass: HomeAssistant, app, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test access signed url uses content user."""
     await async_setup_auth(hass, app)
     signed_path = async_sign_path(hass, "/", timedelta(seconds=5))
@@ -481,7 +537,12 @@ async def test_auth_access_signed_path_with_content_user(hass, app, aiohttp_clie
     assert claims["iss"] == hass.data[STORAGE_KEY]
 
 
-async def test_local_only_user_rejected(hass, app, aiohttp_client, hass_access_token):
+async def test_local_only_user_rejected(
+    hass: HomeAssistant,
+    app,
+    aiohttp_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test access with access token in header."""
     token = hass_access_token
     await async_setup_auth(hass, app)
@@ -501,7 +562,7 @@ async def test_local_only_user_rejected(hass, app, aiohttp_client, hass_access_t
         assert req.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_async_user_not_allowed_do_auth(hass, app):
+async def test_async_user_not_allowed_do_auth(hass: HomeAssistant, app) -> None:
     """Test for not allowing auth."""
     user = await hass.auth.async_create_user("Hello")
     user.is_active = False

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -76,8 +76,10 @@ async def test_access_from_banned_ip(
 
 
 async def test_access_from_banned_ip_with_partially_broken_yaml_file(
-    hass, aiohttp_client, caplog
-):
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test accessing to server from banned IP. Both trusted and not.
 
     We inject some garbage into the yaml file to make sure it can
@@ -150,7 +152,11 @@ async def test_failure_loading_ip_bans_file(
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_ip_ban_manager_never_started(hass, aiohttp_client, caplog):
+async def test_ip_ban_manager_never_started(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we handle the ip ban manager not being started."""
     app = web.Application()
     app["hass"] = hass
@@ -183,8 +189,13 @@ async def test_ip_ban_manager_never_started(hass, aiohttp_client, caplog):
     ),
 )
 async def test_access_from_supervisor_ip(
-    remote_addr, bans, status, hass, aiohttp_client, hassio_env
-):
+    remote_addr,
+    bans,
+    status,
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    hassio_env,
+) -> None:
     """Test accessing to server from supervisor IP."""
     app = web.Application()
     app["hass"] = hass
@@ -251,7 +262,11 @@ async def test_ban_middleware_loaded_by_default(hass: HomeAssistant) -> None:
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_ip_bans_file_creation(hass, aiohttp_client, caplog):
+async def test_ip_bans_file_creation(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Testing if banned IP file created."""
     app = web.Application()
     app["hass"] = hass

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -60,7 +60,7 @@ def client(event_loop, aiohttp_client):
     return event_loop.run_until_complete(aiohttp_client(app))
 
 
-async def test_cors_requests(client):
+async def test_cors_requests(client) -> None:
     """Test cross origin requests."""
     req = await client.get("/", headers={ORIGIN: TRUSTED_ORIGIN})
     assert req.status == HTTPStatus.OK
@@ -88,7 +88,7 @@ async def test_cors_requests(client):
     assert req.headers[ACCESS_CONTROL_ALLOW_ORIGIN] == TRUSTED_ORIGIN
 
 
-async def test_cors_preflight_allowed(client):
+async def test_cors_preflight_allowed(client) -> None:
     """Test cross origin resource sharing preflight (OPTIONS) request."""
     req = await client.options(
         "/",

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -8,6 +8,8 @@ import voluptuous as vol
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 
+from tests.typing import ClientSessionGenerator
+
 
 async def get_client(aiohttp_client, validator):
     """Generate a client that hits a view decorated with validator."""
@@ -30,7 +32,7 @@ async def get_client(aiohttp_client, validator):
     return client
 
 
-async def test_validator(aiohttp_client):
+async def test_validator(aiohttp_client: ClientSessionGenerator) -> None:
     """Test the validator."""
     client = await get_client(
         aiohttp_client, RequestDataValidator(vol.Schema({vol.Required("test"): str}))
@@ -46,7 +48,7 @@ async def test_validator(aiohttp_client):
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_validator_allow_empty(aiohttp_client):
+async def test_validator_allow_empty(aiohttp_client: ClientSessionGenerator) -> None:
     """Test the validator with empty data."""
     client = await get_client(
         aiohttp_client,

--- a/tests/components/http/test_forwarded.py
+++ b/tests/components/http/test_forwarded.py
@@ -9,13 +9,17 @@ import pytest
 
 from homeassistant.components.http.forwarded import async_setup_forwarded
 
+from tests.typing import ClientSessionGenerator
+
 
 async def mock_handler(request):
     """Return the real IP as text."""
     return web.Response(text=request.remote)
 
 
-async def test_x_forwarded_for_without_trusted_proxy(aiohttp_client, caplog):
+async def test_x_forwarded_for_without_trusted_proxy(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we get the IP from the transport."""
 
     async def handler(request):
@@ -60,8 +64,8 @@ async def test_x_forwarded_for_without_trusted_proxy(aiohttp_client, caplog):
     ],
 )
 async def test_x_forwarded_for_with_trusted_proxy(
-    trusted_proxies, x_forwarded_for, remote, aiohttp_client
-):
+    trusted_proxies, x_forwarded_for, remote, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test that we get the IP from the forwarded for header."""
 
     async def handler(request):
@@ -85,7 +89,9 @@ async def test_x_forwarded_for_with_trusted_proxy(
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_for_disabled_with_proxy(aiohttp_client, caplog):
+async def test_x_forwarded_for_disabled_with_proxy(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we warn when processing is disabled, but proxy has been detected."""
 
     async def handler(request):
@@ -112,7 +118,9 @@ async def test_x_forwarded_for_disabled_with_proxy(aiohttp_client, caplog):
     )
 
 
-async def test_x_forwarded_for_with_spoofed_header(aiohttp_client):
+async def test_x_forwarded_for_with_spoofed_header(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that we get the IP from the transport with a spoofed header."""
 
     async def handler(request):
@@ -150,8 +158,10 @@ async def test_x_forwarded_for_with_spoofed_header(aiohttp_client):
     ],
 )
 async def test_x_forwarded_for_with_malformed_header(
-    x_forwarded_for, aiohttp_client, caplog
-):
+    x_forwarded_for,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that we get a HTTP 400 bad request with a malformed header."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -165,7 +175,9 @@ async def test_x_forwarded_for_with_malformed_header(
     assert "Invalid IP address in X-Forwarded-For" in caplog.text
 
 
-async def test_x_forwarded_for_with_multiple_headers(aiohttp_client, caplog):
+async def test_x_forwarded_for_with_multiple_headers(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -214,8 +226,12 @@ async def test_x_forwarded_for_with_multiple_headers(aiohttp_client, caplog):
     ],
 )
 async def test_x_forwarded_proto_with_trusted_proxy(
-    x_forwarded_for, remote, x_forwarded_proto, secure, aiohttp_client
-):
+    x_forwarded_for,
+    remote,
+    x_forwarded_proto,
+    secure,
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that we get the proto header if proxy is trusted."""
 
     async def handler(request):
@@ -241,7 +257,9 @@ async def test_x_forwarded_proto_with_trusted_proxy(
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_proto_with_trusted_proxy_multiple_for(aiohttp_client):
+async def test_x_forwarded_proto_with_trusted_proxy_multiple_for(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that we get the proto with 1 element in the proto, multiple in the for."""
 
     async def handler(request):
@@ -269,7 +287,9 @@ async def test_x_forwarded_proto_with_trusted_proxy_multiple_for(aiohttp_client)
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_proto_not_processed_without_for(aiohttp_client):
+async def test_x_forwarded_proto_not_processed_without_for(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that proto header isn't processed without a for header."""
 
     async def handler(request):
@@ -291,7 +311,9 @@ async def test_x_forwarded_proto_not_processed_without_for(aiohttp_client):
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_proto_with_multiple_headers(aiohttp_client, caplog):
+async def test_x_forwarded_proto_with_multiple_headers(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -316,8 +338,10 @@ async def test_x_forwarded_proto_with_multiple_headers(aiohttp_client, caplog):
     ["", ",", "https, , https", "https, https, "],
 )
 async def test_x_forwarded_proto_empty_element(
-    x_forwarded_proto, aiohttp_client, caplog
-):
+    x_forwarded_proto,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that we get a HTTP 400 bad request with empty proto."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -341,8 +365,13 @@ async def test_x_forwarded_proto_empty_element(
     ],
 )
 async def test_x_forwarded_proto_incorrect_number_of_elements(
-    x_forwarded_for, x_forwarded_proto, expected, got, aiohttp_client, caplog
-):
+    x_forwarded_for,
+    x_forwarded_proto,
+    expected,
+    got,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that we get a HTTP 400 bad request with incorrect number of elements."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -364,7 +393,9 @@ async def test_x_forwarded_proto_incorrect_number_of_elements(
     )
 
 
-async def test_x_forwarded_host_with_trusted_proxy(aiohttp_client):
+async def test_x_forwarded_host_with_trusted_proxy(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that we get the host header if proxy is trusted."""
 
     async def handler(request):
@@ -388,7 +419,9 @@ async def test_x_forwarded_host_with_trusted_proxy(aiohttp_client):
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_host_not_processed_without_for(aiohttp_client):
+async def test_x_forwarded_host_not_processed_without_for(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that host header isn't processed without a for header."""
 
     async def handler(request):
@@ -410,7 +443,9 @@ async def test_x_forwarded_host_not_processed_without_for(aiohttp_client):
     assert resp.status == HTTPStatus.OK
 
 
-async def test_x_forwarded_host_with_multiple_headers(aiohttp_client, caplog):
+async def test_x_forwarded_host_with_multiple_headers(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -430,7 +465,9 @@ async def test_x_forwarded_host_with_multiple_headers(aiohttp_client, caplog):
     assert "Too many headers for X-Forwarded-Host" in caplog.text
 
 
-async def test_x_forwarded_host_with_empty_header(aiohttp_client, caplog):
+async def test_x_forwarded_host_with_empty_header(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we get a HTTP 400 bad request with empty host value."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
@@ -445,7 +482,9 @@ async def test_x_forwarded_host_with_empty_header(aiohttp_client, caplog):
     assert "Empty value received in X-Forward-Host header" in caplog.text
 
 
-async def test_x_forwarded_cloud(aiohttp_client, caplog):
+async def test_x_forwarded_cloud(
+    aiohttp_client: ClientSessionGenerator, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that cloud requests are not processed."""
     app = web.Application()
     app.router.add_get("/", mock_handler)

--- a/tests/components/http/test_request_context.py
+++ b/tests/components/http/test_request_context.py
@@ -6,8 +6,12 @@ from aiohttp import web
 
 from homeassistant.components.http.request_context import setup_request_context
 
+from tests.typing import ClientSessionGenerator
 
-async def test_request_context_middleware(aiohttp_client):
+
+async def test_request_context_middleware(
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
     """Test that request context is set from middleware."""
     context = ContextVar("request", default=None)
     app = web.Application()

--- a/tests/components/http/test_security_filter.py
+++ b/tests/components/http/test_security_filter.py
@@ -7,6 +7,8 @@ import urllib3
 
 from homeassistant.components.http.security_filter import setup_security_filter
 
+from tests.typing import ClientSessionGenerator
+
 
 async def mock_handler(request):
     """Return OK."""
@@ -23,7 +25,9 @@ async def mock_handler(request):
         ("/", {"test": "123"}),
     ],
 )
-async def test_ok_requests(request_path, request_params, aiohttp_client):
+async def test_ok_requests(
+    request_path, request_params, aiohttp_client: ClientSessionGenerator
+) -> None:
     """Test request paths that should not be filtered."""
     app = web.Application()
     app.router.add_get("/{all:.*}", mock_handler)
@@ -56,8 +60,13 @@ async def test_ok_requests(request_path, request_params, aiohttp_client):
     ],
 )
 async def test_bad_requests(
-    request_path, request_params, fail_on_query_string, aiohttp_client, caplog, loop
-):
+    request_path,
+    request_params,
+    fail_on_query_string,
+    aiohttp_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    loop,
+) -> None:
     """Test request paths that should be filtered."""
     app = web.Application()
     app.router.add_get("/{all:.*}", mock_handler)

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -31,7 +31,7 @@ def mock_request_with_stopping():
     return Mock(app={"hass": Mock(is_stopping=True)}, match_info={})
 
 
-async def test_invalid_json(caplog):
+async def test_invalid_json(caplog: pytest.LogCaptureFixture) -> None:
     """Test trying to return invalid JSON."""
     with pytest.raises(HTTPInternalServerError):
         HomeAssistantView.json({"hello": Decimal("2.0")})
@@ -48,7 +48,7 @@ async def test_nan_serialized_to_null() -> None:
     assert json.loads(response.body.decode("utf-8")) is None
 
 
-async def test_handling_unauthorized(mock_request):
+async def test_handling_unauthorized(mock_request) -> None:
     """Test handling unauth exceptions."""
     with pytest.raises(HTTPUnauthorized):
         await request_handler_factory(
@@ -56,7 +56,7 @@ async def test_handling_unauthorized(mock_request):
         )(mock_request)
 
 
-async def test_handling_invalid_data(mock_request):
+async def test_handling_invalid_data(mock_request) -> None:
     """Test handling unauth exceptions."""
     with pytest.raises(HTTPBadRequest):
         await request_handler_factory(
@@ -64,7 +64,7 @@ async def test_handling_invalid_data(mock_request):
         )(mock_request)
 
 
-async def test_handling_service_not_found(mock_request):
+async def test_handling_service_not_found(mock_request) -> None:
     """Test handling unauth exceptions."""
     with pytest.raises(HTTPInternalServerError):
         await request_handler_factory(
@@ -73,7 +73,7 @@ async def test_handling_service_not_found(mock_request):
         )(mock_request)
 
 
-async def test_not_running(mock_request_with_stopping):
+async def test_not_running(mock_request_with_stopping) -> None:
     """Test we get a 503 when not running."""
     response = await request_handler_factory(
         Mock(requires_auth=False), AsyncMock(side_effect=Unauthorized)

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -6,6 +6,7 @@ from huawei_lte_api.enums.user import LoginErrorEnum, LoginStateEnum, PasswordTy
 import pytest
 import requests.exceptions
 from requests.exceptions import ConnectionError
+import requests_mock
 from requests_mock import ANY
 
 from homeassistant import config_entries, data_entry_flow
@@ -46,7 +47,9 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_urlize_plain_host(hass, requests_mock):
+async def test_urlize_plain_host(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test that plain host or IP gets converted to a URL."""
     requests_mock.request(ANY, ANY, exc=ConnectionError())
     host = "192.168.100.1"
@@ -60,7 +63,9 @@ async def test_urlize_plain_host(hass, requests_mock):
     assert user_input[CONF_URL] == f"http://{host}/"
 
 
-async def test_already_configured(hass, requests_mock, login_requests_mock):
+async def test_already_configured(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker, login_requests_mock
+) -> None:
     """Test we reject already configured devices."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -90,7 +95,9 @@ async def test_already_configured(hass, requests_mock, login_requests_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_connection_error(hass, requests_mock):
+async def test_connection_error(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we show user form on connection error."""
     requests_mock.request(ANY, ANY, exc=ConnectionError())
     result = await hass.config_entries.flow.async_init(
@@ -168,8 +175,8 @@ def login_requests_mock(requests_mock):
     ),
 )
 async def test_login_error(
-    hass, login_requests_mock, request_outcome, fixture_override, errors
-):
+    hass: HomeAssistant, login_requests_mock, request_outcome, fixture_override, errors
+) -> None:
     """Test we show user form with appropriate error on response failure."""
     login_requests_mock.request(
         ANY,
@@ -187,7 +194,7 @@ async def test_login_error(
     assert result["errors"] == errors
 
 
-async def test_success(hass, login_requests_mock):
+async def test_success(hass: HomeAssistant, login_requests_mock) -> None:
     """Test successful flow provides entry creation data."""
     login_requests_mock.request(
         ANY,
@@ -262,8 +269,12 @@ async def test_success(hass, login_requests_mock):
     ),
 )
 async def test_ssdp(
-    hass, login_requests_mock, requests_mock_request_kwargs, upnp_data, expected_result
-):
+    hass: HomeAssistant,
+    login_requests_mock,
+    requests_mock_request_kwargs,
+    upnp_data,
+    expected_result,
+) -> None:
     """Test SSDP discovery initiates config properly."""
     url = FIXTURE_USER_INPUT[CONF_URL][:-1]  # strip trailing slash for appending port
     context = {"source": config_entries.SOURCE_SSDP}
@@ -317,8 +328,12 @@ async def test_ssdp(
     ),
 )
 async def test_reauth(
-    hass, login_requests_mock, login_response_text, expected_result, expected_entry_data
-):
+    hass: HomeAssistant,
+    login_requests_mock,
+    login_response_text,
+    expected_result,
+    expected_entry_data,
+) -> None:
     """Test reauth."""
     mock_entry_data = {**FIXTURE_USER_INPUT, CONF_PASSWORD: "invalid-password"}
     entry = MockConfigEntry(

--- a/tests/components/huawei_lte/test_device_tracker.py
+++ b/tests/components/huawei_lte/test_device_tracker.py
@@ -15,6 +15,6 @@ from homeassistant.components.huawei_lte import device_tracker
         ("foo_bar", "foo_bar"),
     ),
 )
-def test_better_snakecase(value, expected):
+def test_better_snakecase(value, expected) -> None:
     """Test that better snakecase works better."""
     assert device_tracker._better_snakecase(value) == expected

--- a/tests/components/huawei_lte/test_sensor.py
+++ b/tests/components/huawei_lte/test_sensor.py
@@ -17,6 +17,6 @@ from homeassistant.const import (
         (">=-51dBm", (-51, SIGNAL_STRENGTH_DECIBELS_MILLIWATT)),
     ),
 )
-def test_format_default(value, expected):
+def test_format_default(value, expected) -> None:
     """Test that default formatter copes with expected values."""
     assert sensor.format_default(value) == expected

--- a/tests/components/huawei_lte/test_switches.py
+++ b/tests/components/huawei_lte/test_switches.py
@@ -123,7 +123,7 @@ async def test_turn_off_switch_wifi_guest_network(client, hass: HomeAssistant) -
 )
 async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_str(
     client, hass: HomeAssistant
-):
+) -> None:
     """Test switch wifi guest network config entry when ssid is a str.
 
     Issue #76244. Huawai models: H312-371, E5372 and E8372.
@@ -143,7 +143,7 @@ async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_str(
 )
 async def test_huawei_lte_wifi_guest_network_config_entry_when_ssid_is_none(
     client, hass: HomeAssistant
-):
+) -> None:
     """Test switch wifi guest network config entry when ssid is a None.
 
     Issue #76244.

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -1,11 +1,13 @@
 """Philips Hue binary_sensor platform tests for V2 bridge/api."""
-
+from homeassistant.core import HomeAssistant
 
 from .conftest import setup_platform
 from .const import FAKE_BINARY_SENSOR, FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY
 
 
-async def test_binary_sensors(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_binary_sensors(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if all v2 binary_sensors get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -33,7 +35,7 @@ async def test_binary_sensors(hass, mock_bridge_v2, v2_resources_test_data):
     assert sensor.attributes["device_class"] == "running"
 
 
-async def test_binary_sensor_add_update(hass, mock_bridge_v2):
+async def test_binary_sensor_add_update(hass: HomeAssistant, mock_bridge_v2) -> None:
     """Test if binary_sensor get added/updated from events."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
     await setup_platform(hass, mock_bridge_v2, "binary_sensor")

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 
-async def test_bridge_setup_v1(hass, mock_api_v1):
+async def test_bridge_setup_v1(hass: HomeAssistant, mock_api_v1) -> None:
     """Test a successful setup for V1 bridge."""
     config_entry = Mock()
     config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
@@ -37,7 +37,7 @@ async def test_bridge_setup_v1(hass, mock_api_v1):
     assert forward_entries == {"light", "binary_sensor", "sensor"}
 
 
-async def test_bridge_setup_v2(hass, mock_api_v2):
+async def test_bridge_setup_v2(hass: HomeAssistant, mock_api_v2) -> None:
     """Test a successful setup for V2 bridge."""
     config_entry = Mock()
     config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 2}
@@ -87,7 +87,7 @@ async def test_bridge_setup_timeout(hass: HomeAssistant) -> None:
         await hue_bridge.async_initialize_bridge()
 
 
-async def test_reset_unloads_entry_if_setup(hass, mock_api_v1):
+async def test_reset_unloads_entry_if_setup(hass: HomeAssistant, mock_api_v1) -> None:
     """Test calling reset while the entry has been setup."""
     config_entry = Mock()
     config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
@@ -113,7 +113,7 @@ async def test_reset_unloads_entry_if_setup(hass, mock_api_v1):
     assert len(hass.services.async_services()) == 0
 
 
-async def test_handle_unauthorized(hass, mock_api_v1):
+async def test_handle_unauthorized(hass: HomeAssistant, mock_api_v1) -> None:
     """Test handling an unauthorized error on update."""
     config_entry = Mock(async_setup=AsyncMock())
     config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -353,8 +353,8 @@ async def test_import_with_no_config(
 
 
 async def test_creating_entry_removes_entries_for_same_host_or_bridge(
-    hass, aioclient_mock
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test that we clean up entries for same host and bridge.
 
     An IP can only hold a single bridge and a single bridge can only be

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -1,8 +1,8 @@
 """The tests for Philips Hue device triggers for V1 bridge."""
-
 from homeassistant.components import automation, hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v1 import device_trigger
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import setup_platform
@@ -13,7 +13,7 @@ from tests.common import assert_lists_same, async_get_device_automations
 REMOTES_RESPONSE = {"7": HUE_TAP_REMOTE_1, "8": HUE_DIMMER_REMOTE_1}
 
 
-async def test_get_triggers(hass, mock_bridge_v1, device_reg):
+async def test_get_triggers(hass: HomeAssistant, mock_bridge_v1, device_reg) -> None:
     """Test we get the expected triggers from a hue remote."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
     await setup_platform(hass, mock_bridge_v1, ["sensor", "binary_sensor"])
@@ -76,7 +76,9 @@ async def test_get_triggers(hass, mock_bridge_v1, device_reg):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_if_fires_on_state_change(hass, mock_bridge_v1, device_reg, calls):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, mock_bridge_v1, device_reg, calls
+) -> None:
     """Test for button press trigger firing."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
     await setup_platform(hass, mock_bridge_v1, ["sensor", "binary_sensor"])

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -5,6 +5,7 @@ from homeassistant.components import hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v2.device import async_setup_devices
 from homeassistant.components.hue.v2.hue_event import async_setup_hue_events
+from homeassistant.core import HomeAssistant
 
 from .conftest import setup_platform
 
@@ -15,7 +16,9 @@ from tests.common import (
 )
 
 
-async def test_hue_event(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_hue_event(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test hue button events."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(hass, mock_bridge_v2, ["binary_sensor", "sensor"])
@@ -43,7 +46,9 @@ async def test_hue_event(hass, mock_bridge_v2, v2_resources_test_data):
     assert events[0].data["subtype"] == btn_event["metadata"]["control_id"]
 
 
-async def test_get_triggers(hass, mock_bridge_v2, v2_resources_test_data, device_reg):
+async def test_get_triggers(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data, device_reg
+) -> None:
     """Test we get the expected triggers from a hue remote."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(hass, mock_bridge_v2, ["binary_sensor", "sensor"])

--- a/tests/components/hue/test_diagnostics.py
+++ b/tests/components/hue/test_diagnostics.py
@@ -1,11 +1,15 @@
 """Test Hue diagnostics."""
+from homeassistant.core import HomeAssistant
 
 from .conftest import setup_platform
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_diagnostics_v1(hass, hass_client, mock_bridge_v1):
+async def test_diagnostics_v1(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_bridge_v1
+) -> None:
     """Test diagnostics v1."""
     await setup_platform(hass, mock_bridge_v1, [])
     config_entry = hass.config_entries.async_entries("hue")[0]
@@ -13,7 +17,9 @@ async def test_diagnostics_v1(hass, hass_client, mock_bridge_v1):
     assert result == {}
 
 
-async def test_diagnostics_v2(hass, hass_client, mock_bridge_v2):
+async def test_diagnostics_v2(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_bridge_v2
+) -> None:
     """Test diagnostics v2."""
     mock_bridge_v2.api.get_diagnostics.return_value = {"hello": "world"}
     await setup_platform(hass, mock_bridge_v2, [])

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -44,7 +44,7 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     assert hue.DOMAIN not in hass.data
 
 
-async def test_unload_entry(hass, mock_bridge_setup):
+async def test_unload_entry(hass: HomeAssistant, mock_bridge_setup) -> None:
     """Test being able to unload an entry."""
     entry = MockConfigEntry(
         domain=hue.DOMAIN, data={"host": "0.0.0.0", "api_version": 2}
@@ -65,7 +65,7 @@ async def test_unload_entry(hass, mock_bridge_setup):
     assert hue.DOMAIN not in hass.data
 
 
-async def test_setting_unique_id(hass, mock_bridge_setup):
+async def test_setting_unique_id(hass: HomeAssistant, mock_bridge_setup) -> None:
     """Test we set unique ID if not set yet."""
     entry = MockConfigEntry(
         domain=hue.DOMAIN, data={"host": "0.0.0.0", "api_version": 2}
@@ -75,7 +75,9 @@ async def test_setting_unique_id(hass, mock_bridge_setup):
     assert entry.unique_id == "mock-id"
 
 
-async def test_fixing_unique_id_no_other(hass, mock_bridge_setup):
+async def test_fixing_unique_id_no_other(
+    hass: HomeAssistant, mock_bridge_setup
+) -> None:
     """Test we set unique ID if not set yet."""
     entry = MockConfigEntry(
         domain=hue.DOMAIN,
@@ -87,7 +89,9 @@ async def test_fixing_unique_id_no_other(hass, mock_bridge_setup):
     assert entry.unique_id == "mock-id"
 
 
-async def test_fixing_unique_id_other_ignored(hass, mock_bridge_setup):
+async def test_fixing_unique_id_other_ignored(
+    hass: HomeAssistant, mock_bridge_setup
+) -> None:
     """Test we set unique ID if not set yet."""
     MockConfigEntry(
         domain=hue.DOMAIN,
@@ -107,7 +111,9 @@ async def test_fixing_unique_id_other_ignored(hass, mock_bridge_setup):
     assert hass.config_entries.async_entries() == [entry]
 
 
-async def test_fixing_unique_id_other_correct(hass, mock_bridge_setup):
+async def test_fixing_unique_id_other_correct(
+    hass: HomeAssistant, mock_bridge_setup
+) -> None:
     """Test we remove config entry if another one has correct ID."""
     correct_entry = MockConfigEntry(
         domain=hue.DOMAIN,

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -8,6 +8,7 @@ from homeassistant.components import hue
 from homeassistant.components.hue.const import CONF_ALLOW_HUE_GROUPS
 from homeassistant.components.hue.v1 import light as hue_light
 from homeassistant.components.light import ColorMode
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import color
 
@@ -185,7 +186,9 @@ async def setup_bridge(hass, mock_bridge_v1):
     await hass.async_block_till_done()
 
 
-async def test_not_load_groups_if_old_bridge(hass, mock_bridge_v1):
+async def test_not_load_groups_if_old_bridge(
+    hass: HomeAssistant, mock_bridge_v1
+) -> None:
     """Test that we don't try to load groups if bridge runs old software."""
     mock_bridge_v1.api.config.apiversion = "1.12.0"
     mock_bridge_v1.mock_light_responses.append({})
@@ -195,7 +198,7 @@ async def test_not_load_groups_if_old_bridge(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_no_lights_or_groups(hass, mock_bridge_v1):
+async def test_no_lights_or_groups(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test the update_lights function when no lights are found."""
     mock_bridge_v1.mock_light_responses.append({})
     mock_bridge_v1.mock_group_responses.append({})
@@ -204,7 +207,7 @@ async def test_no_lights_or_groups(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_lights(hass, mock_bridge_v1):
+async def test_lights(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test the update_lights function with some lights."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -224,7 +227,7 @@ async def test_lights(hass, mock_bridge_v1):
     assert lamp_2.state == "off"
 
 
-async def test_lights_color_mode(hass, mock_bridge_v1):
+async def test_lights_color_mode(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test that lights only report appropriate color mode."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
     mock_bridge_v1.mock_group_responses.append(GROUP_RESPONSE)
@@ -269,7 +272,7 @@ async def test_lights_color_mode(hass, mock_bridge_v1):
     ]
 
 
-async def test_groups(hass, mock_bridge_v1):
+async def test_groups(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test the update_lights function with some lights."""
     mock_bridge_v1.mock_light_responses.append({})
     mock_bridge_v1.mock_group_responses.append(GROUP_RESPONSE)
@@ -294,7 +297,7 @@ async def test_groups(hass, mock_bridge_v1):
     assert ent_reg.async_get("light.group_2").unique_id == "2"
 
 
-async def test_new_group_discovered(hass, mock_bridge_v1):
+async def test_new_group_discovered(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has a new group."""
     mock_bridge_v1.allow_groups = True
     mock_bridge_v1.mock_light_responses.append({})
@@ -341,7 +344,7 @@ async def test_new_group_discovered(hass, mock_bridge_v1):
     assert new_group.attributes["color_temp"] == 250
 
 
-async def test_new_light_discovered(hass, mock_bridge_v1):
+async def test_new_light_discovered(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has a new light."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -387,7 +390,7 @@ async def test_new_light_discovered(hass, mock_bridge_v1):
     assert light.state == "off"
 
 
-async def test_group_removed(hass, mock_bridge_v1):
+async def test_group_removed(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has removed group."""
     mock_bridge_v1.allow_groups = True
     mock_bridge_v1.mock_light_responses.append({})
@@ -416,7 +419,7 @@ async def test_group_removed(hass, mock_bridge_v1):
     assert removed_group is None
 
 
-async def test_light_removed(hass, mock_bridge_v1):
+async def test_light_removed(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has removed light."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -443,7 +446,7 @@ async def test_light_removed(hass, mock_bridge_v1):
     assert removed_light is None
 
 
-async def test_other_group_update(hass, mock_bridge_v1):
+async def test_other_group_update(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test changing one group that will impact the state of other light."""
     mock_bridge_v1.allow_groups = True
     mock_bridge_v1.mock_light_responses.append({})
@@ -496,7 +499,7 @@ async def test_other_group_update(hass, mock_bridge_v1):
     assert group_2.state == "off"
 
 
-async def test_other_light_update(hass, mock_bridge_v1):
+async def test_other_light_update(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test changing one light that will impact state of other light."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -549,7 +552,7 @@ async def test_other_light_update(hass, mock_bridge_v1):
     assert lamp_2.attributes["brightness"] == 100
 
 
-async def test_update_timeout(hass, mock_bridge_v1):
+async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not available if timeout error during update."""
     mock_bridge_v1.api.lights.update = Mock(side_effect=asyncio.TimeoutError)
     mock_bridge_v1.api.groups.update = Mock(side_effect=asyncio.TimeoutError)
@@ -558,7 +561,7 @@ async def test_update_timeout(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_update_unauthorized(hass, mock_bridge_v1):
+async def test_update_unauthorized(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not authorized if unauthorized during update."""
     mock_bridge_v1.api.lights.update = Mock(side_effect=aiohue.Unauthorized)
     await setup_bridge(hass, mock_bridge_v1)
@@ -567,7 +570,7 @@ async def test_update_unauthorized(hass, mock_bridge_v1):
     assert len(mock_bridge_v1.handle_unauthorized_error.mock_calls) == 1
 
 
-async def test_light_turn_on_service(hass, mock_bridge_v1):
+async def test_light_turn_on_service(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test calling the turn on service on a light."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -620,7 +623,7 @@ async def test_light_turn_on_service(hass, mock_bridge_v1):
     }
 
 
-async def test_light_turn_off_service(hass, mock_bridge_v1):
+async def test_light_turn_off_service(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test calling the turn on service on a light."""
     mock_bridge_v1.mock_light_responses.append(LIGHT_RESPONSE)
 
@@ -758,7 +761,7 @@ def test_hs_color() -> None:
     assert light.hs_color == color.color_xy_to_hs(0.4, 0.5, LIGHT_GAMUT)
 
 
-async def test_group_features(hass, mock_bridge_v1):
+async def test_group_features(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test group features."""
     color_temp_type = "Color temperature light"
     extended_color_type = "Extended color light"

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -1,13 +1,15 @@
 """Philips Hue lights platform tests for V2 bridge/api."""
-
 from homeassistant.components.light import ColorMode
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
 from .const import FAKE_DEVICE, FAKE_LIGHT, FAKE_ZIGBEE_CONNECTIVITY
 
 
-async def test_lights(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_lights(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if all v2 lights get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -73,7 +75,9 @@ async def test_lights(hass, mock_bridge_v2, v2_resources_test_data):
     assert light_4.attributes["supported_color_modes"] == []
 
 
-async def test_light_turn_on_service(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_light_turn_on_service(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the turn on service on a light."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -201,7 +205,9 @@ async def test_light_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
     assert mock_bridge_v2.mock_requests[8]["json"]["timed_effects"]["duration"] == 6000
 
 
-async def test_light_turn_off_service(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_light_turn_off_service(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the turn off service on a light."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -271,7 +277,7 @@ async def test_light_turn_off_service(hass, mock_bridge_v2, v2_resources_test_da
     assert mock_bridge_v2.mock_requests[3]["json"]["identify"]["action"] == "identify"
 
 
-async def test_light_added(hass, mock_bridge_v2):
+async def test_light_added(hass: HomeAssistant, mock_bridge_v2) -> None:
     """Test new light added to bridge."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
 
@@ -293,7 +299,9 @@ async def test_light_added(hass, mock_bridge_v2):
     assert test_entity.attributes["friendly_name"] == FAKE_DEVICE["metadata"]["name"]
 
 
-async def test_light_availability(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_light_availability(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test light availability property."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -323,7 +331,9 @@ async def test_light_availability(hass, mock_bridge_v2, v2_resources_test_data):
         assert test_light.state == "on" if status == "connected" else "unavailable"
 
 
-async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_grouped_lights(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if all v2 grouped lights get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 

--- a/tests/components/hue/test_logbook.py
+++ b/tests/components/hue/test_logbook.py
@@ -1,5 +1,4 @@
 """The tests for hue logbook."""
-
 from homeassistant.components.hue.const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN
 from homeassistant.components.hue.v1.hue_event import CONF_LAST_UPDATED
 from homeassistant.config_entries import ConfigEntry
@@ -10,6 +9,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_UNIQUE_ID,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 
@@ -35,7 +35,7 @@ SAMPLE_V2_EVENT = {
 }
 
 
-async def test_humanify_hue_events(hass, mock_bridge_v2):
+async def test_humanify_hue_events(hass: HomeAssistant, mock_bridge_v2) -> None:
     """Test hue events when the devices are present in the registry."""
     await setup_platform(hass, mock_bridge_v2, "sensor")
     hass.config.components.add("recorder")
@@ -74,7 +74,9 @@ async def test_humanify_hue_events(hass, mock_bridge_v2):
     assert v2_event["message"] == "first button pressed initially"
 
 
-async def test_humanify_hue_events_devices_removed(hass, mock_bridge_v2):
+async def test_humanify_hue_events_devices_removed(
+    hass: HomeAssistant, mock_bridge_v2
+) -> None:
     """Test hue events when the devices have been removed from the registry."""
     await setup_platform(hass, mock_bridge_v2, "sensor")
     hass.config.components.add("recorder")

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -44,8 +44,8 @@ async def test_auto_switchover(hass: HomeAssistant) -> None:
 
 
 async def test_light_entity_migration(
-    hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
-):
+    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+) -> None:
     """Test if entity schema for lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 
@@ -88,8 +88,8 @@ async def test_light_entity_migration(
 
 
 async def test_sensor_entity_migration(
-    hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
-):
+    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+) -> None:
     """Test if entity schema for sensors migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 
@@ -147,8 +147,8 @@ async def test_sensor_entity_migration(
 
 
 async def test_group_entity_migration_with_v1_id(
-    hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
-):
+    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+) -> None:
     """Test if entity schema for grouped_lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 
@@ -180,8 +180,8 @@ async def test_group_entity_migration_with_v1_id(
 
 
 async def test_group_entity_migration_with_v2_group_id(
-    hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
-):
+    hass: HomeAssistant, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+) -> None:
     """Test if entity schema for grouped_lights migrates from v1 to v2."""
     config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
 

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -1,14 +1,15 @@
 """Philips Hue scene platform tests for V2 bridge/api."""
-
-
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
 from .const import FAKE_SCENE
 
 
-async def test_scene(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_scene(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if (config) scenes get created."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -67,7 +68,9 @@ async def test_scene(hass, mock_bridge_v2, v2_resources_test_data):
         assert entity_entry.device_id is not None
 
 
-async def test_scene_turn_on_service(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_scene_turn_on_service(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the turn on service on a scene."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -103,8 +106,8 @@ async def test_scene_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
 
 
 async def test_scene_advanced_turn_on_service(
-    hass, mock_bridge_v2, v2_resources_test_data
-):
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the advanced turn on service on a scene."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -139,7 +142,9 @@ async def test_scene_advanced_turn_on_service(
     }
 
 
-async def test_scene_updates(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_scene_updates(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test scene events from bridge."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -8,6 +8,7 @@ from homeassistant.components import hue
 from homeassistant.components.hue.const import ATTR_HUE_EVENT
 from homeassistant.components.hue.v1 import sensor_base
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util
 
@@ -281,7 +282,7 @@ SENSOR_RESPONSE = {
 }
 
 
-async def test_no_sensors(hass, mock_bridge_v1):
+async def test_no_sensors(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test the update_items function when no sensors are found."""
     mock_bridge_v1.mock_sensor_responses.append({})
     await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
@@ -289,7 +290,9 @@ async def test_no_sensors(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_sensors_with_multiple_bridges(hass, mock_bridge_v1):
+async def test_sensors_with_multiple_bridges(
+    hass: HomeAssistant, mock_bridge_v1
+) -> None:
     """Test the update_items function with some sensors."""
     mock_bridge_2 = create_mock_bridge(hass, api_version=1)
     mock_bridge_2.mock_sensor_responses.append(
@@ -311,7 +314,7 @@ async def test_sensors_with_multiple_bridges(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 10
 
 
-async def test_sensors(hass, mock_bridge_v1):
+async def test_sensors(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test the update_items function with some sensors."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
     await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
@@ -355,7 +358,7 @@ async def test_sensors(hass, mock_bridge_v1):
     )
 
 
-async def test_unsupported_sensors(hass, mock_bridge_v1):
+async def test_unsupported_sensors(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test that unsupported sensors don't get added and don't fail."""
     response_with_unsupported = dict(SENSOR_RESPONSE)
     response_with_unsupported["7"] = UNSUPPORTED_SENSOR
@@ -366,7 +369,7 @@ async def test_unsupported_sensors(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 7
 
 
-async def test_new_sensor_discovered(hass, mock_bridge_v1):
+async def test_new_sensor_discovered(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has a new sensor."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
 
@@ -400,7 +403,7 @@ async def test_new_sensor_discovered(hass, mock_bridge_v1):
     assert temperature.state == "17.75"
 
 
-async def test_sensor_removed(hass, mock_bridge_v1):
+async def test_sensor_removed(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test if 2nd update has removed sensor."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
 
@@ -428,7 +431,7 @@ async def test_sensor_removed(hass, mock_bridge_v1):
     assert removed_sensor is None
 
 
-async def test_update_timeout(hass, mock_bridge_v1):
+async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not available if timeout error during update."""
     mock_bridge_v1.api.sensors.update = Mock(side_effect=asyncio.TimeoutError)
     await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
@@ -436,7 +439,7 @@ async def test_update_timeout(hass, mock_bridge_v1):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_update_unauthorized(hass, mock_bridge_v1):
+async def test_update_unauthorized(hass: HomeAssistant, mock_bridge_v1) -> None:
     """Test bridge marked as not authorized if unauthorized during update."""
     mock_bridge_v1.api.sensors.update = Mock(side_effect=aiohue.Unauthorized)
     await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
@@ -445,7 +448,7 @@ async def test_update_unauthorized(hass, mock_bridge_v1):
     assert len(mock_bridge_v1.handle_unauthorized_error.mock_calls) == 1
 
 
-async def test_hue_events(hass, mock_bridge_v1, device_reg):
+async def test_hue_events(hass: HomeAssistant, mock_bridge_v1, device_reg) -> None:
     """Test that hue remotes fire events when pressed."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
 

--- a/tests/components/hue/test_sensor_v2.py
+++ b/tests/components/hue/test_sensor_v2.py
@@ -1,6 +1,6 @@
 """Philips Hue sensor platform tests for V2 bridge/api."""
-
 from homeassistant.components import hue
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -8,7 +8,9 @@ from .conftest import setup_bridge, setup_platform
 from .const import FAKE_DEVICE, FAKE_SENSOR, FAKE_ZIGBEE_CONNECTIVITY
 
 
-async def test_sensors(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_sensors(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if all v2 sensors get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -60,8 +62,8 @@ async def test_sensors(hass, mock_bridge_v2, v2_resources_test_data):
 
 
 async def test_enable_sensor(
-    hass, mock_bridge_v2, v2_resources_test_data, mock_config_entry_v2
-):
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data, mock_config_entry_v2
+) -> None:
     """Test enabling of the by default disabled zigbee_connectivity sensor."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_bridge(hass, mock_bridge_v2, mock_config_entry_v2)
@@ -95,7 +97,7 @@ async def test_enable_sensor(
     assert state.attributes["mac_address"] == "00:17:88:01:0b:aa:bb:99"
 
 
-async def test_sensor_add_update(hass, mock_bridge_v2):
+async def test_sensor_add_update(hass: HomeAssistant, mock_bridge_v2) -> None:
     """Test if sensors get added/updated from events."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
     await setup_platform(hass, mock_bridge_v2, "sensor")

--- a/tests/components/hue/test_services.py
+++ b/tests/components/hue/test_services.py
@@ -8,6 +8,7 @@ from homeassistant.components.hue.const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from .conftest import setup_bridge, setup_component
 
@@ -45,7 +46,7 @@ SCENE_RESPONSE = {
 }
 
 
-async def test_hue_activate_scene(hass, mock_api_v1):
+async def test_hue_activate_scene(hass: HomeAssistant, mock_api_v1) -> None:
     """Test successful hue_activate_scene."""
     config_entry = config_entries.ConfigEntry(
         1,
@@ -81,7 +82,7 @@ async def test_hue_activate_scene(hass, mock_api_v1):
     assert mock_api_v1.mock_requests[2]["path"] == "groups/group_1/action"
 
 
-async def test_hue_activate_scene_transition(hass, mock_api_v1):
+async def test_hue_activate_scene_transition(hass: HomeAssistant, mock_api_v1) -> None:
     """Test successful hue_activate_scene with transition."""
     config_entry = config_entries.ConfigEntry(
         1,
@@ -117,7 +118,9 @@ async def test_hue_activate_scene_transition(hass, mock_api_v1):
     assert mock_api_v1.mock_requests[2]["path"] == "groups/group_1/action"
 
 
-async def test_hue_activate_scene_group_not_found(hass, mock_api_v1):
+async def test_hue_activate_scene_group_not_found(
+    hass: HomeAssistant, mock_api_v1
+) -> None:
     """Test failed hue_activate_scene due to missing group."""
     config_entry = config_entries.ConfigEntry(
         1,
@@ -148,7 +151,9 @@ async def test_hue_activate_scene_group_not_found(hass, mock_api_v1):
         )
 
 
-async def test_hue_activate_scene_scene_not_found(hass, mock_api_v1):
+async def test_hue_activate_scene_scene_not_found(
+    hass: HomeAssistant, mock_api_v1
+) -> None:
     """Test failed hue_activate_scene due to missing scene."""
     config_entry = config_entries.ConfigEntry(
         1,
@@ -180,8 +185,12 @@ async def test_hue_activate_scene_scene_not_found(hass, mock_api_v1):
 
 
 async def test_hue_multi_bridge_activate_scene_all_respond(
-    hass, mock_bridge_v1, mock_bridge_v2, mock_config_entry_v1, mock_config_entry_v2
-):
+    hass: HomeAssistant,
+    mock_bridge_v1,
+    mock_bridge_v2,
+    mock_config_entry_v1,
+    mock_config_entry_v2,
+) -> None:
     """Test that makes multiple bridges successfully activate a scene."""
     await setup_component(hass)
 
@@ -210,8 +219,12 @@ async def test_hue_multi_bridge_activate_scene_all_respond(
 
 
 async def test_hue_multi_bridge_activate_scene_one_responds(
-    hass, mock_bridge_v1, mock_bridge_v2, mock_config_entry_v1, mock_config_entry_v2
-):
+    hass: HomeAssistant,
+    mock_bridge_v1,
+    mock_bridge_v2,
+    mock_config_entry_v1,
+    mock_config_entry_v2,
+) -> None:
     """Test that makes only one bridge successfully activate a scene."""
     await setup_component(hass)
 
@@ -239,8 +252,12 @@ async def test_hue_multi_bridge_activate_scene_one_responds(
 
 
 async def test_hue_multi_bridge_activate_scene_zero_responds(
-    hass, mock_bridge_v1, mock_bridge_v2, mock_config_entry_v1, mock_config_entry_v2
-):
+    hass: HomeAssistant,
+    mock_bridge_v1,
+    mock_bridge_v2,
+    mock_config_entry_v1,
+    mock_config_entry_v2,
+) -> None:
     """Test that makes no bridge successfully activate a scene."""
     await setup_component(hass)
     mock_api_v1 = mock_bridge_v1.api

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -1,10 +1,13 @@
 """Philips Hue switch platform tests for V2 bridge/api."""
+from homeassistant.core import HomeAssistant
 
 from .conftest import setup_platform
 from .const import FAKE_BINARY_SENSOR, FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY
 
 
-async def test_switch(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_switch(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test if (config) switches get created."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -22,7 +25,9 @@ async def test_switch(hass, mock_bridge_v2, v2_resources_test_data):
     assert test_entity.attributes["device_class"] == "switch"
 
 
-async def test_switch_turn_on_service(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_switch_turn_on_service(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the turn on service on a switch."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -44,7 +49,9 @@ async def test_switch_turn_on_service(hass, mock_bridge_v2, v2_resources_test_da
     assert mock_bridge_v2.mock_requests[0]["json"]["enabled"] is True
 
 
-async def test_switch_turn_off_service(hass, mock_bridge_v2, v2_resources_test_data):
+async def test_switch_turn_off_service(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
     """Test calling the turn off service on a switch."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
@@ -83,7 +90,7 @@ async def test_switch_turn_off_service(hass, mock_bridge_v2, v2_resources_test_d
     assert test_entity.state == "off"
 
 
-async def test_switch_added(hass, mock_bridge_v2):
+async def test_switch_added(hass: HomeAssistant, mock_bridge_v2) -> None:
     """Test new switch added to bridge."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
