### PR TITLE
Add type hints to integration tests (part 11)

### DIFF
--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -579,7 +579,7 @@ async def test_send_usage_with_certificate(
 
 
 async def test_send_with_recorder(
-    recorder_mock: AsyncMock,
+    recorder_mock: Recorder,
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import time
+from typing import Any
 from unittest.mock import patch
 
 from bleak.backends.device import BLEDevice
@@ -353,7 +354,7 @@ async def test_base_scanner_connecting_behavior(
 
 
 async def test_restore_history_remote_adapter(
-    hass: HomeAssistant, hass_storage, disable_new_discovery_flows
+    hass: HomeAssistant, hass_storage: dict[str, Any], disable_new_discovery_flows
 ) -> None:
     """Test we can restore history for a remote adapter."""
 

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1,8 +1,8 @@
 """Tests for the Bluetooth integration manager."""
-
 from collections.abc import Generator
 from datetime import timedelta
 import time
+from typing import Any
 from unittest.mock import patch
 
 from bleak.backends.scanner import AdvertisementData, BLEDevice
@@ -319,7 +319,10 @@ async def test_restore_history_from_dbus(
 
 
 async def test_restore_history_from_dbus_and_remote_adapters(
-    hass: HomeAssistant, one_adapter: None, hass_storage, disable_new_discovery_flows
+    hass: HomeAssistant,
+    one_adapter: None,
+    hass_storage: dict[str, Any],
+    disable_new_discovery_flows,
 ) -> None:
     """Test we can restore history from dbus along with remote adapters."""
     address = "AA:BB:CC:CC:CC:FF"
@@ -356,7 +359,10 @@ async def test_restore_history_from_dbus_and_remote_adapters(
 
 
 async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
-    hass: HomeAssistant, one_adapter: None, hass_storage, disable_new_discovery_flows
+    hass: HomeAssistant,
+    one_adapter: None,
+    hass_storage: dict[str, Any],
+    disable_new_discovery_flows,
 ) -> None:
     """Test we can restore history from dbus when the remote adapters data is corrupted."""
     address = "AA:BB:CC:CC:CC:FF"

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -16,8 +16,8 @@ from homeassistant.components.device_tracker import (
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
     DOMAIN,
+    legacy,
 )
-from homeassistant.components.device_tracker.legacy import Device
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -66,7 +66,9 @@ class MockBleakClientBattery5(MockBleakClient):
 
 
 async def test_preserve_new_tracked_device_name(
-    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+    hass: HomeAssistant,
+    mock_bluetooth: None,
+    mock_device_tracker_conf: list[legacy.Device],
 ) -> None:
     """Test preserving tracked device name across new seens."""
 
@@ -134,7 +136,9 @@ async def test_preserve_new_tracked_device_name(
 
 
 async def test_tracking_battery_times_out(
-    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+    hass: HomeAssistant,
+    mock_bluetooth: None,
+    mock_device_tracker_conf: list[legacy.Device],
 ) -> None:
     """Test tracking the battery times out."""
 
@@ -201,7 +205,9 @@ async def test_tracking_battery_times_out(
 
 
 async def test_tracking_battery_fails(
-    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+    hass: HomeAssistant,
+    mock_bluetooth: None,
+    mock_device_tracker_conf: list[legacy.Device],
 ) -> None:
     """Test tracking the battery fails."""
 
@@ -268,7 +274,9 @@ async def test_tracking_battery_fails(
 
 
 async def test_tracking_battery_successful(
-    hass: HomeAssistant, mock_bluetooth: None, mock_device_tracker_conf: list[Device]
+    hass: HomeAssistant,
+    mock_bluetooth: None,
+    mock_device_tracker_conf: list[legacy.Device],
 ) -> None:
     """Test tracking the battery gets a value."""
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -1,4 +1,5 @@
 """Test the cloud component."""
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -105,7 +106,9 @@ async def test_startup_shutdown_events(hass: HomeAssistant, mock_cloud_fixture) 
     assert mock_stop.called
 
 
-async def test_setup_existing_cloud_user(hass: HomeAssistant, hass_storage) -> None:
+async def test_setup_existing_cloud_user(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test setup with API push default data."""
     user = await hass.auth.async_create_system_user("Cloud test")
     hass_storage[STORAGE_KEY] = {"version": 1, "data": {"cloud_user": user.id}}

--- a/tests/components/cloud/test_prefs.py
+++ b/tests/components/cloud/test_prefs.py
@@ -1,4 +1,5 @@
 """Test Cloud preferences."""
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
@@ -40,7 +41,9 @@ async def test_set_username_migration(hass: HomeAssistant) -> None:
     assert not prefs.google_enabled
 
 
-async def test_set_new_username(hass: HomeAssistant, hass_storage) -> None:
+async def test_set_new_username(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test if setting new username returns true."""
     hass_storage[STORAGE_KEY] = {"version": 1, "data": {"username": "old-user"}}
 
@@ -52,7 +55,9 @@ async def test_set_new_username(hass: HomeAssistant, hass_storage) -> None:
     assert await prefs.async_set_username("new-user")
 
 
-async def test_load_invalid_cloud_user(hass: HomeAssistant, hass_storage) -> None:
+async def test_load_invalid_cloud_user(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test loading cloud user with invalid storage."""
     hass_storage[STORAGE_KEY] = {"version": 1, "data": {"cloud_user": "non-existing"}}
 
@@ -71,7 +76,9 @@ async def test_load_invalid_cloud_user(hass: HomeAssistant, hass_storage) -> Non
     assert cloud_user.groups[0].id == GROUP_ID_ADMIN
 
 
-async def test_setup_remove_cloud_user(hass: HomeAssistant, hass_storage) -> None:
+async def test_setup_remove_cloud_user(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test creating and removing cloud user."""
     hass_storage[STORAGE_KEY] = {"version": 1, "data": {"cloud_user": None}}
 

--- a/tests/components/config/test_auth_provider_homeassistant.py
+++ b/tests/components/config/test_auth_provider_homeassistant.py
@@ -1,4 +1,6 @@
 """Test config entries API."""
+from typing import Any
+
 import pytest
 
 from homeassistant.auth.providers import homeassistant as prov_ha
@@ -116,7 +118,9 @@ async def test_create_auth_requires_admin(
 
 
 async def test_create_auth(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test create auth command works."""
     client = await hass_ws_client(hass)
@@ -147,7 +151,9 @@ async def test_create_auth(
 
 
 async def test_create_auth_duplicate_username(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test we can't create auth with a duplicate username."""
     client = await hass_ws_client(hass)
@@ -174,7 +180,9 @@ async def test_create_auth_duplicate_username(
 
 
 async def test_delete_removes_just_auth(
-    hass_ws_client: WebSocketGenerator, hass: HomeAssistant, hass_storage
+    hass_ws_client: WebSocketGenerator,
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test deleting an auth without being connected to a user."""
     client = await hass_ws_client(hass)
@@ -198,7 +206,9 @@ async def test_delete_removes_just_auth(
 
 
 async def test_delete_removes_credential(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test deleting auth that is connected to a user."""
     client = await hass_ws_client(hass)

--- a/tests/components/elgato/test_sensor.py
+++ b/tests/components/elgato/test_sensor.py
@@ -1,5 +1,4 @@
 """Tests for the Elgato sensor platform."""
-
 import pytest
 
 from homeassistant.components.elgato.const import DOMAIN

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,5 +1,6 @@
 """Test the Emulated Hue component."""
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.emulated_hue.config import (
@@ -18,7 +19,7 @@ from tests.common import async_fire_time_changed
 
 
 async def test_config_google_home_entity_id_to_number(
-    hass: HomeAssistant, hass_storage
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
@@ -51,7 +52,7 @@ async def test_config_google_home_entity_id_to_number(
 
 
 async def test_config_google_home_entity_id_to_number_altered(
-    hass: HomeAssistant, hass_storage
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
@@ -84,7 +85,7 @@ async def test_config_google_home_entity_id_to_number_altered(
 
 
 async def test_config_google_home_entity_id_to_number_empty(
-    hass: HomeAssistant, hass_storage
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test config adheres to the type."""
     conf = Config(hass, {"type": "google_home"}, "127.0.0.1")

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -2,6 +2,7 @@
 import copy
 from datetime import timedelta
 import gc
+from typing import Any
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -71,7 +72,7 @@ def get_statistics_for_entity(statistics_results, entity_id):
 
 
 async def test_cost_sensor_no_states(
-    setup_integration, hass: HomeAssistant, hass_storage
+    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test sensors are created."""
     energy_data = data.EnergyManager.default_preferences()
@@ -99,7 +100,7 @@ async def test_cost_sensor_no_states(
 
 
 async def test_cost_sensor_attributes(
-    setup_integration, hass: HomeAssistant, hass_storage
+    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test sensor attributes."""
     energy_data = data.EnergyManager.default_preferences()
@@ -151,7 +152,7 @@ async def test_cost_sensor_attributes(
 async def test_cost_sensor_price_entity_total_increasing(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
@@ -354,7 +355,7 @@ async def test_cost_sensor_price_entity_total_increasing(
 async def test_cost_sensor_price_entity_total(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
@@ -560,7 +561,7 @@ async def test_cost_sensor_price_entity_total(
 async def test_cost_sensor_price_entity_total_no_reset(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
     initial_energy,
     initial_cost,
@@ -732,7 +733,11 @@ async def test_cost_sensor_price_entity_total_no_reset(
     ],
 )
 async def test_cost_sensor_handle_energy_units(
-    setup_integration, hass: HomeAssistant, hass_storage, energy_unit, factor
+    setup_integration,
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    energy_unit,
+    factor,
 ) -> None:
     """Test energy cost price from sensor entity."""
     energy_attributes = {
@@ -798,7 +803,11 @@ async def test_cost_sensor_handle_energy_units(
     ],
 )
 async def test_cost_sensor_handle_price_units(
-    setup_integration, hass: HomeAssistant, hass_storage, price_unit, factor
+    setup_integration,
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    price_unit,
+    factor,
 ) -> None:
     """Test energy cost price from sensor entity."""
     energy_attributes = {
@@ -864,7 +873,7 @@ async def test_cost_sensor_handle_price_units(
     (UnitOfVolume.CUBIC_FEET, UnitOfVolume.CUBIC_METERS),
 )
 async def test_cost_sensor_handle_gas(
-    setup_integration, hass: HomeAssistant, hass_storage, unit
+    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any], unit
 ) -> None:
     """Test gas cost price from sensor entity."""
     energy_attributes = {
@@ -914,7 +923,7 @@ async def test_cost_sensor_handle_gas(
 
 
 async def test_cost_sensor_handle_gas_kwh(
-    setup_integration, hass: HomeAssistant, hass_storage
+    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test gas cost price from sensor entity."""
     energy_attributes = {
@@ -975,7 +984,7 @@ async def test_cost_sensor_handle_gas_kwh(
 async def test_cost_sensor_handle_water(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     unit_system,
     usage_unit,
     growth,
@@ -1032,7 +1041,7 @@ async def test_cost_sensor_handle_water(
 async def test_cost_sensor_wrong_state_class(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
     state_class,
 ) -> None:
@@ -1097,7 +1106,7 @@ async def test_cost_sensor_wrong_state_class(
 async def test_cost_sensor_state_class_measurement_no_reset(
     setup_integration,
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
     state_class,
 ) -> None:
@@ -1155,7 +1164,7 @@ async def test_cost_sensor_state_class_measurement_no_reset(
 
 
 async def test_inherit_source_unique_id(
-    setup_integration, hass: HomeAssistant, hass_storage
+    setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test sensor inherits unique ID from source."""
     energy_data = data.EnergyManager.default_preferences()

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Test the Energy websocket API."""
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -60,7 +61,9 @@ async def test_get_preferences_no_data(
 
 
 async def test_get_preferences_default(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test we get preferences."""
     assert not await is_configured(hass)
@@ -82,7 +85,7 @@ async def test_get_preferences_default(
 async def test_save_preferences(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    hass_storage,
+    hass_storage: dict[str, Any],
     mock_energy_platform,
 ) -> None:
     """Test we can save preferences."""

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from http import HTTPStatus
 import re
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -189,7 +190,7 @@ async def test_themes_api(hass: HomeAssistant, themes_ws_client) -> None:
 
 async def test_themes_persist(
     hass: HomeAssistant,
-    hass_storage,
+    hass_storage: dict[str, Any],
     hass_ws_client: WebSocketGenerator,
     ignore_frontend_deps,
 ) -> None:
@@ -214,7 +215,7 @@ async def test_themes_persist(
 
 
 async def test_themes_save_storage(
-    hass: HomeAssistant, hass_storage, frontend_themes
+    hass: HomeAssistant, hass_storage: dict[str, Any], frontend_themes
 ) -> None:
     """Test that theme settings are restores after restart."""
 

--- a/tests/components/frontend/test_storage.py
+++ b/tests/components/frontend/test_storage.py
@@ -1,4 +1,6 @@
 """The tests for frontend storage."""
+from typing import Any
+
 import pytest
 
 from homeassistant.components.frontend import DOMAIN
@@ -16,7 +18,9 @@ def setup_frontend(hass):
 
 
 async def test_get_user_data_empty(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test get_user_data command."""
     client = await hass_ws_client(hass)
@@ -34,7 +38,7 @@ async def test_get_user_data(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_admin_user: MockUser,
-    hass_storage,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test get_user_data command."""
     storage_key = f"{DOMAIN}.user_data_{hass_admin_user.id}"
@@ -77,7 +81,9 @@ async def test_get_user_data(
 
 
 async def test_set_user_data_empty(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_storage
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test set_user_data command."""
     client = await hass_ws_client(hass)
@@ -116,7 +122,7 @@ async def test_set_user_data_empty(
 async def test_set_user_data(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    hass_storage,
+    hass_storage: dict[str, Any],
     hass_admin_user: MockUser,
 ) -> None:
     """Test set_user_data command with initial data."""

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -1,6 +1,7 @@
 """Test Google Assistant helpers."""
 from datetime import timedelta
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -219,7 +220,9 @@ async def test_config_local_sdk_if_ssl_enabled(
     assert await resp.read() == b""
 
 
-async def test_agent_user_id_storage(hass: HomeAssistant, hass_storage) -> None:
+async def test_agent_user_id_storage(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test a disconnect message."""
 
     hass_storage["google_assistant"] = {

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -1,6 +1,7 @@
 """Test Google http services."""
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import ANY, patch
 
 import pytest
@@ -115,7 +116,7 @@ async def test_update_access_token(hass: HomeAssistant) -> None:
 async def test_call_homegraph_api(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_storage,
+    hass_storage: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the function to call the homegraph api."""
@@ -141,7 +142,9 @@ async def test_call_homegraph_api(
 
 
 async def test_call_homegraph_api_retry(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test the that the calls get retried with new token on 401."""
     config = GoogleConfig(hass, DUMMY_CONFIG)
@@ -168,7 +171,9 @@ async def test_call_homegraph_api_retry(
 
 
 async def test_report_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test the report state function."""
     agent_user_id = "user"
@@ -191,7 +196,9 @@ async def test_report_state(
 
 
 async def test_google_config_local_fulfillment(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test the google config for local fulfillment."""
     agent_user_id = "user"
@@ -287,7 +294,7 @@ async def test_missing_service_account(hass: HomeAssistant) -> None:
 async def test_async_enable_local_sdk(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    hass_storage,
+    hass_storage: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the google config enable and disable local sdk."""

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the hassio component."""
 from datetime import timedelta
 import os
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -279,7 +280,9 @@ async def test_setup_api_push_api_data_server_host(
 
 
 async def test_setup_api_push_api_data_default(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with API push default data."""
     with patch.dict(os.environ, MOCK_ENVIRON):
@@ -307,7 +310,9 @@ async def test_setup_api_push_api_data_default(
 
 
 async def test_setup_adds_admin_group_to_user(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with API push default data."""
     # Create user without admin
@@ -329,7 +334,9 @@ async def test_setup_adds_admin_group_to_user(
 
 
 async def test_setup_migrate_user_name(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with migrating the user name."""
     # Create user with old name
@@ -350,7 +357,9 @@ async def test_setup_migrate_user_name(
 
 
 async def test_setup_api_existing_hassio_user(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_storage
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with API push default data."""
     user = await hass.auth.async_create_system_user("Hass.io test")

--- a/tests/components/homekit/test_iidmanager.py
+++ b/tests/components/homekit/test_iidmanager.py
@@ -1,4 +1,5 @@
 """Tests for the HomeKit IID manager."""
+from typing import Any
 from uuid import UUID
 
 from homeassistant.components.homekit.const import DOMAIN
@@ -14,7 +15,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 async def test_iid_generation_and_restore(
-    hass: HomeAssistant, iid_storage, hass_storage
+    hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test generating iids and restoring them from storage."""
     entry = MockConfigEntry(domain=DOMAIN)
@@ -90,7 +91,7 @@ async def test_iid_generation_and_restore(
 
 
 async def test_iid_storage_filename(
-    hass: HomeAssistant, iid_storage, hass_storage
+    hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test iid storage uses the expected filename."""
     entry = MockConfigEntry(domain=DOMAIN)
@@ -103,7 +104,7 @@ async def test_iid_storage_filename(
 
 
 async def test_iid_migration_to_v2(
-    hass: HomeAssistant, iid_storage, hass_storage
+    hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test iid storage migration."""
     v1_iids = json_loads(load_fixture("iids_v1", DOMAIN))
@@ -127,7 +128,7 @@ async def test_iid_migration_to_v2(
 
 
 async def test_iid_migration_to_v2_with_underscore(
-    hass: HomeAssistant, iid_storage, hass_storage
+    hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test iid storage migration with underscore."""
     v1_iids = json_loads(load_fixture("iids_v1_with_underscore", DOMAIN))
@@ -151,7 +152,7 @@ async def test_iid_migration_to_v2_with_underscore(
 
 
 async def test_iid_generation_and_restore_v2(
-    hass: HomeAssistant, iid_storage, hass_storage
+    hass: HomeAssistant, iid_storage, hass_storage: dict[str, Any]
 ) -> None:
     """Test generating iids and restoring them from storage."""
     entry = MockConfigEntry(domain=DOMAIN)

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -1,4 +1,6 @@
 """Basic checks for entity map storage."""
+from typing import Any
+
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -11,7 +13,9 @@ from .common import setup_platform, setup_test_component
 from tests.common import flush_store
 
 
-async def test_load_from_storage(hass: HomeAssistant, hass_storage) -> None:
+async def test_load_from_storage(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test that entity map can be correctly loaded from cache."""
     hkid = "00:00:00:00:00:00"
 
@@ -24,7 +28,9 @@ async def test_load_from_storage(hass: HomeAssistant, hass_storage) -> None:
     assert hkid in hass.data[ENTITY_MAP].storage_data
 
 
-async def test_storage_is_removed(hass: HomeAssistant, hass_storage) -> None:
+async def test_storage_is_removed(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test entity map storage removal is idempotent."""
     await setup_platform(hass)
 
@@ -65,7 +71,7 @@ def create_lightbulb_service(accessory):
 
 
 async def test_storage_is_updated_on_add(
-    hass: HomeAssistant, hass_storage, utcnow
+    hass: HomeAssistant, hass_storage: dict[str, Any], utcnow
 ) -> None:
     """Test entity map storage is cleaned up on adding an accessory."""
     await setup_test_component(hass, create_lightbulb_service)

--- a/tests/components/huisbaasje/test_init.py
+++ b/tests/components/huisbaasje/test_init.py
@@ -14,14 +14,14 @@ from .test_data import MOCK_CURRENT_MEASUREMENTS
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistant):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test for successfully setting up the platform."""
     assert await async_setup_component(hass, huisbaasje.DOMAIN, {})
     await hass.async_block_till_done()
     assert huisbaasje.DOMAIN in hass.config.components
 
 
-async def test_setup_entry(hass: HomeAssistant):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test for successfully setting a config entry."""
     with patch(
         "energyflip.EnergyFlip.authenticate", return_value=None
@@ -65,7 +65,7 @@ async def test_setup_entry(hass: HomeAssistant):
         assert len(mock_current_measurements.mock_calls) == 1
 
 
-async def test_setup_entry_error(hass: HomeAssistant):
+async def test_setup_entry_error(hass: HomeAssistant) -> None:
     """Test for successfully setting a config entry."""
     with patch(
         "energyflip.EnergyFlip.authenticate", side_effect=EnergyFlipException
@@ -100,7 +100,7 @@ async def test_setup_entry_error(hass: HomeAssistant):
         assert len(mock_authenticate.mock_calls) == 1
 
 
-async def test_unload_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant) -> None:
     """Test for successfully unloading the config entry."""
     with patch(
         "energyflip.EnergyFlip.authenticate", return_value=None

--- a/tests/components/huisbaasje/test_sensor.py
+++ b/tests/components/huisbaasje/test_sensor.py
@@ -26,7 +26,7 @@ from .test_data import MOCK_CURRENT_MEASUREMENTS, MOCK_LIMITED_CURRENT_MEASUREME
 from tests.common import MockConfigEntry
 
 
-async def test_setup_entry(hass: HomeAssistant):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test for successfully loading sensor states."""
     with patch(
         "energyflip.EnergyFlip.authenticate", return_value=None
@@ -353,7 +353,7 @@ async def test_setup_entry(hass: HomeAssistant):
         assert len(mock_current_measurements.mock_calls) == 1
 
 
-async def test_setup_entry_absent_measurement(hass: HomeAssistant):
+async def test_setup_entry_absent_measurement(hass: HomeAssistant) -> None:
     """Test for successfully loading sensor states when response does not contain all measurements."""
     with patch(
         "energyflip.EnergyFlip.authenticate", return_value=None

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -7,7 +7,11 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_action
 from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -30,14 +34,14 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
     ],
 )
 async def test_get_actions(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_action_types,
-):
+) -> None:
     """Test we get the expected actions from a humidifier."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -94,12 +98,12 @@ async def test_get_actions(
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -350,15 +354,15 @@ async def test_action(hass: HomeAssistant) -> None:
     ],
 )
 async def test_capabilities(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     capabilities_reg,
     capabilities_state,
     action,
     expected_capabilities,
-):
+) -> None:
     """Test getting capabilities."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -407,7 +411,9 @@ async def test_capabilities(
         ("set_mode", "mode", {"type": "select", "options": []}),
     ],
 )
-async def test_capabilities_missing_entity(hass, action, capability_name, extra):
+async def test_capabilities_missing_entity(
+    hass: HomeAssistant, action, capability_name, extra
+) -> None:
     """Test getting capabilities."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -6,7 +6,12 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_condition
 from homeassistant.const import ATTR_MODE, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -35,14 +40,14 @@ def calls(hass):
     ],
 )
 async def test_get_conditions(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_condition_types,
-):
+) -> None:
     """Test we get the expected conditions from a humidifier."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -101,12 +106,12 @@ async def test_get_conditions(
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -139,7 +144,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("humidifier.entity", STATE_ON, {ATTR_MODE: const.MODE_AWAY})
 
@@ -355,15 +360,15 @@ async def test_if_state(hass, calls):
     ],
 )
 async def test_capabilities(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     capabilities_reg,
     capabilities_state,
     condition,
     expected_capabilities,
-):
+) -> None:
     """Test getting capabilities."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -411,7 +416,9 @@ async def test_capabilities(
         ("is_mode", "mode", {"type": "select", "options": []}),
     ],
 )
-async def test_capabilities_missing_entity(hass, condition, capability_name, extra):
+async def test_capabilities_missing_entity(
+    hass: HomeAssistant, condition, capability_name, extra
+) -> None:
     """Test getting capabilities."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -15,7 +15,11 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -36,7 +40,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a humidifier device."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -90,12 +98,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -133,7 +141,7 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off triggers firing."""
     hass.states.async_set(
         "humidifier.entity",
@@ -307,7 +315,7 @@ async def test_if_fires_on_state_change(hass, calls):
     }
 
 
-async def test_invalid_config(hass, calls):
+async def test_invalid_config(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off triggers firing."""
     hass.states.async_set(
         "humidifier.entity",

--- a/tests/components/humidifier/test_recorder.py
+++ b/tests/components/humidifier/test_recorder.py
@@ -9,10 +9,11 @@ from homeassistant.components.humidifier import (
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,7 +21,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test humidifier registered attributes to be excluded."""
     await async_setup_component(
         hass, humidifier.DOMAIN, {humidifier.DOMAIN: {"platform": "demo"}}

--- a/tests/components/humidifier/test_reproduce_state.py
+++ b/tests/components/humidifier/test_reproduce_state.py
@@ -226,7 +226,7 @@ async def test_state_with_context(hass: HomeAssistant) -> None:
     "service,attribute",
     [(SERVICE_SET_MODE, ATTR_MODE), (SERVICE_SET_HUMIDITY, ATTR_HUMIDITY)],
 )
-async def test_attribute(hass, service, attribute):
+async def test_attribute(hass: HomeAssistant, service, attribute) -> None:
     """Test that service call is made for each attribute."""
     hass.states.async_set(ENTITY_1, STATE_ON, {})
 

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -177,7 +177,9 @@ async def test_user_form_legacy(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
-async def test_form_homekit_and_dhcp_cannot_connect(hass, source, discovery_info):
+async def test_form_homekit_and_dhcp_cannot_connect(
+    hass: HomeAssistant, source, discovery_info
+) -> None:
     """Test we get the form with homekit and dhcp source."""
 
     ignored_config_entry = MockConfigEntry(
@@ -203,7 +205,9 @@ async def test_form_homekit_and_dhcp_cannot_connect(hass, source, discovery_info
 
 
 @pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
-async def test_form_homekit_and_dhcp(hass, source, discovery_info):
+async def test_form_homekit_and_dhcp(
+    hass: HomeAssistant, source, discovery_info
+) -> None:
     """Test we get the form with homekit and dhcp source."""
 
     ignored_config_entry = MockConfigEntry(

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, call, patch
 
 from hyperion import const
+import pytest
 
 from homeassistant.components.hyperion import (
     get_hyperion_device_id,
@@ -864,7 +865,9 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     assert client.async_client_disconnect.call_count == 2
 
 
-async def test_version_log_warning(caplog, hass: HomeAssistant) -> None:
+async def test_version_log_warning(
+    caplog: pytest.LogCaptureFixture, hass: HomeAssistant
+) -> None:
     """Test warning on old version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.7")
@@ -873,7 +876,9 @@ async def test_version_log_warning(caplog, hass: HomeAssistant) -> None:
     assert "Please consider upgrading" in caplog.text
 
 
-async def test_version_no_log_warning(caplog, hass: HomeAssistant) -> None:
+async def test_version_no_log_warning(
+    caplog: pytest.LogCaptureFixture, hass: HomeAssistant
+) -> None:
     """Test no warning on acceptable version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.9")
@@ -1373,7 +1378,9 @@ async def test_lights_can_be_enabled(hass: HomeAssistant) -> None:
     assert entity_state
 
 
-async def test_deprecated_effect_names(caplog, hass: HomeAssistant) -> None:
+async def test_deprecated_effect_names(
+    caplog: pytest.LogCaptureFixture, hass: HomeAssistant
+) -> None:
     """Test deprecated effects function and issue a warning."""
     client = create_mock_client()
     client.async_send_clear = AsyncMock(return_value=True)

--- a/tests/components/ialarm/test_init.py
+++ b/tests/components/ialarm/test_init.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.ialarm.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -28,7 +29,7 @@ def mock_config_fixture():
     )
 
 
-async def test_setup_entry(hass, ialarm_api, mock_config_entry):
+async def test_setup_entry(hass: HomeAssistant, ialarm_api, mock_config_entry) -> None:
     """Test setup entry."""
     ialarm_api.return_value.get_mac = Mock(return_value="00:00:54:12:34:56")
 
@@ -40,7 +41,9 @@ async def test_setup_entry(hass, ialarm_api, mock_config_entry):
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_not_ready(hass, ialarm_api, mock_config_entry):
+async def test_setup_not_ready(
+    hass: HomeAssistant, ialarm_api, mock_config_entry
+) -> None:
     """Test setup failed because we can't connect to the alarm system."""
     ialarm_api.return_value.get_mac = Mock(side_effect=ConnectionError)
 
@@ -50,7 +53,7 @@ async def test_setup_not_ready(hass, ialarm_api, mock_config_entry):
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass, ialarm_api, mock_config_entry):
+async def test_unload_entry(hass: HomeAssistant, ialarm_api, mock_config_entry) -> None:
     """Test being able to unload an entry."""
     ialarm_api.return_value.get_mac = Mock(return_value="00:00:54:12:34:56")
 

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -10,7 +10,9 @@ from homeassistant.components.iaqualink import config_flow
 from homeassistant.core import HomeAssistant
 
 
-async def test_already_configured(hass, config_entry, config_data):
+async def test_already_configured(
+    hass: HomeAssistant, config_entry, config_data
+) -> None:
     """Test config flow when iaqualink component is already setup."""
     config_entry.add_to_hass(hass)
 
@@ -36,7 +38,7 @@ async def test_without_config(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_with_invalid_credentials(hass, config_data):
+async def test_with_invalid_credentials(hass: HomeAssistant, config_data) -> None:
     """Test config flow with invalid username and/or password."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -52,7 +54,7 @@ async def test_with_invalid_credentials(hass, config_data):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_service_exception(hass, config_data):
+async def test_service_exception(hass: HomeAssistant, config_data) -> None:
     """Test config flow encountering service exception."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -68,7 +70,7 @@ async def test_service_exception(hass, config_data):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_with_existing_config(hass, config_data):
+async def test_with_existing_config(hass: HomeAssistant, config_data) -> None:
     """Test config flow with existing configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -1,5 +1,4 @@
 """Tests for iAqualink integration."""
-
 import asyncio
 import logging
 from unittest.mock import AsyncMock, patch
@@ -13,6 +12,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaThermostat,
 )
 from iaqualink.systems.iaqua.system import IaquaSystem
+import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -22,6 +22,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .conftest import get_aqualink_device, get_aqualink_system
@@ -35,7 +36,7 @@ async def _ffwd_next_update_interval(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_login_exception(hass, config_entry):
+async def test_setup_login_exception(hass: HomeAssistant, config_entry) -> None:
     """Test setup encountering a login exception."""
     config_entry.add_to_hass(hass)
 
@@ -49,7 +50,7 @@ async def test_setup_login_exception(hass, config_entry):
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_login_timeout(hass, config_entry):
+async def test_setup_login_timeout(hass: HomeAssistant, config_entry) -> None:
     """Test setup encountering a timeout while logging in."""
     config_entry.add_to_hass(hass)
 
@@ -63,7 +64,7 @@ async def test_setup_login_timeout(hass, config_entry):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_systems_exception(hass, config_entry):
+async def test_setup_systems_exception(hass: HomeAssistant, config_entry) -> None:
     """Test setup encountering an exception while retrieving systems."""
     config_entry.add_to_hass(hass)
 
@@ -80,7 +81,7 @@ async def test_setup_systems_exception(hass, config_entry):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_no_systems_recognized(hass, config_entry):
+async def test_setup_no_systems_recognized(hass: HomeAssistant, config_entry) -> None:
     """Test setup ending in no systems recognized."""
     config_entry.add_to_hass(hass)
 
@@ -97,7 +98,9 @@ async def test_setup_no_systems_recognized(hass, config_entry):
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_devices_exception(hass, config_entry, client):
+async def test_setup_devices_exception(
+    hass: HomeAssistant, config_entry, client
+) -> None:
     """Test setup encountering an exception while retrieving devices."""
     config_entry.add_to_hass(hass)
 
@@ -120,7 +123,9 @@ async def test_setup_devices_exception(hass, config_entry, client):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
+async def test_setup_all_good_no_recognized_devices(
+    hass: HomeAssistant, config_entry, client
+) -> None:
     """Test setup ending in no devices recognized."""
     config_entry.add_to_hass(hass)
 
@@ -157,7 +162,9 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_all_good_all_device_types(hass, config_entry, client):
+async def test_setup_all_good_all_device_types(
+    hass: HomeAssistant, config_entry, client
+) -> None:
     """Test setup ending in one device of each type recognized."""
     config_entry.add_to_hass(hass)
 
@@ -199,7 +206,9 @@ async def test_setup_all_good_all_device_types(hass, config_entry, client):
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_multiple_updates(hass, config_entry, caplog, client):
+async def test_multiple_updates(
+    hass: HomeAssistant, config_entry, caplog: pytest.LogCaptureFixture, client
+) -> None:
     """Test all possible results of online status transition after update."""
     config_entry.add_to_hass(hass)
 
@@ -303,7 +312,9 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_entity_assumed_and_available(hass, config_entry, client):
+async def test_entity_assumed_and_available(
+    hass: HomeAssistant, config_entry, client
+) -> None:
     """Test assumed_state and_available properties for all values of online."""
     config_entry.add_to_hass(hass)
 

--- a/tests/components/ibeacon/test_config_flow.py
+++ b/tests/components/ibeacon/test_config_flow.py
@@ -1,15 +1,17 @@
 """Test the ibeacon config flow."""
-
 from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.ibeacon.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
 
-async def test_setup_user_no_bluetooth(hass, mock_bluetooth_adapters):
+async def test_setup_user_no_bluetooth(
+    hass: HomeAssistant, mock_bluetooth_adapters: None
+) -> None:
     """Test setting up via user interaction when bluetooth is not enabled."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -19,7 +21,7 @@ async def test_setup_user_no_bluetooth(hass, mock_bluetooth_adapters):
     assert result["reason"] == "bluetooth_not_available"
 
 
-async def test_setup_user(hass, enable_bluetooth):
+async def test_setup_user(hass: HomeAssistant, enable_bluetooth: None) -> None:
     """Test setting up via user interaction with bluetooth enabled."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -36,7 +38,9 @@ async def test_setup_user(hass, enable_bluetooth):
     assert result2["data"] == {}
 
 
-async def test_setup_user_already_setup(hass, enable_bluetooth):
+async def test_setup_user_already_setup(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
     """Test setting up via user when already setup ."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -153,7 +153,7 @@ def mock_controller_service_validate_verification_code_failed():
         yield service_mock
 
 
-async def test_user(hass: HomeAssistant, service: MagicMock):
+async def test_user(hass: HomeAssistant, service: MagicMock) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=None
@@ -171,7 +171,9 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
     assert result["step_id"] == CONF_TRUSTED_DEVICE
 
 
-async def test_user_with_cookie(hass: HomeAssistant, service_authenticated: MagicMock):
+async def test_user_with_cookie(
+    hass: HomeAssistant, service_authenticated: MagicMock
+) -> None:
     """Test user config with presence of a cookie."""
     # test with all provided
     result = await hass.config_entries.flow.async_init(
@@ -193,7 +195,7 @@ async def test_user_with_cookie(hass: HomeAssistant, service_authenticated: Magi
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
 
-async def test_login_failed(hass: HomeAssistant):
+async def test_login_failed(hass: HomeAssistant) -> None:
     """Test when we have errors during login."""
     with patch(
         "homeassistant.components.icloud.config_flow.PyiCloudService.authenticate",
@@ -210,7 +212,7 @@ async def test_login_failed(hass: HomeAssistant):
 
 async def test_no_device(
     hass: HomeAssistant, service_authenticated_no_device: MagicMock
-):
+) -> None:
     """Test when we have no devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -221,7 +223,7 @@ async def test_no_device(
     assert result["reason"] == "no_device"
 
 
-async def test_trusted_device(hass: HomeAssistant, service: MagicMock):
+async def test_trusted_device(hass: HomeAssistant, service: MagicMock) -> None:
     """Test trusted_device step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -234,7 +236,7 @@ async def test_trusted_device(hass: HomeAssistant, service: MagicMock):
     assert result["step_id"] == CONF_TRUSTED_DEVICE
 
 
-async def test_trusted_device_success(hass: HomeAssistant, service: MagicMock):
+async def test_trusted_device_success(hass: HomeAssistant, service: MagicMock) -> None:
     """Test trusted_device step success."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -251,7 +253,7 @@ async def test_trusted_device_success(hass: HomeAssistant, service: MagicMock):
 
 async def test_send_verification_code_failed(
     hass: HomeAssistant, service_send_verification_code_failed: MagicMock
-):
+) -> None:
     """Test when we have errors during send_verification_code."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -267,7 +269,7 @@ async def test_send_verification_code_failed(
     assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
 
 
-async def test_verification_code(hass: HomeAssistant, service: MagicMock):
+async def test_verification_code(hass: HomeAssistant, service: MagicMock) -> None:
     """Test verification_code step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -283,7 +285,9 @@ async def test_verification_code(hass: HomeAssistant, service: MagicMock):
     assert result["step_id"] == CONF_VERIFICATION_CODE
 
 
-async def test_verification_code_success(hass: HomeAssistant, service: MagicMock):
+async def test_verification_code_success(
+    hass: HomeAssistant, service: MagicMock
+) -> None:
     """Test verification_code step success."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -310,7 +314,7 @@ async def test_verification_code_success(hass: HomeAssistant, service: MagicMock
 
 async def test_validate_verification_code_failed(
     hass: HomeAssistant, service_validate_verification_code_failed: MagicMock
-):
+) -> None:
     """Test when we have errors during validate_verification_code."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -329,7 +333,7 @@ async def test_validate_verification_code_failed(
     assert result["errors"] == {"base": "validate_verification_code"}
 
 
-async def test_2fa_code_success(hass: HomeAssistant, service_2fa: MagicMock):
+async def test_2fa_code_success(hass: HomeAssistant, service_2fa: MagicMock) -> None:
     """Test 2fa step success."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -355,7 +359,7 @@ async def test_2fa_code_success(hass: HomeAssistant, service_2fa: MagicMock):
 
 async def test_validate_2fa_code_failed(
     hass: HomeAssistant, service_validate_2fa_code_failed: MagicMock
-):
+) -> None:
     """Test when we have errors during validate_verification_code."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -372,7 +376,9 @@ async def test_validate_2fa_code_failed(
     assert result["errors"] == {"base": "validate_verification_code"}
 
 
-async def test_password_update(hass: HomeAssistant, service_authenticated: MagicMock):
+async def test_password_update(
+    hass: HomeAssistant, service_authenticated: MagicMock
+) -> None:
     """Test that password reauthentication works successfully."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
@@ -396,7 +402,7 @@ async def test_password_update(hass: HomeAssistant, service_authenticated: Magic
     assert config_entry.data[CONF_PASSWORD] == PASSWORD_2
 
 
-async def test_password_update_wrong_password(hass: HomeAssistant):
+async def test_password_update_wrong_password(hass: HomeAssistant) -> None:
     """Test that during password reauthentication wrong password returns correct error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -75,8 +75,11 @@ async def test_setup_component_with_service(hass: HomeAssistant) -> None:
     return_value=b"Test",
 )
 async def test_get_image_from_camera(
-    mock_camera_read, hass, aiohttp_unused_port, enable_custom_integrations
-):
+    mock_camera_read,
+    hass: HomeAssistant,
+    aiohttp_unused_port,
+    enable_custom_integrations: None,
+) -> None:
     """Grab an image from camera entity."""
     await setup_image_processing(hass, aiohttp_unused_port)
 
@@ -95,8 +98,11 @@ async def test_get_image_from_camera(
     side_effect=HomeAssistantError(),
 )
 async def test_get_image_without_exists_camera(
-    mock_image, hass, aiohttp_unused_port, enable_custom_integrations
-):
+    mock_image,
+    hass: HomeAssistant,
+    aiohttp_unused_port,
+    enable_custom_integrations: None,
+) -> None:
     """Try to get image without exists camera."""
     await setup_image_processing(hass, aiohttp_unused_port)
 
@@ -141,7 +147,9 @@ async def test_face_event_call(
     "homeassistant.components.demo.image_processing.DemoImageProcessingFace.confidence",
     new_callable=PropertyMock(return_value=None),
 )
-async def test_face_event_call_no_confidence(mock_config, hass, aioclient_mock):
+async def test_face_event_call_no_confidence(
+    mock_config, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up and scan a picture and test faces from event."""
     face_events = await setup_image_processing_face(hass)
     aioclient_mock.get(get_url(hass), content=b"image")

--- a/tests/components/image_upload/test_init.py
+++ b/tests/components/image_upload/test_init.py
@@ -6,13 +6,20 @@ from unittest.mock import patch
 from aiohttp import ClientSession, ClientWebSocketResponse
 
 from homeassistant.components.websocket_api import const as ws_const
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as util_dt
 
 from . import TEST_IMAGE
 
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
-async def test_upload_image(hass, hass_client, hass_ws_client):
+
+async def test_upload_image(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test we can upload an image."""
     now = util_dt.utcnow()
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_STANDBY,
 )
-from homeassistant.core import split_entity_id
+from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.setup import async_setup_component
 
 INFLUX_PATH = "homeassistant.components.influxdb"
@@ -112,7 +112,9 @@ def _get_write_api_mock_v2(mock_influx_client):
     ],
     indirect=["mock_client"],
 )
-async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
+async def test_setup_config_full(
+    hass: HomeAssistant, mock_client, config_ext, get_write_api
+) -> None:
     """Test the setup with full configuration."""
     config = {
         "influxdb": {
@@ -249,8 +251,8 @@ async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
     indirect=["mock_client"],
 )
 async def test_setup_config_ssl(
-    hass, mock_client, config_base, config_ext, expected_client_args
-):
+    hass: HomeAssistant, mock_client, config_base, config_ext, expected_client_args
+) -> None:
     """Test the setup with various verify_ssl values."""
     config = {"influxdb": config_base.copy()}
     config["influxdb"].update(config_ext)
@@ -274,7 +276,9 @@ async def test_setup_config_ssl(
     ],
     indirect=["mock_client"],
 )
-async def test_setup_minimal_config(hass, mock_client, config_ext, get_write_api):
+async def test_setup_minimal_config(
+    hass: HomeAssistant, mock_client, config_ext, get_write_api
+) -> None:
     """Test the setup with minimal configuration and defaults."""
     config = {"influxdb": {}}
     config["influxdb"].update(config_ext)
@@ -319,7 +323,9 @@ async def test_setup_minimal_config(hass, mock_client, config_ext, get_write_api
     ],
     indirect=["mock_client"],
 )
-async def test_invalid_config(hass, mock_client, config_ext, get_write_api):
+async def test_invalid_config(
+    hass: HomeAssistant, mock_client, config_ext, get_write_api
+) -> None:
     """Test the setup with invalid config or config options specified for wrong version."""
     config = {"influxdb": {}}
     config["influxdb"].update(config_ext)
@@ -363,8 +369,8 @@ async def _setup(hass, mock_influx_client, config_ext, get_write_api):
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -449,8 +455,8 @@ async def test_event_listener(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_no_units(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener for missing units."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -503,8 +509,8 @@ async def test_event_listener_no_units(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_inf(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with large or invalid numbers."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -552,8 +558,8 @@ async def test_event_listener_inf(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_states(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against ignored states."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -636,8 +642,8 @@ def execute_filter_test(hass, tests, handler_method, write_api, get_mock_call):
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_denylist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a denylist."""
     config = {"exclude": {"entities": ["fake.denylisted"]}, "include": {}}
     config.update(config_ext)
@@ -670,8 +676,8 @@ async def test_event_listener_denylist(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_denylist_domain(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a domain denylist."""
     config = {"exclude": {"domains": ["another_fake"]}, "include": {}}
     config.update(config_ext)
@@ -704,8 +710,8 @@ async def test_event_listener_denylist_domain(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_denylist_glob(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a glob denylist."""
     config = {"exclude": {"entity_globs": ["*.excluded_*"]}, "include": {}}
     config.update(config_ext)
@@ -738,8 +744,8 @@ async def test_event_listener_denylist_glob(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_allowlist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against an allowlist."""
     config = {"include": {"entities": ["fake.included"]}, "exclude": {}}
     config.update(config_ext)
@@ -772,8 +778,8 @@ async def test_event_listener_allowlist(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_allowlist_domain(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a domain allowlist."""
     config = {"include": {"domains": ["fake"]}, "exclude": {}}
     config.update(config_ext)
@@ -806,8 +812,8 @@ async def test_event_listener_allowlist_domain(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_allowlist_glob(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a glob allowlist."""
     config = {"include": {"entity_globs": ["*.included_*"]}, "exclude": {}}
     config.update(config_ext)
@@ -840,8 +846,8 @@ async def test_event_listener_allowlist_glob(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_filtered_allowlist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against an allowlist filtered by denylist."""
     config = {
         "include": {
@@ -890,8 +896,8 @@ async def test_event_listener_filtered_allowlist(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_filtered_denylist(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener against a domain/glob denylist with an entity id allowlist."""
     config = {
         "include": {"entities": ["another_fake.included", "fake.excluded_pass"]},
@@ -930,8 +936,8 @@ async def test_event_listener_filtered_denylist(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_invalid_type(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener when an attribute has an invalid type."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -1004,8 +1010,8 @@ async def test_event_listener_invalid_type(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_default_measurement(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with a default measurement."""
     config = {"default_measurement": "state"}
     config.update(config_ext)
@@ -1054,8 +1060,8 @@ async def test_event_listener_default_measurement(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_unit_of_measurement_field(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener for unit of measurement field."""
     config = {"override_measurement": "state"}
     config.update(config_ext)
@@ -1105,8 +1111,8 @@ async def test_event_listener_unit_of_measurement_field(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_tags_attributes(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener when some attributes should be tags."""
     config = {"tags_attributes": ["friendly_fake"]}
     config.update(config_ext)
@@ -1160,8 +1166,8 @@ async def test_event_listener_tags_attributes(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_component_override_measurement(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with overridden measurements."""
     config = {
         "component_config": {
@@ -1226,8 +1232,8 @@ async def test_event_listener_component_override_measurement(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_component_measurement_attr(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with a different measurement_attr."""
     config = {
         "measurement_attr": "domain__device_class",
@@ -1299,8 +1305,8 @@ async def test_event_listener_component_measurement_attr(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_ignore_attributes(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with overridden measurements."""
     config = {
         "ignore_attributes": ["ignore"],
@@ -1387,8 +1393,8 @@ async def test_event_listener_ignore_attributes(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_ignore_attributes_overlapping_entities(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener with overridden measurements."""
     config = {
         "component_config": {"sensor.fake": {"override_measurement": "units"}},
@@ -1441,8 +1447,8 @@ async def test_event_listener_ignore_attributes_overlapping_entities(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_scheduled_write(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener retries after a write failure."""
     config = {"max_retries": 1}
     config.update(config_ext)
@@ -1494,8 +1500,8 @@ async def test_event_listener_scheduled_write(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_backlog_full(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener drops old events when backlog gets full."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -1542,8 +1548,8 @@ async def test_event_listener_backlog_full(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_event_listener_attribute_name_conflict(
-    hass, mock_client, config_ext, get_write_api, get_mock_call
-):
+    hass: HomeAssistant, mock_client, config_ext, get_write_api, get_mock_call
+) -> None:
     """Test the event listener when an attribute conflicts with another field."""
     handler_method = await _setup(hass, mock_client, config_ext, get_write_api)
 
@@ -1614,8 +1620,14 @@ async def test_event_listener_attribute_name_conflict(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_connection_failure_on_startup(
-    hass, caplog, mock_client, config_ext, get_write_api, get_mock_call, test_exception
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    get_write_api,
+    get_mock_call,
+    test_exception,
+) -> None:
     """Test the event listener when it fails to connect to Influx on startup."""
     write_api = get_write_api(mock_client)
     write_api.side_effect = test_exception
@@ -1656,8 +1668,14 @@ async def test_connection_failure_on_startup(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_invalid_inputs_error(
-    hass, caplog, mock_client, config_ext, get_write_api, get_mock_call, test_exception
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    get_write_api,
+    get_mock_call,
+    test_exception,
+) -> None:
     """Test the event listener when influx returns invalid inputs on write.
 
     The difference in error handling in this case is that we do not sleep
@@ -1756,8 +1774,13 @@ async def test_invalid_inputs_error(
     indirect=["mock_client", "get_mock_call"],
 )
 async def test_precision(
-    hass, mock_client, config_ext, get_write_api, get_mock_call, precision
-):
+    hass: HomeAssistant,
+    mock_client,
+    config_ext,
+    get_write_api,
+    get_mock_call,
+    precision,
+) -> None:
     """Test the precision setup."""
     config = {
         "precision": precision,

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.components.influxdb.const import (
 from homeassistant.components.influxdb.sensor import PLATFORM_SCHEMA
 import homeassistant.components.sensor as sensor
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import PLATFORM_NOT_READY_BASE_WAIT_TIME
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -216,7 +217,9 @@ async def _setup(hass, config_ext, queries, expected_sensors):
     ],
     indirect=["mock_client"],
 )
-async def test_minimal_config(hass, mock_client, config_ext, queries, set_query_mock):
+async def test_minimal_config(
+    hass: HomeAssistant, mock_client, config_ext, queries, set_query_mock
+) -> None:
     """Test the minimal config and defaults."""
     set_query_mock(mock_client)
     await _setup(hass, config_ext, queries, ["sensor.test"])
@@ -286,14 +289,16 @@ async def test_minimal_config(hass, mock_client, config_ext, queries, set_query_
     ],
     indirect=["mock_client"],
 )
-async def test_full_config(hass, mock_client, config_ext, queries, set_query_mock):
+async def test_full_config(
+    hass: HomeAssistant, mock_client, config_ext, queries, set_query_mock
+) -> None:
     """Test the full config."""
     set_query_mock(mock_client)
     await _setup(hass, config_ext, queries, ["sensor.test"])
 
 
 @pytest.mark.parametrize("config_ext", [(BASE_V1_CONFIG), (BASE_V2_CONFIG)])
-async def test_config_failure(hass, config_ext):
+async def test_config_failure(hass: HomeAssistant, config_ext) -> None:
     """Test an invalid config."""
     config = {"platform": DOMAIN}
     config.update(config_ext)
@@ -323,8 +328,13 @@ async def test_config_failure(hass, config_ext):
     indirect=["mock_client"],
 )
 async def test_state_matches_query_result(
-    hass, mock_client, config_ext, queries, set_query_mock, make_resultset
-):
+    hass: HomeAssistant,
+    mock_client,
+    config_ext,
+    queries,
+    set_query_mock,
+    make_resultset,
+) -> None:
     """Test state of sensor matches response from query api."""
     set_query_mock(mock_client, return_value=make_resultset(42))
 
@@ -354,8 +364,14 @@ async def test_state_matches_query_result(
     indirect=["mock_client"],
 )
 async def test_state_matches_first_query_result_for_multiple_return(
-    hass, caplog, mock_client, config_ext, queries, set_query_mock, make_resultset
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    queries,
+    set_query_mock,
+    make_resultset,
+) -> None:
     """Test state of sensor matches response from query api."""
     set_query_mock(mock_client, return_value=make_resultset(42, "not used"))
 
@@ -380,8 +396,13 @@ async def test_state_matches_first_query_result_for_multiple_return(
     indirect=["mock_client"],
 )
 async def test_state_for_no_results(
-    hass, caplog, mock_client, config_ext, queries, set_query_mock
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    queries,
+    set_query_mock,
+) -> None:
     """Test state of sensor matches response from query api."""
     set_query_mock(mock_client)
 
@@ -441,8 +462,14 @@ async def test_state_for_no_results(
     indirect=["mock_client"],
 )
 async def test_error_querying_influx(
-    hass, caplog, mock_client, config_ext, queries, set_query_mock, query_exception
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    queries,
+    set_query_mock,
+    query_exception,
+) -> None:
     """Test behavior of sensor when influx returns error."""
     set_query_mock(mock_client, query_exception=query_exception)
 
@@ -494,8 +521,15 @@ async def test_error_querying_influx(
     indirect=["mock_client"],
 )
 async def test_error_rendering_template(
-    hass, caplog, mock_client, config_ext, queries, set_query_mock, make_resultset, key
-):
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    config_ext,
+    queries,
+    set_query_mock,
+    make_resultset,
+    key,
+) -> None:
     """Test behavior of sensor with error rendering template."""
     set_query_mock(mock_client, return_value=make_resultset(42))
 
@@ -561,15 +595,15 @@ async def test_error_rendering_template(
     indirect=["mock_client"],
 )
 async def test_connection_error_at_startup(
-    hass,
-    caplog,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     mock_client,
     config_ext,
     queries,
     set_query_mock,
     test_exception,
     make_resultset,
-):
+) -> None:
     """Test behavior of sensor when influx returns error."""
     query_api = set_query_mock(mock_client, side_effect=test_exception)
     expected_sensor = "sensor.test"
@@ -614,13 +648,13 @@ async def test_connection_error_at_startup(
     indirect=["mock_client"],
 )
 async def test_data_repository_not_found(
-    hass,
-    caplog,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     mock_client,
     config_ext,
     queries,
     set_query_mock,
-):
+) -> None:
     """Test sensor is not setup when bucket not available."""
     set_query_mock(mock_client)
     await _setup(hass, config_ext, queries, [])

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -22,7 +22,8 @@ from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_component, mock_restore_cache
+from tests.common import MockUser, mock_component, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -169,7 +170,9 @@ async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> Non
     assert state.state == "on"
 
 
-async def test_input_boolean_context(hass, hass_admin_user):
+async def test_input_boolean_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_boolean context works."""
     assert await async_setup_component(
         hass, "input_boolean", {"input_boolean": {"ac": {CONF_INITIAL: True}}}
@@ -192,7 +195,7 @@ async def test_input_boolean_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass, hass_admin_user):
+async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -267,7 +270,7 @@ async def test_reload(hass, hass_admin_user):
     assert state_2.attributes.get(ATTR_ICON) == "mdi:work_reloaded"
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -276,7 +279,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -290,7 +293,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -310,7 +315,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -335,7 +342,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_ws_update(hass, hass_ws_client, storage_setup):
+async def test_ws_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test update WS."""
 
     settings = {
@@ -390,7 +399,9 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
     assert state.attributes["friendly_name"] == "new_name_2"
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -418,7 +429,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.state
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/input_boolean/test_recorder.py
+++ b/tests/components/input_boolean/test_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.input_boolean import DOMAIN
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -16,8 +17,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 

--- a/tests/components/input_button/test_init.py
+++ b/tests/components/input_button/test_init.py
@@ -19,7 +19,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_component, mock_restore_cache
+from tests.common import MockUser, mock_component, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,7 +110,9 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     assert state.state == STATE_UNKNOWN
 
 
-async def test_input_button_context(hass, hass_admin_user):
+async def test_input_button_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_button context works."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"update": {}}})
 
@@ -130,7 +133,7 @@ async def test_input_button_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass, hass_admin_user):
+async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -199,7 +202,7 @@ async def test_reload(hass, hass_admin_user):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
 
-async def test_reload_not_changing_state(hass, storage_setup):
+async def test_reload_not_changing_state(hass: HomeAssistant, storage_setup) -> None:
     """Test reload not changing state."""
     assert await storage_setup()
     state_changes = []
@@ -239,7 +242,7 @@ async def test_reload_not_changing_state(hass, storage_setup):
     assert len(state_changes) == 1
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -248,7 +251,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -262,7 +265,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -282,7 +287,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_create_update(hass, hass_ws_client, storage_setup):
+async def test_ws_create_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test creating and updating via WS."""
     assert await storage_setup(config={DOMAIN: {}})
 
@@ -315,7 +322,9 @@ async def test_ws_create_update(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -340,7 +349,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/input_button/test_recorder.py
+++ b/tests/components/input_button/test_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.input_button import DOMAIN
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -16,8 +17,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -31,7 +31,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import mock_restore_cache
+from tests.common import MockUser, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 INITIAL_DATE = "2020-01-10"
 INITIAL_TIME = "23:45:56"
@@ -114,7 +115,7 @@ async def async_set_timestamp(hass, entity_id, timestamp):
         {"test_no_value": {"has_time": False, "has_date": False}},
     ],
 )
-def test_invalid_configs(config):
+def test_invalid_configs(config) -> None:
     """Test config."""
     with pytest.raises(vol.Invalid):
         CONFIG_SCHEMA({DOMAIN: config})
@@ -392,7 +393,9 @@ async def test_default_value(hass: HomeAssistant) -> None:
     assert state_datetime.attributes.get("timestamp") is not None
 
 
-async def test_input_datetime_context(hass, hass_admin_user):
+async def test_input_datetime_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_datetime context works."""
     assert await async_setup_component(
         hass, "input_datetime", {"input_datetime": {"only_date": {"has_date": True}}}
@@ -415,7 +418,9 @@ async def test_input_datetime_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -489,7 +494,7 @@ async def test_reload(hass, hass_admin_user, hass_read_only_user):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "dt3") is None
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.datetime_from_storage")
@@ -497,7 +502,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={
@@ -521,7 +526,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes[ATTR_EDITABLE]
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": {CONF_HAS_DATE: True}}})
 
@@ -541,7 +548,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "datetime from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -566,7 +575,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update(hass, hass_ws_client, storage_setup):
+async def test_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating min/max updates the state."""
 
     assert await storage_setup()
@@ -605,7 +616,9 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_FRIENDLY_NAME] == "even newer name"
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -638,7 +651,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_EDITABLE]
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})
@@ -768,7 +781,9 @@ async def test_timestamp(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_invalid_initial(hass, caplog, config, error):
+async def test_invalid_initial(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config, error
+) -> None:
     """Test configuration is rejected if the initial value is invalid."""
     assert not await async_setup_component(
         hass,

--- a/tests/components/input_datetime/test_recorder.py
+++ b/tests/components/input_datetime/test_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.input_datetime import CONF_HAS_DATE, CONF_HAS_TIME, DOMAIN
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -16,8 +17,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {CONF_HAS_TIME: True}}}

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -23,7 +23,8 @@ from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockUser, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -316,7 +317,9 @@ async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> Non
     assert float(state.state) == 0
 
 
-async def test_input_number_context(hass, hass_admin_user):
+async def test_input_number_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_number context works."""
     assert await async_setup_component(
         hass, "input_number", {"input_number": {"b1": {"min": 0, "max": 100}}}
@@ -339,7 +342,9 @@ async def test_input_number_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -411,7 +416,7 @@ async def test_reload(hass, hass_admin_user, hass_read_only_user):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -420,7 +425,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={
@@ -446,7 +451,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(
         config={
@@ -478,7 +485,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -503,7 +512,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update_min_max(hass, hass_ws_client, storage_setup):
+async def test_update_min_max(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating min/max updates the state."""
 
     settings = {
@@ -560,7 +571,9 @@ async def test_update_min_max(hass, hass_ws_client, storage_setup):
     assert float(state.state) == 5
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -593,7 +606,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert float(state.state) == 10
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/input_number/test_recorder.py
+++ b/tests/components/input_number/test_recorder.py
@@ -10,6 +10,7 @@ from homeassistant.components.input_number import (
     ATTR_STEP,
     DOMAIN,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -22,8 +23,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {"min": 0, "max": 100}}}

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -30,7 +30,8 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockUser, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -412,7 +413,9 @@ async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> Non
     assert state.state == "middle option"
 
 
-async def test_input_select_context(hass, hass_admin_user):
+async def test_input_select_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_select context works."""
     assert await async_setup_component(
         hass,
@@ -441,7 +444,9 @@ async def test_input_select_context(hass, hass_admin_user):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -524,7 +529,7 @@ async def test_reload(hass, hass_admin_user, hass_read_only_user):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -537,7 +542,9 @@ async def test_load_from_storage(hass, storage_setup):
     ]
 
 
-async def test_load_from_storage_duplicate(hass, storage_setup, caplog):
+async def test_load_from_storage_duplicate(
+    hass: HomeAssistant, storage_setup, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test set up from old storage with duplicates."""
     items = [
         {
@@ -561,7 +568,7 @@ async def test_load_from_storage_duplicate(hass, storage_setup, caplog):
     assert state.attributes.get(ATTR_OPTIONS) == ["yaml update 1", "yaml update 2"]
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={DOMAIN: {"from_yaml": {"options": ["yaml option", "other option"]}}}
@@ -577,7 +584,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(
         config={DOMAIN: {"from_yaml": {"options": ["yaml option"]}}}
@@ -599,7 +608,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -624,7 +635,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update(hass, hass_ws_client, storage_setup):
+async def test_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating options updates the state."""
 
     settings = {
@@ -680,7 +693,12 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert not resp["success"]
 
 
-async def test_update_duplicates(hass, hass_ws_client, storage_setup, caplog):
+async def test_update_duplicates(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test updating options updates the state."""
 
     settings = {
@@ -721,7 +739,9 @@ async def test_update_duplicates(hass, hass_ws_client, storage_setup, caplog):
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -752,7 +772,12 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_OPTIONS] == ["new option", "even newer option"]
 
 
-async def test_ws_create_duplicates(hass, hass_ws_client, storage_setup, caplog):
+async def test_ws_create_duplicates(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test create WS with duplicates."""
     assert await storage_setup(items=[])
 
@@ -783,7 +808,7 @@ async def test_ws_create_duplicates(hass, hass_ws_client, storage_setup, caplog)
     assert not hass.states.get(input_entity_id)
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.input_select import ATTR_OPTIONS, DOMAIN
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -16,8 +17,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(
         hass,

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -27,7 +27,8 @@ from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockUser, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 TEST_VAL_MIN = 2
 TEST_VAL_MAX = 22
@@ -219,7 +220,9 @@ async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> Non
     assert str(state.state) == "unknown"
 
 
-async def test_input_text_context(hass, hass_admin_user):
+async def test_input_text_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that input_text context works."""
     assert await async_setup_component(
         hass, "input_text", {"input_text": {"t1": {"initial": "bla"}}}
@@ -256,7 +259,9 @@ async def test_config_none(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_MIN] == CONF_MIN_VALUE
 
 
-async def test_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
 
@@ -318,7 +323,7 @@ async def test_reload(hass, hass_admin_user, hass_read_only_user):
     assert state_3.attributes[ATTR_MAX] == 21
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -328,7 +333,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes[ATTR_MIN] == TEST_VAL_MIN
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={
@@ -357,7 +362,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert state.attributes[ATTR_MIN] == 3
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(
         config={
@@ -389,7 +396,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -414,7 +423,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update(hass, hass_ws_client, storage_setup):
+async def test_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating min/max updates the state."""
 
     assert await storage_setup()
@@ -458,7 +469,9 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_MAX] == TEST_VAL_MAX
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -492,7 +505,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_MIN] == 0
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/input_text/test_recorder.py
+++ b/tests/components/input_text/test_recorder.py
@@ -11,6 +11,7 @@ from homeassistant.components.input_text import (
     DOMAIN,
     MODE_TEXT,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_EDITABLE
@@ -23,8 +24,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test attributes to be excluded."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
