### PR TITLE
Add type hints to integration tests (part 13)

### DIFF
--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components import sensor
 from homeassistant.components.lastfm.sensor import STATE_NOT_SCROBBLING
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -51,7 +52,7 @@ def lastfm_network_fixture():
         yield lastfm_network
 
 
-async def test_update_not_playing(hass, lastfm_network):
+async def test_update_not_playing(hass: HomeAssistant, lastfm_network) -> None:
     """Test update when no playing song."""
 
     lastfm_network.return_value.get_user.return_value = MockUser(None)
@@ -70,7 +71,7 @@ async def test_update_not_playing(hass, lastfm_network):
     assert state.state == STATE_NOT_SCROBBLING
 
 
-async def test_update_playing(hass, lastfm_network):
+async def test_update_playing(hass: HomeAssistant, lastfm_network) -> None:
     """Test update when song playing."""
 
     lastfm_network.return_value.get_user.return_value = MockUser(

--- a/tests/components/laundrify/test_config_flow.py
+++ b/tests/components/laundrify/test_config_flow.py
@@ -63,7 +63,9 @@ async def test_form_invalid_auth(hass: HomeAssistant, laundrify_exchange_code) -
     assert result["errors"] == {CONF_CODE: "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass: HomeAssistant, laundrify_exchange_code):
+async def test_form_cannot_connect(
+    hass: HomeAssistant, laundrify_exchange_code
+) -> None:
     """Test we handle cannot connect error."""
     laundrify_exchange_code.side_effect = exceptions.ApiConnectionException
     result = await hass.config_entries.flow.async_init(
@@ -76,7 +78,9 @@ async def test_form_cannot_connect(hass: HomeAssistant, laundrify_exchange_code)
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unkown_exception(hass: HomeAssistant, laundrify_exchange_code):
+async def test_form_unkown_exception(
+    hass: HomeAssistant, laundrify_exchange_code
+) -> None:
     """Test we handle all other errors."""
     laundrify_exchange_code.side_effect = Exception
     result = await hass.config_entries.flow.async_init(
@@ -107,7 +111,7 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.FORM
 
 
-async def test_integration_already_exists(hass: HomeAssistant):
+async def test_integration_already_exists(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     create_entry(hass)
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/laundrify/test_coordinator.py
+++ b/tests/components/laundrify/test_coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from . import create_entry
 
 
-async def test_coordinator_update_success(hass: HomeAssistant):
+async def test_coordinator_update_success(hass: HomeAssistant) -> None:
     """Test the coordinator update is performed successfully."""
     config_entry = create_entry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -20,7 +20,9 @@ async def test_coordinator_update_success(hass: HomeAssistant):
     assert coordinator.last_update_success
 
 
-async def test_coordinator_update_unauthorized(hass: HomeAssistant, laundrify_api_mock):
+async def test_coordinator_update_unauthorized(
+    hass: HomeAssistant, laundrify_api_mock
+) -> None:
     """Test the coordinator update fails if an UnauthorizedException is thrown."""
     config_entry = create_entry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -36,7 +38,7 @@ async def test_coordinator_update_unauthorized(hass: HomeAssistant, laundrify_ap
 
 async def test_coordinator_update_connection_failed(
     hass: HomeAssistant, laundrify_api_mock
-):
+) -> None:
     """Test the coordinator update fails if an ApiConnectionException is thrown."""
     config_entry = create_entry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/laundrify/test_init.py
+++ b/tests/components/laundrify/test_init.py
@@ -11,7 +11,7 @@ from . import create_entry
 
 async def test_setup_entry_api_unauthorized(
     hass: HomeAssistant, laundrify_validate_token
-):
+) -> None:
     """Test that ConfigEntryAuthFailed is thrown when authentication fails."""
     laundrify_validate_token.side_effect = exceptions.UnauthorizedException
     config_entry = create_entry(hass)
@@ -26,7 +26,7 @@ async def test_setup_entry_api_unauthorized(
 
 async def test_setup_entry_api_cannot_connect(
     hass: HomeAssistant, laundrify_validate_token
-):
+) -> None:
     """Test that ApiConnectionException is thrown when connection fails."""
     laundrify_validate_token.side_effect = exceptions.ApiConnectionException
     config_entry = create_entry(hass)
@@ -39,7 +39,7 @@ async def test_setup_entry_api_cannot_connect(
     assert not hass.data.get(DOMAIN)
 
 
-async def test_setup_entry_successful(hass: HomeAssistant):
+async def test_setup_entry_successful(hass: HomeAssistant) -> None:
     """Test entry can be setup successfully."""
     config_entry = create_entry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -49,7 +49,7 @@ async def test_setup_entry_successful(hass: HomeAssistant):
     assert config_entry.state == ConfigEntryState.LOADED
 
 
-async def test_setup_entry_unload(hass: HomeAssistant):
+async def test_setup_entry_unload(hass: HomeAssistant) -> None:
     """Test unloading the laundrify entry."""
     config_entry = create_entry(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/lcn/test_binary_sensor.py
+++ b/tests/components/lcn/test_binary_sensor.py
@@ -5,6 +5,7 @@ from pypck.lcn_defs import Var, VarValue
 
 from homeassistant.components.lcn.helpers import get_device_connection
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 BINARY_SENSOR_LOCKREGULATOR1 = "binary_sensor.sensor_lockregulator1"
@@ -12,7 +13,7 @@ BINARY_SENSOR_SENSOR1 = "binary_sensor.binary_sensor1"
 BINARY_SENSOR_KEYLOCK = "binary_sensor.sensor_keylock"
 
 
-async def test_setup_lcn_binary_sensor(hass, lcn_connection):
+async def test_setup_lcn_binary_sensor(hass: HomeAssistant, lcn_connection) -> None:
     """Test the setup of binary sensor."""
     for entity_id in (
         BINARY_SENSOR_LOCKREGULATOR1,
@@ -24,7 +25,7 @@ async def test_setup_lcn_binary_sensor(hass, lcn_connection):
         assert state.state == STATE_UNKNOWN
 
 
-async def test_entity_state(hass, lcn_connection):
+async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     """Test state of entity."""
     state = hass.states.get(BINARY_SENSOR_LOCKREGULATOR1)
     assert state
@@ -36,7 +37,7 @@ async def test_entity_state(hass, lcn_connection):
     assert state
 
 
-async def test_entity_attributes(hass, entry, lcn_connection):
+async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the attributes of an entity."""
     entity_registry = er.async_get(hass)
 
@@ -56,7 +57,9 @@ async def test_entity_attributes(hass, entry, lcn_connection):
     assert entity_keylock.original_name == "Sensor_KeyLock"
 
 
-async def test_pushed_lock_setpoint_status_change(hass, entry, lcn_connection):
+async def test_pushed_lock_setpoint_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the lock setpoint sensor changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -80,7 +83,9 @@ async def test_pushed_lock_setpoint_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_pushed_binsensor_status_change(hass, entry, lcn_connection):
+async def test_pushed_binsensor_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the binary port sensor changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -106,7 +111,9 @@ async def test_pushed_binsensor_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_ON
 
 
-async def test_pushed_keylock_status_change(hass, entry, lcn_connection):
+async def test_pushed_keylock_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the keylock sensor changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -132,7 +139,7 @@ async def test_pushed_keylock_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_ON
 
 
-async def test_unload_config_entry(hass, entry, lcn_connection):
+async def test_unload_config_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the binary sensor is removed when the config entry is unloaded."""
     await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get(BINARY_SENSOR_LOCKREGULATOR1).state == STATE_UNAVAILABLE

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -80,7 +80,7 @@ async def test_step_import_existing_host(hass: HomeAssistant) -> None:
         (TimeoutError, "connection_timeout"),
     ],
 )
-async def test_step_import_error(hass, error, reason):
+async def test_step_import_error(hass: HomeAssistant, error, reason) -> None:
     """Test for error in import is handled correctly."""
     with patch(
         "pypck.connection.PchkConnectionManager.async_connect", side_effect=error

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
@@ -26,7 +27,7 @@ COVER_OUTPUTS = "cover.cover_outputs"
 COVER_RELAYS = "cover.cover_relays"
 
 
-async def test_setup_lcn_cover(hass, entry, lcn_connection):
+async def test_setup_lcn_cover(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the setup of cover."""
     for entity_id in (
         COVER_OUTPUTS,
@@ -37,7 +38,7 @@ async def test_setup_lcn_cover(hass, entry, lcn_connection):
         assert state.state == STATE_OPEN
 
 
-async def test_entity_attributes(hass, entry, lcn_connection):
+async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the attributes of an entity."""
     entity_registry = er.async_get(hass)
 
@@ -55,7 +56,9 @@ async def test_entity_attributes(hass, entry, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_outputs")
-async def test_outputs_open(control_motors_outputs, hass, lcn_connection):
+async def test_outputs_open(
+    control_motors_outputs, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the outputs cover opens."""
     state = hass.states.get(COVER_OUTPUTS)
     state.state = STATE_CLOSED
@@ -99,7 +102,9 @@ async def test_outputs_open(control_motors_outputs, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_outputs")
-async def test_outputs_close(control_motors_outputs, hass, lcn_connection):
+async def test_outputs_close(
+    control_motors_outputs, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the outputs cover closes."""
     state = hass.states.get(COVER_OUTPUTS)
     state.state = STATE_OPEN
@@ -143,7 +148,9 @@ async def test_outputs_close(control_motors_outputs, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_outputs")
-async def test_outputs_stop(control_motors_outputs, hass, lcn_connection):
+async def test_outputs_stop(
+    control_motors_outputs, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the outputs cover stops."""
     state = hass.states.get(COVER_OUTPUTS)
     state.state = STATE_CLOSING
@@ -183,7 +190,9 @@ async def test_outputs_stop(control_motors_outputs, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_relays")
-async def test_relays_open(control_motors_relays, hass, lcn_connection):
+async def test_relays_open(
+    control_motors_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relays cover opens."""
     states = [MotorStateModifier.NOCHANGE] * 4
     states[0] = MotorStateModifier.UP
@@ -226,7 +235,9 @@ async def test_relays_open(control_motors_relays, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_relays")
-async def test_relays_close(control_motors_relays, hass, lcn_connection):
+async def test_relays_close(
+    control_motors_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relays cover closes."""
     states = [MotorStateModifier.NOCHANGE] * 4
     states[0] = MotorStateModifier.DOWN
@@ -269,7 +280,9 @@ async def test_relays_close(control_motors_relays, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_motors_relays")
-async def test_relays_stop(control_motors_relays, hass, lcn_connection):
+async def test_relays_stop(
+    control_motors_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relays cover stops."""
     states = [MotorStateModifier.NOCHANGE] * 4
     states[0] = MotorStateModifier.STOP
@@ -311,7 +324,9 @@ async def test_relays_stop(control_motors_relays, hass, lcn_connection):
     assert state.state not in (STATE_CLOSING, STATE_OPENING)
 
 
-async def test_pushed_outputs_status_change(hass, entry, lcn_connection):
+async def test_pushed_outputs_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the outputs cover changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -347,7 +362,9 @@ async def test_pushed_outputs_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_CLOSING
 
 
-async def test_pushed_relays_status_change(hass, entry, lcn_connection):
+async def test_pushed_relays_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the relays cover changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -387,7 +404,7 @@ async def test_pushed_relays_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_CLOSING
 
 
-async def test_unload_config_entry(hass, entry, lcn_connection):
+async def test_unload_config_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the cover is removed when the config entry is unloaded."""
     await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get(COVER_OUTPUTS).state == STATE_UNAVAILABLE

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.lcn import device_trigger
 from homeassistant.components.lcn.const import DOMAIN, KEY_ACTIONS, SENDKEYS
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -17,7 +18,9 @@ from .conftest import get_device
 from tests.common import assert_lists_same, async_get_device_automations
 
 
-async def test_get_triggers_module_device(hass, entry, lcn_connection):
+async def test_get_triggers_module_device(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected triggers from a LCN module device."""
     device = get_device(hass, entry, (0, 7, False))
 
@@ -44,7 +47,9 @@ async def test_get_triggers_module_device(hass, entry, lcn_connection):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_non_module_device(hass, entry, lcn_connection):
+async def test_get_triggers_non_module_device(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected triggers from a LCN non-module device."""
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
@@ -63,7 +68,9 @@ async def test_get_triggers_non_module_device(hass, entry, lcn_connection):
             assert trigger[CONF_TYPE] not in not_included_types
 
 
-async def test_if_fires_on_transponder_event(hass, calls, entry, lcn_connection):
+async def test_if_fires_on_transponder_event(
+    hass: HomeAssistant, calls, entry, lcn_connection
+) -> None:
     """Test for transponder event triggers firing."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -108,7 +115,9 @@ async def test_if_fires_on_transponder_event(hass, calls, entry, lcn_connection)
     }
 
 
-async def test_if_fires_on_fingerprint_event(hass, calls, entry, lcn_connection):
+async def test_if_fires_on_fingerprint_event(
+    hass: HomeAssistant, calls, entry, lcn_connection
+) -> None:
     """Test for fingerprint event triggers firing."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -153,7 +162,9 @@ async def test_if_fires_on_fingerprint_event(hass, calls, entry, lcn_connection)
     }
 
 
-async def test_if_fires_on_codelock_event(hass, calls, entry, lcn_connection):
+async def test_if_fires_on_codelock_event(
+    hass: HomeAssistant, calls, entry, lcn_connection
+) -> None:
     """Test for codelock event triggers firing."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -198,7 +209,9 @@ async def test_if_fires_on_codelock_event(hass, calls, entry, lcn_connection):
     }
 
 
-async def test_if_fires_on_transmitter_event(hass, calls, entry, lcn_connection):
+async def test_if_fires_on_transmitter_event(
+    hass: HomeAssistant, calls, entry, lcn_connection
+) -> None:
     """Test for transmitter event triggers firing."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -252,7 +265,9 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry, lcn_connection)
     }
 
 
-async def test_if_fires_on_send_keys_event(hass, calls, entry, lcn_connection):
+async def test_if_fires_on_send_keys_event(
+    hass: HomeAssistant, calls, entry, lcn_connection
+) -> None:
     """Test for send_keys event triggers firing."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -299,7 +314,9 @@ async def test_if_fires_on_send_keys_event(hass, calls, entry, lcn_connection):
     }
 
 
-async def test_get_transponder_trigger_capabilities(hass, entry, lcn_connection):
+async def test_get_transponder_trigger_capabilities(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected capabilities from a transponder device trigger."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -320,7 +337,9 @@ async def test_get_transponder_trigger_capabilities(hass, entry, lcn_connection)
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-async def test_get_fingerprint_trigger_capabilities(hass, entry, lcn_connection):
+async def test_get_fingerprint_trigger_capabilities(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected capabilities from a fingerprint device trigger."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -341,7 +360,9 @@ async def test_get_fingerprint_trigger_capabilities(hass, entry, lcn_connection)
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-async def test_get_transmitter_trigger_capabilities(hass, entry, lcn_connection):
+async def test_get_transmitter_trigger_capabilities(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected capabilities from a transmitter device trigger."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -372,7 +393,9 @@ async def test_get_transmitter_trigger_capabilities(hass, entry, lcn_connection)
     ]
 
 
-async def test_get_send_keys_trigger_capabilities(hass, entry, lcn_connection):
+async def test_get_send_keys_trigger_capabilities(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get the expected capabilities from a send_keys device trigger."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -408,7 +431,9 @@ async def test_get_send_keys_trigger_capabilities(hass, entry, lcn_connection):
     ]
 
 
-async def test_unknown_trigger_capabilities(hass, entry, lcn_connection):
+async def test_unknown_trigger_capabilities(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test we get empty capabilities if trigger is unknown."""
     address = (0, 7, False)
     device = get_device(hass, entry, address)

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -3,6 +3,8 @@ from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
 
+from homeassistant.core import HomeAssistant
+
 from tests.common import async_capture_events
 
 LCN_TRANSPONDER = "lcn_transponder"
@@ -11,7 +13,7 @@ LCN_TRANSMITTER = "lcn_transmitter"
 LCN_SEND_KEYS = "lcn_send_keys"
 
 
-async def test_fire_transponder_event(hass, lcn_connection):
+async def test_fire_transponder_event(hass: HomeAssistant, lcn_connection) -> None:
     """Test the transponder event is fired."""
     events = async_capture_events(hass, LCN_TRANSPONDER)
 
@@ -29,7 +31,7 @@ async def test_fire_transponder_event(hass, lcn_connection):
     assert events[0].data["code"] == "aabbcc"
 
 
-async def test_fire_fingerprint_event(hass, lcn_connection):
+async def test_fire_fingerprint_event(hass: HomeAssistant, lcn_connection) -> None:
     """Test the fingerprint event is fired."""
     events = async_capture_events(hass, LCN_FINGERPRINT)
 
@@ -47,7 +49,7 @@ async def test_fire_fingerprint_event(hass, lcn_connection):
     assert events[0].data["code"] == "aabbcc"
 
 
-async def test_fire_codelock_event(hass, lcn_connection):
+async def test_fire_codelock_event(hass: HomeAssistant, lcn_connection) -> None:
     """Test the codelock event is fired."""
     events = async_capture_events(hass, "lcn_codelock")
 
@@ -65,7 +67,7 @@ async def test_fire_codelock_event(hass, lcn_connection):
     assert events[0].data["code"] == "aabbcc"
 
 
-async def test_fire_transmitter_event(hass, lcn_connection):
+async def test_fire_transmitter_event(hass: HomeAssistant, lcn_connection) -> None:
     """Test the transmitter event is fired."""
     events = async_capture_events(hass, LCN_TRANSMITTER)
 
@@ -89,7 +91,7 @@ async def test_fire_transmitter_event(hass, lcn_connection):
     assert events[0].data["action"] == "hit"
 
 
-async def test_fire_sendkeys_event(hass, lcn_connection):
+async def test_fire_sendkeys_event(hass: HomeAssistant, lcn_connection) -> None:
     """Test the send_keys event is fired."""
     events = async_capture_events(hass, LCN_SEND_KEYS)
 
@@ -117,7 +119,9 @@ async def test_fire_sendkeys_event(hass, lcn_connection):
     assert events[3].data["action"] == "make"
 
 
-async def test_dont_fire_on_non_module_input(hass, lcn_connection):
+async def test_dont_fire_on_non_module_input(
+    hass: HomeAssistant, lcn_connection
+) -> None:
     """Test for no event is fired if a non-module input is received."""
     inp = Input()
 
@@ -133,7 +137,7 @@ async def test_dont_fire_on_non_module_input(hass, lcn_connection):
         assert len(events) == 0
 
 
-async def test_dont_fire_on_unknown_module(hass, lcn_connection):
+async def test_dont_fire_on_unknown_module(hass: HomeAssistant, lcn_connection) -> None:
     """Test for no event is fired if an input from an unknown module is received."""
     inp = ModStatusAccessControl(
         LcnAddr(0, 10, False),  # unknown module

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .conftest import MockPchkConnectionManager, setup_component
 
 
-async def test_async_setup_entry(hass, entry, lcn_connection):
+async def test_async_setup_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test a successful setup entry and unload of entry."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state == ConfigEntryState.LOADED
@@ -28,7 +28,7 @@ async def test_async_setup_entry(hass, entry, lcn_connection):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_multiple_entries(hass, entry, entry2):
+async def test_async_setup_multiple_entries(hass: HomeAssistant, entry, entry2) -> None:
     """Test a successful setup and unload of multiple entries."""
     with patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager):
         for config_entry in (entry, entry2):
@@ -48,7 +48,7 @@ async def test_async_setup_multiple_entries(hass, entry, entry2):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_update(hass, entry):
+async def test_async_setup_entry_update(hass: HomeAssistant, entry) -> None:
     """Test a successful setup entry if entry with same id already exists."""
     # setup first entry
     entry.source = config_entries.SOURCE_IMPORT
@@ -81,7 +81,9 @@ async def test_async_setup_entry_update(hass, entry):
     assert dummy_entity not in entity_registry.entities.values()
 
 
-async def test_async_setup_entry_raises_authentication_error(hass, entry):
+async def test_async_setup_entry_raises_authentication_error(
+    hass: HomeAssistant, entry
+) -> None:
     """Test that an authentication error is handled properly."""
     with patch.object(
         PchkConnectionManager, "async_connect", side_effect=PchkAuthenticationError
@@ -93,7 +95,9 @@ async def test_async_setup_entry_raises_authentication_error(hass, entry):
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
-async def test_async_setup_entry_raises_license_error(hass, entry):
+async def test_async_setup_entry_raises_license_error(
+    hass: HomeAssistant, entry
+) -> None:
     """Test that an authentication error is handled properly."""
     with patch.object(
         PchkConnectionManager, "async_connect", side_effect=PchkLicenseError
@@ -105,7 +109,9 @@ async def test_async_setup_entry_raises_license_error(hass, entry):
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
-async def test_async_setup_entry_raises_timeout_error(hass, entry):
+async def test_async_setup_entry_raises_timeout_error(
+    hass: HomeAssistant, entry
+) -> None:
     """Test that an authentication error is handled properly."""
     with patch.object(PchkConnectionManager, "async_connect", side_effect=TimeoutError):
         entry.add_to_hass(hass)

--- a/tests/components/lcn/test_light.py
+++ b/tests/components/lcn/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
@@ -32,7 +33,7 @@ LIGHT_OUTPUT2 = "light.light_output2"
 LIGHT_RELAY1 = "light.light_relay1"
 
 
-async def test_setup_lcn_light(hass, lcn_connection):
+async def test_setup_lcn_light(hass: HomeAssistant, lcn_connection) -> None:
     """Test the setup of light."""
     for entity_id in (
         LIGHT_OUTPUT1,
@@ -44,7 +45,7 @@ async def test_setup_lcn_light(hass, lcn_connection):
         assert state.state == STATE_OFF
 
 
-async def test_entity_state(hass, lcn_connection):
+async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     """Test state of entity."""
     state = hass.states.get(LIGHT_OUTPUT1)
     assert state
@@ -57,7 +58,7 @@ async def test_entity_state(hass, lcn_connection):
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.ONOFF]
 
 
-async def test_entity_attributes(hass, entry, lcn_connection):
+async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the attributes of an entity."""
     entity_registry = er.async_get(hass)
 
@@ -75,7 +76,7 @@ async def test_entity_attributes(hass, entry, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_on(dim_output, hass, lcn_connection):
+async def test_output_turn_on(dim_output, hass: HomeAssistant, lcn_connection) -> None:
     """Test the output light turns on."""
     # command failed
     dim_output.return_value = False
@@ -112,7 +113,9 @@ async def test_output_turn_on(dim_output, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_on_with_attributes(dim_output, hass, lcn_connection):
+async def test_output_turn_on_with_attributes(
+    dim_output, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the output light turns on."""
     dim_output.return_value = True
 
@@ -135,7 +138,7 @@ async def test_output_turn_on_with_attributes(dim_output, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_off(dim_output, hass, lcn_connection):
+async def test_output_turn_off(dim_output, hass: HomeAssistant, lcn_connection) -> None:
     """Test the output light turns off."""
     state = hass.states.get(LIGHT_OUTPUT1)
     state.state = STATE_ON
@@ -175,7 +178,9 @@ async def test_output_turn_off(dim_output, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_off_with_attributes(dim_output, hass, lcn_connection):
+async def test_output_turn_off_with_attributes(
+    dim_output, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the output light turns off."""
     dim_output.return_value = True
 
@@ -200,7 +205,9 @@ async def test_output_turn_off_with_attributes(dim_output, hass, lcn_connection)
 
 
 @patch.object(MockModuleConnection, "control_relays")
-async def test_relay_turn_on(control_relays, hass, lcn_connection):
+async def test_relay_turn_on(
+    control_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relay light turns on."""
     states = [RelayStateModifier.NOCHANGE] * 8
     states[0] = RelayStateModifier.ON
@@ -240,7 +247,9 @@ async def test_relay_turn_on(control_relays, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_relays")
-async def test_relay_turn_off(control_relays, hass, lcn_connection):
+async def test_relay_turn_off(
+    control_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relay light turns off."""
     states = [RelayStateModifier.NOCHANGE] * 8
     states[0] = RelayStateModifier.OFF
@@ -282,7 +291,9 @@ async def test_relay_turn_off(control_relays, hass, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_pushed_output_status_change(hass, entry, lcn_connection):
+async def test_pushed_output_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the output light changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -307,7 +318,9 @@ async def test_pushed_output_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_pushed_relay_status_change(hass, entry, lcn_connection):
+async def test_pushed_relay_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the relay light changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -334,7 +347,7 @@ async def test_pushed_relay_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_unload_config_entry(hass, entry, lcn_connection):
+async def test_unload_config_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the light is removed when the config entry is unloaded."""
     await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get(LIGHT_OUTPUT1).state == STATE_UNAVAILABLE

--- a/tests/components/lcn/test_sensor.py
+++ b/tests/components/lcn/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 SENSOR_VAR1 = "sensor.sensor_var1"
@@ -18,7 +19,7 @@ SENSOR_LED6 = "sensor.sensor_led6"
 SENSOR_LOGICOP1 = "sensor.sensor_logicop1"
 
 
-async def test_setup_lcn_sensor(hass, entry, lcn_connection):
+async def test_setup_lcn_sensor(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the setup of sensor."""
     for entity_id in (
         SENSOR_VAR1,
@@ -31,7 +32,7 @@ async def test_setup_lcn_sensor(hass, entry, lcn_connection):
         assert state.state == STATE_UNKNOWN
 
 
-async def test_entity_state(hass, lcn_connection):
+async def test_entity_state(hass: HomeAssistant, lcn_connection) -> None:
     """Test state of entity."""
     state = hass.states.get(SENSOR_VAR1)
     assert state
@@ -48,7 +49,7 @@ async def test_entity_state(hass, lcn_connection):
     assert state
 
 
-async def test_entity_attributes(hass, entry, lcn_connection):
+async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the attributes of an entity."""
     entity_registry = er.async_get(hass)
 
@@ -73,7 +74,9 @@ async def test_entity_attributes(hass, entry, lcn_connection):
     assert entity_logicop1.original_name == "Sensor_LogicOp1"
 
 
-async def test_pushed_variable_status_change(hass, entry, lcn_connection):
+async def test_pushed_variable_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the variable sensor changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -97,7 +100,9 @@ async def test_pushed_variable_status_change(hass, entry, lcn_connection):
     assert float(state.state) == 42.0
 
 
-async def test_pushed_ledlogicop_status_change(hass, entry, lcn_connection):
+async def test_pushed_ledlogicop_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the led and logicop sensor changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -122,7 +127,7 @@ async def test_pushed_ledlogicop_status_change(hass, entry, lcn_connection):
     assert state.state == "all"
 
 
-async def test_unload_config_entry(hass, entry, lcn_connection):
+async def test_unload_config_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the sensor is removed when the config entry is unloaded."""
     await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get(SENSOR_VAR1).state == STATE_UNAVAILABLE

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import MockModuleConnection
@@ -25,7 +26,7 @@ SWITCH_RELAY1 = "switch.switch_relay1"
 SWITCH_RELAY2 = "switch.switch_relay2"
 
 
-async def test_setup_lcn_switch(hass, lcn_connection):
+async def test_setup_lcn_switch(hass: HomeAssistant, lcn_connection) -> None:
     """Test the setup of switch."""
     for entity_id in (
         SWITCH_OUTPUT1,
@@ -38,7 +39,7 @@ async def test_setup_lcn_switch(hass, lcn_connection):
         assert state.state == STATE_OFF
 
 
-async def test_entity_attributes(hass, entry, lcn_connection):
+async def test_entity_attributes(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the attributes of an entity."""
     entity_registry = er.async_get(hass)
 
@@ -56,7 +57,7 @@ async def test_entity_attributes(hass, entry, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_on(dim_output, hass, lcn_connection):
+async def test_output_turn_on(dim_output, hass: HomeAssistant, lcn_connection) -> None:
     """Test the output switch turns on."""
     # command failed
     dim_output.return_value = False
@@ -91,7 +92,7 @@ async def test_output_turn_on(dim_output, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "dim_output")
-async def test_output_turn_off(dim_output, hass, lcn_connection):
+async def test_output_turn_off(dim_output, hass: HomeAssistant, lcn_connection) -> None:
     """Test the output switch turns off."""
     state = hass.states.get(SWITCH_OUTPUT1)
     state.state = STATE_ON
@@ -129,7 +130,9 @@ async def test_output_turn_off(dim_output, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_relays")
-async def test_relay_turn_on(control_relays, hass, lcn_connection):
+async def test_relay_turn_on(
+    control_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relay switch turns on."""
     states = [RelayStateModifier.NOCHANGE] * 8
     states[0] = RelayStateModifier.ON
@@ -167,7 +170,9 @@ async def test_relay_turn_on(control_relays, hass, lcn_connection):
 
 
 @patch.object(MockModuleConnection, "control_relays")
-async def test_relay_turn_off(control_relays, hass, lcn_connection):
+async def test_relay_turn_off(
+    control_relays, hass: HomeAssistant, lcn_connection
+) -> None:
     """Test the relay switch turns off."""
     states = [RelayStateModifier.NOCHANGE] * 8
     states[0] = RelayStateModifier.OFF
@@ -207,7 +212,9 @@ async def test_relay_turn_off(control_relays, hass, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_pushed_output_status_change(hass, entry, lcn_connection):
+async def test_pushed_output_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the output switch changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -229,7 +236,9 @@ async def test_pushed_output_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_pushed_relay_status_change(hass, entry, lcn_connection):
+async def test_pushed_relay_status_change(
+    hass: HomeAssistant, entry, lcn_connection
+) -> None:
     """Test the relay switch changes its state on status received."""
     device_connection = get_device_connection(hass, (0, 7, False), entry)
     address = LcnAddr(0, 7, False)
@@ -254,7 +263,7 @@ async def test_pushed_relay_status_change(hass, entry, lcn_connection):
     assert state.state == STATE_OFF
 
 
-async def test_unload_config_entry(hass, entry, lcn_connection):
+async def test_unload_config_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test the switch is removed when the config entry is unloaded."""
     await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get(SWITCH_OUTPUT1).state == STATE_UNAVAILABLE

--- a/tests/components/life360/test_config_flow.py
+++ b/tests/components/life360/test_config_flow.py
@@ -99,7 +99,7 @@ def create_config_entry(hass, state=None):
 # ========== User Flow Tests ===========================================================
 
 
-async def test_user_show_form(hass, life360_api):
+async def test_user_show_form(hass: HomeAssistant, life360_api) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -120,7 +120,7 @@ async def test_user_show_form(hass, life360_api):
         assert keys[keys.index(key)].default == vol.UNDEFINED
 
 
-async def test_user_config_flow_success(hass, life360_api):
+async def test_user_config_flow_success(hass: HomeAssistant, life360_api) -> None:
     """Test a successful user config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -145,7 +145,9 @@ async def test_user_config_flow_success(hass, life360_api):
 @pytest.mark.parametrize(
     "exception,error", [(LoginError, "invalid_auth"), (Life360Error, "cannot_connect")]
 )
-async def test_user_config_flow_error(hass, life360_api, caplog, exception, error):
+async def test_user_config_flow_error(
+    hass: HomeAssistant, life360_api, caplog: pytest.LogCaptureFixture, exception, error
+) -> None:
     """Test a user config flow with an error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -178,7 +180,9 @@ async def test_user_config_flow_error(hass, life360_api, caplog, exception, erro
         assert default() == val
 
 
-async def test_user_config_flow_already_configured(hass, life360_api):
+async def test_user_config_flow_already_configured(
+    hass: HomeAssistant, life360_api
+) -> None:
     """Test a user config flow with an account already configured."""
     create_config_entry(hass)
 
@@ -200,7 +204,9 @@ async def test_user_config_flow_already_configured(hass, life360_api):
 
 
 @pytest.mark.parametrize("state", [None, config_entries.ConfigEntryState.LOADED])
-async def test_reauth_config_flow_success(hass, life360_api, caplog, state):
+async def test_reauth_config_flow_success(
+    hass: HomeAssistant, life360_api, caplog: pytest.LogCaptureFixture, state
+) -> None:
     """Test a successful reauthorization config flow."""
     config_entry = create_config_entry(hass, state=state)
 
@@ -230,7 +236,9 @@ async def test_reauth_config_flow_success(hass, life360_api, caplog, state):
     assert config_entry.data == TEST_CONFIG_DATA_2
 
 
-async def test_reauth_config_flow_login_error(hass, life360_api, caplog):
+async def test_reauth_config_flow_login_error(
+    hass: HomeAssistant, life360_api, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a reauthorization config flow with a login error."""
     config_entry = create_config_entry(hass)
 

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -32,7 +32,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_discovery(hass: HomeAssistant):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     with _patch_discovery(), _patch_config_flow_try_connect():
         result = await hass.config_entries.flow.async_init(
@@ -96,7 +96,7 @@ async def test_discovery(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_but_cannot_connect(hass: HomeAssistant):
+async def test_discovery_but_cannot_connect(hass: HomeAssistant) -> None:
     """Test we can discover the device but we cannot connect."""
     with _patch_discovery(), _patch_config_flow_try_connect(no_device=True):
         result = await hass.config_entries.flow.async_init(
@@ -123,7 +123,7 @@ async def test_discovery_but_cannot_connect(hass: HomeAssistant):
     assert result3["reason"] == "cannot_connect"
 
 
-async def test_discovery_with_existing_device_present(hass: HomeAssistant):
+async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.2"}, unique_id="dd:dd:dd:dd:dd:dd"
@@ -197,7 +197,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_no_device(hass: HomeAssistant):
+async def test_discovery_no_device(hass: HomeAssistant) -> None:
     """Test discovery without device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -213,7 +213,7 @@ async def test_discovery_no_device(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_manual(hass: HomeAssistant):
+async def test_manual(hass: HomeAssistant) -> None:
     """Test manually setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -265,7 +265,7 @@ async def test_manual(hass: HomeAssistant):
     assert result2["reason"] == "already_configured"
 
 
-async def test_manual_dns_error(hass: HomeAssistant):
+async def test_manual_dns_error(hass: HomeAssistant) -> None:
     """Test manually setup with unresolving host."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -303,7 +303,7 @@ async def test_manual_dns_error(hass: HomeAssistant):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_manual_no_capabilities(hass: HomeAssistant):
+async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
     """Test manually setup without successful get_capabilities."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -403,7 +403,9 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery(hass, source, data):
+async def test_discovered_by_dhcp_or_discovery(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we can setup when discovered from dhcp or discovery."""
 
     with _patch_discovery(), _patch_config_flow_try_connect():
@@ -456,7 +458,9 @@ async def test_discovered_by_dhcp_or_discovery(hass, source, data):
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(hass, source, data):
+async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort if we cannot get the unique id when discovered from dhcp."""
 
     with _patch_discovery(no_device=True), _patch_config_flow_try_connect(
@@ -491,7 +495,9 @@ async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(hass, source
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_homekit_updates_ip(hass, source, data):
+async def test_discovered_by_dhcp_or_homekit_updates_ip(
+    hass: HomeAssistant, source, data
+) -> None:
     """Update host from dhcp."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.2"}, unique_id=SERIAL
@@ -509,7 +515,7 @@ async def test_discovered_by_dhcp_or_homekit_updates_ip(hass, source, data):
     assert config_entry.data[CONF_HOST] == IP_ADDRESS
 
 
-async def test_refuse_relays(hass: HomeAssistant):
+async def test_refuse_relays(hass: HomeAssistant) -> None:
     """Test we refuse to setup relays."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/lifx/test_diagnostics.py
+++ b/tests/components/lifx/test_diagnostics.py
@@ -19,9 +19,12 @@ from . import (
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
+async def test_bulb_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test diagnostics for a standard bulb."""
     config_entry = MockConfigEntry(
         domain=lifx.DOMAIN,
@@ -66,7 +69,9 @@ async def test_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
     }
 
 
-async def test_clean_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
+async def test_clean_bulb_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test diagnostics for a standard bulb."""
     config_entry = MockConfigEntry(
         domain=lifx.DOMAIN,
@@ -116,7 +121,9 @@ async def test_clean_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
     }
 
 
-async def test_infrared_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
+async def test_infrared_bulb_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test diagnostics for a standard bulb."""
     config_entry = MockConfigEntry(
         domain=lifx.DOMAIN,
@@ -163,7 +170,7 @@ async def test_infrared_bulb_diagnostics(hass: HomeAssistant, hass_client) -> No
 
 
 async def test_legacy_multizone_bulb_diagnostics(
-    hass: HomeAssistant, hass_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test diagnostics for a standard bulb."""
     config_entry = MockConfigEntry(
@@ -273,7 +280,9 @@ async def test_legacy_multizone_bulb_diagnostics(
     }
 
 
-async def test_multizone_bulb_diagnostics(hass: HomeAssistant, hass_client) -> None:
+async def test_multizone_bulb_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test diagnostics for a standard bulb."""
     config_entry = MockConfigEntry(
         domain=lifx.DOMAIN,

--- a/tests/components/lifx/test_migration.py
+++ b/tests/components/lifx/test_migration.py
@@ -31,7 +31,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_migration_device_online_end_to_end(
     hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
-):
+) -> None:
     """Test migration from single config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, title="LEGACY", data={}, unique_id=DOMAIN
@@ -84,7 +84,7 @@ async def test_migration_device_online_end_to_end(
 
 async def test_discovery_is_more_frequent_during_migration(
     hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
-):
+) -> None:
     """Test that discovery is more frequent during migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, title="LEGACY", data={}, unique_id=DOMAIN
@@ -157,7 +157,7 @@ async def test_discovery_is_more_frequent_during_migration(
 
 async def test_migration_device_online_end_to_end_after_downgrade(
     hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
-):
+) -> None:
     """Test migration from single config entry can happen again after a downgrade."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, title="LEGACY", data={}, unique_id=DOMAIN
@@ -206,7 +206,7 @@ async def test_migration_device_online_end_to_end_after_downgrade(
 
 async def test_migration_device_online_end_to_end_ignores_other_devices(
     hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
-):
+) -> None:
     """Test migration from single config entry."""
     legacy_config_entry = MockConfigEntry(
         domain=DOMAIN, title="LEGACY", data={}, unique_id=DOMAIN

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -12,7 +12,8 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -32,7 +33,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a light."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -82,12 +87,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -122,7 +127,11 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_get_action_capabilities(hass, device_registry, entity_registry):
+async def test_get_action_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a light action."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -250,9 +259,9 @@ async def test_get_action_capabilities(hass, device_registry, entity_registry):
     ],
 )
 async def test_get_action_capabilities_features(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     expected_actions,
     supported_features_reg,
@@ -260,7 +269,7 @@ async def test_get_action_capabilities_features(
     capabilities_reg,
     attributes_state,
     expected_capabilities,
-):
+) -> None:
     """Test we get the expected capabilities from a light action."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -297,7 +306,9 @@ async def test_get_action_capabilities_features(
         assert capabilities == expected
 
 
-async def test_action(hass, calls, enable_custom_integrations):
+async def test_action(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -8,7 +8,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a light."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_get_condition_capabilities(hass, device_registry, entity_registry):
+async def test_get_condition_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a light condition."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_condition_capabilities(hass, device_registry, entity_registry
         assert capabilities == expected_capabilities
 
 
-async def test_if_state(hass, calls, enable_custom_integrations):
+async def test_if_state(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -205,7 +216,9 @@ async def test_if_state(hass, calls, enable_custom_integrations):
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
-async def test_if_fires_on_for_condition(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_for_condition(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a light."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a light trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -245,8 +256,8 @@ async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations)
 
 
 async def test_if_fires_on_state_change_with_for(
-    hass, calls, enable_custom_integrations
-):
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.setup import async_setup_component
 import homeassistant.util.color as color_util
 
-from tests.common import async_mock_service
+from tests.common import MockUser, async_mock_service
 
 orig_Profiles = light.Profiles
 
@@ -106,7 +106,9 @@ async def test_methods(hass: HomeAssistant) -> None:
     assert call.data[light.ATTR_TRANSITION] == "transition_val"
 
 
-async def test_services(hass, mock_light_profiles, enable_custom_integrations):
+async def test_services(
+    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+) -> None:
     """Test the provided services."""
     platform = getattr(hass.components, "test.light")
 
@@ -498,13 +500,13 @@ async def test_services(hass, mock_light_profiles, enable_custom_integrations):
     ),
 )
 async def test_light_profiles(
-    hass,
+    hass: HomeAssistant,
     mock_light_profiles,
     profile_name,
     expected_data,
     last_call,
-    enable_custom_integrations,
-):
+    enable_custom_integrations: None,
+) -> None:
     """Test light profiles."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -550,8 +552,8 @@ async def test_light_profiles(
 
 
 async def test_default_profiles_group(
-    hass, mock_light_profiles, enable_custom_integrations
-):
+    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+) -> None:
     """Test default turn-on light profile for all lights."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -767,13 +769,13 @@ async def test_default_profiles_group(
     ),
 )
 async def test_default_profiles_light(
-    hass,
+    hass: HomeAssistant,
     mock_light_profiles,
     extra_call_params,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     expected_params_state_was_off,
     expected_params_state_was_on,
-):
+) -> None:
     """Test default turn-on light profile for a specific light."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -839,7 +841,9 @@ async def test_default_profiles_light(
     }
 
 
-async def test_light_context(hass, hass_admin_user, enable_custom_integrations):
+async def test_light_context(
+    hass: HomeAssistant, hass_admin_user: MockUser, enable_custom_integrations: None
+) -> None:
     """Test that light context works."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -863,7 +867,9 @@ async def test_light_context(hass, hass_admin_user, enable_custom_integrations):
     assert state2.context.user_id == hass_admin_user.id
 
 
-async def test_light_turn_on_auth(hass, hass_admin_user, enable_custom_integrations):
+async def test_light_turn_on_auth(
+    hass: HomeAssistant, hass_admin_user: MockUser, enable_custom_integrations: None
+) -> None:
     """Test that light context works."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -885,7 +891,9 @@ async def test_light_turn_on_auth(hass, hass_admin_user, enable_custom_integrati
         )
 
 
-async def test_light_brightness_step(hass, enable_custom_integrations):
+async def test_light_brightness_step(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test that light context works."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -947,7 +955,9 @@ async def test_light_brightness_step(hass, enable_custom_integrations):
     assert entity0.state == "off"  # 126 - 126; brightness is 0, light should turn off
 
 
-async def test_light_brightness_pct_conversion(hass, enable_custom_integrations):
+async def test_light_brightness_pct_conversion(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test that light brightness percent conversion."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -1103,8 +1113,8 @@ invalid_no_brightness_no_color_no_transition,,,
 
 @pytest.mark.parametrize("light_state", (STATE_ON, STATE_OFF))
 async def test_light_backwards_compatibility_supported_color_modes(
-    hass, light_state, enable_custom_integrations
-):
+    hass: HomeAssistant, light_state, enable_custom_integrations: None
+) -> None:
     """Test supported_color_modes if not implemented by the entity."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1174,8 +1184,8 @@ async def test_light_backwards_compatibility_supported_color_modes(
 
 
 async def test_light_backwards_compatibility_color_mode(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color_mode if not implemented by the entity."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1238,7 +1248,9 @@ async def test_light_backwards_compatibility_color_mode(
     assert state.attributes["color_mode"] == light.ColorMode.HS
 
 
-async def test_light_service_call_rgbw(hass, enable_custom_integrations):
+async def test_light_service_call_rgbw(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test rgbw functionality in service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1269,7 +1281,9 @@ async def test_light_service_call_rgbw(hass, enable_custom_integrations):
     assert data == {"brightness": 255, "rgbw_color": (10, 20, 30, 40)}
 
 
-async def test_light_state_rgbw(hass, enable_custom_integrations):
+async def test_light_state_rgbw(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test rgbw color conversion in state updates."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1301,7 +1315,9 @@ async def test_light_state_rgbw(hass, enable_custom_integrations):
     }
 
 
-async def test_light_state_rgbww(hass, enable_custom_integrations):
+async def test_light_state_rgbww(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test rgbww color conversion in state updates."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1333,7 +1349,9 @@ async def test_light_state_rgbww(hass, enable_custom_integrations):
     }
 
 
-async def test_light_service_call_color_conversion(hass, enable_custom_integrations):
+async def test_light_service_call_color_conversion(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color conversion in service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1737,8 +1755,8 @@ async def test_light_service_call_color_conversion(hass, enable_custom_integrati
 
 
 async def test_light_service_call_color_conversion_named_tuple(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test a named tuple (RGBColor) is handled correctly."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1814,8 +1832,8 @@ async def test_light_service_call_color_conversion_named_tuple(
 
 
 async def test_light_service_call_color_temp_emulation(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color conversion in service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -1874,8 +1892,8 @@ async def test_light_service_call_color_temp_emulation(
 
 
 async def test_light_service_call_color_temp_conversion(
-    hass, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color temp conversion in service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -2006,7 +2024,9 @@ async def test_light_service_call_color_temp_conversion(
     assert data == {"brightness": 255, "rgbww_color": (0, 0, 0, 66, 189)}
 
 
-async def test_light_mired_color_temp_conversion(hass, enable_custom_integrations):
+async def test_light_mired_color_temp_conversion(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color temp conversion from K to legacy mired."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -2052,7 +2072,9 @@ async def test_light_mired_color_temp_conversion(hass, enable_custom_integration
     assert state.attributes["color_temp_kelvin"] == 3500
 
 
-async def test_light_service_call_white_mode(hass, enable_custom_integrations):
+async def test_light_service_call_white_mode(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color_mode white in service calls."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -2134,7 +2156,9 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     assert data == {}
 
 
-async def test_light_state_color_conversion(hass, enable_custom_integrations):
+async def test_light_state_color_conversion(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test color conversion in state updates."""
     platform = getattr(hass.components, "test.light")
     platform.init(empty=True)
@@ -2198,8 +2222,8 @@ async def test_light_state_color_conversion(hass, enable_custom_integrations):
 
 
 async def test_services_filter_parameters(
-    hass, mock_light_profiles, enable_custom_integrations
-):
+    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+) -> None:
     """Test turn_on and turn_off filters unsupported parameters."""
     platform = getattr(hass.components, "test.light")
 

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -10,10 +10,11 @@ from homeassistant.components.light import (
     ATTR_MIN_MIREDS,
     ATTR_SUPPORTED_COLOR_MODES,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -21,7 +22,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test light registered attributes to be excluded."""
     await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {"platform": "demo"}}

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -171,7 +171,9 @@ async def test_reproducing_states(
         light.ColorMode.XY,
     ),
 )
-async def test_filter_color_modes(hass, caplog, color_mode):
+async def test_filter_color_modes(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, color_mode
+) -> None:
     """Test filtering of parameters according to color mode."""
     hass.states.async_set("light.entity", "off", {})
     all_colors = {

--- a/tests/components/litejet/test_config_flow.py
+++ b/tests/components/litejet/test_config_flow.py
@@ -21,7 +21,7 @@ async def test_show_config_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_create_entry(hass, mock_litejet):
+async def test_create_entry(hass: HomeAssistant, mock_litejet) -> None:
     """Test create entry from user input."""
     test_data = {CONF_PORT: "/dev/test"}
 

--- a/tests/components/litejet/test_diagnostics.py
+++ b/tests/components/litejet/test_diagnostics.py
@@ -1,10 +1,15 @@
 """The tests for the litejet component."""
+from homeassistant.core import HomeAssistant
+
 from . import async_init_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_diagnostics(hass, hass_client, mock_litejet):
+async def test_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_litejet
+) -> None:
     """Test getting the LiteJet diagnostics."""
 
     config_entry = await async_init_integration(hass)

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -14,7 +14,7 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     assert DOMAIN not in hass.data
 
 
-async def test_setup_with_config_to_import(hass, mock_litejet):
+async def test_setup_with_config_to_import(hass: HomeAssistant, mock_litejet) -> None:
     """Test that import happens."""
     assert (
         await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PORT: "/dev/hello"}})
@@ -23,7 +23,7 @@ async def test_setup_with_config_to_import(hass, mock_litejet):
     assert DOMAIN in hass.data
 
 
-async def test_unload_entry(hass, mock_litejet):
+async def test_unload_entry(hass: HomeAssistant, mock_litejet) -> None:
     """Test being able to unload an entry."""
     entry = await async_init_integration(hass, use_switch=True, use_scene=True)
 

--- a/tests/components/litejet/test_light.py
+++ b/tests/components/litejet/test_light.py
@@ -3,6 +3,7 @@ from homeassistant.components import light
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_TRANSITION
 from homeassistant.components.litejet.const import CONF_DEFAULT_TRANSITION
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 
 from . import async_init_integration
 
@@ -12,7 +13,7 @@ ENTITY_OTHER_LIGHT = "light.mock_load_2"
 ENTITY_OTHER_LIGHT_NUMBER = 2
 
 
-async def test_on_brightness(hass, mock_litejet):
+async def test_on_brightness(hass: HomeAssistant, mock_litejet) -> None:
     """Test turning the light on with brightness."""
     await async_init_integration(hass)
 
@@ -30,7 +31,7 @@ async def test_on_brightness(hass, mock_litejet):
     mock_litejet.activate_load_at.assert_called_with(ENTITY_LIGHT_NUMBER, 39, 0)
 
 
-async def test_default_transition(hass, mock_litejet):
+async def test_default_transition(hass: HomeAssistant, mock_litejet) -> None:
     """Test turning the light on with the default transition option."""
     entry = await async_init_integration(hass)
 
@@ -51,7 +52,7 @@ async def test_default_transition(hass, mock_litejet):
     mock_litejet.activate_load_at.assert_called_with(ENTITY_LIGHT_NUMBER, 39, 12)
 
 
-async def test_transition(hass, mock_litejet):
+async def test_transition(hass: HomeAssistant, mock_litejet) -> None:
     """Test turning the light on with transition."""
     await async_init_integration(hass)
 
@@ -79,7 +80,7 @@ async def test_transition(hass, mock_litejet):
     mock_litejet.activate_load_at.assert_called_with(ENTITY_LIGHT_NUMBER, 0, 5)
 
 
-async def test_on_off(hass, mock_litejet):
+async def test_on_off(hass: HomeAssistant, mock_litejet) -> None:
     """Test turning the light on and off."""
     await async_init_integration(hass)
 
@@ -105,7 +106,7 @@ async def test_on_off(hass, mock_litejet):
     mock_litejet.deactivate_load.assert_called_with(ENTITY_LIGHT_NUMBER)
 
 
-async def test_activated_event(hass, mock_litejet):
+async def test_activated_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass)
@@ -140,7 +141,7 @@ async def test_activated_event(hass, mock_litejet):
     assert hass.states.get(ENTITY_OTHER_LIGHT).attributes.get(ATTR_BRIGHTNESS) == 103
 
 
-async def test_deactivated_event(hass, mock_litejet):
+async def test_deactivated_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
     await async_init_integration(hass)
 

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -1,6 +1,7 @@
 """The tests for the litejet component."""
 from homeassistant.components import scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import async_init_integration
@@ -11,7 +12,7 @@ ENTITY_OTHER_SCENE = "scene.mock_scene_2"
 ENTITY_OTHER_SCENE_NUMBER = 2
 
 
-async def test_disabled_by_default(hass, mock_litejet):
+async def test_disabled_by_default(hass: HomeAssistant, mock_litejet) -> None:
     """Test the scene is disabled by default."""
     await async_init_integration(hass)
 
@@ -26,7 +27,7 @@ async def test_disabled_by_default(hass, mock_litejet):
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_activate(hass, mock_litejet):
+async def test_activate(hass: HomeAssistant, mock_litejet) -> None:
     """Test activating the scene."""
 
     await async_init_integration(hass, use_scene=True)

--- a/tests/components/litejet/test_switch.py
+++ b/tests/components/litejet/test_switch.py
@@ -1,6 +1,7 @@
 """The tests for the litejet component."""
 from homeassistant.components import switch
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 
 from . import async_init_integration
 
@@ -10,7 +11,7 @@ ENTITY_OTHER_SWITCH = "switch.mock_switch_2"
 ENTITY_OTHER_SWITCH_NUMBER = 2
 
 
-async def test_on_off(hass, mock_litejet):
+async def test_on_off(hass: HomeAssistant, mock_litejet) -> None:
     """Test turning the switch on and off."""
 
     await async_init_integration(hass, use_switch=True)
@@ -31,7 +32,7 @@ async def test_on_off(hass, mock_litejet):
     mock_litejet.release_switch.assert_called_with(ENTITY_SWITCH_NUMBER)
 
 
-async def test_pressed_event(hass, mock_litejet):
+async def test_pressed_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass, use_switch=True)
@@ -55,7 +56,7 @@ async def test_pressed_event(hass, mock_litejet):
     assert hass.states.get(ENTITY_OTHER_SWITCH).state == "on"
 
 
-async def test_released_event(hass, mock_litejet):
+async def test_released_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass, use_switch=True)

--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant import setup
 import homeassistant.components.automation as automation
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from . import async_init_integration
@@ -93,7 +94,7 @@ async def setup_automation(hass, trigger):
     await hass.async_block_till_done()
 
 
-async def test_simple(hass, calls, mock_litejet):
+async def test_simple(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
         hass, {"platform": "litejet", "number": ENTITY_OTHER_SWITCH_NUMBER}
@@ -106,7 +107,7 @@ async def test_simple(hass, calls, mock_litejet):
     assert calls[0].data["id"] == 0
 
 
-async def test_held_more_than_short(hass, calls, mock_litejet):
+async def test_held_more_than_short(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test a too short hold."""
     await setup_automation(
         hass,
@@ -123,7 +124,7 @@ async def test_held_more_than_short(hass, calls, mock_litejet):
     assert len(calls) == 0
 
 
-async def test_held_more_than_long(hass, calls, mock_litejet):
+async def test_held_more_than_long(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test a hold that is long enough."""
     await setup_automation(
         hass,
@@ -143,7 +144,7 @@ async def test_held_more_than_long(hass, calls, mock_litejet):
     assert len(calls) == 1
 
 
-async def test_held_less_than_short(hass, calls, mock_litejet):
+async def test_held_less_than_short(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test a hold that is short enough."""
     await setup_automation(
         hass,
@@ -162,7 +163,7 @@ async def test_held_less_than_short(hass, calls, mock_litejet):
     assert calls[0].data["id"] == 0
 
 
-async def test_held_less_than_long(hass, calls, mock_litejet):
+async def test_held_less_than_long(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test a hold that is too long."""
     await setup_automation(
         hass,
@@ -181,7 +182,7 @@ async def test_held_less_than_long(hass, calls, mock_litejet):
     assert len(calls) == 0
 
 
-async def test_held_in_range_short(hass, calls, mock_litejet):
+async def test_held_in_range_short(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test an in-range trigger with a too short hold."""
     await setup_automation(
         hass,
@@ -199,7 +200,9 @@ async def test_held_in_range_short(hass, calls, mock_litejet):
     assert len(calls) == 0
 
 
-async def test_held_in_range_just_right(hass, calls, mock_litejet):
+async def test_held_in_range_just_right(
+    hass: HomeAssistant, calls, mock_litejet
+) -> None:
     """Test an in-range trigger with a just right hold."""
     await setup_automation(
         hass,
@@ -220,7 +223,7 @@ async def test_held_in_range_just_right(hass, calls, mock_litejet):
     assert calls[0].data["id"] == 0
 
 
-async def test_held_in_range_long(hass, calls, mock_litejet):
+async def test_held_in_range_long(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test an in-range trigger with a too long hold."""
     await setup_automation(
         hass,
@@ -240,7 +243,7 @@ async def test_held_in_range_long(hass, calls, mock_litejet):
     assert len(calls) == 0
 
 
-async def test_reload(hass, calls, mock_litejet):
+async def test_reload(hass: HomeAssistant, calls, mock_litejet) -> None:
     """Test reloading automation."""
     await setup_automation(
         hass,

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -15,7 +15,7 @@ from .common import CONF_USERNAME, CONFIG, DOMAIN
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass, mock_account):
+async def test_form(hass: HomeAssistant, mock_account) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 
 from .common import CONFIG, VACUUM_ENTITY_ID
 from .conftest import setup_integration
@@ -19,7 +20,7 @@ from .conftest import setup_integration
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass, mock_account):
+async def test_unload_entry(hass: HomeAssistant, mock_account) -> None:
     """Test being able to unload an entry."""
     entry = await setup_integration(hass, mock_account, VACUUM_DOMAIN)
 
@@ -47,7 +48,9 @@ async def test_unload_entry(hass, mock_account):
         (LitterRobotException, ConfigEntryState.SETUP_RETRY),
     ),
 )
-async def test_entry_not_setup(hass, side_effect, expected_state):
+async def test_entry_not_setup(
+    hass: HomeAssistant, side_effect, expected_state
+) -> None:
     """Test being able to handle config entry not setup."""
     entry = MockConfigEntry(
         domain=litterrobot.DOMAIN,

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -16,7 +16,7 @@ from .conftest import setup_integration
 SELECT_ENTITY_ID = "select.test_clean_cycle_wait_time_minutes"
 
 
-async def test_wait_time_select(hass: HomeAssistant, mock_account):
+async def test_wait_time_select(hass: HomeAssistant, mock_account) -> None:
     """Tests the wait time select entity."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
@@ -45,7 +45,7 @@ async def test_wait_time_select(hass: HomeAssistant, mock_account):
         assert mock_account.robots[0].set_wait_time.call_count == count
 
 
-async def test_invalid_wait_time_select(hass: HomeAssistant, mock_account):
+async def test_invalid_wait_time_select(hass: HomeAssistant, mock_account) -> None:
     """Tests the wait time select entity with invalid value."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -19,7 +19,7 @@ NIGHT_LIGHT_MODE_ENTITY_ID = "switch.test_night_light_mode"
 PANEL_LOCKOUT_ENTITY_ID = "switch.test_panel_lockout"
 
 
-async def test_switch(hass: HomeAssistant, mock_account: MagicMock):
+async def test_switch(hass: HomeAssistant, mock_account: MagicMock) -> None:
     """Tests the switch entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
@@ -46,7 +46,7 @@ async def test_on_off_commands(
     entity_id: str,
     robot_command: str,
     updated_field: str,
-):
+) -> None:
     """Test sending commands to the switch."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
     robot: Robot = mock_account.robots[0]

--- a/tests/components/litterrobot/test_update.py
+++ b/tests/components/litterrobot/test_update.py
@@ -30,7 +30,7 @@ NEW_FIRMWARE = "ESP: 1.1.51 / PIC: 10512.2560.2.53 / TOF: 4.0.65.4"
 
 async def test_robot_with_no_update(
     hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
-):
+) -> None:
     """Tests the update entity was set up."""
     robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
     robot.has_firmware_update = AsyncMock(return_value=False)
@@ -53,7 +53,7 @@ async def test_robot_with_no_update(
 
 async def test_robot_with_update(
     hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
-):
+) -> None:
     """Tests the update entity was set up."""
     robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
     robot.has_firmware_update = AsyncMock(return_value=True)
@@ -90,7 +90,7 @@ async def test_robot_with_update(
 
 async def test_robot_with_update_already_in_progress(
     hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
-):
+) -> None:
     """Tests the update entity was set up."""
     robot: LitterRobot4 = mock_account_with_litterrobot_4.robots[0]
     robot._update_data({"isFirmwareUpdateTriggered": True}, partial=True)

--- a/tests/components/livisi/test_config_flow.py
+++ b/tests/components/livisi/test_config_flow.py
@@ -44,8 +44,8 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     ],
 )
 async def test_create_entity_after_login_error(
-    hass, exception: livisi_errors.LivisiException, expected_reason: str
-):
+    hass: HomeAssistant, exception: livisi_errors.LivisiException, expected_reason: str
+) -> None:
     """Test the LIVISI integration can create an entity after the user had login errors."""
     with patch(
         "homeassistant.components.livisi.config_flow.AioLivisi.async_set_token",

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -163,7 +163,7 @@ async def ws_client(
 
 async def test_empty_calendar(
     hass: HomeAssistant, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test querying the API and fetching events."""
     events = await get_events("1997-07-14T00:00:00", "1997-07-16T00:00:00")
     assert len(events) == 0
@@ -179,7 +179,7 @@ async def test_empty_calendar(
 
 async def test_api_date_time_event(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test an event with a start/end date time."""
     client = await ws_client()
     await client.cmd_result(
@@ -220,7 +220,7 @@ async def test_api_date_time_event(
 
 async def test_api_date_event(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test an event with a start/end date all day event."""
     client = await ws_client()
     await client.cmd_result(
@@ -263,7 +263,7 @@ async def test_active_event(
     hass: HomeAssistant,
     ws_client: ClientFixture,
     setup_integration: None,
-):
+) -> None:
     """Test an event with a start/end date time."""
     start = dt_util.now() - datetime.timedelta(minutes=30)
     end = dt_util.now() + datetime.timedelta(minutes=30)
@@ -299,7 +299,7 @@ async def test_upcoming_event(
     hass: HomeAssistant,
     ws_client: ClientFixture,
     setup_integration: None,
-):
+) -> None:
     """Test an event with a start/end date time."""
     start = dt_util.now() + datetime.timedelta(days=1)
     end = dt_util.now() + datetime.timedelta(days=1, hours=1)
@@ -336,7 +336,7 @@ async def test_recurring_event(
     setup_integration: None,
     hass: HomeAssistant,
     get_events: GetEventsFn,
-):
+) -> None:
     """Test an event with a recurrence rule."""
     client = await ws_client()
     await client.cmd_result(
@@ -383,7 +383,7 @@ async def test_recurring_event(
 
 async def test_websocket_delete(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test websocket delete command."""
     client = await ws_client()
     await client.cmd_result(
@@ -422,7 +422,7 @@ async def test_websocket_delete(
 
 async def test_websocket_delete_recurring(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test deleting a recurring event."""
     client = await ws_client()
     await client.cmd_result(
@@ -522,7 +522,7 @@ async def test_websocket_delete_recurring(
 
 async def test_websocket_update(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test websocket update command."""
     client = await ws_client()
     await client.cmd_result(
@@ -572,7 +572,7 @@ async def test_websocket_update(
 
 async def test_websocket_update_recurring_this_and_future(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test updating a recurring event."""
     client = await ws_client()
     await client.cmd_result(
@@ -664,7 +664,7 @@ async def test_websocket_update_recurring_this_and_future(
 
 async def test_websocket_update_recurring(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test updating a recurring event."""
     client = await ws_client()
     await client.cmd_result(
@@ -768,7 +768,7 @@ async def test_invalid_rrule(
     hass: HomeAssistant,
     get_events: GetEventsFn,
     rrule: str,
-):
+) -> None:
     """Test an event with a recurrence rule."""
     client = await ws_client()
     resp = await client.cmd(
@@ -847,7 +847,7 @@ async def test_all_day_iter_order(
 async def test_start_end_types(
     ws_client: ClientFixture,
     setup_integration: None,
-):
+) -> None:
     """Test a start and end with different date and date time types."""
     client = await ws_client()
     result = await client.cmd(
@@ -870,7 +870,7 @@ async def test_start_end_types(
 async def test_end_before_start(
     ws_client: ClientFixture,
     setup_integration: None,
-):
+) -> None:
     """Test an event with a start/end date time."""
     client = await ws_client()
     result = await client.cmd(
@@ -893,7 +893,7 @@ async def test_end_before_start(
 async def test_invalid_recurrence_rule(
     ws_client: ClientFixture,
     setup_integration: None,
-):
+) -> None:
     """Test an event with a recurrence rule."""
     client = await ws_client()
     result = await client.cmd(
@@ -916,7 +916,7 @@ async def test_invalid_recurrence_rule(
 
 async def test_invalid_date_formats(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Exercises a validation error within rfc5545 parsing in ical."""
     client = await ws_client()
     result = await client.cmd(
@@ -941,7 +941,7 @@ async def test_update_invalid_event_id(
     ws_client: ClientFixture,
     setup_integration: None,
     hass: HomeAssistant,
-):
+) -> None:
     """Test updating an event with an invalid event uid."""
     client = await ws_client()
     resp = await client.cmd(
@@ -963,7 +963,7 @@ async def test_update_invalid_event_id(
 
 async def test_create_event_service(
     hass: HomeAssistant, setup_integration: None, get_events: GetEventsFn
-):
+) -> None:
     """Test creating an event using the create_event service."""
 
     await hass.services.async_call(

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.components import locative
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.locative import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
@@ -47,7 +48,7 @@ async def webhook_id(hass, locative_client):
     return result["result"].data["webhook_id"]
 
 
-async def test_missing_data(locative_client, webhook_id):
+async def test_missing_data(locative_client, webhook_id) -> None:
     """Test missing data."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -107,7 +108,7 @@ async def test_missing_data(locative_client, webhook_id):
     assert req.status == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
-async def test_enter_and_exit(hass, locative_client, webhook_id):
+async def test_enter_and_exit(hass: HomeAssistant, locative_client, webhook_id) -> None:
     """Test when there is a known zone."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -176,7 +177,9 @@ async def test_enter_and_exit(hass, locative_client, webhook_id):
     assert state_name == "work"
 
 
-async def test_exit_after_enter(hass, locative_client, webhook_id):
+async def test_exit_after_enter(
+    hass: HomeAssistant, locative_client, webhook_id
+) -> None:
     """Test when an exit message comes after an enter message."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -218,7 +221,7 @@ async def test_exit_after_enter(hass, locative_client, webhook_id):
     assert state.state == "work"
 
 
-async def test_exit_first(hass, locative_client, webhook_id):
+async def test_exit_first(hass: HomeAssistant, locative_client, webhook_id) -> None:
     """Test when an exit message is sent first on a new device."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -239,7 +242,7 @@ async def test_exit_first(hass, locative_client, webhook_id):
     assert state.state == "not_home"
 
 
-async def test_two_devices(hass, locative_client, webhook_id):
+async def test_two_devices(hass: HomeAssistant, locative_client, webhook_id) -> None:
     """Test updating two different devices."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -282,7 +285,9 @@ async def test_two_devices(hass, locative_client, webhook_id):
 @pytest.mark.xfail(
     reason="The device_tracker component does not support unloading yet."
 )
-async def test_load_unload_entry(hass, locative_client, webhook_id):
+async def test_load_unload_entry(
+    hass: HomeAssistant, locative_client, webhook_id
+) -> None:
     """Test that the appropriate dispatch signals are added and removed."""
     url = f"/api/webhook/{webhook_id}"
 

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -6,7 +6,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.lock import DOMAIN, LockEntityFeature
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -29,14 +29,14 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
     ],
 )
 async def test_get_actions(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     set_state,
     features_reg,
     features_state,
     expected_action_types,
-):
+) -> None:
     """Test we get the expected actions from a lock."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -93,12 +93,12 @@ async def test_get_actions(
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -12,7 +12,8 @@ from homeassistant.const import (
     STATE_UNLOCKING,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -31,7 +32,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a lock."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -75,12 +80,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -119,7 +124,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("lock.entity", STATE_LOCKED)
 

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -14,7 +14,8 @@ from homeassistant.const import (
     STATE_UNLOCKING,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -36,7 +37,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a lock."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -74,12 +79,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -112,7 +117,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a lock."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -139,7 +148,7 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         }
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off triggers firing."""
     hass.states.async_set("lock.entity", STATE_UNLOCKED)
 
@@ -207,7 +216,7 @@ async def test_if_fires_on_state_change(hass, calls):
     ] == "unlocked - device - {} - locked - unlocked - None".format("lock.entity")
 
 
-async def test_if_fires_on_state_change_with_for(hass, calls):
+async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for triggers firing with delay."""
     entity_id = f"{DOMAIN}.entity"
     hass.states.async_set(entity_id, STATE_UNLOCKED)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.logbook.models import LazyEventPartialState
 from homeassistant.components.logbook.processor import EventProcessor
 from homeassistant.components.logbook.queries.common import PSEUDO_EVENT_STATE_CHANGED
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
@@ -53,6 +54,7 @@ from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
 )
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 EMPTY_CONFIG = logbook.CONFIG_SCHEMA({logbook.DOMAIN: {}})
 
@@ -70,7 +72,7 @@ def set_utc(hass):
     hass.config.set_time_zone("UTC")
 
 
-async def test_service_call_create_logbook_entry(hass_):
+async def test_service_call_create_logbook_entry(hass_) -> None:
     """Test if service call create log book entry."""
     calls = async_capture_events(hass_, logbook.EVENT_LOGBOOK_ENTRY)
 
@@ -123,7 +125,9 @@ async def test_service_call_create_logbook_entry(hass_):
     assert last_call.data.get(logbook.ATTR_DOMAIN) == "logbook"
 
 
-async def test_service_call_create_logbook_entry_invalid_entity_id(recorder_mock, hass):
+async def test_service_call_create_logbook_entry_invalid_entity_id(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test if service call create log book entry with an invalid entity id."""
     await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()
@@ -151,7 +155,7 @@ async def test_service_call_create_logbook_entry_invalid_entity_id(recorder_mock
     assert events[0][logbook.ATTR_MESSAGE] == "is triggered"
 
 
-async def test_service_call_create_log_book_entry_no_message(hass_):
+async def test_service_call_create_log_book_entry_no_message(hass_) -> None:
     """Test if service call create log book entry without message."""
     calls = async_capture_events(hass_, logbook.EVENT_LOGBOOK_ENTRY)
 
@@ -166,7 +170,9 @@ async def test_service_call_create_log_book_entry_no_message(hass_):
     assert len(calls) == 0
 
 
-async def test_filter_sensor(hass_: ha.HomeAssistant, hass_client):
+async def test_filter_sensor(
+    hass_: ha.HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test numeric sensors are filtered."""
 
     registry = er.async_get(hass_)
@@ -213,7 +219,7 @@ async def test_filter_sensor(hass_: ha.HomeAssistant, hass_client):
     _assert_entry(entries[2], name="ble", entity_id=entity_id4, state="10")
 
 
-async def test_home_assistant_start_stop_not_grouped(hass_):
+async def test_home_assistant_start_stop_not_grouped(hass_) -> None:
     """Test if HA start and stop events are no longer grouped."""
     await async_setup_component(hass_, "homeassistant", {})
     await hass_.async_block_till_done()
@@ -230,7 +236,7 @@ async def test_home_assistant_start_stop_not_grouped(hass_):
     assert_entry(entries[1], name="Home Assistant", message="started", domain=ha.DOMAIN)
 
 
-async def test_home_assistant_start(hass_):
+async def test_home_assistant_start(hass_) -> None:
     """Test if HA start is not filtered or converted into a restart."""
     await async_setup_component(hass_, "homeassistant", {})
     await hass_.async_block_till_done()
@@ -250,7 +256,7 @@ async def test_home_assistant_start(hass_):
     assert_entry(entries[1], pointA, "bla", entity_id=entity_id)
 
 
-def test_process_custom_logbook_entries(hass_):
+def test_process_custom_logbook_entries(hass_) -> None:
     """Test if custom log book entries get added as an entry."""
     name = "Nice name"
     message = "has a custom entry"
@@ -354,7 +360,9 @@ def create_state_changed_event_from_old_new(
     return LazyEventPartialState(row, {})
 
 
-async def test_logbook_view(recorder_mock, hass, hass_client):
+async def test_logbook_view(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -363,7 +371,9 @@ async def test_logbook_view(recorder_mock, hass, hass_client):
     assert response.status == HTTPStatus.OK
 
 
-async def test_logbook_view_invalid_start_date_time(recorder_mock, hass, hass_client):
+async def test_logbook_view_invalid_start_date_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with an invalid date time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -372,7 +382,9 @@ async def test_logbook_view_invalid_start_date_time(recorder_mock, hass, hass_cl
     assert response.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_logbook_view_invalid_end_date_time(recorder_mock, hass, hass_client):
+async def test_logbook_view_invalid_end_date_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -383,7 +395,12 @@ async def test_logbook_view_invalid_end_date_time(recorder_mock, hass, hass_clie
     assert response.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_logbook_view_period_entity(recorder_mock, hass, hass_client, set_utc):
+async def test_logbook_view_period_entity(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    set_utc,
+) -> None:
     """Test the logbook view with period and entity."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -464,7 +481,9 @@ async def test_logbook_view_period_entity(recorder_mock, hass, hass_client, set_
     assert response_json[0]["entity_id"] == entity_id_test
 
 
-async def test_logbook_describe_event(recorder_mock, hass, hass_client):
+async def test_logbook_describe_event(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test teaching logbook about a new event."""
 
     def _describe(event):
@@ -508,7 +527,9 @@ async def test_logbook_describe_event(recorder_mock, hass, hass_client):
     assert event["domain"] == "test_domain"
 
 
-async def test_exclude_described_event(recorder_mock, hass, hass_client):
+async def test_exclude_described_event(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test exclusions of events that are described by another integration."""
     name = "My Automation Rule"
     entity_id = "automation.excluded_rule"
@@ -579,7 +600,9 @@ async def test_exclude_described_event(recorder_mock, hass, hass_client):
     assert event["entity_id"] == "automation.included_rule"
 
 
-async def test_logbook_view_end_time_entity(recorder_mock, hass, hass_client):
+async def test_logbook_view_end_time_entity(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with end_time and entity."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -634,7 +657,9 @@ async def test_logbook_view_end_time_entity(recorder_mock, hass, hass_client):
     assert response_json[0]["entity_id"] == entity_id_test
 
 
-async def test_logbook_entity_filter_with_automations(recorder_mock, hass, hass_client):
+async def test_logbook_entity_filter_with_automations(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
         *[
@@ -710,8 +735,8 @@ async def test_logbook_entity_filter_with_automations(recorder_mock, hass, hass_
 
 
 async def test_logbook_entity_no_longer_in_state_machine(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with an entity that hass been removed from the state machine."""
     await async_setup_component(hass, "logbook", {})
     await async_setup_component(hass, "automation", {})
@@ -748,8 +773,11 @@ async def test_logbook_entity_no_longer_in_state_machine(
 
 
 async def test_filter_continuous_sensor_values(
-    recorder_mock, hass, hass_client, set_utc
-):
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    set_utc,
+) -> None:
     """Test remove continuous sensor events from logbook."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -788,7 +816,12 @@ async def test_filter_continuous_sensor_values(
     assert response_json[1]["entity_id"] == entity_id_third
 
 
-async def test_exclude_new_entities(recorder_mock, hass, hass_client, set_utc):
+async def test_exclude_new_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    set_utc,
+) -> None:
     """Test if events are excluded on first update."""
     await asyncio.gather(
         *[
@@ -825,7 +858,12 @@ async def test_exclude_new_entities(recorder_mock, hass, hass_client, set_utc):
     assert response_json[1]["message"] == "started"
 
 
-async def test_exclude_removed_entities(recorder_mock, hass, hass_client, set_utc):
+async def test_exclude_removed_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    set_utc,
+) -> None:
     """Test if events are excluded on last update."""
     await asyncio.gather(
         *[
@@ -869,7 +907,12 @@ async def test_exclude_removed_entities(recorder_mock, hass, hass_client, set_ut
     assert response_json[2]["entity_id"] == entity_id2
 
 
-async def test_exclude_attribute_changes(recorder_mock, hass, hass_client, set_utc):
+async def test_exclude_attribute_changes(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    set_utc,
+) -> None:
     """Test if events of attribute changes are filtered."""
     await asyncio.gather(
         *[
@@ -909,7 +952,9 @@ async def test_exclude_attribute_changes(recorder_mock, hass, hass_client, set_u
     assert response_json[2]["entity_id"] == "light.kitchen"
 
 
-async def test_logbook_entity_context_id(recorder_mock, hass, hass_client):
+async def test_logbook_entity_context_id(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
         *[
@@ -1060,8 +1105,8 @@ async def test_logbook_entity_context_id(recorder_mock, hass, hass_client):
 
 
 async def test_logbook_context_id_automation_script_started_manually(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook populates context_ids for scripts and automations started manually."""
     await asyncio.gather(
         *[
@@ -1150,7 +1195,9 @@ async def test_logbook_context_id_automation_script_started_manually(
     assert json_dict[4]["context_domain"] == "script"
 
 
-async def test_logbook_entity_context_parent_id(recorder_mock, hass, hass_client):
+async def test_logbook_entity_context_parent_id(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view links events via context parent_id."""
     await asyncio.gather(
         *[
@@ -1329,7 +1376,9 @@ async def test_logbook_entity_context_parent_id(recorder_mock, hass, hass_client
     assert json_dict[8]["context_user_id"] == "485cacf93ef84d25a99ced3126b921d2"
 
 
-async def test_logbook_context_from_template(recorder_mock, hass, hass_client):
+async def test_logbook_context_from_template(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
         *[
@@ -1416,7 +1465,9 @@ async def test_logbook_context_from_template(recorder_mock, hass, hass_client):
     assert json_dict[5]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_logbook_(recorder_mock, hass, hass_client):
+async def test_logbook_(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with a single entity and ."""
     await async_setup_component(hass, "logbook", {})
     assert await async_setup_component(
@@ -1485,7 +1536,9 @@ async def test_logbook_(recorder_mock, hass, hass_client):
     assert json_dict[1]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_logbook_many_entities_multiple_calls(recorder_mock, hass, hass_client):
+async def test_logbook_many_entities_multiple_calls(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with a many entities called multiple times."""
     await async_setup_component(hass, "logbook", {})
     await async_setup_component(hass, "automation", {})
@@ -1555,7 +1608,9 @@ async def test_logbook_many_entities_multiple_calls(recorder_mock, hass, hass_cl
     assert len(json_dict) == 0
 
 
-async def test_custom_log_entry_discoverable_via_(recorder_mock, hass, hass_client):
+async def test_custom_log_entry_discoverable_via_(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if a custom log entry is later discoverable via ."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -1590,7 +1645,9 @@ async def test_custom_log_entry_discoverable_via_(recorder_mock, hass, hass_clie
     assert json_dict[0]["entity_id"] == "switch.test_switch"
 
 
-async def test_logbook_multiple_entities(recorder_mock, hass, hass_client):
+async def test_logbook_multiple_entities(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with a multiple entities."""
     await async_setup_component(hass, "logbook", {})
     assert await async_setup_component(
@@ -1714,7 +1771,9 @@ async def test_logbook_multiple_entities(recorder_mock, hass, hass_client):
     assert json_dict[3]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_logbook_invalid_entity(recorder_mock, hass, hass_client):
+async def test_logbook_invalid_entity(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with requesting an invalid entity."""
     await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()
@@ -1732,7 +1791,9 @@ async def test_logbook_invalid_entity(recorder_mock, hass, hass_client):
     assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
-async def test_icon_and_state(recorder_mock, hass, hass_client):
+async def test_icon_and_state(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test to ensure state and custom icons are returned."""
     await asyncio.gather(
         *[
@@ -1775,7 +1836,9 @@ async def test_icon_and_state(recorder_mock, hass, hass_client):
     assert response_json[2]["state"] == STATE_OFF
 
 
-async def test_fire_logbook_entries(recorder_mock, hass, hass_client):
+async def test_fire_logbook_entries(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test many logbook entry calls."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -1811,7 +1874,9 @@ async def test_fire_logbook_entries(recorder_mock, hass, hass_client):
     assert len(response_json) == 11
 
 
-async def test_exclude_events_domain(recorder_mock, hass, hass_client):
+async def test_exclude_events_domain(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if domain is excluded in config."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
@@ -1845,7 +1910,9 @@ async def test_exclude_events_domain(recorder_mock, hass, hass_client):
     _assert_entry(entries[1], name="blu", entity_id=entity_id2)
 
 
-async def test_exclude_events_domain_glob(recorder_mock, hass, hass_client):
+async def test_exclude_events_domain_glob(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if domain or glob is excluded in config."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
@@ -1888,7 +1955,9 @@ async def test_exclude_events_domain_glob(recorder_mock, hass, hass_client):
     _assert_entry(entries[1], name="blu", entity_id=entity_id2)
 
 
-async def test_include_events_entity(recorder_mock, hass, hass_client):
+async def test_include_events_entity(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if entity is included in config."""
     entity_id = "sensor.bla"
     entity_id2 = "sensor.blu"
@@ -1928,7 +1997,9 @@ async def test_include_events_entity(recorder_mock, hass, hass_client):
     _assert_entry(entries[1], name="blu", entity_id=entity_id2)
 
 
-async def test_exclude_events_entity(recorder_mock, hass, hass_client):
+async def test_exclude_events_entity(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if entity is excluded in config."""
     entity_id = "sensor.bla"
     entity_id2 = "sensor.blu"
@@ -1962,7 +2033,9 @@ async def test_exclude_events_entity(recorder_mock, hass, hass_client):
     _assert_entry(entries[1], name="blu", entity_id=entity_id2)
 
 
-async def test_include_events_domain(recorder_mock, hass, hass_client):
+async def test_include_events_domain(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if domain is included in config."""
     assert await async_setup_component(hass, "alexa", {})
     entity_id = "switch.bla"
@@ -2004,7 +2077,9 @@ async def test_include_events_domain(recorder_mock, hass, hass_client):
     _assert_entry(entries[2], name="blu", entity_id=entity_id2)
 
 
-async def test_include_events_domain_glob(recorder_mock, hass, hass_client):
+async def test_include_events_domain_glob(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if domain or glob is included in config."""
     assert await async_setup_component(hass, "alexa", {})
     entity_id = "switch.bla"
@@ -2061,7 +2136,9 @@ async def test_include_events_domain_glob(recorder_mock, hass, hass_client):
     _assert_entry(entries[3], name="included", entity_id=entity_id3)
 
 
-async def test_include_exclude_events_no_globs(recorder_mock, hass, hass_client):
+async def test_include_exclude_events_no_globs(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if include and exclude is configured."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
@@ -2118,8 +2195,8 @@ async def test_include_exclude_events_no_globs(recorder_mock, hass, hass_client)
 
 
 async def test_include_exclude_events_with_glob_filters(
-    recorder_mock, hass, hass_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test if events are filtered if include and exclude is configured."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
@@ -2183,7 +2260,9 @@ async def test_include_exclude_events_with_glob_filters(
     _assert_entry(entries[6], name="included", entity_id=entity_id5, state="30")
 
 
-async def test_empty_config(recorder_mock, hass, hass_client):
+async def test_empty_config(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test we can handle an empty entity filter."""
     entity_id = "sensor.blu"
 
@@ -2215,7 +2294,9 @@ async def test_empty_config(recorder_mock, hass, hass_client):
     _assert_entry(entries[1], name="blu", entity_id=entity_id)
 
 
-async def test_context_filter(recorder_mock, hass, hass_client):
+async def test_context_filter(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test we can filter by context."""
     assert await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -2287,7 +2368,9 @@ def _assert_entry(
         assert state == entry["state"]
 
 
-async def test_get_events(recorder_mock, hass, hass_ws_client):
+async def test_get_events(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2405,7 +2488,9 @@ async def test_get_events(recorder_mock, hass, hass_ws_client):
     assert isinstance(results[0]["when"], float)
 
 
-async def test_get_events_future_start_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_future_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events with a future start time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -2428,7 +2513,9 @@ async def test_get_events_future_start_time(recorder_mock, hass, hass_ws_client)
     assert len(results) == 0
 
 
-async def test_get_events_bad_start_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_bad_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events bad start time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -2446,7 +2533,9 @@ async def test_get_events_bad_start_time(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_start_time"
 
 
-async def test_get_events_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "logbook", {})
@@ -2466,7 +2555,9 @@ async def test_get_events_bad_end_time(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_end_time"
 
 
-async def test_get_events_invalid_filters(recorder_mock, hass, hass_ws_client):
+async def test_get_events_invalid_filters(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events invalid filters."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -2494,7 +2585,9 @@ async def test_get_events_invalid_filters(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_format"
 
 
-async def test_get_events_with_device_ids(recorder_mock, hass, hass_ws_client):
+async def test_get_events_with_device_ids(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events for device ids."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2631,7 +2724,9 @@ async def test_get_events_with_device_ids(recorder_mock, hass, hass_ws_client):
     assert isinstance(results[3]["when"], float)
 
 
-async def test_logbook_select_entities_context_id(recorder_mock, hass, hass_client):
+async def test_logbook_select_entities_context_id(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
         *[
@@ -2764,7 +2859,9 @@ async def test_logbook_select_entities_context_id(recorder_mock, hass, hass_clie
     assert json_dict[3]["context_user_id"] == "9400facee45711eaa9308bfd3d19e474"
 
 
-async def test_get_events_with_context_state(recorder_mock, hass, hass_ws_client):
+async def test_get_events_with_context_state(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events with a context state."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2827,7 +2924,9 @@ async def test_get_events_with_context_state(recorder_mock, hass, hass_ws_client
     assert "context_event_type" not in results[3]
 
 
-async def test_logbook_with_empty_config(recorder_mock, hass):
+async def test_logbook_with_empty_config(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test we handle a empty configuration."""
     assert await async_setup_component(
         hass,
@@ -2840,7 +2939,9 @@ async def test_logbook_with_empty_config(recorder_mock, hass):
     await hass.async_block_till_done()
 
 
-async def test_logbook_with_non_iterable_entity_filter(recorder_mock, hass):
+async def test_logbook_with_non_iterable_entity_filter(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test we handle a non-iterable entity filter."""
     assert await async_setup_component(
         hass,

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -11,6 +11,7 @@ from homeassistant import core
 from homeassistant.components import logbook, recorder
 from homeassistant.components.automation import ATTR_SOURCE, EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.logbook import websocket_api
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.util import get_instance
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.websocket_api.const import TYPE_RESULT
@@ -35,16 +36,13 @@ from homeassistant.helpers.entityfilter import CONF_ENTITY_GLOBS
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import (
-    MockConfigEntry,
-    SetupRecorderInstanceT,
-    async_fire_time_changed,
-)
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.recorder.common import (
     async_block_recorder,
     async_recorder_block_till_done,
     async_wait_recording_done,
 )
+from tests.typing import RecorderInstanceGenerator, WebSocketGenerator
 
 
 @pytest.fixture
@@ -133,7 +131,9 @@ async def _async_mock_devices_with_logbook_platform(hass):
     return [device, device2]
 
 
-async def test_get_events(recorder_mock, hass, hass_ws_client):
+async def test_get_events(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -251,7 +251,9 @@ async def test_get_events(recorder_mock, hass, hass_ws_client):
     assert isinstance(results[0]["when"], float)
 
 
-async def test_get_events_entities_filtered_away(recorder_mock, hass, hass_ws_client):
+async def test_get_events_entities_filtered_away(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events all entities filtered away."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -313,7 +315,9 @@ async def test_get_events_entities_filtered_away(recorder_mock, hass, hass_ws_cl
     assert len(results) == 0
 
 
-async def test_get_events_future_start_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_future_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events with a future start time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -336,7 +340,9 @@ async def test_get_events_future_start_time(recorder_mock, hass, hass_ws_client)
     assert len(results) == 0
 
 
-async def test_get_events_bad_start_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_bad_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events bad start time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -354,7 +360,9 @@ async def test_get_events_bad_start_time(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_start_time"
 
 
-async def test_get_events_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_get_events_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "logbook", {})
@@ -374,7 +382,9 @@ async def test_get_events_bad_end_time(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_end_time"
 
 
-async def test_get_events_invalid_filters(recorder_mock, hass, hass_ws_client):
+async def test_get_events_invalid_filters(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_events invalid filters."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -402,7 +412,9 @@ async def test_get_events_invalid_filters(recorder_mock, hass, hass_ws_client):
     assert response["error"]["code"] == "invalid_format"
 
 
-async def test_get_events_with_device_ids(recorder_mock, hass, hass_ws_client):
+async def test_get_events_with_device_ids(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook get_events for device ids."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -514,8 +526,8 @@ async def test_get_events_with_device_ids(recorder_mock, hass, hass_ws_client):
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with excluded entities."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -701,8 +713,8 @@ async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_included_entities(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with included entities."""
     test_entities = (
         "light.inc",
@@ -911,8 +923,8 @@ async def test_subscribe_unsubscribe_logbook_stream_included_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_excluded_entities_inherits_filters_from_recorder(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream inherits filters from recorder."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1104,8 +1116,8 @@ async def test_logbook_stream_excluded_entities_inherits_filters_from_recorder(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1409,8 +1421,8 @@ async def test_subscribe_unsubscribe_logbook_stream(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1509,8 +1521,8 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities and an end_time."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1613,8 +1625,8 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities in the past."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1683,8 +1695,8 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_big_query(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream and ask for a large time frame.
 
     We should get the data for the first 24 hours in the first message, and
@@ -1785,8 +1797,8 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_device(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with a device."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -1889,7 +1901,9 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
     ) == listeners_without_writes(init_listeners)
 
 
-async def test_event_stream_bad_start_time(recorder_mock, hass, hass_ws_client):
+async def test_event_stream_bad_start_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test event_stream bad start time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -1909,8 +1923,8 @@ async def test_event_stream_bad_start_time(recorder_mock, hass, hass_ws_client):
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_match_multiple_entities(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook stream with a described integration that uses multiple entities."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2014,7 +2028,9 @@ async def test_logbook_stream_match_multiple_entities(
     ) == listeners_without_writes(init_listeners)
 
 
-async def test_event_stream_bad_end_time(recorder_mock, hass, hass_ws_client):
+async def test_event_stream_bad_end_time(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test event_stream bad end time."""
     await async_setup_component(hass, "logbook", {})
     await async_recorder_block_till_done(hass)
@@ -2047,10 +2063,10 @@ async def test_event_stream_bad_end_time(recorder_mock, hass, hass_ws_client):
 
 
 async def test_live_stream_with_one_second_commit_interval(
-    async_setup_recorder_instance: SetupRecorderInstanceT,
+    async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the recorder with a 1s commit interval."""
     config = {recorder.CONF_COMMIT_INTERVAL: 0.5}
     await async_setup_recorder_instance(hass, config)
@@ -2140,7 +2156,9 @@ async def test_live_stream_with_one_second_commit_interval(
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
-async def test_subscribe_disconnected(recorder_mock, hass, hass_ws_client):
+async def test_subscribe_disconnected(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream gets disconnected."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2197,7 +2215,9 @@ async def test_subscribe_disconnected(recorder_mock, hass, hass_ws_client):
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
-async def test_stream_consumer_stop_processing(recorder_mock, hass, hass_ws_client):
+async def test_stream_consumer_stop_processing(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we unsubscribe if the stream consumer fails or is canceled."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2256,7 +2276,12 @@ async def test_stream_consumer_stop_processing(recorder_mock, hass, hass_ws_clie
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
-async def test_recorder_is_far_behind(recorder_mock, hass, hass_ws_client, caplog):
+async def test_recorder_is_far_behind(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test we still start live streaming if the recorder is far behind."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2337,8 +2362,8 @@ async def test_recorder_is_far_behind(recorder_mock, hass, hass_ws_client, caplo
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_are_continuous(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with entities that are always filtered."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2397,8 +2422,8 @@ async def test_subscribe_all_entities_are_continuous(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_have_uom_multiple(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook stream with specific request for multiple entities that are always filtered."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2454,8 +2479,8 @@ async def test_subscribe_all_entities_have_uom_multiple(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_entities_some_have_uom_multiple(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook stream with uom filtered entities and non-filtered entities."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2561,8 +2586,8 @@ async def test_subscribe_entities_some_have_uom_multiple(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_ignores_forced_updates(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test logbook live stream ignores forced updates."""
     now = dt_util.utcnow()
     await asyncio.gather(
@@ -2677,8 +2702,8 @@ async def test_logbook_stream_ignores_forced_updates(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_are_continuous_with_device(
-    recorder_mock, hass, hass_ws_client
-):
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe/unsubscribe logbook stream with entities that are always filtered and a device."""
     now = dt_util.utcnow()
     await asyncio.gather(

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -41,7 +41,7 @@ def mock_requests():
         yield mock_requests
 
 
-async def test_event_listener(hass, mock_dump, mock_requests):
+async def test_event_listener(hass: HomeAssistant, mock_dump, mock_requests) -> None:
     """Test event listener."""
     mock_dump.side_effect = lambda x: x
     mock_post = mock_requests.post

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the Logger component."""
 from collections import defaultdict
 import logging
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -179,7 +180,9 @@ async def test_can_set_level_from_yaml(hass: HomeAssistant) -> None:
     _reset_logging()
 
 
-async def test_can_set_level_from_store(hass, hass_storage):
+async def test_can_set_level_from_store(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test setting up logs from store."""
     hass_storage["core.logger"] = {
         "data": {
@@ -308,7 +311,9 @@ def _reset_logging():
     logging.getLogger(INTEGRATION_NS).orig_setLevel(logging.NOTSET)
 
 
-async def test_can_set_integration_level_from_store(hass, hass_storage):
+async def test_can_set_integration_level_from_store(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test setting up integration logs from store."""
     hass_storage["core.logger"] = {
         "data": {
@@ -331,7 +336,9 @@ async def test_can_set_integration_level_from_store(hass, hass_storage):
     _reset_logging()
 
 
-async def test_chattier_log_level_wins_1(hass, hass_storage):
+async def test_chattier_log_level_wins_1(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test chattier log level in store takes precedence."""
     hass_storage["core.logger"] = {
         "data": {
@@ -364,7 +371,9 @@ async def test_chattier_log_level_wins_1(hass, hass_storage):
     _reset_logging()
 
 
-async def test_chattier_log_level_wins_2(hass, hass_storage):
+async def test_chattier_log_level_wins_2(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test chattier log level in yaml takes precedence."""
     hass_storage["core.logger"] = {
         "data": {
@@ -389,7 +398,9 @@ async def test_chattier_log_level_wins_2(hass, hass_storage):
     _reset_logging()
 
 
-async def test_log_once_removed_from_store(hass, hass_storage):
+async def test_log_once_removed_from_store(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test logs with persistence "once" are removed from the store at startup."""
     hass_storage["core.logger"] = {
         "data": {

--- a/tests/components/logger/test_websocket_api.py
+++ b/tests/components/logger/test_websocket_api.py
@@ -3,10 +3,16 @@ import logging
 
 from homeassistant.components.logger.helpers import async_get_domain_config
 from homeassistant.components.websocket_api import const
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockUser
+from tests.typing import WebSocketGenerator
 
-async def test_integration_log_info(hass, hass_ws_client, hass_admin_user):
+
+async def test_integration_log_info(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test fetching integration log info."""
 
     assert await async_setup_component(hass, "logger", {})
@@ -26,8 +32,8 @@ async def test_integration_log_info(hass, hass_ws_client, hass_admin_user):
 
 
 async def test_integration_log_level_logger_not_loaded(
-    hass, hass_ws_client, hass_admin_user
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test setting integration log level."""
     websocket_client = await hass_ws_client()
     await websocket_client.send_json(
@@ -46,7 +52,9 @@ async def test_integration_log_level_logger_not_loaded(
     assert not msg["success"]
 
 
-async def test_integration_log_level(hass, hass_ws_client, hass_admin_user):
+async def test_integration_log_level(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test setting integration log level."""
     websocket_client = await hass_ws_client()
     assert await async_setup_component(hass, "logger", {})
@@ -72,8 +80,8 @@ async def test_integration_log_level(hass, hass_ws_client, hass_admin_user):
 
 
 async def test_integration_log_level_unknown_integration(
-    hass, hass_ws_client, hass_admin_user
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test setting integration log level for an unknown integration."""
     websocket_client = await hass_ws_client()
     assert await async_setup_component(hass, "logger", {})
@@ -94,7 +102,9 @@ async def test_integration_log_level_unknown_integration(
     assert not msg["success"]
 
 
-async def test_module_log_level(hass, hass_ws_client, hass_admin_user):
+async def test_module_log_level(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test setting integration log level."""
     websocket_client = await hass_ws_client()
     assert await async_setup_component(
@@ -124,7 +134,9 @@ async def test_module_log_level(hass, hass_ws_client, hass_admin_user):
     }
 
 
-async def test_module_log_level_override(hass, hass_ws_client, hass_admin_user):
+async def test_module_log_level_override(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, hass_admin_user: MockUser
+) -> None:
     """Test override yaml integration log level."""
     websocket_client = await hass_ws_client()
     assert await async_setup_component(

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -58,7 +58,7 @@ def mock_logi_circle():
         yield LogiCircle
 
 
-async def test_step_import(hass, mock_logi_circle):
+async def test_step_import(hass: HomeAssistant, mock_logi_circle) -> None:
     """Test that we trigger import when configuring with client."""
     flow = init_config_flow(hass)
 
@@ -67,7 +67,7 @@ async def test_step_import(hass, mock_logi_circle):
     assert result["step_id"] == "auth"
 
 
-async def test_full_flow_implementation(hass, mock_logi_circle):
+async def test_full_flow_implementation(hass: HomeAssistant, mock_logi_circle) -> None:
     """Test registering an implementation and finishing flow works."""
     config_flow.register_flow_implementation(
         hass,
@@ -148,7 +148,9 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
         (AuthorizationFailed, "invalid_auth"),
     ],
 )
-async def test_abort_if_authorize_fails(hass, mock_logi_circle, side_effect, error):
+async def test_abort_if_authorize_fails(
+    hass: HomeAssistant, mock_logi_circle, side_effect, error
+) -> None:
     """Test we abort if authorizing fails."""
     flow = init_config_flow(hass)
     mock_logi_circle.authorize.side_effect = side_effect
@@ -170,7 +172,7 @@ async def test_not_pick_implementation_if_only_one(hass: HomeAssistant) -> None:
     assert result["step_id"] == "auth"
 
 
-async def test_gen_auth_url(hass, mock_logi_circle):
+async def test_gen_auth_url(hass: HomeAssistant, mock_logi_circle) -> None:
     """Test generating authorize URL from Logi Circle API."""
     config_flow.register_flow_implementation(
         hass,
@@ -198,7 +200,9 @@ async def test_callback_view_rejects_missing_code(hass: HomeAssistant) -> None:
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_callback_view_accepts_code(hass, mock_logi_circle):
+async def test_callback_view_accepts_code(
+    hass: HomeAssistant, mock_logi_circle
+) -> None:
     """Test the auth callback view handles requests with auth code."""
     init_config_flow(hass)
     view = LogiCircleAuthCallbackView()

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -1,7 +1,10 @@
 """The tests for the london_air platform."""
 from http import HTTPStatus
 
+import requests_mock
+
 from homeassistant.components.london_air.sensor import CONF_LOCATIONS, URL
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
@@ -9,7 +12,9 @@ from tests.common import load_fixture
 VALID_CONFIG = {"sensor": {"platform": "london_air", CONF_LOCATIONS: ["Merton"]}}
 
 
-async def test_valid_state(hass, requests_mock):
+async def test_valid_state(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test for operational london_air sensor with proper attributes."""
     requests_mock.get(
         URL, text=load_fixture("london_air.json"), status_code=HTTPStatus.OK
@@ -42,7 +47,9 @@ async def test_valid_state(hass, requests_mock):
     assert pollutants[0]["summary"] == "PM10 is Low"
 
 
-async def test_api_failure(hass, requests_mock):
+async def test_api_failure(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test for failure in the API."""
     requests_mock.get(URL, status_code=HTTPStatus.SERVICE_UNAVAILABLE)
     assert await async_setup_component(hass, "sensor", VALID_CONFIG)

--- a/tests/components/lookin/test_config_flow.py
+++ b/tests/components/lookin/test_config_flow.py
@@ -24,7 +24,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_manual_setup(hass: HomeAssistant):
+async def test_manual_setup(hass: HomeAssistant) -> None:
     """Test manually setting up."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -47,7 +47,7 @@ async def test_manual_setup(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_manual_setup_already_exists(hass: HomeAssistant):
+async def test_manual_setup_already_exists(hass: HomeAssistant) -> None:
     """Test manually setting up and the device already exists."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=DEVICE_ID
@@ -70,7 +70,7 @@ async def test_manual_setup_already_exists(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_manual_setup_device_offline(hass: HomeAssistant):
+async def test_manual_setup_device_offline(hass: HomeAssistant) -> None:
     """Test manually setting up, device offline."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -89,7 +89,7 @@ async def test_manual_setup_device_offline(hass: HomeAssistant):
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
-async def test_manual_setup_unknown_exception(hass: HomeAssistant):
+async def test_manual_setup_unknown_exception(hass: HomeAssistant) -> None:
     """Test manually setting up, unknown exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -98,7 +98,9 @@ async def test_browse_media_error(hass: HomeAssistant) -> None:
     )
 
 
-async def test_browse_media(hass, mock_yaml_dashboard, mock_https_url):
+async def test_browse_media(
+    hass: HomeAssistant, mock_yaml_dashboard, mock_https_url
+) -> None:
     """Test browse media."""
     top_level_items = await lovelace_cast.async_browse_media(
         hass, "lovelace", "", lovelace_cast.CAST_TYPE_CHROMECAST
@@ -161,7 +163,7 @@ async def test_browse_media(hass, mock_yaml_dashboard, mock_https_url):
         )
 
 
-async def test_play_media(hass, mock_yaml_dashboard):
+async def test_play_media(hass: HomeAssistant, mock_yaml_dashboard) -> None:
     """Test playing media."""
     calls = async_mock_service(hass, "cast", "show_lovelace_view")
 

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -1,4 +1,5 @@
 """Test the Lovelace initialization."""
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -12,7 +13,9 @@ from tests.common import assert_setup_component, async_capture_events
 from tests.typing import WebSocketGenerator
 
 
-async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
+async def test_lovelace_from_storage(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test we load lovelace config from storage."""
     assert await async_setup_component(hass, "lovelace", {})
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "storage"}
@@ -64,8 +67,8 @@ async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
 
 
 async def test_lovelace_from_storage_save_before_load(
-    hass, hass_ws_client, hass_storage
-):
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test we can load lovelace config from storage."""
     assert await async_setup_component(hass, "lovelace", {})
     client = await hass_ws_client(hass)
@@ -81,7 +84,9 @@ async def test_lovelace_from_storage_save_before_load(
     }
 
 
-async def test_lovelace_from_storage_delete(hass, hass_ws_client, hass_storage):
+async def test_lovelace_from_storage_delete(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test we delete lovelace config from storage."""
     assert await async_setup_component(hass, "lovelace", {})
     client = await hass_ws_client(hass)
@@ -162,7 +167,9 @@ async def test_lovelace_from_yaml(
 
 
 @pytest.mark.parametrize("url_path", ("test-panel", "test-panel-no-sidebar"))
-async def test_dashboard_from_yaml(hass, hass_ws_client, url_path):
+async def test_dashboard_from_yaml(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, url_path
+) -> None:
     """Test we load lovelace dashboard config from yaml."""
     assert await async_setup_component(
         hass,
@@ -290,7 +297,9 @@ async def test_wrong_key_dashboard_from_yaml(hass: HomeAssistant) -> None:
         )
 
 
-async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
+async def test_storage_dashboards(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test we load lovelace config from storage."""
     assert await async_setup_component(hass, "lovelace", {})
     assert hass.data[frontend.DATA_PANELS]["lovelace"].config == {"mode": "storage"}
@@ -431,7 +440,9 @@ async def test_storage_dashboards(hass, hass_ws_client, hass_storage):
     assert dashboard.CONFIG_STORAGE_KEY.format(dashboard_id) not in hass_storage
 
 
-async def test_storage_dashboard_migrate(hass, hass_ws_client, hass_storage):
+async def test_storage_dashboard_migrate(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test changing url path from storage config."""
     hass_storage[dashboard.DASHBOARDS_STORAGE_KEY] = {
         "key": "lovelace_dashboards",

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -1,5 +1,6 @@
 """Test Lovelace resources."""
 import copy
+from typing import Any
 from unittest.mock import patch
 import uuid
 
@@ -53,7 +54,9 @@ async def test_yaml_resources_backwards(
     assert response["result"] == RESOURCE_EXAMPLES
 
 
-async def test_storage_resources(hass, hass_ws_client, hass_storage):
+async def test_storage_resources(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test defining resources in storage config."""
     resource_config = [{**item, "id": uuid.uuid4().hex} for item in RESOURCE_EXAMPLES]
     hass_storage[resources.RESOURCE_STORAGE_KEY] = {
@@ -72,7 +75,9 @@ async def test_storage_resources(hass, hass_ws_client, hass_storage):
     assert response["result"] == resource_config
 
 
-async def test_storage_resources_import(hass, hass_ws_client, hass_storage):
+async def test_storage_resources_import(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test importing resources from storage config."""
     assert await async_setup_component(hass, "lovelace", {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
@@ -158,7 +163,9 @@ async def test_storage_resources_import(hass, hass_ws_client, hass_storage):
     assert first_item["id"] not in (item["id"] for item in response["result"])
 
 
-async def test_storage_resources_import_invalid(hass, hass_ws_client, hass_storage):
+async def test_storage_resources_import_invalid(
+    hass: HomeAssistant, hass_ws_client, hass_storage: dict[str, Any]
+) -> None:
     """Test importing resources from storage config."""
     assert await async_setup_component(hass, "lovelace", {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -1,4 +1,5 @@
 """Tests for Lovelace system health."""
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant.components.lovelace import dashboard
@@ -16,7 +17,9 @@ async def test_system_health_info_autogen(hass: HomeAssistant) -> None:
     assert info == {"dashboards": 1, "mode": "auto-gen", "resources": 0}
 
 
-async def test_system_health_info_storage(hass, hass_storage):
+async def test_system_health_info_storage(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "system_health", {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
