### PR TITLE
Add type hints to integration tests (part 12)

### DIFF
--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -1,5 +1,4 @@
 """Test the Insteon All-Link Database APIs."""
-
 import json
 from unittest.mock import patch
 
@@ -18,10 +17,12 @@ from homeassistant.components.insteon.api.aldb import (
     TYPE,
 )
 from homeassistant.components.insteon.api.device import INSTEON_DEVICE_NOT_FOUND
+from homeassistant.core import HomeAssistant
 
 from .mock_devices import MockDevices
 
 from tests.common import load_fixture
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="aldb_data", scope="session")
@@ -68,7 +69,9 @@ def _aldb_dict(mem_addr):
     }
 
 
-async def test_get_aldb(hass, hass_ws_client, aldb_data):
+async def test_get_aldb(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test getting an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -82,7 +85,9 @@ async def test_get_aldb(hass, hass_ws_client, aldb_data):
         assert len(result) == 5
 
 
-async def test_change_aldb_record(hass, hass_ws_client, aldb_data):
+async def test_change_aldb_record(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test changing an Insteon device's All-Link Database record."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
     change_rec = _aldb_dict(4079)
@@ -103,7 +108,9 @@ async def test_change_aldb_record(hass, hass_ws_client, aldb_data):
         _compare_records(rec, change_rec)
 
 
-async def test_create_aldb_record(hass, hass_ws_client, aldb_data):
+async def test_create_aldb_record(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test creating a new Insteon All-Link Database record."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
     new_rec = _aldb_dict(4079)
@@ -124,7 +131,9 @@ async def test_create_aldb_record(hass, hass_ws_client, aldb_data):
         _compare_records(rec, new_rec)
 
 
-async def test_write_aldb(hass, hass_ws_client, aldb_data):
+async def test_write_aldb(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test writing an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -143,7 +152,9 @@ async def test_write_aldb(hass, hass_ws_client, aldb_data):
         assert devices.async_save.call_count == 1
 
 
-async def test_load_aldb(hass, hass_ws_client, aldb_data):
+async def test_load_aldb(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test loading an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -161,7 +172,9 @@ async def test_load_aldb(hass, hass_ws_client, aldb_data):
         assert devices.async_save.call_count == 1
 
 
-async def test_reset_aldb(hass, hass_ws_client, aldb_data):
+async def test_reset_aldb(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test resetting an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
     record = _aldb_dict(4079)
@@ -190,7 +203,9 @@ async def test_reset_aldb(hass, hass_ws_client, aldb_data):
         assert not devices["33.33.33"].aldb.pending_changes
 
 
-async def test_default_links(hass, hass_ws_client, aldb_data):
+async def test_default_links(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test getting an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -209,7 +224,9 @@ async def test_default_links(hass, hass_ws_client, aldb_data):
         assert devices.async_save.call_count == 1
 
 
-async def test_notify_on_aldb_status(hass, hass_ws_client, aldb_data):
+async def test_notify_on_aldb_status(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test getting an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -230,7 +247,9 @@ async def test_notify_on_aldb_status(hass, hass_ws_client, aldb_data):
         assert not msg["event"]["is_loading"]
 
 
-async def test_notify_on_aldb_record_added(hass, hass_ws_client, aldb_data):
+async def test_notify_on_aldb_record_added(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test getting an Insteon device's All-Link Database."""
     ws_client, devices = await _setup(hass, hass_ws_client, aldb_data)
 
@@ -255,7 +274,9 @@ async def test_notify_on_aldb_record_added(hass, hass_ws_client, aldb_data):
         assert msg["event"]["type"] == "record_loaded"
 
 
-async def test_bad_address(hass, hass_ws_client, aldb_data):
+async def test_bad_address(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
+) -> None:
     """Test for a bad Insteon address."""
     ws_client, _ = await _setup(hass, hass_ws_client, aldb_data)
     record = _aldb_dict(0)

--- a/tests/components/insteon/test_api_properties.py
+++ b/tests/components/insteon/test_api_properties.py
@@ -1,5 +1,4 @@
 """Test the Insteon properties APIs."""
-
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -21,10 +20,12 @@ from homeassistant.components.insteon.api.properties import (
     SHOW_ADVANCED,
     TYPE,
 )
+from homeassistant.core import HomeAssistant
 
 from .mock_devices import MockDevices
 
 from tests.common import load_fixture
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="kpl_properties_data", scope="session")
@@ -50,8 +51,11 @@ async def _setup(hass, hass_ws_client, address, properties_data):
 
 
 async def test_get_properties(
-    hass, hass_ws_client, kpl_properties_data, iolinc_properties_data
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    kpl_properties_data,
+    iolinc_properties_data,
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -108,7 +112,9 @@ async def test_get_properties(
         assert len(msg["result"]["properties"]) == 14
 
 
-async def test_get_read_only_properties(hass, hass_ws_client, iolinc_properties_data):
+async def test_get_read_only_properties(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, iolinc_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     mock_read_only = ExtendedProperty(
         "44.44.44", "mock_read_only", bool, is_read_only=True
@@ -145,7 +151,9 @@ async def test_get_read_only_properties(hass, hass_ws_client, iolinc_properties_
         assert len(msg["result"]["properties"]) == 15
 
 
-async def test_get_unknown_properties(hass, hass_ws_client, iolinc_properties_data):
+async def test_get_unknown_properties(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, iolinc_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
 
     class UnknownType:
@@ -183,7 +191,9 @@ async def test_get_unknown_properties(hass, hass_ws_client, iolinc_properties_da
         assert len(msg["result"]["properties"]) == 14
 
 
-async def test_change_bool_property(hass, hass_ws_client, kpl_properties_data):
+async def test_change_bool_property(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test changing a bool type properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -204,7 +214,9 @@ async def test_change_bool_property(hass, hass_ws_client, kpl_properties_data):
         assert devices["33.33.33"].operating_flags["led_off"].is_dirty
 
 
-async def test_change_int_property(hass, hass_ws_client, kpl_properties_data):
+async def test_change_int_property(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test changing a int type properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -226,7 +238,9 @@ async def test_change_int_property(hass, hass_ws_client, kpl_properties_data):
         assert devices["33.33.33"].properties["led_dimming"].is_dirty
 
 
-async def test_change_ramp_rate_property(hass, hass_ws_client, kpl_properties_data):
+async def test_change_ramp_rate_property(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test changing an Insteon device's ramp rate properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -248,7 +262,9 @@ async def test_change_ramp_rate_property(hass, hass_ws_client, kpl_properties_da
         assert devices["33.33.33"].properties["ramp_rate"].is_dirty
 
 
-async def test_change_radio_button_group(hass, hass_ws_client, kpl_properties_data):
+async def test_change_radio_button_group(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test changing an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -292,7 +308,9 @@ async def test_change_radio_button_group(hass, hass_ws_client, kpl_properties_da
         assert rb_groups.new_value[1] == [7, 8]
 
 
-async def test_change_toggle_property(hass, hass_ws_client, kpl_properties_data):
+async def test_change_toggle_property(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Update a button's toggle mode."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -316,7 +334,9 @@ async def test_change_toggle_property(hass, hass_ws_client, kpl_properties_data)
         assert toggle_prop.new_value == ToggleMode.ON_ONLY
 
 
-async def test_change_relay_mode(hass, hass_ws_client, iolinc_properties_data):
+async def test_change_relay_mode(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, iolinc_properties_data
+) -> None:
     """Update a device's relay mode."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "44.44.44", iolinc_properties_data
@@ -339,7 +359,9 @@ async def test_change_relay_mode(hass, hass_ws_client, iolinc_properties_data):
         assert relay_prop.new_value == RelayMode.LATCHING
 
 
-async def test_change_float_property(hass, hass_ws_client, iolinc_properties_data):
+async def test_change_float_property(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, iolinc_properties_data
+) -> None:
     """Update a float type property."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "44.44.44", iolinc_properties_data
@@ -363,7 +385,9 @@ async def test_change_float_property(hass, hass_ws_client, iolinc_properties_dat
         assert delay_prop.new_value == 1.8
 
 
-async def test_write_properties(hass, hass_ws_client, kpl_properties_data):
+async def test_write_properties(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -379,7 +403,9 @@ async def test_write_properties(hass, hass_ws_client, kpl_properties_data):
         assert devices["33.33.33"].async_write_ext_properties.call_count == 1
 
 
-async def test_write_properties_failure(hass, hass_ws_client, kpl_properties_data):
+async def test_write_properties_failure(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -394,7 +420,9 @@ async def test_write_properties_failure(hass, hass_ws_client, kpl_properties_dat
         assert msg["error"]["code"] == "write_failed"
 
 
-async def test_load_properties(hass, hass_ws_client, kpl_properties_data):
+async def test_load_properties(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -411,7 +439,9 @@ async def test_load_properties(hass, hass_ws_client, kpl_properties_data):
         assert devices["33.33.33"].async_read_config.call_count == 1
 
 
-async def test_load_properties_failure(hass, hass_ws_client, kpl_properties_data):
+async def test_load_properties_failure(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -428,7 +458,9 @@ async def test_load_properties_failure(hass, hass_ws_client, kpl_properties_data
         assert msg["error"]["code"] == "load_failed"
 
 
-async def test_reset_properties(hass, hass_ws_client, kpl_properties_data):
+async def test_reset_properties(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test getting an Insteon device's properties."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data
@@ -449,7 +481,9 @@ async def test_reset_properties(hass, hass_ws_client, kpl_properties_data):
         assert not device.properties["on_mask"].is_dirty
 
 
-async def test_bad_address(hass, hass_ws_client, kpl_properties_data):
+async def test_bad_address(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, kpl_properties_data
+) -> None:
     """Test for a bad Insteon address."""
     ws_client, devices = await _setup(
         hass, hass_ws_client, "33.33.33", kpl_properties_data

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -96,7 +96,7 @@ async def _device_form(hass, flow_id, connection, user_input):
     return result, mock_setup, mock_setup_entry
 
 
-async def test_form_select_modem(hass: HomeAssistant):
+async def test_form_select_modem(hass: HomeAssistant) -> None:
     """Test we get a modem form."""
 
     result = await _init_form(hass, HUB2)
@@ -104,7 +104,7 @@ async def test_form_select_modem(hass: HomeAssistant):
     assert result["type"] == "form"
 
 
-async def test_fail_on_existing(hass: HomeAssistant):
+async def test_fail_on_existing(hass: HomeAssistant) -> None:
     """Test we fail if the integration is already configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -124,7 +124,7 @@ async def test_fail_on_existing(hass: HomeAssistant):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_form_select_plm(hass: HomeAssistant):
+async def test_form_select_plm(hass: HomeAssistant) -> None:
     """Test we set up the PLM correctly."""
 
     result = await _init_form(hass, PLM)
@@ -139,7 +139,7 @@ async def test_form_select_plm(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_select_hub_v1(hass: HomeAssistant):
+async def test_form_select_hub_v1(hass: HomeAssistant) -> None:
     """Test we set up the Hub v1 correctly."""
 
     result = await _init_form(hass, HUB1)
@@ -157,7 +157,7 @@ async def test_form_select_hub_v1(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_select_hub_v2(hass: HomeAssistant):
+async def test_form_select_hub_v2(hass: HomeAssistant) -> None:
     """Test we set up the Hub v2 correctly."""
 
     result = await _init_form(hass, HUB2)
@@ -175,7 +175,7 @@ async def test_form_select_hub_v2(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_failed_connection_plm(hass: HomeAssistant):
+async def test_failed_connection_plm(hass: HomeAssistant) -> None:
     """Test a failed connection with the PLM."""
 
     result = await _init_form(hass, PLM)
@@ -187,7 +187,7 @@ async def test_failed_connection_plm(hass: HomeAssistant):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_failed_connection_hub(hass: HomeAssistant):
+async def test_failed_connection_hub(hass: HomeAssistant) -> None:
     """Test a failed connection with a Hub."""
 
     result = await _init_form(hass, HUB2)
@@ -212,7 +212,7 @@ async def _import_config(hass, config):
         )
 
 
-async def test_import_plm(hass: HomeAssistant):
+async def test_import_plm(hass: HomeAssistant) -> None:
     """Test importing a minimum PLM config from yaml."""
 
     result = await _import_config(hass, MOCK_IMPORT_CONFIG_PLM)
@@ -238,7 +238,7 @@ async def _options_init_form(hass, entry_id, step):
     return result2
 
 
-async def test_import_min_hub_v2(hass: HomeAssistant):
+async def test_import_min_hub_v2(hass: HomeAssistant) -> None:
     """Test importing a minimum Hub v2 config from yaml."""
 
     result = await _import_config(
@@ -255,7 +255,7 @@ async def test_import_min_hub_v2(hass: HomeAssistant):
         assert entry.data[CONF_HUB_VERSION] == 2
 
 
-async def test_import_min_hub_v1(hass: HomeAssistant):
+async def test_import_min_hub_v1(hass: HomeAssistant) -> None:
     """Test importing a minimum Hub v1 config from yaml."""
 
     result = await _import_config(
@@ -270,7 +270,7 @@ async def test_import_min_hub_v1(hass: HomeAssistant):
         assert entry.data[CONF_HUB_VERSION] == 1
 
 
-async def test_import_existing(hass: HomeAssistant):
+async def test_import_existing(hass: HomeAssistant) -> None:
     """Test we fail on an existing config imported."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -288,7 +288,7 @@ async def test_import_existing(hass: HomeAssistant):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_import_failed_connection(hass: HomeAssistant):
+async def test_import_failed_connection(hass: HomeAssistant) -> None:
     """Test a failed connection on import."""
 
     with patch(
@@ -315,7 +315,7 @@ async def _options_form(hass, flow_id, user_input):
         return result, mock_setup_entry
 
 
-async def test_options_change_hub_config(hass: HomeAssistant):
+async def test_options_change_hub_config(hass: HomeAssistant) -> None:
     """Test changing Hub v2 config."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -342,7 +342,7 @@ async def test_options_change_hub_config(hass: HomeAssistant):
     assert config_entry.data == {**user_input, CONF_HUB_VERSION: 2}
 
 
-async def test_options_change_plm_config(hass: HomeAssistant):
+async def test_options_change_plm_config(hass: HomeAssistant) -> None:
     """Test changing PLM config."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -364,7 +364,7 @@ async def test_options_change_plm_config(hass: HomeAssistant):
     assert config_entry.data == user_input
 
 
-async def test_options_add_device_override(hass: HomeAssistant):
+async def test_options_add_device_override(hass: HomeAssistant) -> None:
     """Test adding a device override."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -407,7 +407,7 @@ async def test_options_add_device_override(hass: HomeAssistant):
     assert result["data"] != result3["data"]
 
 
-async def test_options_remove_device_override(hass: HomeAssistant):
+async def test_options_remove_device_override(hass: HomeAssistant) -> None:
     """Test removing a device override."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -431,7 +431,7 @@ async def test_options_remove_device_override(hass: HomeAssistant):
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
 
 
-async def test_options_remove_device_override_with_x10(hass: HomeAssistant):
+async def test_options_remove_device_override_with_x10(hass: HomeAssistant) -> None:
     """Test removing a device override when an X10 device is configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -464,7 +464,7 @@ async def test_options_remove_device_override_with_x10(hass: HomeAssistant):
     assert len(config_entry.options[CONF_X10]) == 1
 
 
-async def test_options_add_x10_device(hass: HomeAssistant):
+async def test_options_add_x10_device(hass: HomeAssistant) -> None:
     """Test adding an X10 device."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -511,7 +511,7 @@ async def test_options_add_x10_device(hass: HomeAssistant):
     assert result2["data"] != result3["data"]
 
 
-async def test_options_remove_x10_device(hass: HomeAssistant):
+async def test_options_remove_x10_device(hass: HomeAssistant) -> None:
     """Test removing an X10 device."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -545,7 +545,7 @@ async def test_options_remove_x10_device(hass: HomeAssistant):
     assert len(config_entry.options[CONF_X10]) == 1
 
 
-async def test_options_remove_x10_device_with_override(hass: HomeAssistant):
+async def test_options_remove_x10_device_with_override(hass: HomeAssistant) -> None:
     """Test removing an X10 device when a device override is configured."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -581,7 +581,7 @@ async def test_options_remove_x10_device_with_override(hass: HomeAssistant):
     assert len(config_entry.options[CONF_OVERRIDE]) == 1
 
 
-async def test_options_dup_selection(hass: HomeAssistant):
+async def test_options_dup_selection(hass: HomeAssistant) -> None:
     """Test if a duplicate selection was made in options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -603,7 +603,7 @@ async def test_options_dup_selection(hass: HomeAssistant):
     assert result2["errors"] == {"base": "select_single"}
 
 
-async def test_options_override_bad_data(hass: HomeAssistant):
+async def test_options_override_bad_data(hass: HomeAssistant) -> None:
     """Test for bad data in a device override."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/insteon/test_init.py
+++ b/tests/components/insteon/test_init.py
@@ -3,6 +3,7 @@ import asyncio
 from unittest.mock import patch
 
 from pyinsteon.address import Address
+import pytest
 
 from homeassistant.components import insteon
 from homeassistant.components.insteon.const import (
@@ -55,7 +56,7 @@ async def mock_failed_connection(*args, **kwargs):
     raise ConnectionError("Connection failed")
 
 
-async def test_setup_entry(hass: HomeAssistant):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setting up the entry."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)
@@ -78,7 +79,7 @@ async def test_setup_entry(hass: HomeAssistant):
         assert mock_close.called
 
 
-async def test_import_plm(hass: HomeAssistant):
+async def test_import_plm(hass: HomeAssistant) -> None:
     """Test setting up the entry from YAML to a PLM."""
     config = {}
     config[DOMAIN] = MOCK_IMPORT_CONFIG_PLM
@@ -103,7 +104,7 @@ async def test_import_plm(hass: HomeAssistant):
     assert CONF_PORT not in data
 
 
-async def test_import_hub1(hass: HomeAssistant):
+async def test_import_hub1(hass: HomeAssistant) -> None:
     """Test setting up the entry from YAML to a hub v1."""
     config = {}
     config[DOMAIN] = MOCK_IMPORT_MINIMUM_HUB_V1
@@ -130,7 +131,7 @@ async def test_import_hub1(hass: HomeAssistant):
     assert CONF_PASSWORD not in data
 
 
-async def test_import_hub2(hass: HomeAssistant):
+async def test_import_hub2(hass: HomeAssistant) -> None:
     """Test setting up the entry from YAML to a hub v2."""
     config = {}
     config[DOMAIN] = MOCK_IMPORT_MINIMUM_HUB_V2
@@ -157,7 +158,7 @@ async def test_import_hub2(hass: HomeAssistant):
     assert data[CONF_PASSWORD] == MOCK_IMPORT_MINIMUM_HUB_V2[CONF_PASSWORD]
 
 
-async def test_import_options(hass: HomeAssistant):
+async def test_import_options(hass: HomeAssistant) -> None:
     """Test setting up the entry from YAML including options."""
     config = {}
     config[DOMAIN] = MOCK_IMPORT_FULL_CONFIG_PLM
@@ -190,7 +191,7 @@ async def test_import_options(hass: HomeAssistant):
     assert options[CONF_X10][1] == MOCK_IMPORT_FULL_CONFIG_PLM[CONF_X10][1]
 
 
-async def test_import_failed_connection(hass: HomeAssistant):
+async def test_import_failed_connection(hass: HomeAssistant) -> None:
     """Test a failed connection in import does not create a config entry."""
     config = {}
     config[DOMAIN] = MOCK_IMPORT_CONFIG_PLM
@@ -209,7 +210,9 @@ async def test_import_failed_connection(hass: HomeAssistant):
         assert not hass.config_entries.async_entries(DOMAIN)
 
 
-async def test_setup_entry_failed_connection(hass: HomeAssistant, caplog):
+async def test_setup_entry_failed_connection(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setting up the entry with a failed connection."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)
@@ -225,7 +228,7 @@ async def test_setup_entry_failed_connection(hass: HomeAssistant, caplog):
         assert "Could not connect to Insteon modem" in caplog.text
 
 
-async def test_import_frontend_dev_url(hass: HomeAssistant):
+async def test_import_frontend_dev_url(hass: HomeAssistant) -> None:
     """Test importing a dev_url config entry."""
     config = {}
     config[DOMAIN] = {CONF_DEV_PATH: "/some/path"}

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -13,10 +13,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry, entity_registry, intent
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_service
+from tests.common import MockUser, async_mock_service
+from tests.typing import ClientSessionGenerator
 
 
-async def test_http_handle_intent(hass, hass_client, hass_admin_user):
+async def test_http_handle_intent(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_admin_user: MockUser
+) -> None:
     """Test handle intent via HTTP API."""
 
     class TestIntentHandler(intent.IntentHandler):

--- a/tests/components/iotawatt/test_init.py
+++ b/tests/components/iotawatt/test_init.py
@@ -2,12 +2,13 @@
 import httpx
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import INPUT_SENSOR
 
 
-async def test_setup_unload(hass, mock_iotawatt, entry):
+async def test_setup_unload(hass: HomeAssistant, mock_iotawatt, entry) -> None:
     """Test we can setup and unload an entry."""
     mock_iotawatt.getSensors.return_value["sensors"]["my_sensor_key"] = INPUT_SENSOR
     assert await async_setup_component(hass, "iotawatt", {})
@@ -15,7 +16,9 @@ async def test_setup_unload(hass, mock_iotawatt, entry):
     assert await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_setup_connection_failed(hass, mock_iotawatt, entry):
+async def test_setup_connection_failed(
+    hass: HomeAssistant, mock_iotawatt, entry
+) -> None:
     """Test connection error during startup."""
     mock_iotawatt.connect.side_effect = httpx.ConnectError("")
     assert await async_setup_component(hass, "iotawatt", {})
@@ -23,7 +26,7 @@ async def test_setup_connection_failed(hass, mock_iotawatt, entry):
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_auth_failed(hass, mock_iotawatt, entry):
+async def test_setup_auth_failed(hass: HomeAssistant, mock_iotawatt, entry) -> None:
     """Test auth error during startup."""
     mock_iotawatt.connect.return_value = False
     assert await async_setup_component(hass, "iotawatt", {})

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfPower,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -21,7 +22,7 @@ from . import INPUT_SENSOR, OUTPUT_SENSOR
 from tests.common import async_fire_time_changed
 
 
-async def test_sensor_type_input(hass, mock_iotawatt):
+async def test_sensor_type_input(hass: HomeAssistant, mock_iotawatt) -> None:
     """Test input sensors work."""
     assert await async_setup_component(hass, "iotawatt", {})
     await hass.async_block_till_done()
@@ -52,7 +53,7 @@ async def test_sensor_type_input(hass, mock_iotawatt):
     assert hass.states.get("sensor.my_sensor") is None
 
 
-async def test_sensor_type_output(hass, mock_iotawatt):
+async def test_sensor_type_output(hass: HomeAssistant, mock_iotawatt) -> None:
     """Tests the sensor type of Output."""
     mock_iotawatt.getSensors.return_value["sensors"][
         "my_watthour_sensor_key"

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -328,7 +328,7 @@ async def test_zeroconf_no_unique_id(
 
 
 async def test_full_user_flow_implementation(
-    hass: HomeAssistant, aioclient_mock
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the full manual user flow from start to finish."""
     mock_connection(aioclient_mock)

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 
 
-async def test_duplicate_error(hass, config, config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -32,7 +32,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_step_user(hass, config, setup_iqvia):
+async def test_step_user(hass: HomeAssistant, config, setup_iqvia) -> None:
     """Test that the user step works (without MFA)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config

--- a/tests/components/iqvia/test_diagnostics.py
+++ b/tests/components/iqvia/test_diagnostics.py
@@ -1,10 +1,14 @@
 """Test IQVIA diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_iqvia):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, config_entry, hass_client: ClientSessionGenerator, setup_iqvia
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/iss/test_config_flow.py
+++ b/tests/components/iss/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_create_entry(hass: HomeAssistant):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -30,7 +30,7 @@ async def test_create_entry(hass: HomeAssistant):
         assert result.get("result").data == {}
 
 
-async def test_integration_already_exists(hass: HomeAssistant):
+async def test_integration_already_exists(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
 
     MockConfigEntry(
@@ -46,7 +46,7 @@ async def test_integration_already_exists(hass: HomeAssistant):
     assert result.get("reason") == "single_instance_allowed"
 
 
-async def test_options(hass: HomeAssistant):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options flow."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -3,6 +3,7 @@ import re
 from unittest.mock import patch
 
 from pyisy import ISYConnectionError, ISYInvalidAuthError
+import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, ssdp
@@ -110,7 +111,7 @@ def _get_schema_default(schema, key_name):
     raise KeyError(f"{key_name} not found in schema")
 
 
-async def test_form(hass: HomeAssistant):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -138,7 +139,7 @@ async def test_form(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_host(hass: HomeAssistant):
+async def test_form_invalid_host(hass: HomeAssistant) -> None:
     """Test we handle invalid host."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -158,7 +159,7 @@ async def test_form_invalid_host(hass: HomeAssistant):
     assert result2["errors"] == {"base": "invalid_host"}
 
 
-async def test_form_invalid_auth(hass: HomeAssistant):
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -176,7 +177,7 @@ async def test_form_invalid_auth(hass: HomeAssistant):
     assert result2["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
 
-async def test_form_unknown_exeption(hass: HomeAssistant):
+async def test_form_unknown_exeption(hass: HomeAssistant) -> None:
     """Test we handle generic exceptions."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -194,7 +195,7 @@ async def test_form_unknown_exeption(hass: HomeAssistant):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_isy_connection_error(hass: HomeAssistant):
+async def test_form_isy_connection_error(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -212,7 +213,9 @@ async def test_form_isy_connection_error(hass: HomeAssistant):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_isy_parse_response_error(hass: HomeAssistant, caplog):
+async def test_form_isy_parse_response_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle poorly formatted XML response from ISY."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -230,7 +233,7 @@ async def test_form_isy_parse_response_error(hass: HomeAssistant, caplog):
     assert "ISY Could not parse response, poorly formatted XML." in caplog.text
 
 
-async def test_form_no_name_in_response(hass: HomeAssistant):
+async def test_form_no_name_in_response(hass: HomeAssistant) -> None:
     """Test we handle invalid response from ISY with name not set."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -250,7 +253,7 @@ async def test_form_no_name_in_response(hass: HomeAssistant):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_existing_config_entry(hass: HomeAssistant):
+async def test_form_existing_config_entry(hass: HomeAssistant) -> None:
     """Test if config entry already exists."""
     MockConfigEntry(domain=DOMAIN, unique_id=MOCK_UUID).add_to_hass(hass)
 
@@ -359,7 +362,7 @@ async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_form_ssdp(hass: HomeAssistant):
+async def test_form_ssdp(hass: HomeAssistant) -> None:
     """Test we can setup from ssdp."""
 
     result = await hass.config_entries.flow.async_init(
@@ -399,7 +402,7 @@ async def test_form_ssdp(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_ssdp_existing_entry(hass: HomeAssistant):
+async def test_form_ssdp_existing_entry(hass: HomeAssistant) -> None:
     """Test we update the ip of an existing entry from ssdp."""
 
     entry = MockConfigEntry(
@@ -430,7 +433,7 @@ async def test_form_ssdp_existing_entry(hass: HomeAssistant):
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:80{ISY_URL_POSTFIX}"
 
 
-async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant):
+async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant) -> None:
     """Test we update the ip of an existing entry from ssdp with no port."""
 
     entry = MockConfigEntry(
@@ -461,7 +464,9 @@ async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant):
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:80/{ISY_URL_POSTFIX}"
 
 
-async def test_form_ssdp_existing_entry_with_alternate_port(hass: HomeAssistant):
+async def test_form_ssdp_existing_entry_with_alternate_port(
+    hass: HomeAssistant,
+) -> None:
     """Test we update the ip of an existing entry from ssdp with an alternate port."""
 
     entry = MockConfigEntry(
@@ -492,7 +497,7 @@ async def test_form_ssdp_existing_entry_with_alternate_port(hass: HomeAssistant)
     assert entry.data[CONF_HOST] == f"http://3.3.3.3:1443/{ISY_URL_POSTFIX}"
 
 
-async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant):
+async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant) -> None:
     """Test we update the ip of an existing entry from ssdp with no port and https."""
 
     entry = MockConfigEntry(
@@ -523,7 +528,7 @@ async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant):
     assert entry.data[CONF_HOST] == f"https://3.3.3.3:443/{ISY_URL_POSTFIX}"
 
 
-async def test_form_dhcp(hass: HomeAssistant):
+async def test_form_dhcp(hass: HomeAssistant) -> None:
     """Test we can setup from dhcp."""
 
     result = await hass.config_entries.flow.async_init(
@@ -559,7 +564,7 @@ async def test_form_dhcp(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_dhcp_with_polisy(hass: HomeAssistant):
+async def test_form_dhcp_with_polisy(hass: HomeAssistant) -> None:
     """Test we can setup from dhcp with polisy."""
 
     result = await hass.config_entries.flow.async_init(
@@ -599,7 +604,7 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_dhcp_with_eisy(hass: HomeAssistant):
+async def test_form_dhcp_with_eisy(hass: HomeAssistant) -> None:
     """Test we can setup from dhcp with eisy."""
 
     result = await hass.config_entries.flow.async_init(
@@ -639,7 +644,7 @@ async def test_form_dhcp_with_eisy(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_dhcp_existing_entry(hass: HomeAssistant):
+async def test_form_dhcp_existing_entry(hass: HomeAssistant) -> None:
     """Test we update the ip of an existing entry from dhcp."""
 
     entry = MockConfigEntry(
@@ -666,7 +671,7 @@ async def test_form_dhcp_existing_entry(hass: HomeAssistant):
     assert entry.data[CONF_HOST] == f"http://1.2.3.4{ISY_URL_POSTFIX}"
 
 
-async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant):
+async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant) -> None:
     """Test we update the ip of an existing entry from dhcp preserves port."""
 
     entry = MockConfigEntry(
@@ -697,7 +702,7 @@ async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant):
     assert entry.data[CONF_USERNAME] == "bob"
 
 
-async def test_form_dhcp_existing_ignored_entry(hass: HomeAssistant):
+async def test_form_dhcp_existing_ignored_entry(hass: HomeAssistant) -> None:
     """Test we handled an ignored entry from dhcp."""
 
     entry = MockConfigEntry(

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -1,11 +1,11 @@
 """Tests for iZone."""
-
 from unittest.mock import Mock, patch
 
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.izone.const import DISPATCH_CONTROLLER_DISCOVERED, IZONE
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def _mock_start_discovery(hass, mock_disco):
     return do_disovered
 
 
-async def test_not_found(hass, mock_disco):
+async def test_not_found(hass: HomeAssistant, mock_disco) -> None:
     """Test not finding iZone controller."""
 
     with patch(
@@ -52,7 +52,7 @@ async def test_not_found(hass, mock_disco):
     stop_disco.assert_called_once()
 
 
-async def test_found(hass, mock_disco):
+async def test_found(hass: HomeAssistant, mock_disco) -> None:
     """Test not finding iZone controller."""
     mock_disco.pi_disco.controllers["blah"] = object()
 

--- a/tests/components/jellyfin/test_config_flow.py
+++ b/tests/components/jellyfin/test_config_flow.py
@@ -12,7 +12,7 @@ from .const import TEST_PASSWORD, TEST_URL, TEST_USERNAME
 from tests.common import MockConfigEntry
 
 
-async def test_abort_if_existing_entry(hass: HomeAssistant):
+async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     """Check flow abort when an entry already exist."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
@@ -29,7 +29,7 @@ async def test_form(
     mock_client: MagicMock,
     mock_client_device_id: MagicMock,
     mock_setup_entry: MagicMock,
-):
+) -> None:
     """Test the complete configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -68,7 +68,7 @@ async def test_form_cannot_connect(
     mock_jellyfin: MagicMock,
     mock_client: MagicMock,
     mock_client_device_id: MagicMock,
-):
+) -> None:
     """Test we handle an unreachable server."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -101,7 +101,7 @@ async def test_form_invalid_auth(
     mock_jellyfin: MagicMock,
     mock_client: MagicMock,
     mock_client_device_id: MagicMock,
-):
+) -> None:
     """Test that we can handle invalid credentials."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -132,7 +132,7 @@ async def test_form_invalid_auth(
 
 async def test_form_exception(
     hass: HomeAssistant, mock_jellyfin: MagicMock, mock_client: MagicMock
-):
+) -> None:
     """Test we handle an unexpected exception during server setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -163,7 +163,7 @@ async def test_form_persists_device_id_on_error(
     mock_jellyfin: MagicMock,
     mock_client: MagicMock,
     mock_client_device_id: MagicMock,
-):
+) -> None:
     """Test that we can handle invalid credentials."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/jellyfin/test_diagnostics.py
+++ b/tests/components/jellyfin/test_diagnostics.py
@@ -11,7 +11,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     hass_client: ClientSessionGenerator,
-):
+) -> None:
     """Test generating diagnostics for a config entry."""
     entry = init_integration
 

--- a/tests/components/jellyfin/test_media_player.py
+++ b/tests/components/jellyfin/test_media_player.py
@@ -2,8 +2,6 @@
 from datetime import timedelta
 from unittest.mock import MagicMock
 
-from aiohttp import ClientSession
-
 from homeassistant.components.jellyfin.const import DOMAIN
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ALBUM_ARTIST,
@@ -36,6 +34,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 
 async def test_media_player(
@@ -249,7 +248,7 @@ async def test_services(
 
 async def test_browse_media(
     hass: HomeAssistant,
-    hass_ws_client: ClientSession,
+    hass_ws_client: WebSocketGenerator,
     init_integration: MockConfigEntry,
     mock_jellyfin: MagicMock,
     mock_api: MagicMock,

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -168,7 +168,7 @@ MELACHA_TEST_IDS = [
     ids=MELACHA_TEST_IDS,
 )
 async def test_issur_melacha_sensor(
-    hass,
+    hass: HomeAssistant,
     now,
     candle_lighting,
     havdalah,
@@ -177,7 +177,7 @@ async def test_issur_melacha_sensor(
     latitude,
     longitude,
     result,
-):
+) -> None:
     """Test Issur Melacha sensor output."""
     time_zone = dt_util.get_time_zone(tzname)
     test_time = now.replace(tzinfo=time_zone)
@@ -258,7 +258,7 @@ async def test_issur_melacha_sensor(
     ids=["before_candle_lighting", "before_havdalah"],
 )
 async def test_issur_melacha_sensor_update(
-    hass,
+    hass: HomeAssistant,
     now,
     candle_lighting,
     havdalah,
@@ -267,7 +267,7 @@ async def test_issur_melacha_sensor_update(
     latitude,
     longitude,
     result,
-):
+) -> None:
     """Test Issur Melacha sensor output."""
     time_zone = dt_util.get_time_zone(tzname)
     test_time = now.replace(tzinfo=time_zone)

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -152,7 +152,7 @@ TEST_IDS = [
     ids=TEST_IDS,
 )
 async def test_jewish_calendar_sensor(
-    hass,
+    hass: HomeAssistant,
     now,
     tzname,
     latitude,
@@ -161,7 +161,7 @@ async def test_jewish_calendar_sensor(
     sensor,
     diaspora,
     result,
-):
+) -> None:
     """Test Jewish calendar sensor output."""
     time_zone = dt_util.get_time_zone(tzname)
     test_time = now.replace(tzinfo=time_zone)
@@ -495,7 +495,7 @@ SHABBAT_TEST_IDS = [
     ids=SHABBAT_TEST_IDS,
 )
 async def test_shabbat_times_sensor(
-    hass,
+    hass: HomeAssistant,
     language,
     now,
     candle_lighting,
@@ -505,7 +505,7 @@ async def test_shabbat_times_sensor(
     latitude,
     longitude,
     result,
-):
+) -> None:
     """Test sensor output for upcoming shabbat/yomtov times."""
     time_zone = dt_util.get_time_zone(tzname)
     test_time = now.replace(tzinfo=time_zone)
@@ -592,7 +592,7 @@ OMER_TEST_IDS = [
 
 
 @pytest.mark.parametrize(["test_time", "result"], OMER_PARAMS, ids=OMER_TEST_IDS)
-async def test_omer_sensor(hass, test_time, result):
+async def test_omer_sensor(hass: HomeAssistant, test_time, result) -> None:
     """Test Omer Count sensor output."""
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))
 
@@ -626,7 +626,7 @@ DAFYOMI_TEST_IDS = [
 
 
 @pytest.mark.parametrize(["test_time", "result"], DAFYOMI_PARAMS, ids=DAFYOMI_TEST_IDS)
-async def test_dafyomi_sensor(hass, test_time, result):
+async def test_dafyomi_sensor(hass: HomeAssistant, test_time, result) -> None:
     """Test Daf Yomi sensor output."""
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))
 

--- a/tests/components/kira/test_init.py
+++ b/tests/components/kira/test_init.py
@@ -66,14 +66,14 @@ async def test_kira_setup(hass: HomeAssistant) -> None:
     ]
 
 
-async def test_kira_creates_codes(work_dir):
+async def test_kira_creates_codes(work_dir) -> None:
     """Kira module should create codes file if missing."""
     code_path = os.path.join(work_dir, "codes.yaml")
     kira.load_codes(code_path)
     assert os.path.exists(code_path), "Kira component didn't create codes file"
 
 
-async def test_load_codes(work_dir):
+async def test_load_codes(work_dir) -> None:
     """Kira should ignore invalid codes."""
     code_path = os.path.join(work_dir, "codes.yaml")
     with open(code_path, "w") as code_file:

--- a/tests/components/kira/test_sensor.py
+++ b/tests/components/kira/test_sensor.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock, patch
 
 from homeassistant.components.kira import sensor as kira
+from homeassistant.core import HomeAssistant
 
 TEST_CONFIG = {kira.DOMAIN: {"sensors": [{"host": "127.0.0.1", "port": 17324}]}}
 
@@ -17,7 +18,9 @@ def add_entities(devices):
 
 
 @patch("homeassistant.components.kira.sensor.KiraReceiver.schedule_update_ha_state")
-def test_kira_sensor_callback(mock_schedule_update_ha_state, hass):
+def test_kira_sensor_callback(
+    mock_schedule_update_ha_state, hass: HomeAssistant
+) -> None:
     """Ensure Kira sensor properly updates its attributes from callback."""
     mock_kira = MagicMock()
     hass.data[kira.DOMAIN] = {kira.CONF_SENSOR: {}}

--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -6,18 +6,20 @@ from unittest.mock import ANY
 import pytest
 
 from homeassistant.components.kitchen_sink import DOMAIN
-from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder import Recorder, get_instance
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
     list_statistic_ids,
 )
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from tests.components.recorder.common import async_wait_recording_done
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
@@ -26,7 +28,9 @@ def mock_history(hass):
     hass.config.components.add("history")
 
 
-async def test_demo_statistics(recorder_mock, mock_history, hass):
+async def test_demo_statistics(
+    recorder_mock: Recorder, mock_history, hass: HomeAssistant
+) -> None:
     """Test that the kitchen sink component makes some statistics available."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()
@@ -58,7 +62,9 @@ async def test_demo_statistics(recorder_mock, mock_history, hass):
     } in statistic_ids
 
 
-async def test_demo_statistics_growth(recorder_mock, mock_history, hass):
+async def test_demo_statistics_growth(
+    recorder_mock: Recorder, mock_history, hass: HomeAssistant
+) -> None:
     """Test that the kitchen sink sum statistics adds to the previous state."""
     hass.config.units = US_CUSTOMARY_SYSTEM
 
@@ -96,7 +102,12 @@ async def test_demo_statistics_growth(recorder_mock, mock_history, hass):
     assert statistics[statistic_id][0]["sum"] <= (2**20 + 24)
 
 
-async def test_issues_created(mock_history, hass, hass_client, hass_ws_client):
+async def test_issues_created(
+    mock_history,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test issues are created and can be fixed."""
     assert await async_setup_component(hass, REPAIRS_DOMAIN, {REPAIRS_DOMAIN: {}})
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -23,7 +23,9 @@ from tests.common import (
 )
 
 
-async def test_binary_sensor_entity_category(hass: HomeAssistant, knx: KNXTestKit):
+async def test_binary_sensor_entity_category(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test KNX binary sensor entity category."""
     await knx.setup_integration(
         {
@@ -46,7 +48,7 @@ async def test_binary_sensor_entity_category(hass: HomeAssistant, knx: KNXTestKi
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
 
-async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
+async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX binary sensor and inverted binary_sensor."""
     await knx.setup_integration(
         {
@@ -99,7 +101,7 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
 
 async def test_binary_sensor_ignore_internal_state(
     hass: HomeAssistant, knx: KNXTestKit
-):
+) -> None:
     """Test KNX binary_sensor with ignore_internal_state."""
     events = async_capture_events(hass, "state_changed")
 
@@ -149,7 +151,7 @@ async def test_binary_sensor_ignore_internal_state(
     assert len(events) == 8
 
 
-async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
+async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX binary_sensor with context timeout."""
     async_fire_time_changed(hass, dt.utcnow())
     events = async_capture_events(hass, "state_changed")
@@ -218,7 +220,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
     assert event.get("old_state").attributes.get("counter") == 2
 
 
-async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit):
+async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX binary_sensor with reset_after function."""
     async_fire_time_changed(hass, dt.utcnow())
 
@@ -249,7 +251,7 @@ async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit):
     assert state.state is STATE_OFF
 
 
-async def test_binary_sensor_restore_and_respond(hass, knx):
+async def test_binary_sensor_restore_and_respond(hass: HomeAssistant, knx) -> None:
     """Test restoring KNX binary sensor state and respond to read."""
     _ADDRESS = "2/2/2"
     fake_state = State("binary_sensor.test", STATE_ON)
@@ -278,7 +280,7 @@ async def test_binary_sensor_restore_and_respond(hass, knx):
     assert state.state is STATE_OFF
 
 
-async def test_binary_sensor_restore_invert(hass, knx):
+async def test_binary_sensor_restore_invert(hass: HomeAssistant, knx) -> None:
     """Test restoring KNX binary sensor state with invert."""
     _ADDRESS = "2/2/2"
     fake_state = State("binary_sensor.test", STATE_ON)

--- a/tests/components/knx/test_button.py
+++ b/tests/components/knx/test_button.py
@@ -16,7 +16,7 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events, async_fire_time_changed
 
 
-async def test_button_simple(hass: HomeAssistant, knx: KNXTestKit):
+async def test_button_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX button with default payload."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
@@ -53,7 +53,7 @@ async def test_button_simple(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_button_raw(hass: HomeAssistant, knx: KNXTestKit):
+async def test_button_raw(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX button with raw payload."""
     await knx.setup_integration(
         {
@@ -72,7 +72,7 @@ async def test_button_raw(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write("1/2/3", False)
 
 
-async def test_button_type(hass: HomeAssistant, knx: KNXTestKit):
+async def test_button_type(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX button with encoded payload."""
     await knx.setup_integration(
         {

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -11,7 +11,9 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events
 
 
-async def test_climate_basic_temperature_set(hass: HomeAssistant, knx: KNXTestKit):
+async def test_climate_basic_temperature_set(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test KNX climate basic."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
@@ -45,7 +47,7 @@ async def test_climate_basic_temperature_set(hass: HomeAssistant, knx: KNXTestKi
     events.pop()
 
 
-async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit):
+async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate hvac mode."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
@@ -97,7 +99,7 @@ async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write("1/2/6", (0x01,))
 
 
-async def test_climate_preset_mode(hass: HomeAssistant, knx: KNXTestKit):
+async def test_climate_preset_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate preset mode."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
@@ -161,7 +163,7 @@ async def test_climate_preset_mode(hass: HomeAssistant, knx: KNXTestKit):
     assert len(knx.xknx.devices) == 0
 
 
-async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit):
+async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test update climate entity for KNX."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
@@ -205,7 +207,7 @@ async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_read("1/2/7")
 
 
-async def test_command_value_idle_mode(hass: HomeAssistant, knx: KNXTestKit):
+async def test_command_value_idle_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate command_value."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -901,7 +901,7 @@ async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
 async def test_get_secure_menu_step_manual_tunnelling(
     _request_description_mock,
     hass: HomeAssistant,
-):
+) -> None:
     """Test flow reaches secure_tunnellinn menu step from manual tunnelling configuration."""
     gateway = _gateway_descriptor(
         "192.168.0.1",
@@ -948,7 +948,7 @@ async def test_get_secure_menu_step_manual_tunnelling(
     assert result3["step_id"] == "secure_key_source"
 
 
-async def test_configure_secure_tunnel_manual(hass: HomeAssistant, knx_setup):
+async def test_configure_secure_tunnel_manual(hass: HomeAssistant, knx_setup) -> None:
     """Test configure tunnelling secure keys manually."""
     menu_step = await _get_menu_step(hass)
 
@@ -985,7 +985,7 @@ async def test_configure_secure_tunnel_manual(hass: HomeAssistant, knx_setup):
     knx_setup.assert_called_once()
 
 
-async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup):
+async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     """Test configure secure knxkeys."""
     menu_step = await _get_menu_step(hass)
 
@@ -1040,7 +1040,7 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup):
     knx_setup.assert_called_once()
 
 
-async def test_configure_secure_knxkeys_file_not_found(hass: HomeAssistant):
+async def test_configure_secure_knxkeys_file_not_found(hass: HomeAssistant) -> None:
     """Test configure secure knxkeys but file was not found."""
     menu_step = await _get_menu_step(hass)
 
@@ -1068,7 +1068,7 @@ async def test_configure_secure_knxkeys_file_not_found(hass: HomeAssistant):
         assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_FILENAME] == "keyfile_not_found"
 
 
-async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant):
+async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant) -> None:
     """Test configure secure knxkeys but file was not found."""
     menu_step = await _get_menu_step(hass)
 
@@ -1099,7 +1099,7 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant):
         )
 
 
-async def test_configure_secure_knxkeys_no_tunnel_for_host(hass: HomeAssistant):
+async def test_configure_secure_knxkeys_no_tunnel_for_host(hass: HomeAssistant) -> None:
     """Test configure secure knxkeys but file was not found."""
     menu_step = await _get_menu_step(hass)
 

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -8,7 +8,7 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events
 
 
-async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit):
+async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX cover basic."""
     events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(

--- a/tests/components/knx/test_diagnostic.py
+++ b/tests/components/knx/test_diagnostic.py
@@ -34,7 +34,7 @@ async def test_diagnostics(
     hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
     knx: KNXTestKit,
-):
+) -> None:
     """Test diagnostics."""
     await knx.setup_integration({})
 
@@ -63,7 +63,7 @@ async def test_diagnostic_config_error(
     hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
     knx: KNXTestKit,
-):
+) -> None:
     """Test diagnostics."""
     await knx.setup_integration({})
 
@@ -93,7 +93,7 @@ async def test_diagnostic_config_error(
 async def test_diagnostic_redact(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-):
+) -> None:
     """Test diagnostics redacting data."""
     mock_config_entry: MockConfigEntry = MockConfigEntry(
         title="KNX",

--- a/tests/components/knx/test_events.py
+++ b/tests/components/knx/test_events.py
@@ -8,7 +8,7 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events
 
 
-async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
+async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test the `knx_event` event."""
     test_group_a = "0/4/*"
     test_address_a_1 = "0/4/0"

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -14,7 +14,7 @@ from .conftest import KNXTestKit
 from tests.common import async_fire_time_changed_exact
 
 
-async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit):
+async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test a binary expose to only send telegrams on state change."""
     entity_id = "fake.entity"
     await knx.setup_integration(
@@ -41,7 +41,7 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write("1/1/8", False)
 
 
-async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test an expose to only send telegrams on attribute change."""
     entity_id = "fake.entity"
     attribute = "fake_attribute"
@@ -86,7 +86,9 @@ async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_expose_attribute_with_default(hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_attribute_with_default(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test an expose to only send telegrams on attribute change."""
     entity_id = "fake.entity"
     attribute = "fake_attribute"
@@ -132,7 +134,7 @@ async def test_expose_attribute_with_default(hass: HomeAssistant, knx: KNXTestKi
     await knx.assert_write("1/1/8", (0,))
 
 
-async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test an expose to send string values of up to 14 bytes only."""
 
     entity_id = "fake.entity"
@@ -167,7 +169,7 @@ async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit):
     )
 
 
-async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test an expose with cooldown."""
     cooldown_time = 2
     entity_id = "fake.entity"
@@ -198,7 +200,9 @@ async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write("1/1/8", (3,))
 
 
-async def test_expose_conversion_exception(hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_conversion_exception(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test expose throws exception."""
 
     entity_id = "fake.entity"
@@ -231,7 +235,9 @@ async def test_expose_conversion_exception(hass: HomeAssistant, knx: KNXTestKit)
 
 
 @patch("time.localtime")
-async def test_expose_with_date(localtime, hass: HomeAssistant, knx: KNXTestKit):
+async def test_expose_with_date(
+    localtime, hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test an expose with a date."""
     localtime.return_value = time.struct_time([2022, 1, 7, 9, 13, 14, 6, 0, 0])
     await knx.setup_integration(

--- a/tests/components/knx/test_fan.py
+++ b/tests/components/knx/test_fan.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import KNXTestKit
 
 
-async def test_fan_percent(hass: HomeAssistant, knx: KNXTestKit):
+async def test_fan_percent(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX fan with percentage speed."""
     await knx.setup_integration(
         {
@@ -52,7 +52,7 @@ async def test_fan_percent(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_fan_step(hass: HomeAssistant, knx: KNXTestKit):
+async def test_fan_step(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX fan with speed steps."""
     await knx.setup_integration(
         {
@@ -105,7 +105,7 @@ async def test_fan_step(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit):
+async def test_fan_oscillation(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX fan oscillation."""
     await knx.setup_integration(
         {

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -202,7 +202,7 @@ async def test_init_connection_handling(
     knx: KNXTestKit,
     config_entry_data: KNXConfigEntryData,
     connection_config: ConnectionConfig,
-):
+) -> None:
     """Test correctly generating connection config."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -25,7 +25,7 @@ from .conftest import KNXTestKit
 from tests.common import async_fire_time_changed
 
 
-async def test_light_simple(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test simple KNX light."""
     test_address = "1/1/1"
     await knx.setup_integration(
@@ -74,7 +74,7 @@ async def test_light_simple(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_light_brightness(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_brightness(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test dimmable KNX light."""
     test_address = "1/1/1"
     test_brightness = "1/1/2"
@@ -127,7 +127,7 @@ async def test_light_brightness(hass: HomeAssistant, knx: KNXTestKit):
     knx.assert_state("light.test", STATE_OFF)
 
 
-async def test_light_color_temp_absolute(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_color_temp_absolute(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light color temperature adjustable in Kelvin."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -187,7 +187,7 @@ async def test_light_color_temp_absolute(hass: HomeAssistant, knx: KNXTestKit):
     )
 
 
-async def test_light_color_temp_relative(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_color_temp_relative(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light color temperature adjustable in percent."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -257,7 +257,7 @@ async def test_light_color_temp_relative(hass: HomeAssistant, knx: KNXTestKit):
     )
 
 
-async def test_light_hs_color(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_hs_color(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with hs color."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -345,7 +345,7 @@ async def test_light_hs_color(hass: HomeAssistant, knx: KNXTestKit):
     knx.assert_state("light.test", STATE_ON, brightness=178, hs_color=(176, 82))
 
 
-async def test_light_xyy_color(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_xyy_color(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with xyy color."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -418,7 +418,9 @@ async def test_light_xyy_color(hass: HomeAssistant, knx: KNXTestKit):
     knx.assert_state("light.test", STATE_ON, brightness=128, xy_color=(0.18, 0.25))
 
 
-async def test_light_xyy_color_with_brightness(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_xyy_color_with_brightness(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test KNX light with xyy color and explicit brightness address."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -496,7 +498,7 @@ async def test_light_xyy_color_with_brightness(hass: HomeAssistant, knx: KNXTest
     knx.assert_state("light.test", STATE_ON, brightness=21, xy_color=(0.52, 0.31))
 
 
-async def test_light_rgb_individual(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_rgb_individual(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with rgb color in individual GAs."""
     test_red = "1/1/3"
     test_red_state = "1/1/4"
@@ -642,7 +644,7 @@ async def test_light_rgb_individual(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write(test_blue, (45,))
 
 
-async def test_light_rgbw_individual(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_rgbw_individual(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with rgbw color in individual GAs."""
     test_red = "1/1/3"
     test_red_state = "1/1/4"
@@ -820,7 +822,7 @@ async def test_light_rgbw_individual(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_write(test_white, (45,))
 
 
-async def test_light_rgb(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_rgb(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with rgb color."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -928,7 +930,7 @@ async def test_light_rgb(hass: HomeAssistant, knx: KNXTestKit):
     knx.assert_state("light.test", STATE_ON, brightness=180, rgb_color=(0, 255, 0))
 
 
-async def test_light_rgbw(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_rgbw(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with rgbw color."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"
@@ -1039,7 +1041,7 @@ async def test_light_rgbw(hass: HomeAssistant, knx: KNXTestKit):
     knx.assert_state("light.test", STATE_ON, brightness=180, rgbw_color=(0, 255, 0, 0))
 
 
-async def test_light_rgbw_brightness(hass: HomeAssistant, knx: KNXTestKit):
+async def test_light_rgbw_brightness(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX light with rgbw color with dedicated brightness."""
     test_address = "1/1/1"
     test_address_state = "1/1/2"

--- a/tests/components/knx/test_notify.py
+++ b/tests/components/knx/test_notify.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import KNXTestKit
 
 
-async def test_notify_simple(hass: HomeAssistant, knx: KNXTestKit):
+async def test_notify_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX notify can send to one device."""
     await knx.setup_integration(
         {
@@ -77,7 +77,7 @@ async def test_notify_simple(hass: HomeAssistant, knx: KNXTestKit):
 
 async def test_notify_multiple_sends_to_all_with_different_encodings(
     hass: HomeAssistant, knx: KNXTestKit
-):
+) -> None:
     """Test KNX notify `type` configuration."""
     await knx.setup_integration(
         {

--- a/tests/components/knx/test_number.py
+++ b/tests/components/knx/test_number.py
@@ -11,7 +11,7 @@ from .conftest import KNXTestKit
 from tests.common import mock_restore_cache_with_extra_data
 
 
-async def test_number_set_value(hass: HomeAssistant, knx: KNXTestKit):
+async def test_number_set_value(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX number with passive_address and respond_to_read restoring state."""
     test_address = "1/1/1"
     await knx.setup_integration(
@@ -60,7 +60,7 @@ async def test_number_set_value(hass: HomeAssistant, knx: KNXTestKit):
     assert state.state == "90"
 
 
-async def test_number_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit):
+async def test_number_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX number with passive_address and respond_to_read restoring state."""
     test_address = "1/1/1"
     test_passive_address = "3/3/3"

--- a/tests/components/knx/test_scene.py
+++ b/tests/components/knx/test_scene.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from .conftest import KNXTestKit
 
 
-async def test_activate_knx_scene(hass: HomeAssistant, knx: KNXTestKit):
+async def test_activate_knx_scene(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX scene."""
     await knx.setup_integration(
         {

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -18,7 +18,7 @@ from .conftest import KNXTestKit
 from tests.common import mock_restore_cache
 
 
-async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit):
+async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test simple KNX select."""
     _options = [
         {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
@@ -88,7 +88,7 @@ async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_no_telegram()
 
 
-async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit):
+async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX select with passive_address and respond_to_read restoring state."""
     _options = [
         {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
@@ -125,7 +125,9 @@ async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_no_telegram()
 
 
-async def test_select_dpt_20_103_all_options(hass: HomeAssistant, knx: KNXTestKit):
+async def test_select_dpt_20_103_all_options(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
     """Test KNX select with state_address, passive_address and respond_to_read."""
     _options = [
         {CONF_PAYLOAD: 0, SelectSchema.CONF_OPTION: "Auto"},

--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -9,7 +9,7 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events
 
 
-async def test_sensor(hass: HomeAssistant, knx: KNXTestKit):
+async def test_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test simple KNX sensor."""
 
     await knx.setup_integration(
@@ -41,7 +41,7 @@ async def test_sensor(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_no_telegram()
 
 
-async def test_always_callback(hass: HomeAssistant, knx: KNXTestKit):
+async def test_always_callback(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX sensor with always_callback."""
 
     events = async_capture_events(hass, "state_changed")

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -104,7 +104,7 @@ async def test_send(
     service_payload,
     expected_telegrams,
     expected_apci,
-):
+) -> None:
     """Test `knx.send` service."""
     await knx.setup_integration({})
 
@@ -120,7 +120,7 @@ async def test_send(
         await knx.assert_telegram(group_address, payload, expected_apci)
 
 
-async def test_read(hass: HomeAssistant, knx: KNXTestKit):
+async def test_read(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test `knx.read` service."""
     await knx.setup_integration({})
 
@@ -140,7 +140,7 @@ async def test_read(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_read("3/3/3")
 
 
-async def test_event_register(hass: HomeAssistant, knx: KNXTestKit):
+async def test_event_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test `knx.event_register` service."""
     events = async_capture_events(hass, "knx_event")
     test_address = "1/2/3"
@@ -193,7 +193,7 @@ async def test_event_register(hass: HomeAssistant, knx: KNXTestKit):
     assert untyped_event_1.data["value"] is None
 
 
-async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit):
+async def test_exposure_register(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test `knx.exposure_register` service."""
     test_address = "1/2/3"
     test_entity = "fake.entity"

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -13,7 +13,7 @@ from .conftest import KNXTestKit
 from tests.common import mock_restore_cache
 
 
-async def test_switch_simple(hass: HomeAssistant, knx: KNXTestKit):
+async def test_switch_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test simple KNX switch."""
     await knx.setup_integration(
         {
@@ -52,7 +52,7 @@ async def test_switch_simple(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit):
+async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX switch with state_address."""
     _ADDRESS = "1/1/1"
     _STATE_ADDRESS = "2/2/2"
@@ -111,7 +111,7 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_telegram_count(0)
 
 
-async def test_switch_restore_and_respond(hass, knx):
+async def test_switch_restore_and_respond(hass: HomeAssistant, knx) -> None:
     """Test restoring KNX switch state and respond to read."""
     _ADDRESS = "1/1/1"
     fake_state = State("switch.test", "on")

--- a/tests/components/knx/test_text.py
+++ b/tests/components/knx/test_text.py
@@ -9,7 +9,7 @@ from .conftest import KNXTestKit
 from tests.common import mock_restore_cache
 
 
-async def test_text(hass: HomeAssistant, knx: KNXTestKit):
+async def test_text(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX text."""
     test_address = "1/1/1"
     await knx.setup_integration(
@@ -58,7 +58,7 @@ async def test_text(hass: HomeAssistant, knx: KNXTestKit):
     assert state.state == "hallo"
 
 
-async def test_text_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit):
+async def test_text_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX text with passive_address, restoring state and respond_to_read."""
     test_address = "1/1/1"
     test_passive_address = "3/3/3"

--- a/tests/components/knx/test_weather.py
+++ b/tests/components/knx/test_weather.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import KNXTestKit
 
 
-async def test_weather(hass: HomeAssistant, knx: KNXTestKit):
+async def test_weather(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX weather."""
 
     await knx.setup_integration(

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -39,7 +39,7 @@ async def user_flow(hass):
     return result["flow_id"]
 
 
-async def test_user_flow(hass, user_flow):
+async def test_user_flow(hass: HomeAssistant, user_flow) -> None:
     """Test a successful user initiated flow."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -68,7 +68,7 @@ async def test_user_flow(hass, user_flow):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_valid_auth(hass, user_flow):
+async def test_form_valid_auth(hass: HomeAssistant, user_flow) -> None:
     """Test we handle valid auth."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -111,7 +111,7 @@ async def test_form_valid_auth(hass, user_flow):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_valid_ws_port(hass, user_flow):
+async def test_form_valid_ws_port(hass: HomeAssistant, user_flow) -> None:
     """Test we handle valid websocket port."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -159,7 +159,7 @@ async def test_form_valid_ws_port(hass, user_flow):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_empty_ws_port(hass, user_flow):
+async def test_form_empty_ws_port(hass: HomeAssistant, user_flow) -> None:
     """Test we handle an empty websocket port input."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -201,7 +201,7 @@ async def test_form_empty_ws_port(hass, user_flow):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass, user_flow):
+async def test_form_invalid_auth(hass: HomeAssistant, user_flow) -> None:
     """Test we handle invalid auth."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -281,7 +281,7 @@ async def test_form_invalid_auth(hass, user_flow):
     assert result["errors"] == {}
 
 
-async def test_form_cannot_connect_http(hass, user_flow):
+async def test_form_cannot_connect_http(hass: HomeAssistant, user_flow) -> None:
     """Test we handle cannot connect over HTTP error."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -297,7 +297,7 @@ async def test_form_cannot_connect_http(hass, user_flow):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_exception_http(hass, user_flow):
+async def test_form_exception_http(hass: HomeAssistant, user_flow) -> None:
     """Test we handle generic exception over HTTP."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -313,7 +313,7 @@ async def test_form_exception_http(hass, user_flow):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_form_cannot_connect_ws(hass, user_flow):
+async def test_form_cannot_connect_ws(hass: HomeAssistant, user_flow) -> None:
     """Test we handle cannot connect over WebSocket error."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -365,7 +365,7 @@ async def test_form_cannot_connect_ws(hass, user_flow):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_exception_ws(hass, user_flow):
+async def test_form_exception_ws(hass: HomeAssistant, user_flow) -> None:
     """Test we handle generic exception over WebSocket."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",
@@ -486,7 +486,7 @@ async def test_discovery_cannot_connect_ws(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_discovery_exception_http(hass, user_flow):
+async def test_discovery_exception_http(hass: HomeAssistant, user_flow) -> None:
     """Test we handle generic exception during discovery validation."""
     with patch(
         "homeassistant.components.kodi.config_flow.Kodi.ping",

--- a/tests/components/kodi/test_device_trigger.py
+++ b/tests/components/kodi/test_device_trigger.py
@@ -5,6 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.kodi import DOMAIN
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import init_integration
@@ -30,7 +32,11 @@ async def kodi_media_player(hass):
     return f"{MP_DOMAIN}.name"
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a kodi."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={})
     config_entry.add_to_hass(hass)
@@ -63,7 +69,9 @@ async def test_get_triggers(hass, device_registry, entity_registry):
         assert trigger in expected_triggers or trigger["domain"] == "media_player"
 
 
-async def test_if_fires_on_state_change(hass, calls, kodi_media_player):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, kodi_media_player
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     assert await async_setup_component(
         hass,

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import konnected, ssdp
 from homeassistant.components.konnected import config_flow
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -26,7 +27,7 @@ async def mock_panel_fixture():
         yield konn_client
 
 
-async def test_flow_works(hass, mock_panel):
+async def test_flow_works(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow ."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -63,7 +64,7 @@ async def test_flow_works(hass, mock_panel):
     )
 
 
-async def test_pro_flow_works(hass, mock_panel):
+async def test_pro_flow_works(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow ."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -102,7 +103,7 @@ async def test_pro_flow_works(hass, mock_panel):
     )
 
 
-async def test_ssdp(hass, mock_panel):
+async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     """Test a panel being discovered."""
     mock_panel.get_status.return_value = {
         "mac": "11:22:33:44:55:66",
@@ -229,7 +230,7 @@ async def test_ssdp(hass, mock_panel):
     assert result["reason"] == "already_configured"
 
 
-async def test_import_no_host_user_finish(hass, mock_panel):
+async def test_import_no_host_user_finish(hass: HomeAssistant, mock_panel) -> None:
     """Test importing a panel with no host info."""
     mock_panel.get_status.return_value = {
         "mac": "aa:bb:cc:dd:ee:ff",
@@ -295,7 +296,7 @@ async def test_import_no_host_user_finish(hass, mock_panel):
     assert result["type"] == "create_entry"
 
 
-async def test_import_ssdp_host_user_finish(hass, mock_panel):
+async def test_import_ssdp_host_user_finish(hass: HomeAssistant, mock_panel) -> None:
     """Test importing a pro panel with no host info which ssdp discovers."""
     mock_panel.get_status.return_value = {
         "chipId": "somechipid",
@@ -372,7 +373,7 @@ async def test_import_ssdp_host_user_finish(hass, mock_panel):
     assert result["type"] == "create_entry"
 
 
-async def test_ssdp_already_configured(hass, mock_panel):
+async def test_ssdp_already_configured(hass: HomeAssistant, mock_panel) -> None:
     """Test if a discovered panel has already been configured."""
     MockConfigEntry(
         domain="konnected",
@@ -401,7 +402,7 @@ async def test_ssdp_already_configured(hass, mock_panel):
     assert result["reason"] == "already_configured"
 
 
-async def test_ssdp_host_update(hass, mock_panel):
+async def test_ssdp_host_update(hass: HomeAssistant, mock_panel) -> None:
     """Test if a discovered panel has already been configured but changed host."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -486,7 +487,7 @@ async def test_ssdp_host_update(hass, mock_panel):
     assert entry.data["access_token"] == "11223344556677889900"
 
 
-async def test_import_existing_config(hass, mock_panel):
+async def test_import_existing_config(hass: HomeAssistant, mock_panel) -> None:
     """Test importing a host with an existing config file."""
     mock_panel.get_status.return_value = {
         "mac": "11:22:33:44:55:66",
@@ -605,7 +606,7 @@ async def test_import_existing_config(hass, mock_panel):
     }
 
 
-async def test_import_existing_config_entry(hass, mock_panel):
+async def test_import_existing_config_entry(hass: HomeAssistant, mock_panel) -> None:
     """Test importing a host that has an existing config entry."""
     MockConfigEntry(
         domain="konnected",
@@ -677,7 +678,7 @@ async def test_import_existing_config_entry(hass, mock_panel):
     }
 
 
-async def test_import_pin_config(hass, mock_panel):
+async def test_import_pin_config(hass: HomeAssistant, mock_panel) -> None:
     """Test importing a host with an existing config file that specifies pin configs."""
     mock_panel.get_status.return_value = {
         "mac": "11:22:33:44:55:66",
@@ -774,7 +775,7 @@ async def test_import_pin_config(hass, mock_panel):
     }
 
 
-async def test_option_flow(hass, mock_panel):
+async def test_option_flow(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow options."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -960,7 +961,7 @@ async def test_option_flow(hass, mock_panel):
     }
 
 
-async def test_option_flow_pro(hass, mock_panel):
+async def test_option_flow_pro(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow options for pro board."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -1146,7 +1147,7 @@ async def test_option_flow_pro(hass, mock_panel):
     }
 
 
-async def test_option_flow_import(hass, mock_panel):
+async def test_option_flow_import(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow options imported from configuration.yaml."""
     device_options = config_flow.OPTIONS_SCHEMA(
         {
@@ -1298,7 +1299,7 @@ async def test_option_flow_import(hass, mock_panel):
     }
 
 
-async def test_option_flow_existing(hass, mock_panel):
+async def test_option_flow_existing(hass: HomeAssistant, mock_panel) -> None:
     """Test config flow options with existing already in place."""
     device_options = config_flow.OPTIONS_SCHEMA(
         {

--- a/tests/components/konnected/test_init.py
+++ b/tests/components/konnected/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(name="mock_panel")
@@ -233,7 +234,7 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     assert konnected.YAML_CONFIGS not in hass.data[konnected.DOMAIN]
 
 
-async def test_setup_defined_hosts_known_auth(hass, mock_panel):
+async def test_setup_defined_hosts_known_auth(hass: HomeAssistant, mock_panel) -> None:
     """Test we don't initiate a config entry if configured panel is known."""
     MockConfigEntry(
         domain="konnected",
@@ -386,7 +387,7 @@ async def test_config_passed_to_config_entry(hass: HomeAssistant) -> None:
     assert p_entry is entry
 
 
-async def test_unload_entry(hass, mock_panel):
+async def test_unload_entry(hass: HomeAssistant, mock_panel) -> None:
     """Test being able to unload an entry."""
     await async_process_ha_core_config(
         hass,
@@ -403,7 +404,9 @@ async def test_unload_entry(hass, mock_panel):
     assert hass.data[konnected.DOMAIN]["devices"] == {}
 
 
-async def test_api(hass, hass_client_no_auth, mock_panel):
+async def test_api(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, mock_panel
+) -> None:
     """Test callback view."""
     await async_setup_component(hass, "http", {"http": {}})
 
@@ -570,7 +573,9 @@ async def test_api(hass, hass_client_no_auth, mock_panel):
     assert result == {"message": "ok"}
 
 
-async def test_state_updates_zone(hass, hass_client_no_auth, mock_panel):
+async def test_state_updates_zone(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, mock_panel
+) -> None:
     """Test callback view."""
     await async_process_ha_core_config(
         hass,
@@ -721,7 +726,9 @@ async def test_state_updates_zone(hass, hass_client_no_auth, mock_panel):
     assert hass.states.get("sensor.temper_temperature").state == "42.0"
 
 
-async def test_state_updates_pin(hass, hass_client_no_auth, mock_panel):
+async def test_state_updates_pin(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, mock_panel
+) -> None:
     """Test callback view."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/konnected/test_panel.py
+++ b/tests/components/konnected/test_panel.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.konnected import config_flow, panel
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
 from homeassistant.util import utcnow
@@ -43,7 +44,7 @@ async def mock_panel_fixture():
         yield konn_client
 
 
-async def test_create_and_setup(hass, mock_panel):
+async def test_create_and_setup(hass: HomeAssistant, mock_panel) -> None:
     """Test that we create a Konnected Panel and save the data."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -217,7 +218,7 @@ async def test_create_and_setup(hass, mock_panel):
     }
 
 
-async def test_create_and_setup_pro(hass, mock_panel):
+async def test_create_and_setup_pro(hass: HomeAssistant, mock_panel) -> None:
     """Test that we create a Konnected Pro Panel and save the data."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -413,7 +414,7 @@ async def test_create_and_setup_pro(hass, mock_panel):
     }
 
 
-async def test_default_options(hass, mock_panel):
+async def test_default_options(hass: HomeAssistant, mock_panel) -> None:
     """Test that we create a Konnected Panel and save the data."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {
@@ -590,7 +591,7 @@ async def test_default_options(hass, mock_panel):
     }
 
 
-async def test_connect_retry(hass, mock_panel):
+async def test_connect_retry(hass: HomeAssistant, mock_panel) -> None:
     """Test that we create a Konnected Panel and save the data."""
     device_config = config_flow.CONFIG_ENTRY_SCHEMA(
         {

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -91,7 +91,7 @@ async def test_setup_all_entries(
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
-):
+) -> None:
     """Test if all available entries are setup."""
 
     mock_config_entry.add_to_hass(hass)
@@ -110,7 +110,7 @@ async def test_setup_no_entries(
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
-):
+) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
     mock_plenticore_client.get_settings.return_value = []
@@ -131,7 +131,7 @@ async def test_number_has_value(
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
-):
+) -> None:
     """Test if number has a value if data is provided on update."""
 
     mock_get_setting_values.append({"devices:local": {"Battery:MinSoc": "42"}})
@@ -156,7 +156,7 @@ async def test_number_is_unavailable(
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
-):
+) -> None:
     """Test if number is unavailable if no data is provided on update."""
 
     mock_config_entry.add_to_hass(hass)
@@ -177,7 +177,7 @@ async def test_set_value(
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
     entity_registry_enabled_by_default,
-):
+) -> None:
     """Test if a new value could be set."""
 
     mock_get_setting_values.append({"devices:local": {"Battery:MinSoc": "42"}})

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 import homeassistant.util.dt as dt_util
 
@@ -62,7 +63,7 @@ async def mock_light(hass, mock_entry):
         yield light
 
 
-async def test_init(hass, mock_light):
+async def test_init(hass: HomeAssistant, mock_light) -> None:
     """Test platform setup."""
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_OFF
@@ -79,7 +80,7 @@ async def test_init(hass, mock_light):
     assert mock_light.disconnect.called
 
 
-async def test_remove_entry(hass, mock_light, mock_entry):
+async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None:
     """Test platform setup."""
     assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:11:22:33"}
     assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
@@ -90,7 +91,9 @@ async def test_remove_entry(hass, mock_light, mock_entry):
     assert DOMAIN not in hass.data
 
 
-async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
+async def test_remove_entry_exceptions_caught(
+    hass: HomeAssistant, mock_light, mock_entry
+) -> None:
     """Assert that disconnect exceptions are caught."""
     mock_light.disconnect.side_effect = pykulersky.PykulerskyException("Mock error")
     await hass.config_entries.async_remove(mock_entry.entry_id)
@@ -98,7 +101,7 @@ async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
     assert mock_light.disconnect.called
 
 
-async def test_update_exception(hass, mock_light):
+async def test_update_exception(hass: HomeAssistant, mock_light) -> None:
     """Test platform setup."""
 
     mock_light.get_color.side_effect = pykulersky.PykulerskyException
@@ -108,7 +111,7 @@ async def test_update_exception(hass, mock_light):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_light_turn_on(hass, mock_light):
+async def test_light_turn_on(hass: HomeAssistant, mock_light) -> None:
     """Test KulerSkyLight turn_on."""
     mock_light.get_color.return_value = (255, 255, 255, 255)
     await hass.services.async_call(
@@ -165,7 +168,7 @@ async def test_light_turn_on(hass, mock_light):
     mock_light.set_color.assert_called_with(50, 41, 0, 50)
 
 
-async def test_light_turn_off(hass, mock_light):
+async def test_light_turn_off(hass: HomeAssistant, mock_light) -> None:
     """Test KulerSkyLight turn_on."""
     mock_light.get_color.return_value = (0, 0, 0, 0)
     await hass.services.async_call(
@@ -178,7 +181,7 @@ async def test_light_turn_off(hass, mock_light):
     mock_light.set_color.assert_called_with(0, 0, 0, 0)
 
 
-async def test_light_update(hass, mock_light):
+async def test_light_update(hass: HomeAssistant, mock_light) -> None:
     """Test KulerSkyLight update."""
     utcnow = dt_util.utcnow()
 

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -44,7 +44,9 @@ async def test_entities_added(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.test_temperature")
 
 
-async def test_sensor_permission(hass: HomeAssistant, caplog) -> None:
+async def test_sensor_permission(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if it raises a warning when there is no permission to read the sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY_DATA)
     config_entry.add_to_hass(hass)
@@ -63,7 +65,9 @@ async def test_sensor_permission(hass: HomeAssistant, caplog) -> None:
     assert "This account does not have permission to read Test" in caplog.text
 
 
-async def test_field_not_supported(hass: HomeAssistant, caplog) -> None:
+async def test_field_not_supported(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test if it raises a warning when the field is not supported."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY_DATA)
     config_entry.add_to_hass(hass)

--- a/tests/components/landisgyr_heat_meter/test_init.py
+++ b/tests/components/landisgyr_heat_meter/test_init.py
@@ -1,11 +1,11 @@
 """Test the Landis + Gyr Heat Meter init."""
-
 from unittest.mock import patch
 
 from homeassistant.components.landisgyr_heat_meter.const import (
     DOMAIN as LANDISGYR_HEAT_METER_DOMAIN,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
@@ -16,7 +16,7 @@ API_HEAT_METER_SERVICE = (
 
 
 @patch(API_HEAT_METER_SERVICE)
-async def test_unload_entry(_, hass):
+async def test_unload_entry(_, hass: HomeAssistant) -> None:
     """Test removing config entry."""
     mock_entry_data = {
         "device": "/dev/USB0",
@@ -39,7 +39,7 @@ async def test_unload_entry(_, hass):
 
 
 @patch(API_HEAT_METER_SERVICE)
-async def test_migrate_entry(_, hass):
+async def test_migrate_entry(_, hass: HomeAssistant) -> None:
     """Test successful migration of entry data from version 1 to 2."""
 
     mock_entry_data = {

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfVolume,
 )
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -43,7 +43,7 @@ class MockHeatMeterResponse:
 
 
 @patch("homeassistant.components.landisgyr_heat_meter.ultraheat_api.HeatMeterService")
-async def test_create_sensors(mock_heat_meter, hass):
+async def test_create_sensors(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test sensor."""
     entry_data = {
         "device": "/dev/USB0",
@@ -108,7 +108,7 @@ async def test_create_sensors(mock_heat_meter, hass):
 
 
 @patch("homeassistant.components.landisgyr_heat_meter.ultraheat_api.HeatMeterService")
-async def test_restore_state(mock_heat_meter, hass):
+async def test_restore_state(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test sensor restore state."""
     # Home assistant is not running yet
     hass.state = CoreState.not_running


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
