### PR TITLE
Add type hints to integration tests (part 14)

### DIFF
--- a/tests/components/luftdaten/test_diagnostics.py
+++ b/tests/components/luftdaten/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -192,7 +192,7 @@ async def test_already_configured_with_ignored(hass: HomeAssistant) -> None:
     assert result["type"] == "form"
 
 
-async def test_form_user(hass, tmpdir):
+async def test_form_user(hass: HomeAssistant, tmpdir) -> None:
     """Test we get the form and can pair."""
 
     hass.config.config_dir = await hass.async_add_executor_job(
@@ -243,7 +243,7 @@ async def test_form_user(hass, tmpdir):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_user_pairing_fails(hass, tmpdir):
+async def test_form_user_pairing_fails(hass: HomeAssistant, tmpdir) -> None:
     """Test we get the form and we handle pairing failure."""
 
     hass.config.config_dir = await hass.async_add_executor_job(
@@ -288,7 +288,9 @@ async def test_form_user_pairing_fails(hass, tmpdir):
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_user_reuses_existing_assets_when_pairing_again(hass, tmpdir):
+async def test_form_user_reuses_existing_assets_when_pairing_again(
+    hass: HomeAssistant, tmpdir
+) -> None:
     """Test the tls assets saved on disk are reused when pairing again."""
 
     hass.config.config_dir = await hass.async_add_executor_job(
@@ -388,7 +390,7 @@ async def test_form_user_reuses_existing_assets_when_pairing_again(hass, tmpdir)
     }
 
 
-async def test_zeroconf_host_already_configured(hass, tmpdir):
+async def test_zeroconf_host_already_configured(hass: HomeAssistant, tmpdir) -> None:
     """Test starting a flow from discovery when the host is already configured."""
 
     hass.config.config_dir = await hass.async_add_executor_job(
@@ -472,7 +474,7 @@ async def test_zeroconf_not_lutron_device(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "source", (config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT)
 )
-async def test_zeroconf(hass, source, tmpdir):
+async def test_zeroconf(hass: HomeAssistant, source, tmpdir) -> None:
     """Test starting a flow from discovery."""
 
     hass.config.config_dir = await hass.async_add_executor_job(

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -130,7 +131,7 @@ async def _async_setup_lutron_with_picos(hass):
     return config_entry.entry_id
 
 
-async def test_get_triggers(hass):
+async def test_get_triggers(hass: HomeAssistant) -> None:
     """Test we get the expected triggers from a lutron pico."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
     data: LutronCasetaData = hass.data[DOMAIN][config_entry_id]
@@ -167,7 +168,9 @@ async def test_get_triggers(hass):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_for_invalid_device_id(hass, device_registry):
+async def test_get_triggers_for_invalid_device_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test error raised for invalid lutron device_id."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
 
@@ -183,7 +186,9 @@ async def test_get_triggers_for_invalid_device_id(hass, device_registry):
     assert triggers == []
 
 
-async def test_get_triggers_for_non_button_device(hass, device_registry):
+async def test_get_triggers_for_non_button_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test error raised for invalid lutron device_id."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
 
@@ -199,7 +204,9 @@ async def test_get_triggers_for_non_button_device(hass, device_registry):
     assert triggers == []
 
 
-async def test_none_serial_keypad(hass, device_registry):
+async def test_none_serial_keypad(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test serial assignment for keypads without serials."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
 
@@ -211,7 +218,9 @@ async def test_none_serial_keypad(hass, device_registry):
     assert keypad_device is not None
 
 
-async def test_if_fires_on_button_event(hass, calls, device_registry):
+async def test_if_fires_on_button_event(
+    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+) -> None:
     """Test for press trigger firing."""
     await _async_setup_lutron_with_picos(hass)
 
@@ -260,7 +269,9 @@ async def test_if_fires_on_button_event(hass, calls, device_registry):
     assert calls[0].data["some"] == "test_trigger_button_press"
 
 
-async def test_if_fires_on_button_event_without_lip(hass, calls, device_registry):
+async def test_if_fires_on_button_event_without_lip(
+    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+) -> None:
     """Test for press trigger firing on a device that does not support lip."""
     await _async_setup_lutron_with_picos(hass)
     device = MOCK_BUTTON_DEVICES[1]
@@ -307,7 +318,7 @@ async def test_if_fires_on_button_event_without_lip(hass, calls, device_registry
     assert calls[0].data["some"] == "test_trigger_button_press"
 
 
-async def test_validate_trigger_config_no_device(hass, calls):
+async def test_validate_trigger_config_no_device(hass: HomeAssistant, calls) -> None:
     """Test for no press with no device."""
 
     assert await async_setup_component(
@@ -345,7 +356,9 @@ async def test_validate_trigger_config_no_device(hass, calls):
     assert len(calls) == 0
 
 
-async def test_validate_trigger_config_unknown_device(hass, calls):
+async def test_validate_trigger_config_unknown_device(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for no press with an unknown device."""
 
     config_entry_id = await _async_setup_lutron_with_picos(hass)
@@ -391,7 +404,9 @@ async def test_validate_trigger_config_unknown_device(hass, calls):
     assert len(calls) == 0
 
 
-async def test_validate_trigger_invalid_triggers(hass, caplog):
+async def test_validate_trigger_invalid_triggers(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for click_event with invalid triggers."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
     data: LutronCasetaData = hass.data[DOMAIN][config_entry_id]
@@ -425,7 +440,9 @@ async def test_validate_trigger_invalid_triggers(hass, caplog):
     assert "value must be one of ['press', 'release']" in caplog.text
 
 
-async def test_if_fires_on_button_event_late_setup(hass, calls, device_registry):
+async def test_if_fires_on_button_event_late_setup(
+    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+) -> None:
     """Test for press trigger firing with integration getting setup late."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)
     await hass.config_entries.async_unload(config_entry_id)

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -41,8 +43,12 @@ async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host, mock_impl
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    mock_impl,
+) -> None:
     """Check full flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -101,8 +107,12 @@ async def test_full_flow(
 
 
 async def test_reauthentication_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host, mock_impl
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    mock_impl,
+) -> None:
     """Test reauthentication flow."""
     old_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -16,7 +16,7 @@ def mock_http_client(hass, hass_client):
     return hass.loop.run_until_complete(hass_client())
 
 
-async def test_get_platforms_from_mailbox(mock_http_client):
+async def test_get_platforms_from_mailbox(mock_http_client) -> None:
     """Get platforms from mailbox."""
     url = "/api/mailbox/platforms"
 
@@ -27,7 +27,7 @@ async def test_get_platforms_from_mailbox(mock_http_client):
     assert result[0].get("name") == "DemoMailbox"
 
 
-async def test_get_messages_from_mailbox(mock_http_client):
+async def test_get_messages_from_mailbox(mock_http_client) -> None:
     """Get messages from mailbox."""
     url = "/api/mailbox/messages/DemoMailbox"
 
@@ -37,7 +37,7 @@ async def test_get_messages_from_mailbox(mock_http_client):
     assert len(result) == 10
 
 
-async def test_get_media_from_mailbox(mock_http_client):
+async def test_get_media_from_mailbox(mock_http_client) -> None:
     """Get audio from mailbox."""
     mp3sha = "3f67c4ea33b37d1710f772a26dd3fb43bb159d50"
     msgtxt = "Message 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -50,7 +50,7 @@ async def test_get_media_from_mailbox(mock_http_client):
     assert sha1(data).hexdigest() == mp3sha
 
 
-async def test_delete_from_mailbox(mock_http_client):
+async def test_delete_from_mailbox(mock_http_client) -> None:
     """Get audio from mailbox."""
     msgtxt1 = "Message 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
     msgtxt2 = "Message 3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -69,7 +69,7 @@ async def test_delete_from_mailbox(mock_http_client):
     assert len(result) == 8
 
 
-async def test_get_messages_from_invalid_mailbox(mock_http_client):
+async def test_get_messages_from_invalid_mailbox(mock_http_client) -> None:
     """Get messages from mailbox."""
     url = "/api/mailbox/messages/mailbox.invalid_mailbox"
 
@@ -77,7 +77,7 @@ async def test_get_messages_from_invalid_mailbox(mock_http_client):
     assert req.status == HTTPStatus.NOT_FOUND
 
 
-async def test_get_media_from_invalid_mailbox(mock_http_client):
+async def test_get_media_from_invalid_mailbox(mock_http_client) -> None:
     """Get messages from mailbox."""
     msgsha = "0000000000000000000000000000000000000000"
     url = f"/api/mailbox/media/mailbox.invalid_mailbox/{msgsha}"
@@ -86,7 +86,7 @@ async def test_get_media_from_invalid_mailbox(mock_http_client):
     assert req.status == HTTPStatus.NOT_FOUND
 
 
-async def test_get_media_from_invalid_msgid(mock_http_client):
+async def test_get_media_from_invalid_msgid(mock_http_client) -> None:
     """Get messages from mailbox."""
     msgsha = "0000000000000000000000000000000000000000"
     url = f"/api/mailbox/media/DemoMailbox/{msgsha}"
@@ -95,7 +95,7 @@ async def test_get_media_from_invalid_msgid(mock_http_client):
     assert req.status == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
-async def test_delete_from_invalid_mailbox(mock_http_client):
+async def test_delete_from_invalid_mailbox(mock_http_client) -> None:
     """Get audio from mailbox."""
     msgsha = "0000000000000000000000000000000000000000"
     url = f"/api/mailbox/delete/mailbox.invalid_mailbox/{msgsha}"

--- a/tests/components/mailgun/test_init.py
+++ b/tests/components/mailgun/test_init.py
@@ -82,7 +82,7 @@ async def mailgun_events(hass):
 
 async def test_mailgun_webhook_with_missing_signature(
     http_client, webhook_id_with_api_key, mailgun_events
-):
+) -> None:
     """Test that webhook doesn't trigger an event without a signature."""
     event_count = len(mailgun_events)
 
@@ -102,7 +102,7 @@ async def test_mailgun_webhook_with_missing_signature(
 
 async def test_mailgun_webhook_with_different_api_key(
     http_client, webhook_id_with_api_key, mailgun_events
-):
+) -> None:
     """Test that webhook doesn't trigger an event with a wrong signature."""
     timestamp = "1529006854"
     token = "a8ce0edb2dd8301dee6c2405235584e45aa91d1e9f979f3de0"
@@ -130,7 +130,7 @@ async def test_mailgun_webhook_with_different_api_key(
 
 async def test_mailgun_webhook_event_with_correct_api_key(
     http_client, webhook_id_with_api_key, mailgun_events
-):
+) -> None:
     """Test that webhook triggers an event after validating a signature."""
     timestamp = "1529006854"
     token = "a8ce0edb2dd8301dee6c2405235584e45aa91d1e9f979f3de0"
@@ -160,7 +160,7 @@ async def test_mailgun_webhook_event_with_correct_api_key(
 
 async def test_mailgun_webhook_with_missing_signature_without_api_key(
     http_client, webhook_id_without_api_key, mailgun_events
-):
+) -> None:
     """Test that webhook triggers an event without a signature w/o API key."""
     event_count = len(mailgun_events)
 
@@ -184,7 +184,7 @@ async def test_mailgun_webhook_with_missing_signature_without_api_key(
 
 async def test_mailgun_webhook_event_without_an_api_key(
     http_client, webhook_id_without_api_key, mailgun_events
-):
+) -> None:
     """Test that webhook triggers an event if there is no api key."""
     timestamp = "1529006854"
     token = "a8ce0edb2dd8301dee6c2405235584e45aa91d1e9f979f3de0"

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -53,7 +53,7 @@ async def test_setup_demo_platform(hass: HomeAssistant) -> None:
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_no_pending(hass, service, expected_state):
+async def test_no_pending(hass: HomeAssistant, service, expected_state) -> None:
     """Test no pending after arming."""
     assert await async_setup_component(
         hass,
@@ -94,7 +94,9 @@ async def test_no_pending(hass, service, expected_state):
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_no_pending_when_code_not_req(hass, service, expected_state):
+async def test_no_pending_when_code_not_req(
+    hass: HomeAssistant, service, expected_state
+) -> None:
     """Test no pending when code not required."""
     assert await async_setup_component(
         hass,
@@ -136,7 +138,7 @@ async def test_no_pending_when_code_not_req(hass, service, expected_state):
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_with_pending(hass, service, expected_state):
+async def test_with_pending(hass: HomeAssistant, service, expected_state) -> None:
     """Test with pending after arming."""
     assert await async_setup_component(
         hass,
@@ -201,7 +203,7 @@ async def test_with_pending(hass, service, expected_state):
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_with_invalid_code(hass, service, expected_state):
+async def test_with_invalid_code(hass: HomeAssistant, service, expected_state) -> None:
     """Attempt to arm without a valid code."""
     assert await async_setup_component(
         hass,
@@ -242,7 +244,7 @@ async def test_with_invalid_code(hass, service, expected_state):
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_with_template_code(hass, service, expected_state):
+async def test_with_template_code(hass: HomeAssistant, service, expected_state) -> None:
     """Attempt to arm with a template-based code."""
     assert await async_setup_component(
         hass,
@@ -284,7 +286,9 @@ async def test_with_template_code(hass, service, expected_state):
         (SERVICE_ALARM_ARM_VACATION, STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_with_specific_pending(hass, service, expected_state):
+async def test_with_specific_pending(
+    hass: HomeAssistant, service, expected_state
+) -> None:
     """Test arming with specific pending."""
     assert await async_setup_component(
         hass,
@@ -1206,7 +1210,7 @@ async def test_arm_away_after_disabled_disarmed(hass: HomeAssistant) -> None:
         (STATE_ALARM_DISARMED),
     ],
 )
-async def test_restore_state(hass, expected_state):
+async def test_restore_state(hass: HomeAssistant, expected_state) -> None:
     """Ensure state is restored on startup."""
     mock_restore_cache(hass, (State("alarm_control_panel.test", expected_state),))
 
@@ -1243,7 +1247,7 @@ async def test_restore_state(hass, expected_state):
         (STATE_ALARM_ARMED_VACATION),
     ],
 )
-async def test_restore_state_arming(hass, expected_state):
+async def test_restore_state_arming(hass: HomeAssistant, expected_state) -> None:
     """Ensure ARMING state is restored on startup."""
     time = dt_util.utcnow() - timedelta(seconds=15)
     entity_id = "alarm_control_panel.test"
@@ -1299,7 +1303,7 @@ async def test_restore_state_arming(hass, expected_state):
         (STATE_ALARM_DISARMED),
     ],
 )
-async def test_restore_state_pending(hass, previous_state):
+async def test_restore_state_pending(hass: HomeAssistant, previous_state) -> None:
     """Ensure PENDING state is restored on startup."""
     time = dt_util.utcnow() - timedelta(seconds=15)
     entity_id = "alarm_control_panel.test"
@@ -1365,7 +1369,7 @@ async def test_restore_state_pending(hass, previous_state):
         (STATE_ALARM_DISARMED),
     ],
 )
-async def test_restore_state_triggered(hass, previous_state):
+async def test_restore_state_triggered(hass: HomeAssistant, previous_state) -> None:
     """Ensure PENDING state is resolved to TRIGGERED on startup."""
     time = dt_util.utcnow() - timedelta(seconds=75)
     entity_id = "alarm_control_panel.test"

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -32,11 +33,14 @@ from tests.common import (
     async_fire_time_changed,
 )
 from tests.components.alarm_control_panel import common
+from tests.typing import MqttMockHAClientGenerator
 
 CODE = "HELLO_CODE"
 
 
-async def test_fail_setup_without_state_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_fail_setup_without_state_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test for failing with no state topic."""
     with assert_setup_component(0, alarm_control_panel.DOMAIN) as config:
         assert await async_setup_component(
@@ -52,7 +56,9 @@ async def test_fail_setup_without_state_topic(hass, mqtt_mock_entry_with_yaml_co
         assert not config[alarm_control_panel.DOMAIN]
 
 
-async def test_fail_setup_without_command_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_fail_setup_without_command_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test failing with no command topic."""
     with assert_setup_component(0, alarm_control_panel.DOMAIN):
         assert await async_setup_component(
@@ -78,8 +84,11 @@ async def test_fail_setup_without_command_topic(hass, mqtt_mock_entry_with_yaml_
     ],
 )
 async def test_no_pending(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Test arm method."""
     assert await async_setup_component(
         hass,
@@ -123,8 +132,11 @@ async def test_no_pending(
     ],
 )
 async def test_no_pending_when_code_not_req(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Test arm method."""
     assert await async_setup_component(
         hass,
@@ -169,8 +181,11 @@ async def test_no_pending_when_code_not_req(
     ],
 )
 async def test_with_pending(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Test arm method."""
     assert await async_setup_component(
         hass,
@@ -238,8 +253,11 @@ async def test_with_pending(
     ],
 )
 async def test_with_invalid_code(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Attempt to arm without a valid code."""
     assert await async_setup_component(
         hass,
@@ -283,8 +301,11 @@ async def test_with_invalid_code(
     ],
 )
 async def test_with_template_code(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Attempt to arm with a template-based code."""
     assert await async_setup_component(
         hass,
@@ -329,8 +350,11 @@ async def test_with_template_code(
     ],
 )
 async def test_with_specific_pending(
-    hass, service, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    service,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Test arm method."""
     assert await async_setup_component(
         hass,
@@ -370,7 +394,9 @@ async def test_with_specific_pending(
     assert hass.states.get(entity_id).state == expected_state
 
 
-async def test_trigger_no_pending(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_no_pending(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test triggering when no pending submitted method."""
     assert await async_setup_component(
         hass,
@@ -408,7 +434,9 @@ async def test_trigger_no_pending(hass, mqtt_mock_entry_with_yaml_config):
     assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_with_delay(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -454,7 +482,9 @@ async def test_trigger_with_delay(hass, mqtt_mock_entry_with_yaml_config):
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_zero_trigger_time(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_zero_trigger_time(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
         hass,
@@ -483,8 +513,8 @@ async def test_trigger_zero_trigger_time(hass, mqtt_mock_entry_with_yaml_config)
 
 
 async def test_trigger_zero_trigger_time_with_pending(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
         hass,
@@ -512,7 +542,9 @@ async def test_trigger_zero_trigger_time_with_pending(
     assert hass.states.get(entity_id).state == STATE_ALARM_DISARMED
 
 
-async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_with_pending(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test arm home method."""
     assert await async_setup_component(
         hass,
@@ -564,8 +596,8 @@ async def test_trigger_with_pending(hass, mqtt_mock_entry_with_yaml_config):
 
 
 async def test_trigger_with_disarm_after_trigger(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -604,8 +636,8 @@ async def test_trigger_with_disarm_after_trigger(
 
 
 async def test_trigger_with_zero_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method."""
     assert await async_setup_component(
         hass,
@@ -635,8 +667,8 @@ async def test_trigger_with_zero_specific_trigger_time(
 
 
 async def test_trigger_with_unused_zero_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -676,8 +708,8 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
 
 
 async def test_trigger_with_specific_trigger_time(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -716,8 +748,8 @@ async def test_trigger_with_specific_trigger_time(
 
 
 async def test_back_to_back_trigger_with_no_disarm_after_trigger(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test no disarm after back to back trigger."""
     assert await async_setup_component(
         hass,
@@ -773,7 +805,9 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
 
-async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_config):
+async def test_disarm_while_pending_trigger(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarming while pending state."""
     assert await async_setup_component(
         hass,
@@ -815,8 +849,8 @@ async def test_disarm_while_pending_trigger(hass, mqtt_mock_entry_with_yaml_conf
 
 
 async def test_disarm_during_trigger_with_invalid_code(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarming while code is invalid."""
     assert await async_setup_component(
         hass,
@@ -863,8 +897,8 @@ async def test_disarm_during_trigger_with_invalid_code(
 
 
 async def test_trigger_with_unused_specific_delay(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -911,7 +945,9 @@ async def test_trigger_with_unused_specific_delay(
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_with_specific_delay(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -958,7 +994,9 @@ async def test_trigger_with_specific_delay(hass, mqtt_mock_entry_with_yaml_confi
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_with_pending_and_delay(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -1018,8 +1056,8 @@ async def test_trigger_with_pending_and_delay(hass, mqtt_mock_entry_with_yaml_co
 
 
 async def test_trigger_with_pending_and_specific_delay(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
         hass,
@@ -1079,7 +1117,9 @@ async def test_trigger_with_pending_and_specific_delay(
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_config):
+async def test_trigger_with_specific_pending(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test arm home method."""
     assert await async_setup_component(
         hass,
@@ -1127,8 +1167,8 @@ async def test_trigger_with_specific_pending(hass, mqtt_mock_entry_with_yaml_con
 
 
 async def test_trigger_with_no_disarm_after_trigger(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
         hass,
@@ -1171,7 +1211,9 @@ async def test_trigger_with_no_disarm_after_trigger(
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
 
 
-async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_config):
+async def test_arm_away_after_disabled_disarmed(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test pending state with and without zero trigger time."""
     assert await async_setup_component(
         hass,
@@ -1235,7 +1277,9 @@ async def test_arm_away_after_disabled_disarmed(hass, mqtt_mock_entry_with_yaml_
     assert state.state == STATE_ALARM_TRIGGERED
 
 
-async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config):
+async def test_disarm_with_template_code(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Attempt to disarm with a valid or invalid template-based code."""
     assert await async_setup_component(
         hass,
@@ -1285,8 +1329,11 @@ async def test_disarm_with_template_code(hass, mqtt_mock_entry_with_yaml_config)
     ],
 )
 async def test_arm_via_command_topic(
-    hass, config, expected_state, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant,
+    config,
+    expected_state,
+    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+) -> None:
     """Test arming via command topic."""
     command = config[8:].upper()
     assert await async_setup_component(
@@ -1326,7 +1373,9 @@ async def test_arm_via_command_topic(
     assert hass.states.get(entity_id).state == expected_state
 
 
-async def test_disarm_pending_via_command_topic(hass, mqtt_mock_entry_with_yaml_config):
+async def test_disarm_pending_via_command_topic(
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test disarming pending alarm via command topic."""
     assert await async_setup_component(
         hass,
@@ -1361,8 +1410,8 @@ async def test_disarm_pending_via_command_topic(hass, mqtt_mock_entry_with_yaml_
 
 
 async def test_state_changes_are_published_to_mqtt(
-    hass, mqtt_mock_entry_with_yaml_config
-):
+    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+) -> None:
     """Test publishing of MQTT messages when state changes."""
     assert await async_setup_component(
         hass,

--- a/tests/components/maxcube/test_maxcube_binary_sensor.py
+++ b/tests/components/maxcube/test_maxcube_binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     STATE_ON,
     EntityCategory,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import utcnow
 
@@ -21,7 +22,9 @@ ENTITY_ID = "binary_sensor.testroom_testshutter"
 BATTERY_ENTITY_ID = f"{ENTITY_ID}_battery"
 
 
-async def test_window_shuttler(hass, cube: MaxCube, windowshutter: MaxWindowShutter):
+async def test_window_shuttler(
+    hass: HomeAssistant, cube: MaxCube, windowshutter: MaxWindowShutter
+) -> None:
     """Test a successful setup with a shuttler device."""
     entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(ENTITY_ID)
@@ -44,8 +47,8 @@ async def test_window_shuttler(hass, cube: MaxCube, windowshutter: MaxWindowShut
 
 
 async def test_window_shuttler_battery(
-    hass, cube: MaxCube, windowshutter: MaxWindowShutter
-):
+    hass: HomeAssistant, cube: MaxCube, windowshutter: MaxWindowShutter
+) -> None:
     """Test battery binary_state with a shuttler device."""
     entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(BATTERY_ENTITY_ID)

--- a/tests/components/maxcube/test_maxcube_climate.py
+++ b/tests/components/maxcube/test_maxcube_climate.py
@@ -49,6 +49,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import utcnow
 
@@ -59,7 +60,7 @@ WALL_ENTITY_ID = "climate.testroom_testwallthermostat"
 VALVE_POSITION = "valve_position"
 
 
-async def test_setup_thermostat(hass, cube: MaxCube):
+async def test_setup_thermostat(hass: HomeAssistant, cube: MaxCube) -> None:
     """Test a successful setup of a thermostat device."""
     entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(ENTITY_ID)
@@ -95,7 +96,7 @@ async def test_setup_thermostat(hass, cube: MaxCube):
     assert state.attributes.get(VALVE_POSITION) == 25
 
 
-async def test_setup_wallthermostat(hass, cube: MaxCube):
+async def test_setup_wallthermostat(hass: HomeAssistant, cube: MaxCube) -> None:
     """Test a successful setup of a wall thermostat device."""
     entity_registry = er.async_get(hass)
     assert entity_registry.async_is_registered(WALL_ENTITY_ID)
@@ -114,8 +115,8 @@ async def test_setup_wallthermostat(hass, cube: MaxCube):
 
 
 async def test_thermostat_set_hvac_mode_off(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Turn off thermostat."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -145,8 +146,8 @@ async def test_thermostat_set_hvac_mode_off(
 
 
 async def test_thermostat_set_hvac_mode_heat(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set hvac mode to heat."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -168,8 +169,8 @@ async def test_thermostat_set_hvac_mode_heat(
 
 
 async def test_thermostat_set_invalid_hvac_mode(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set hvac mode to heat."""
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -182,8 +183,8 @@ async def test_thermostat_set_invalid_hvac_mode(
 
 
 async def test_thermostat_set_temperature(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set hvac mode to heat."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -205,8 +206,8 @@ async def test_thermostat_set_temperature(
 
 
 async def test_thermostat_set_no_temperature(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set hvac mode to heat."""
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -222,7 +223,9 @@ async def test_thermostat_set_no_temperature(
         cube.set_temperature_mode.assert_not_called()
 
 
-async def test_thermostat_set_preset_on(hass, cube: MaxCube, thermostat: MaxThermostat):
+async def test_thermostat_set_preset_on(
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to on."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -247,8 +250,8 @@ async def test_thermostat_set_preset_on(hass, cube: MaxCube, thermostat: MaxTher
 
 
 async def test_thermostat_set_preset_comfort(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to comfort."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -272,8 +275,8 @@ async def test_thermostat_set_preset_comfort(
 
 
 async def test_thermostat_set_preset_eco(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to eco."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -297,8 +300,8 @@ async def test_thermostat_set_preset_eco(
 
 
 async def test_thermostat_set_preset_away(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to away."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -322,8 +325,8 @@ async def test_thermostat_set_preset_away(
 
 
 async def test_thermostat_set_preset_boost(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to boost."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -347,8 +350,8 @@ async def test_thermostat_set_preset_boost(
 
 
 async def test_thermostat_set_preset_none(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set preset mode to boost."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -362,8 +365,8 @@ async def test_thermostat_set_preset_none(
 
 
 async def test_thermostat_set_invalid_preset(
-    hass, cube: MaxCube, thermostat: MaxThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
+) -> None:
     """Set hvac mode to heat."""
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -376,8 +379,8 @@ async def test_thermostat_set_invalid_preset(
 
 
 async def test_wallthermostat_set_hvac_mode_heat(
-    hass, cube: MaxCube, wallthermostat: MaxWallThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, wallthermostat: MaxWallThermostat
+) -> None:
     """Set wall thermostat hvac mode to heat."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -399,8 +402,8 @@ async def test_wallthermostat_set_hvac_mode_heat(
 
 
 async def test_wallthermostat_set_hvac_mode_auto(
-    hass, cube: MaxCube, wallthermostat: MaxWallThermostat
-):
+    hass: HomeAssistant, cube: MaxCube, wallthermostat: MaxWallThermostat
+) -> None:
     """Set wall thermostat hvac mode to auto."""
     await hass.services.async_call(
         CLIMATE_DOMAIN,

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -118,7 +118,9 @@ async def test_button_setup_electric_vehicle(hass: HomeAssistant) -> None:
         ("refresh_status", "refresh_vehicle_status"),
     ],
 )
-async def test_button_press(hass, entity_id_suffix, api_method_name) -> None:
+async def test_button_press(
+    hass: HomeAssistant, entity_id_suffix, api_method_name
+) -> None:
     """Test pressing the button entities."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 

--- a/tests/components/mazda/test_climate.py
+++ b/tests/components/mazda/test_climate.py
@@ -165,7 +165,7 @@ async def test_climate_setup(hass: HomeAssistant) -> None:
     ],
 )
 async def test_climate_state(
-    hass,
+    hass: HomeAssistant,
     region,
     hvac_on,
     target_temperature,
@@ -177,7 +177,7 @@ async def test_climate_state(
     expected_preset_mode,
     expected_min_temp,
     expected_max_temp,
-):
+) -> None:
     """Test getting the state of the climate entity."""
     if temperature_unit == "F":
         hass.config.units = US_CUSTOMARY_SYSTEM
@@ -268,7 +268,7 @@ async def test_climate_state(
         (HVACMode.OFF, "turn_off_hvac"),
     ],
 )
-async def test_set_hvac_mode(hass, hvac_mode, api_method):
+async def test_set_hvac_mode(hass: HomeAssistant, hvac_mode, api_method) -> None:
     """Test turning on and off the HVAC system."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 
@@ -307,7 +307,9 @@ async def test_set_target_temperature(hass: HomeAssistant) -> None:
         (PRESET_DEFROSTER_FRONT_AND_REAR, True, True),
     ],
 )
-async def test_set_preset_mode(hass, preset_mode, front_defroster, rear_defroster):
+async def test_set_preset_mode(
+    hass: HomeAssistant, preset_mode, front_defroster, rear_defroster
+) -> None:
     """Test turning on and off the front and rear defrosters."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 

--- a/tests/components/mazda/test_diagnostics.py
+++ b/tests/components/mazda/test_diagnostics.py
@@ -1,5 +1,4 @@
 """Test Mazda diagnostics."""
-
 import json
 
 import pytest
@@ -15,9 +14,12 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 
-async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client):
+async def test_config_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test config entry diagnostics."""
     await init_integration(hass)
     assert hass.data[DOMAIN]
@@ -34,7 +36,9 @@ async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client):
     )
 
 
-async def test_device_diagnostics(hass: HomeAssistant, hass_client):
+async def test_device_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test device diagnostics."""
     await init_integration(hass)
     assert hass.data[DOMAIN]
@@ -55,7 +59,9 @@ async def test_device_diagnostics(hass: HomeAssistant, hass_client):
     )
 
 
-async def test_device_diagnostics_vehicle_not_found(hass: HomeAssistant, hass_client):
+async def test_device_diagnostics_vehicle_not_found(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
     """Test device diagnostics when the vehicle cannot be found."""
     await init_integration(hass)
     assert hass.data[DOMAIN]

--- a/tests/components/mazda/test_init.py
+++ b/tests/components/mazda/test_init.py
@@ -46,7 +46,7 @@ async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_init_auth_failure(hass: HomeAssistant):
+async def test_init_auth_failure(hass: HomeAssistant) -> None:
     """Test auth failure during setup."""
     with patch(
         "homeassistant.components.mazda.MazdaAPI.validate_credentials",
@@ -67,7 +67,7 @@ async def test_init_auth_failure(hass: HomeAssistant):
     assert flows[0]["step_id"] == "user"
 
 
-async def test_update_auth_failure(hass: HomeAssistant):
+async def test_update_auth_failure(hass: HomeAssistant) -> None:
     """Test auth failure during data update."""
     get_vehicles_fixture = json.loads(load_fixture("mazda/get_vehicles.json"))
     get_vehicle_status_fixture = json.loads(
@@ -106,7 +106,7 @@ async def test_update_auth_failure(hass: HomeAssistant):
     assert flows[0]["step_id"] == "user"
 
 
-async def test_update_general_failure(hass: HomeAssistant):
+async def test_update_general_failure(hass: HomeAssistant) -> None:
     """Test general failure during data update."""
     get_vehicles_fixture = json.loads(load_fixture("mazda/get_vehicles.json"))
     get_vehicle_status_fixture = json.loads(
@@ -210,7 +210,9 @@ async def test_device_no_nickname(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_services(hass, service, service_data, expected_args):
+async def test_services(
+    hass: HomeAssistant, service, service_data, expected_args
+) -> None:
     """Test service calls."""
     client_mock = await init_integration(hass)
 

--- a/tests/components/meater/test_config_flow.py
+++ b/tests/components/meater/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_duplicate_error(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("mock_client", [AsyncMock(side_effect=Exception)])
-async def test_unknown_auth_error(hass, mock_meater):
+async def test_unknown_auth_error(hass: HomeAssistant, mock_meater) -> None:
     """Test that an invalid API/App Key throws an error."""
     conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "password123"}
 
@@ -54,7 +54,7 @@ async def test_unknown_auth_error(hass, mock_meater):
 
 
 @pytest.mark.parametrize("mock_client", [AsyncMock(side_effect=AuthenticationError)])
-async def test_invalid_credentials(hass, mock_meater):
+async def test_invalid_credentials(hass: HomeAssistant, mock_meater) -> None:
     """Test that an invalid API/App Key throws an error."""
     conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "password123"}
 
@@ -67,7 +67,7 @@ async def test_invalid_credentials(hass, mock_meater):
 @pytest.mark.parametrize(
     "mock_client", [AsyncMock(side_effect=ServiceUnavailableError)]
 )
-async def test_service_unavailable(hass, mock_meater):
+async def test_service_unavailable(hass: HomeAssistant, mock_meater) -> None:
     """Test that an invalid API/App Key throws an error."""
     conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "password123"}
 
@@ -77,7 +77,7 @@ async def test_service_unavailable(hass, mock_meater):
     assert result["errors"] == {"base": "service_unavailable_error"}
 
 
-async def test_user_flow(hass, mock_meater):
+async def test_user_flow(hass: HomeAssistant, mock_meater) -> None:
     """Test that the user flow works."""
     conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "password123"}
 
@@ -108,7 +108,7 @@ async def test_user_flow(hass, mock_meater):
     }
 
 
-async def test_reauth_flow(hass, mock_meater):
+async def test_reauth_flow(hass: HomeAssistant, mock_meater) -> None:
     """Test that the reauth flow works."""
     data = {
         CONF_USERNAME: "user@host.com",

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -154,7 +154,7 @@ def player(hass, request):
     return request.param(hass)
 
 
-async def test_volume_up(player):
+async def test_volume_up(player) -> None:
     """Test the volume_up and set volume methods."""
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
@@ -163,7 +163,7 @@ async def test_volume_up(player):
     assert player.volume_level == 0.6
 
 
-async def test_volume_down(player):
+async def test_volume_down(player) -> None:
     """Test the volume_down and set volume methods."""
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
@@ -172,7 +172,7 @@ async def test_volume_down(player):
     assert player.volume_level == 0.4
 
 
-async def test_media_play_pause(player):
+async def test_media_play_pause(player) -> None:
     """Test the media_play_pause method."""
     assert player.state == STATE_OFF
     await player.async_media_play_pause()
@@ -181,7 +181,7 @@ async def test_media_play_pause(player):
     assert player.state == STATE_PAUSED
 
 
-async def test_turn_on_off(player):
+async def test_turn_on_off(player) -> None:
     """Test the turn on and turn off methods."""
     assert player.state == STATE_OFF
     await player.async_turn_on()
@@ -190,7 +190,7 @@ async def test_turn_on_off(player):
     assert player.state == STATE_OFF
 
 
-async def test_toggle(player):
+async def test_toggle(player) -> None:
     """Test the toggle method."""
     assert player.state == STATE_OFF
     await player.async_toggle()

--- a/tests/components/media_player/test_browse_media.py
+++ b/tests/components/media_player/test_browse_media.py
@@ -7,6 +7,7 @@ from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import NoURLAvailableError
 
@@ -23,7 +24,7 @@ def fixture_mock_sign_path():
         yield
 
 
-async def test_process_play_media_url(hass, mock_sign_path):
+async def test_process_play_media_url(hass: HomeAssistant, mock_sign_path) -> None:
     """Test it prefixes and signs urls."""
     await async_process_ha_core_config(
         hass,
@@ -89,7 +90,9 @@ async def test_process_play_media_url(hass, mock_sign_path):
         async_process_play_media_url(hass, "hello")
 
 
-async def test_process_play_media_url_for_addon(hass, mock_sign_path):
+async def test_process_play_media_url_for_addon(
+    hass: HomeAssistant, mock_sign_path
+) -> None:
     """Test it uses the hostname for an addon if available."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -13,7 +13,8 @@ from homeassistant.const import (
     STATE_PLAYING,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -32,7 +33,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a media_player."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -77,12 +82,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -122,7 +127,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("media_player.entity", STATE_ON)
 

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -15,7 +15,8 @@ from homeassistant.const import (
     STATE_PLAYING,
     EntityCategory,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -37,7 +38,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a media player."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -85,12 +90,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +136,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a media player."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -158,7 +167,7 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         }
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test triggers firing."""
     hass.states.async_set("media_player.entity", STATE_OFF)
 
@@ -255,7 +264,7 @@ async def test_if_fires_on_state_change(hass, calls):
     }
 
 
-async def test_if_fires_on_state_change_with_for(hass, calls):
+async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for triggers firing with delay."""
     entity_id = f"{DOMAIN}.entity"
     hass.states.async_set(entity_id, STATE_OFF)

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
@@ -76,8 +77,11 @@ async def test_get_image_http_remote(
 
 
 async def test_get_image_http_log_credentials_redacted(
-    hass, hass_client_no_auth, aioclient_mock, caplog
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test credentials are redacted when logging url when fetching image."""
     url = "http://vi:pass@example.com/default.jpg"
     with patch(
@@ -106,7 +110,11 @@ async def test_get_image_http_log_credentials_redacted(
     ) in caplog.text
 
 
-async def test_get_async_get_browse_image(hass, hass_client_no_auth, hass_ws_client):
+async def test_get_async_get_browse_image(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test get browse image."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -245,7 +253,7 @@ async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
         ("replace", MediaPlayerEnqueue.REPLACE),
     ),
 )
-async def test_enqueue_rewrite(hass, input, expected):
+async def test_enqueue_rewrite(hass: HomeAssistant, input, expected) -> None:
     """Test that group_members are still available when media_player is off."""
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -295,8 +303,10 @@ async def test_enqueue_alert_exclusive(hass: HomeAssistant) -> None:
 
 
 async def test_get_async_get_browse_image_quoting(
-    hass, hass_client_no_auth, hass_ws_client
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test get browse image using media_content_id with special characters.
 
     async_get_browse_image() should get called with the same string that is

--- a/tests/components/media_player/test_recorder.py
+++ b/tests/components/media_player/test_recorder.py
@@ -11,10 +11,11 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_SOUND_MODE_LIST,
 )
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -22,7 +23,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test media_player registered attributes to be excluded."""
     await async_setup_component(
         hass, media_player.DOMAIN, {media_player.DOMAIN: {"platform": "demo"}}

--- a/tests/components/media_player/test_reproduce_state.py
+++ b/tests/components/media_player/test_reproduce_state.py
@@ -50,7 +50,7 @@ ENTITY_2 = "media_player.test2"
         (SERVICE_MEDIA_PAUSE, STATE_PAUSED, MediaPlayerEntityFeature.PAUSE),
     ],
 )
-async def test_state(hass, service, state, supported_feature):
+async def test_state(hass: HomeAssistant, service, state, supported_feature) -> None:
     """Test that we can turn a state into a service call."""
     calls_1 = async_mock_service(hass, DOMAIN, service)
     if service != SERVICE_TURN_ON:
@@ -220,7 +220,9 @@ async def test_attribute_no_state(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_attribute(hass, service, attribute, supported_feature):
+async def test_attribute(
+    hass: HomeAssistant, service, attribute, supported_feature
+) -> None:
     """Test that service call is made for each attribute."""
     hass.states.async_set(
         ENTITY_1,

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -210,7 +210,9 @@ async def test_websocket_browse_media(
 
 
 @pytest.mark.parametrize("filename", ["test.mp3", "Epic Sax Guy 10 Hours.mp4"])
-async def test_websocket_resolve_media(hass, hass_ws_client, filename):
+async def test_websocket_resolve_media(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, filename
+) -> None:
     """Test browse media websocket."""
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/media_source/test_local_source.py
+++ b/tests/components/media_source/test_local_source.py
@@ -13,7 +13,8 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.typing import ClientSessionGenerator
+from tests.common import MockUser
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
@@ -127,7 +128,12 @@ async def test_media_view(
     assert resp.status == HTTPStatus.OK
 
 
-async def test_upload_view(hass, hass_client, temp_dir, hass_admin_user):
+async def test_upload_view(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    temp_dir,
+    hass_admin_user: MockUser,
+) -> None:
     """Allow uploading media."""
 
     img = (Path(__file__).parent.parent / "image_upload/logo.png").read_bytes()
@@ -231,7 +237,12 @@ async def test_upload_view(hass, hass_client, temp_dir, hass_admin_user):
     assert not (Path(temp_dir) / "no-admin-test.png").is_file()
 
 
-async def test_remove_file(hass, hass_ws_client, temp_dir, hass_admin_user):
+async def test_remove_file(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    temp_dir,
+    hass_admin_user: MockUser,
+) -> None:
     """Allow uploading media."""
 
     msg_count = 0

--- a/tests/components/melcloud/test_atw_zone_sensor.py
+++ b/tests/components/melcloud/test_atw_zone_sensor.py
@@ -32,7 +32,7 @@ def mock_zone_2():
         yield mock
 
 
-def test_zone_unique_ids(mock_device, mock_zone_1, mock_zone_2):
+def test_zone_unique_ids(mock_device, mock_zone_1, mock_zone_2) -> None:
     """Test unique id generation correctness."""
     sensor_1 = AtwZoneSensor(
         mock_device,

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.melcloud.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -44,7 +45,7 @@ def mock_request_info():
         yield mock_ri
 
 
-async def test_form(hass, mock_login, mock_get_devices):
+async def test_form(hass: HomeAssistant, mock_login, mock_get_devices) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -77,7 +78,9 @@ async def test_form(hass, mock_login, mock_get_devices):
     "error,reason",
     [(ClientError(), "cannot_connect"), (asyncio.TimeoutError(), "cannot_connect")],
 )
-async def test_form_errors(hass, mock_login, mock_get_devices, error, reason):
+async def test_form_errors(
+    hass: HomeAssistant, mock_login, mock_get_devices, error, reason
+) -> None:
     """Test we handle cannot connect error."""
     mock_login.side_effect = error
 
@@ -101,8 +104,8 @@ async def test_form_errors(hass, mock_login, mock_get_devices, error, reason):
     ],
 )
 async def test_form_response_errors(
-    hass, mock_login, mock_get_devices, mock_request_info, error, message
-):
+    hass: HomeAssistant, mock_login, mock_get_devices, mock_request_info, error, message
+) -> None:
     """Test we handle response errors."""
     mock_login.side_effect = ClientResponseError(mock_request_info(), (), status=error)
 
@@ -116,7 +119,9 @@ async def test_form_response_errors(
     assert result["reason"] == message
 
 
-async def test_import_with_token(hass, mock_login, mock_get_devices):
+async def test_import_with_token(
+    hass: HomeAssistant, mock_login, mock_get_devices
+) -> None:
     """Test successful import."""
     with patch(
         "homeassistant.components.melcloud.async_setup", return_value=True
@@ -140,7 +145,7 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_token_refresh(hass, mock_login, mock_get_devices):
+async def test_token_refresh(hass: HomeAssistant, mock_login, mock_get_devices) -> None:
     """Re-configuration with existing username should refresh token."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -5,12 +5,14 @@ import json
 import pytest
 
 import homeassistant.components.device_tracker as device_tracker
+from homeassistant.components.device_tracker import legacy
 from homeassistant.components.meraki.device_tracker import (
     CONF_SECRET,
     CONF_VALIDATOR,
     URL,
 )
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -35,7 +37,9 @@ def meraki_client(event_loop, hass, hass_client):
     return loop.run_until_complete(hass_client())
 
 
-async def test_invalid_or_missing_data(mock_device_tracker_conf, meraki_client):
+async def test_invalid_or_missing_data(
+    mock_device_tracker_conf: list[legacy.Device], meraki_client
+) -> None:
     """Test validator with invalid or missing data."""
     req = await meraki_client.get(URL)
     text = await req.text()
@@ -80,7 +84,9 @@ async def test_invalid_or_missing_data(mock_device_tracker_conf, meraki_client):
     assert req.status == HTTPStatus.OK
 
 
-async def test_data_will_be_saved(mock_device_tracker_conf, hass, meraki_client):
+async def test_data_will_be_saved(
+    mock_device_tracker_conf: list[legacy.Device], hass: HomeAssistant, meraki_client
+) -> None:
     """Test with valid data."""
     data = {
         "version": "2.0",

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -110,7 +110,9 @@ async def test_onboarding_step(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("latitude,longitude", [(52.3731339, 4.8903147), (0.0, 0.0)])
-async def test_onboarding_step_abort_no_home(hass, latitude, longitude):
+async def test_onboarding_step_abort_no_home(
+    hass: HomeAssistant, latitude, longitude
+) -> None:
     """Test entry not created when default step fails."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -1,12 +1,12 @@
 """Test Met weather entity."""
-
 from homeassistant import config_entries
 from homeassistant.components.met import DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
-async def test_tracking_home(hass, mock_weather):
+async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     """Test we track home."""
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
     await hass.async_block_till_done()
@@ -41,7 +41,7 @@ async def test_tracking_home(hass, mock_weather):
     assert len(hass.states.async_entity_ids("weather")) == 0
 
 
-async def test_not_tracking_home(hass, mock_weather):
+async def test_not_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     """Test when we not track home."""
 
     # Pre-create registry entry for disabled by default hourly weather

--- a/tests/components/met_eireann/test_weather.py
+++ b/tests/components/met_eireann/test_weather.py
@@ -1,11 +1,11 @@
 """Test Met Éireann weather entity."""
-
 from homeassistant.components.met_eireann.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_weather(hass, mock_weather):
+async def test_weather(hass: HomeAssistant, mock_weather) -> None:
     """Test weather entity."""
     # Create a mock configuration for testing
     mock_data = MockConfigEntry(

--- a/tests/components/meteo_france/test_config_flow.py
+++ b/tests/components/meteo_france/test_config_flow.py
@@ -116,7 +116,7 @@ def mock_controller_client_empty():
         yield service_mock
 
 
-async def test_user(hass, client_single):
+async def test_user(hass: HomeAssistant, client_single) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -137,7 +137,7 @@ async def test_user(hass, client_single):
     assert result["data"][CONF_LONGITUDE] == str(CITY_1_LON)
 
 
-async def test_user_list(hass, client_multiple):
+async def test_user_list(hass: HomeAssistant, client_multiple) -> None:
     """Test user config."""
 
     # test with all provided with search returning more than 1 place
@@ -160,7 +160,7 @@ async def test_user_list(hass, client_multiple):
     assert result["data"][CONF_LONGITUDE] == str(CITY_3_LON)
 
 
-async def test_import(hass, client_multiple):
+async def test_import(hass: HomeAssistant, client_multiple) -> None:
     """Test import step."""
     # import with all
     result = await hass.config_entries.flow.async_init(
@@ -175,7 +175,7 @@ async def test_import(hass, client_multiple):
     assert result["data"][CONF_LONGITUDE] == str(CITY_2_LON)
 
 
-async def test_search_failed(hass, client_empty):
+async def test_search_failed(hass: HomeAssistant, client_empty) -> None:
     """Test error displayed if no result in search."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -187,7 +187,7 @@ async def test_search_failed(hass, client_empty):
     assert result["errors"] == {CONF_CITY: "empty"}
 
 
-async def test_abort_if_already_setup(hass, client_single):
+async def test_abort_if_already_setup(hass: HomeAssistant, client_single) -> None:
     """Test we abort if already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -214,7 +214,7 @@ async def test_abort_if_already_setup(hass, client_single):
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow(hass: HomeAssistant):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/meteoclimatic/test_config_flow.py
+++ b/tests/components/meteoclimatic/test_config_flow.py
@@ -38,7 +38,7 @@ def mock_setup():
         yield
 
 
-async def test_user(hass, client):
+async def test_user(hass: HomeAssistant, client) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/metoffice/test_config_flow.py
+++ b/tests/components/metoffice/test_config_flow.py
@@ -2,8 +2,11 @@
 import json
 from unittest.mock import patch
 
+import requests_mock
+
 from homeassistant import config_entries
 from homeassistant.components.metoffice.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from .const import (
     METOFFICE_CONFIG_WAVERTREE,
@@ -16,7 +19,7 @@ from .const import (
 from tests.common import MockConfigEntry, load_fixture
 
 
-async def test_form(hass, requests_mock):
+async def test_form(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test we get the form."""
     hass.config.latitude = TEST_LATITUDE_WAVERTREE
     hass.config.longitude = TEST_LONGITUDE_WAVERTREE
@@ -52,7 +55,9 @@ async def test_form(hass, requests_mock):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_already_configured(hass, requests_mock):
+async def test_form_already_configured(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle duplicate entries."""
     hass.config.latitude = TEST_LATITUDE_WAVERTREE
     hass.config.longitude = TEST_LONGITUDE_WAVERTREE
@@ -88,7 +93,9 @@ async def test_form_already_configured(hass, requests_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_cannot_connect(hass, requests_mock):
+async def test_form_cannot_connect(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle cannot connect error."""
     hass.config.latitude = TEST_LATITUDE_WAVERTREE
     hass.config.longitude = TEST_LONGITUDE_WAVERTREE
@@ -108,7 +115,9 @@ async def test_form_cannot_connect(hass, requests_mock):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass, mock_simple_manager_fail):
+async def test_form_unknown_error(
+    hass: HomeAssistant, mock_simple_manager_fail
+) -> None:
     """Test we handle unknown error."""
     mock_instance = mock_simple_manager_fail.return_value
     mock_instance.get_nearest_forecast_site.side_effect = ValueError

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -5,8 +5,10 @@ import datetime
 
 from freezegun import freeze_time
 import pytest
+import requests_mock
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN, METOFFICE_CONFIG_WAVERTREE, TEST_COORDINATES_WAVERTREE
@@ -87,12 +89,12 @@ from tests.common import MockConfigEntry
     ],
 )
 async def test_migrate_unique_id(
-    hass,
+    hass: HomeAssistant,
     old_unique_id: str,
     new_unique_id: str,
     migration_needed: bool,
-    requests_mock,
-):
+    requests_mock: requests_mock.Mocker,
+) -> None:
     """Test unique id migration."""
 
     entry = MockConfigEntry(

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -3,8 +3,10 @@ import datetime
 import json
 
 from freezegun import freeze_time
+import requests_mock
 
 from homeassistant.components.metoffice.const import ATTRIBUTION, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 
 from .const import (
@@ -23,7 +25,9 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_one_sensor_site_running(hass, requests_mock):
+async def test_one_sensor_site_running(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test the Met Office sensor platform."""
     # all metoffice test data encapsulated in here
     mock_json = json.loads(load_fixture("metoffice.json"))
@@ -69,7 +73,9 @@ async def test_one_sensor_site_running(hass, requests_mock):
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_two_sensor_sites_running(hass, requests_mock):
+async def test_two_sensor_sites_running(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle two sets of sensors running for two different sites."""
 
     # all metoffice test data encapsulated in here

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -4,9 +4,11 @@ from datetime import timedelta
 import json
 
 from freezegun import freeze_time
+import requests_mock
 
 from homeassistant.components.metoffice.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.util import utcnow
 
@@ -22,7 +24,9 @@ from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_site_cannot_connect(hass, requests_mock):
+async def test_site_cannot_connect(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle cannot connect error."""
 
     requests_mock.get("/public/data/val/wxfcs/all/json/sitelist/", text="")
@@ -49,7 +53,9 @@ async def test_site_cannot_connect(hass, requests_mock):
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_site_cannot_update(hass, requests_mock):
+async def test_site_cannot_update(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle cannot connect error."""
 
     # all metoffice test data encapsulated in here
@@ -95,7 +101,9 @@ async def test_site_cannot_update(hass, requests_mock):
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_one_weather_site_running(hass, requests_mock):
+async def test_one_weather_site_running(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test the Met Office weather platform."""
 
     # all metoffice test data encapsulated in here
@@ -176,7 +184,9 @@ async def test_one_weather_site_running(hass, requests_mock):
 
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
-async def test_two_weather_sites_running(hass, requests_mock):
+async def test_two_weather_sites_running(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we handle two different weather sites both running."""
 
     # all metoffice test data encapsulated in here

--- a/tests/components/mfi/test_sensor.py
+++ b/tests/components/mfi/test_sensor.py
@@ -127,47 +127,47 @@ def sensor_fixture(hass, port):
     return sensor
 
 
-async def test_name(port, sensor):
+async def test_name(port, sensor) -> None:
     """Test the name."""
     assert port.label == sensor.name
 
 
-async def test_uom_temp(port, sensor):
+async def test_uom_temp(port, sensor) -> None:
     """Test the UOM temperature."""
     port.tag = "temperature"
     assert sensor.unit_of_measurement == UnitOfTemperature.CELSIUS
     assert sensor.device_class is SensorDeviceClass.TEMPERATURE
 
 
-async def test_uom_power(port, sensor):
+async def test_uom_power(port, sensor) -> None:
     """Test the UOEM power."""
     port.tag = "active_pwr"
     assert sensor.unit_of_measurement == "Watts"
     assert sensor.device_class is None
 
 
-async def test_uom_digital(port, sensor):
+async def test_uom_digital(port, sensor) -> None:
     """Test the UOM digital input."""
     port.model = "Input Digital"
     assert sensor.unit_of_measurement is None
     assert sensor.device_class is None
 
 
-async def test_uom_unknown(port, sensor):
+async def test_uom_unknown(port, sensor) -> None:
     """Test the UOM."""
     port.tag = "balloons"
     assert sensor.unit_of_measurement == "balloons"
     assert sensor.device_class is None
 
 
-async def test_uom_uninitialized(port, sensor):
+async def test_uom_uninitialized(port, sensor) -> None:
     """Test that the UOM defaults if not initialized."""
     type(port).tag = mock.PropertyMock(side_effect=ValueError)
     assert sensor.unit_of_measurement is None
     assert sensor.device_class is None
 
 
-async def test_state_digital(port, sensor):
+async def test_state_digital(port, sensor) -> None:
     """Test the digital input."""
     port.model = "Input Digital"
     port.value = 0
@@ -178,7 +178,7 @@ async def test_state_digital(port, sensor):
     assert sensor.state == mfi.STATE_ON
 
 
-async def test_state_digits(port, sensor):
+async def test_state_digits(port, sensor) -> None:
     """Test the state of digits."""
     port.tag = "didyoucheckthedict?"
     port.value = 1.25
@@ -188,13 +188,13 @@ async def test_state_digits(port, sensor):
         assert sensor.state == 1.0
 
 
-async def test_state_uninitialized(port, sensor):
+async def test_state_uninitialized(port, sensor) -> None:
     """Test the state of uninitialized sensorfs."""
     type(port).tag = mock.PropertyMock(side_effect=ValueError)
     assert sensor.state == mfi.STATE_OFF
 
 
-async def test_update(port, sensor):
+async def test_update(port, sensor) -> None:
     """Test the update."""
     sensor.update()
     assert port.refresh.call_count == 1

--- a/tests/components/mfi/test_switch.py
+++ b/tests/components/mfi/test_switch.py
@@ -61,19 +61,19 @@ def switch_fixture(port):
     return mfi.MfiSwitch(port)
 
 
-async def test_name(port, switch):
+async def test_name(port, switch) -> None:
     """Test the name."""
     assert port.label == switch.name
 
 
-async def test_update(port, switch):
+async def test_update(port, switch) -> None:
     """Test update."""
     switch.update()
     assert port.refresh.call_count == 1
     assert port.refresh.call_args == mock.call()
 
 
-async def test_update_with_target_state(port, switch):
+async def test_update_with_target_state(port, switch) -> None:
     """Test update with target state."""
 
     switch._target_state = True
@@ -88,7 +88,7 @@ async def test_update_with_target_state(port, switch):
     assert port.data["output"] == "untouched"
 
 
-async def test_turn_on(port, switch):
+async def test_turn_on(port, switch) -> None:
     """Test turn_on."""
     switch.turn_on()
     assert port.control.call_count == 1
@@ -97,7 +97,7 @@ async def test_turn_on(port, switch):
     assert switch._target_state
 
 
-async def test_turn_off(port, switch):
+async def test_turn_off(port, switch) -> None:
     """Test turn_off."""
     switch.turn_off()
     assert port.control.call_count == 1

--- a/tests/components/microsoft_face/test_init.py
+++ b/tests/components/microsoft_face/test_init.py
@@ -97,19 +97,19 @@ def mock_update():
         yield mock_update_store
 
 
-async def test_setup_component(hass, mock_update):
+async def test_setup_component(hass: HomeAssistant, mock_update) -> None:
     """Set up component."""
     with assert_setup_component(3, mf.DOMAIN):
         await async_setup_component(hass, mf.DOMAIN, CONFIG)
 
 
-async def test_setup_component_wrong_api_key(hass, mock_update):
+async def test_setup_component_wrong_api_key(hass: HomeAssistant, mock_update) -> None:
     """Set up component without api key."""
     with assert_setup_component(0, mf.DOMAIN):
         await async_setup_component(hass, mf.DOMAIN, {mf.DOMAIN: {}})
 
 
-async def test_setup_component_test_service(hass, mock_update):
+async def test_setup_component_test_service(hass: HomeAssistant, mock_update) -> None:
     """Set up component."""
     with assert_setup_component(3, mf.DOMAIN):
         await async_setup_component(hass, mf.DOMAIN, CONFIG)
@@ -157,7 +157,9 @@ async def test_setup_component_test_entities(
     assert entity_group2.attributes["David"] == "2ae4935b-9659-44c3-977f-61fac20d0538"
 
 
-async def test_service_groups(hass, mock_update, aioclient_mock):
+async def test_service_groups(
+    hass: HomeAssistant, mock_update, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test groups services."""
     aioclient_mock.put(
         ENDPOINT_URL.format("persongroups/service_group"),
@@ -241,7 +243,9 @@ async def test_service_person(
     assert "Hans" not in entity_group1.attributes
 
 
-async def test_service_train(hass, mock_update, aioclient_mock):
+async def test_service_train(
+    hass: HomeAssistant, mock_update, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test train groups services."""
     with assert_setup_component(3, mf.DOMAIN):
         await async_setup_component(hass, mf.DOMAIN, CONFIG)
@@ -301,7 +305,9 @@ async def test_service_face(
     assert aioclient_mock.mock_calls[3][2] == b"Test"
 
 
-async def test_service_status_400(hass, mock_update, aioclient_mock):
+async def test_service_status_400(
+    hass: HomeAssistant, mock_update, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test groups services with error."""
     aioclient_mock.put(
         ENDPOINT_URL.format("persongroups/service_group"),
@@ -320,7 +326,9 @@ async def test_service_status_400(hass, mock_update, aioclient_mock):
     assert len(aioclient_mock.mock_calls) == 1
 
 
-async def test_service_status_timeout(hass, mock_update, aioclient_mock):
+async def test_service_status_timeout(
+    hass: HomeAssistant, mock_update, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up component, test groups services with timeout."""
     aioclient_mock.put(
         ENDPOINT_URL.format("persongroups/service_group"),

--- a/tests/components/microsoft_face_detect/test_image_processing.py
+++ b/tests/components/microsoft_face_detect/test_image_processing.py
@@ -6,11 +6,12 @@ import pytest
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
 from homeassistant.const import ATTR_ENTITY_PICTURE
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, load_fixture
 from tests.components.image_processing import common
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONFIG = {
     ip.DOMAIN: {
@@ -46,7 +47,7 @@ def poll_mock():
         yield
 
 
-async def test_setup_platform(hass, store_mock):
+async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity."""
     config = {
         ip.DOMAIN: {
@@ -65,7 +66,7 @@ async def test_setup_platform(hass, store_mock):
     assert hass.states.get("image_processing.microsoftface_demo_camera")
 
 
-async def test_setup_platform_name(hass, store_mock):
+async def test_setup_platform_name(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity and set name."""
     config = {
         ip.DOMAIN: {
@@ -83,7 +84,9 @@ async def test_setup_platform_name(hass, store_mock):
     assert hass.states.get("image_processing.test_local")
 
 
-async def test_ms_detect_process_image(hass, poll_mock, aioclient_mock):
+async def test_ms_detect_process_image(
+    hass: HomeAssistant, poll_mock, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up and scan a picture and test plates from event."""
     aioclient_mock.get(
         ENDPOINT_URL.format("persongroups"),

--- a/tests/components/microsoft_face_identify/test_image_processing.py
+++ b/tests/components/microsoft_face_identify/test_image_processing.py
@@ -6,11 +6,12 @@ import pytest
 import homeassistant.components.image_processing as ip
 import homeassistant.components.microsoft_face as mf
 from homeassistant.const import ATTR_ENTITY_PICTURE, STATE_UNKNOWN
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, load_fixture
 from tests.components.image_processing import common
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -47,7 +48,7 @@ CONFIG = {
 ENDPOINT_URL = f"https://westus.{mf.FACE_API_URL}"
 
 
-async def test_setup_platform(hass, store_mock):
+async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity."""
     config = {
         ip.DOMAIN: {
@@ -66,7 +67,7 @@ async def test_setup_platform(hass, store_mock):
     assert hass.states.get("image_processing.microsoftface_demo_camera")
 
 
-async def test_setup_platform_name(hass, store_mock):
+async def test_setup_platform_name(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity and set name."""
     config = {
         ip.DOMAIN: {
@@ -85,7 +86,9 @@ async def test_setup_platform_name(hass, store_mock):
     assert hass.states.get("image_processing.test_local")
 
 
-async def test_ms_identify_process_image(hass, poll_mock, aioclient_mock):
+async def test_ms_identify_process_image(
+    hass: HomeAssistant, poll_mock, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set up and scan a picture and test plates from event."""
     aioclient_mock.get(
         ENDPOINT_URL.format("persongroups"),

--- a/tests/components/mikrotik/test_config_flow.py
+++ b/tests/components/mikrotik/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -67,7 +68,7 @@ def mock_api_connection_error():
         yield
 
 
-async def test_flow_works(hass, api):
+async def test_flow_works(hass: HomeAssistant, api) -> None:
     """Test config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -88,7 +89,7 @@ async def test_flow_works(hass, api):
     assert result["data"][CONF_PORT] == 8278
 
 
-async def test_options(hass, api):
+async def test_options(hass: HomeAssistant, api) -> None:
     """Test updating options."""
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
     entry.add_to_hass(hass)
@@ -118,7 +119,7 @@ async def test_options(hass, api):
     }
 
 
-async def test_host_already_configured(hass, auth_error):
+async def test_host_already_configured(hass: HomeAssistant, auth_error) -> None:
     """Test host already configured."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
@@ -134,7 +135,7 @@ async def test_host_already_configured(hass, auth_error):
     assert result["reason"] == "already_configured"
 
 
-async def test_connection_error(hass, conn_error):
+async def test_connection_error(hass: HomeAssistant, conn_error) -> None:
     """Test error when connection is unsuccessful."""
 
     result = await hass.config_entries.flow.async_init(
@@ -147,7 +148,7 @@ async def test_connection_error(hass, conn_error):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_wrong_credentials(hass, auth_error):
+async def test_wrong_credentials(hass: HomeAssistant, auth_error) -> None:
     """Test error when credentials are wrong."""
 
     result = await hass.config_entries.flow.async_init(
@@ -164,7 +165,7 @@ async def test_wrong_credentials(hass, auth_error):
     }
 
 
-async def test_reauth_success(hass, api):
+async def test_reauth_success(hass: HomeAssistant, api) -> None:
     """Test we can reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -196,7 +197,7 @@ async def test_reauth_success(hass, api):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_reauth_failed(hass, auth_error):
+async def test_reauth_failed(hass: HomeAssistant, auth_error) -> None:
     """Test reauth fails due to wrong password."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -229,7 +230,7 @@ async def test_reauth_failed(hass, auth_error):
     }
 
 
-async def test_reauth_failed_conn_error(hass, conn_error):
+async def test_reauth_failed_conn_error(hass: HomeAssistant, conn_error) -> None:
     """Test reauth failed due to connection error."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/minio/test_minio.py
+++ b/tests/components/minio/test_minio.py
@@ -16,7 +16,7 @@ from homeassistant.components.minio import (
     DOMAIN,
     QueueListener,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from .common import TEST_EVENT
@@ -52,7 +52,9 @@ def minio_client_event_fixture():
         yield minio_client_mock
 
 
-async def test_minio_services(hass, caplog, minio_client):
+async def test_minio_services(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, minio_client
+) -> None:
     """Test Minio services."""
     hass.config.allowlist_external_dirs = {"/test"}
 
@@ -105,7 +107,9 @@ async def test_minio_services(hass, caplog, minio_client):
     minio_client.reset_mock()
 
 
-async def test_minio_listen(hass, caplog, minio_client_event):
+async def test_minio_listen(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, minio_client_event
+) -> None:
     """Test minio listen on notifications."""
     minio_client_event.presigned_get_object.return_value = "http://url"
 

--- a/tests/components/mobile_app/test_binary_sensor.py
+++ b/tests/components/mobile_app/test_binary_sensor.py
@@ -1,11 +1,16 @@
 """Entity tests for mobile_app."""
 from http import HTTPStatus
 
+import pytest
+
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 
-async def test_sensor(hass, create_registrations, webhook_client):
+async def test_sensor(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be registered and updated."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -89,7 +94,9 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert restored_entity.attributes == updated_entity.attributes
 
 
-async def test_sensor_must_register(hass, create_registrations, webhook_client):
+async def test_sensor_must_register(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors must be registered before updating."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -110,7 +117,12 @@ async def test_sensor_must_register(hass, create_registrations, webhook_client):
     assert json["battery_state"]["error"]["code"] == "not_registered"
 
 
-async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, caplog):
+async def test_sensor_id_no_dupes(
+    hass: HomeAssistant,
+    create_registrations,
+    webhook_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that a duplicate unique ID in registration updates the sensor."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -169,7 +181,9 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert entity.state == "off"
 
 
-async def test_register_sensor_no_state(hass, create_registrations, webhook_client):
+async def test_register_sensor_no_state(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be registered, when there is no (unknown) state."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -226,7 +240,9 @@ async def test_register_sensor_no_state(hass, create_registrations, webhook_clie
     assert entity.state == STATE_UNKNOWN
 
 
-async def test_update_sensor_no_state(hass, create_registrations, webhook_client):
+async def test_update_sensor_no_state(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be updated, when there is no (unknown) state."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"

--- a/tests/components/mobile_app/test_device_action.py
+++ b/tests/components/mobile_app/test_device_action.py
@@ -1,12 +1,13 @@
 """The tests for Mobile App device actions."""
 from homeassistant.components import automation, device_automation
 from homeassistant.components.mobile_app import DATA_DEVICES, DOMAIN, util
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_get_device_automations, patch
 
 
-async def test_get_actions(hass, push_registration):
+async def test_get_actions(hass: HomeAssistant, push_registration) -> None:
     """Test we get the expected actions from a mobile_app."""
     webhook_id = push_registration["webhook_id"]
     device_id = hass.data[DOMAIN][DATA_DEVICES][webhook_id].id
@@ -23,7 +24,7 @@ async def test_get_actions(hass, push_registration):
     assert "extra_fields" in capabilitites
 
 
-async def test_action(hass, push_registration):
+async def test_action(hass: HomeAssistant, push_registration) -> None:
     """Test for turn_on and turn_off actions."""
     webhook_id = push_registration["webhook_id"]
 

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -1,9 +1,12 @@
 """Test mobile app device tracker."""
-
 from http import HTTPStatus
 
+from homeassistant.core import HomeAssistant
 
-async def test_sending_location(hass, create_registrations, webhook_client):
+
+async def test_sending_location(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test sending a location via a webhook."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
@@ -71,7 +74,9 @@ async def test_sending_location(hass, create_registrations, webhook_client):
     assert state.attributes["vertical_accuracy"] == 8
 
 
-async def test_restoring_location(hass, create_registrations, webhook_client):
+async def test_restoring_location(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test sending a location via a webhook."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -13,11 +13,13 @@ from homeassistant.setup import async_setup_component
 
 from .const import REGISTER, REGISTER_CLEARTEXT, RENDER_TEMPLATE
 
-from tests.common import mock_coro
+from tests.common import MockUser, mock_coro
 from tests.typing import ClientSessionGenerator
 
 
-async def test_registration(hass, hass_client, hass_admin_user):
+async def test_registration(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_admin_user: MockUser
+) -> None:
     """Test that registrations happen."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the mobile app integration."""
 from homeassistant.components.mobile_app.const import DATA_DELETED_IDS, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CALL_SERVICE
@@ -7,7 +8,9 @@ from .const import CALL_SERVICE
 from tests.common import async_mock_service
 
 
-async def test_unload_unloads(hass, create_registrations, webhook_client):
+async def test_unload_unloads(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test we clean up when we unload."""
     # Second config entry is the one without encryption
     config_entry = hass.config_entries.async_entries("mobile_app")[1]
@@ -25,7 +28,7 @@ async def test_unload_unloads(hass, create_registrations, webhook_client):
     assert len(calls) == 1
 
 
-async def test_remove_entry(hass, create_registrations):
+async def test_remove_entry(hass: HomeAssistant, create_registrations) -> None:
     """Test we clean up when we remove entry."""
     for config_entry in hass.config_entries.async_entries("mobile_app"):
         await hass.config_entries.async_remove(config_entry.entry_id)

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -5,10 +5,13 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.mobile_app.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -135,7 +138,9 @@ async def setup_websocket_channel_only_push(hass, hass_admin_user):
     assert hass.services.has_service("notify", "mobile_app_websocket_push_name")
 
 
-async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
+async def test_notify_works(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, setup_push_receiver
+) -> None:
     """Test notify works."""
     assert hass.services.has_service("notify", "mobile_app_test") is True
     assert await hass.services.async_call(
@@ -155,8 +160,11 @@ async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
 
 
 async def test_notify_ws_works(
-    hass, aioclient_mock, setup_push_receiver, hass_ws_client
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    setup_push_receiver,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test notify works."""
     client = await hass_ws_client(hass)
 
@@ -242,8 +250,11 @@ async def test_notify_ws_works(
 
 
 async def test_notify_ws_confirming_works(
-    hass, aioclient_mock, setup_push_receiver, hass_ws_client
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    setup_push_receiver,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test notify confirming works."""
     client = await hass_ws_client(hass)
 
@@ -328,8 +339,11 @@ async def test_notify_ws_confirming_works(
 
 
 async def test_notify_ws_not_confirming(
-    hass, aioclient_mock, setup_push_receiver, hass_ws_client
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    setup_push_receiver,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test we go via cloud when failed to confirm."""
     client = await hass_ws_client(hass)
 
@@ -368,7 +382,11 @@ async def test_notify_ws_not_confirming(
     assert len(aioclient_mock.mock_calls) == 3
 
 
-async def test_local_push_only(hass, hass_ws_client, setup_websocket_channel_only_push):
+async def test_local_push_only(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    setup_websocket_channel_only_push,
+) -> None:
     """Test a local only push registration."""
     with pytest.raises(HomeAssistantError) as e_info:
         assert await hass.services.async_call(

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
@@ -23,8 +24,14 @@ from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
     ),
 )
 async def test_sensor(
-    hass, create_registrations, webhook_client, unit_system, state_unit, state1, state2
-):
+    hass: HomeAssistant,
+    create_registrations,
+    webhook_client,
+    unit_system,
+    state_unit,
+    state1,
+    state2,
+) -> None:
     """Test that sensors can be registered and updated."""
     hass.config.units = unit_system
 
@@ -141,7 +148,7 @@ async def test_sensor(
     ),
 )
 async def test_sensor_migration(
-    hass,
+    hass: HomeAssistant,
     create_registrations,
     webhook_client,
     unique_id,
@@ -149,7 +156,7 @@ async def test_sensor_migration(
     state_unit,
     state1,
     state2,
-):
+) -> None:
     """Test migration to RestoreSensor."""
     hass.config.units = unit_system
 
@@ -235,7 +242,9 @@ async def test_sensor_migration(
     assert "foo" not in updated_entity.attributes
 
 
-async def test_sensor_must_register(hass, create_registrations, webhook_client):
+async def test_sensor_must_register(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors must be registered before updating."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -254,7 +263,12 @@ async def test_sensor_must_register(hass, create_registrations, webhook_client):
     assert json["battery_state"]["error"]["code"] == "not_registered"
 
 
-async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, caplog):
+async def test_sensor_id_no_dupes(
+    hass: HomeAssistant,
+    create_registrations,
+    webhook_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that a duplicate unique ID in registration updates the sensor."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -316,7 +330,9 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert entity.state == "99"
 
 
-async def test_register_sensor_no_state(hass, create_registrations, webhook_client):
+async def test_register_sensor_no_state(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be registered, when there is no (unknown) state."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -373,7 +389,9 @@ async def test_register_sensor_no_state(hass, create_registrations, webhook_clie
     assert entity.state == STATE_UNKNOWN
 
 
-async def test_update_sensor_no_state(hass, create_registrations, webhook_client):
+async def test_update_sensor_no_state(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be updated, when there is no (unknown) state."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -445,8 +463,13 @@ async def test_update_sensor_no_state(hass, create_registrations, webhook_client
     ],
 )
 async def test_sensor_datetime(
-    hass, create_registrations, webhook_client, device_class, native_value, state_value
-):
+    hass: HomeAssistant,
+    create_registrations,
+    webhook_client,
+    device_class,
+    native_value,
+    state_value,
+) -> None:
     """Test that sensors can be registered and updated."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -479,7 +502,9 @@ async def test_sensor_datetime(
     assert entity.state == state_value
 
 
-async def test_default_disabling_entity(hass, create_registrations, webhook_client):
+async def test_default_disabling_entity(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors can be disabled by default upon registration."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -512,7 +537,9 @@ async def test_default_disabling_entity(hass, create_registrations, webhook_clie
     )
 
 
-async def test_updating_disabled_sensor(hass, create_registrations, webhook_client):
+async def test_updating_disabled_sensor(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that sensors return error if disabled in instance."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
     STATE_UNKNOWN,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -120,7 +120,9 @@ def decrypt_payload_legacy(secret_key, encrypted_data):
     return json.loads(decrypted_data)
 
 
-async def test_webhook_handle_render_template(create_registrations, webhook_client):
+async def test_webhook_handle_render_template(
+    create_registrations, webhook_client
+) -> None:
     """Test that we render templates properly."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
@@ -146,7 +148,9 @@ async def test_webhook_handle_render_template(create_registrations, webhook_clie
     }
 
 
-async def test_webhook_handle_call_services(hass, create_registrations, webhook_client):
+async def test_webhook_handle_call_services(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we call services properly."""
     calls = async_mock_service(hass, "test", "mobile_app")
 
@@ -160,7 +164,9 @@ async def test_webhook_handle_call_services(hass, create_registrations, webhook_
     assert len(calls) == 1
 
 
-async def test_webhook_handle_fire_event(hass, create_registrations, webhook_client):
+async def test_webhook_handle_fire_event(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we can fire events."""
     events = []
 
@@ -183,7 +189,7 @@ async def test_webhook_handle_fire_event(hass, create_registrations, webhook_cli
     assert events[0].data["hello"] == "yo world"
 
 
-async def test_webhook_update_registration(webhook_client, authed_api_client):
+async def test_webhook_update_registration(webhook_client, authed_api_client) -> None:
     """Test that a we can update an existing registration via webhook."""
     register_resp = await authed_api_client.post(
         "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
@@ -207,7 +213,9 @@ async def test_webhook_update_registration(webhook_client, authed_api_client):
     assert CONF_SECRET not in update_json
 
 
-async def test_webhook_handle_get_zones(hass, create_registrations, webhook_client):
+async def test_webhook_handle_get_zones(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we can get zones properly."""
     # Zone is already loaded as part of the fixture,
     # so we just trigger a reload.
@@ -257,7 +265,9 @@ async def test_webhook_handle_get_zones(hass, create_registrations, webhook_clie
     assert zones[2]["attributes"]["longitude"] == -118.2494053
 
 
-async def test_webhook_handle_get_config(hass, create_registrations, webhook_client):
+async def test_webhook_handle_get_config(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we can get config properly."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -315,8 +325,8 @@ async def test_webhook_handle_get_config(hass, create_registrations, webhook_cli
 
 
 async def test_webhook_returns_error_incorrect_json(
-    webhook_client, create_registrations, caplog
-):
+    webhook_client, create_registrations, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an error is returned when JSON is invalid."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]), data="not json"
@@ -339,8 +349,8 @@ async def test_webhook_returns_error_incorrect_json(
     ),
 )
 async def test_webhook_handle_decryption(
-    hass, webhook_client, create_registrations, msg, generate_response
-):
+    hass: HomeAssistant, webhook_client, create_registrations, msg, generate_response
+) -> None:
     """Test that we can encrypt/decrypt properly."""
     key = create_registrations[0]["secret"]
     data = encrypt_payload(key, msg["data"])
@@ -361,7 +371,9 @@ async def test_webhook_handle_decryption(
     assert decrypted_data == generate_response(hass)
 
 
-async def test_webhook_handle_decryption_legacy(webhook_client, create_registrations):
+async def test_webhook_handle_decryption_legacy(
+    webhook_client, create_registrations
+) -> None:
     """Test that we can encrypt/decrypt properly."""
     key = create_registrations[0]["secret"]
     data = encrypt_payload_legacy(key, RENDER_TEMPLATE["data"])
@@ -383,8 +395,8 @@ async def test_webhook_handle_decryption_legacy(webhook_client, create_registrat
 
 
 async def test_webhook_handle_decryption_fail(
-    webhook_client, create_registrations, caplog
-):
+    webhook_client, create_registrations, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we can encrypt/decrypt properly."""
     key = create_registrations[0]["secret"]
 
@@ -428,8 +440,8 @@ async def test_webhook_handle_decryption_fail(
 
 
 async def test_webhook_handle_decryption_legacy_fail(
-    webhook_client, create_registrations, caplog
-):
+    webhook_client, create_registrations, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that we can encrypt/decrypt properly."""
     key = create_registrations[0]["secret"]
 
@@ -474,7 +486,7 @@ async def test_webhook_handle_decryption_legacy_fail(
 
 async def test_webhook_handle_decryption_legacy_upgrade(
     webhook_client, create_registrations
-):
+) -> None:
     """Test that we can encrypt/decrypt properly."""
     key = create_registrations[0]["secret"]
 
@@ -536,7 +548,9 @@ async def test_webhook_handle_decryption_legacy_upgrade(
     assert decrypted_data == {}
 
 
-async def test_webhook_requires_encryption(webhook_client, create_registrations):
+async def test_webhook_requires_encryption(
+    webhook_client, create_registrations
+) -> None:
     """Test that encrypted registrations only accept encrypted data."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[0]["webhook_id"]),
@@ -552,8 +566,8 @@ async def test_webhook_requires_encryption(webhook_client, create_registrations)
 
 
 async def test_webhook_update_location_without_locations(
-    hass, webhook_client, create_registrations
-):
+    hass: HomeAssistant, webhook_client, create_registrations
+) -> None:
     """Test that location can be updated."""
 
     # start off with a location set by name
@@ -589,8 +603,8 @@ async def test_webhook_update_location_without_locations(
 
 
 async def test_webhook_update_location_with_gps(
-    hass, webhook_client, create_registrations
-):
+    hass: HomeAssistant, webhook_client, create_registrations
+) -> None:
     """Test that location can be updated."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
@@ -611,8 +625,8 @@ async def test_webhook_update_location_with_gps(
 
 
 async def test_webhook_update_location_with_gps_without_accuracy(
-    hass, webhook_client, create_registrations
-):
+    hass: HomeAssistant, webhook_client, create_registrations
+) -> None:
     """Test that location can be updated."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
@@ -629,8 +643,8 @@ async def test_webhook_update_location_with_gps_without_accuracy(
 
 
 async def test_webhook_update_location_with_location_name(
-    hass, webhook_client, create_registrations
-):
+    hass: HomeAssistant, webhook_client, create_registrations
+) -> None:
     """Test that location can be updated."""
 
     with patch(
@@ -690,7 +704,9 @@ async def test_webhook_update_location_with_location_name(
     assert state.state == STATE_NOT_HOME
 
 
-async def test_webhook_enable_encryption(hass, webhook_client, create_registrations):
+async def test_webhook_enable_encryption(
+    hass: HomeAssistant, webhook_client, create_registrations
+) -> None:
     """Test that encryption can be added to a reg initially created without."""
     webhook_id = create_registrations[1]["webhook_id"]
 
@@ -740,8 +756,8 @@ async def test_webhook_enable_encryption(hass, webhook_client, create_registrati
 
 
 async def test_webhook_camera_stream_non_existent(
-    hass, create_registrations, webhook_client
-):
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test fetching camera stream URLs for a non-existent camera."""
     webhook_id = create_registrations[1]["webhook_id"]
 
@@ -759,8 +775,8 @@ async def test_webhook_camera_stream_non_existent(
 
 
 async def test_webhook_camera_stream_non_hls(
-    hass, create_registrations, webhook_client
-):
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test fetching camera stream URLs for a non-HLS/stream-supporting camera."""
     hass.states.async_set("camera.non_stream_camera", "idle", {"supported_features": 0})
 
@@ -784,8 +800,8 @@ async def test_webhook_camera_stream_non_hls(
 
 
 async def test_webhook_camera_stream_stream_available(
-    hass, create_registrations, webhook_client
-):
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test fetching camera stream URLs for an HLS/stream-supporting camera."""
     hass.states.async_set(
         "camera.stream_camera",
@@ -814,8 +830,8 @@ async def test_webhook_camera_stream_stream_available(
 
 
 async def test_webhook_camera_stream_stream_available_but_errors(
-    hass, create_registrations, webhook_client
-):
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test fetching camera stream URLs for an HLS/stream-supporting camera but that streaming errors."""
     hass.states.async_set(
         "camera.stream_camera",
@@ -843,7 +859,9 @@ async def test_webhook_camera_stream_stream_available_but_errors(
     assert webhook_json["mjpeg_path"] == "/api/camera_proxy_stream/camera.stream_camera"
 
 
-async def test_webhook_handle_scan_tag(hass, create_registrations, webhook_client):
+async def test_webhook_handle_scan_tag(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we can scan tags."""
     device = dr.async_get(hass).async_get_device({(DOMAIN, "mock-device-id")})
     assert device is not None
@@ -865,8 +883,8 @@ async def test_webhook_handle_scan_tag(hass, create_registrations, webhook_clien
 
 
 async def test_register_sensor_limits_state_class(
-    hass, create_registrations, webhook_client
-):
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we limit state classes to sensors only."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -905,7 +923,9 @@ async def test_register_sensor_limits_state_class(
     assert reg_resp.status == HTTPStatus.OK
 
 
-async def test_reregister_sensor(hass, create_registrations, webhook_client):
+async def test_reregister_sensor(
+    hass: HomeAssistant, create_registrations, webhook_client
+) -> None:
     """Test that we can add more info in re-registration."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"
@@ -1007,8 +1027,8 @@ async def test_reregister_sensor(hass, create_registrations, webhook_client):
 
 
 async def test_webhook_handle_conversation_process(
-    hass, create_registrations, webhook_client, mock_agent
-):
+    hass: HomeAssistant, create_registrations, webhook_client, mock_agent
+) -> None:
     """Test that we can converse."""
     webhook_client.server.app.router._frozen = False
 
@@ -1045,7 +1065,12 @@ async def test_webhook_handle_conversation_process(
     }
 
 
-async def test_sending_sensor_state(hass, create_registrations, webhook_client, caplog):
+async def test_sending_sensor_state(
+    hass: HomeAssistant,
+    create_registrations,
+    webhook_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that we can register and send sensor state as number and None."""
     webhook_id = create_registrations[1]["webhook_id"]
     webhook_url = f"/api/webhook/{webhook_id}"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
