### PR TITLE
Add type hints to integration tests (part 16)

### DIFF
--- a/tests/components/notion/test_config_flow.py
+++ b/tests/components/notion/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.notion import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from .conftest import TEST_PASSWORD, TEST_USERNAME
 
@@ -21,8 +22,13 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
     ],
 )
 async def test_create_entry(
-    hass, client, config, errors, get_client_with_exception, mock_aionotion
-):
+    hass: HomeAssistant,
+    client,
+    config,
+    errors,
+    get_client_with_exception,
+    mock_aionotion,
+) -> None:
     """Test creating an etry (including recovery from errors)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -52,7 +58,7 @@ async def test_create_entry(
     }
 
 
-async def test_duplicate_error(hass, config, setup_config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -70,8 +76,13 @@ async def test_duplicate_error(hass, config, setup_config_entry):
     ],
 )
 async def test_reauth(
-    hass, config, config_entry, errors, get_client_with_exception, setup_config_entry
-):
+    hass: HomeAssistant,
+    config,
+    config_entry,
+    errors,
+    get_client_with_exception,
+    setup_config_entry,
+) -> None:
     """Test that re-auth works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/notion/test_diagnostics.py
+++ b/tests/components/notion/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test Notion diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -5,6 +5,7 @@ from nsw_fuel import FuelCheckError
 
 from homeassistant.components import sensor
 from homeassistant.components.nsw_fuel_station import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
@@ -73,7 +74,7 @@ MOCK_FUEL_PRICES_RESPONSE = MockGetFuelPricesResponse(
     "homeassistant.components.nsw_fuel_station.FuelCheckClient.get_fuel_prices",
     return_value=MOCK_FUEL_PRICES_RESPONSE,
 )
-async def test_setup(get_fuel_prices, hass):
+async def test_setup(get_fuel_prices, hass: HomeAssistant) -> None:
     """Test the setup with custom settings."""
     with assert_setup_component(1, sensor.DOMAIN):
         assert await async_setup_component(
@@ -95,7 +96,7 @@ def raise_fuel_check_error():
     "homeassistant.components.nsw_fuel_station.FuelCheckClient.get_fuel_prices",
     side_effect=raise_fuel_check_error,
 )
-async def test_setup_error(get_fuel_prices, hass):
+async def test_setup_error(get_fuel_prices, hass: HomeAssistant) -> None:
     """Test the setup with client throwing error."""
     with assert_setup_component(1, sensor.DOMAIN):
         assert await async_setup_component(
@@ -112,7 +113,7 @@ async def test_setup_error(get_fuel_prices, hass):
     "homeassistant.components.nsw_fuel_station.FuelCheckClient.get_fuel_prices",
     return_value=MOCK_FUEL_PRICES_RESPONSE,
 )
-async def test_setup_error_no_station(get_fuel_prices, hass):
+async def test_setup_error_no_station(get_fuel_prices, hass: HomeAssistant) -> None:
     """Test the setup with specified station not existing."""
     with assert_setup_component(2, sensor.DOMAIN):
         assert await async_setup_component(
@@ -143,7 +144,7 @@ async def test_setup_error_no_station(get_fuel_prices, hass):
     "homeassistant.components.nsw_fuel_station.FuelCheckClient.get_fuel_prices",
     return_value=MOCK_FUEL_PRICES_RESPONSE,
 )
-async def test_sensor_values(get_fuel_prices, hass):
+async def test_sensor_values(get_fuel_prices, hass: HomeAssistant) -> None:
     """Test retrieval of sensor values."""
     assert await async_setup_component(hass, DOMAIN, {})
     assert await async_setup_component(hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})

--- a/tests/components/numato/test_binary_sensor.py
+++ b/tests/components/numato/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the numato binary_sensor platform."""
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -12,7 +13,9 @@ MOCKUP_ENTITY_IDS = {
 }
 
 
-async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
+async def test_failing_setups_no_entities(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
@@ -21,7 +24,9 @@ async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
         assert entity_id not in hass.states.async_entity_ids()
 
 
-async def test_setup_callbacks(hass, numato_fixture, monkeypatch):
+async def test_setup_callbacks(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """During setup a callback shall be registered."""
 
     numato_fixture.discover()
@@ -38,7 +43,9 @@ async def test_setup_callbacks(hass, numato_fixture, monkeypatch):
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
 
 
-async def test_hass_binary_sensor_notification(hass, numato_fixture):
+async def test_hass_binary_sensor_notification(
+    hass: HomeAssistant, numato_fixture
+) -> None:
     """Test regular operations from within Home Assistant."""
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
     await hass.async_block_till_done()  # wait until services are registered
@@ -52,7 +59,9 @@ async def test_hass_binary_sensor_notification(hass, numato_fixture):
     )
 
 
-async def test_binary_sensor_setup_without_discovery_info(hass, config, numato_fixture):
+async def test_binary_sensor_setup_without_discovery_info(
+    hass: HomeAssistant, config, numato_fixture
+) -> None:
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
     await discovery.async_load_platform(

--- a/tests/components/numato/test_init.py
+++ b/tests/components/numato/test_init.py
@@ -3,12 +3,15 @@ from numato_gpio import NumatoGpioError
 import pytest
 
 from homeassistant.components import numato
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import NUMATO_CFG, mockup_raise, mockup_return
 
 
-async def test_setup_no_devices(hass, numato_fixture, monkeypatch):
+async def test_setup_no_devices(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """Test handling of an 'empty' discovery.
 
     Platform setups are expected to return after handling errors locally
@@ -19,7 +22,9 @@ async def test_setup_no_devices(hass, numato_fixture, monkeypatch):
     assert len(numato_fixture.devices) == 0
 
 
-async def test_fail_setup_raising_discovery(hass, numato_fixture, caplog, monkeypatch):
+async def test_fail_setup_raising_discovery(
+    hass: HomeAssistant, numato_fixture, caplog: pytest.LogCaptureFixture, monkeypatch
+) -> None:
     """Test handling of an exception during discovery.
 
     Setup shall return False.
@@ -29,7 +34,9 @@ async def test_fail_setup_raising_discovery(hass, numato_fixture, caplog, monkey
     await hass.async_block_till_done()
 
 
-async def test_hass_numato_api_wrong_port_directions(hass, numato_fixture):
+async def test_hass_numato_api_wrong_port_directions(
+    hass: HomeAssistant, numato_fixture
+) -> None:
     """Test handling of wrong port directions.
 
     This won't happen in the current platform implementation but would raise
@@ -46,7 +53,9 @@ async def test_hass_numato_api_wrong_port_directions(hass, numato_fixture):
         api.write_output(0, 2, 1)  # write to input
 
 
-async def test_hass_numato_api_errors(hass, numato_fixture, monkeypatch):
+async def test_hass_numato_api_errors(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """Test whether Home Assistant numato API (re-)raises errors."""
     numato_fixture.discover()
     monkeypatch.setattr(numato_fixture.devices[0], "setup", mockup_raise)
@@ -61,7 +70,7 @@ async def test_hass_numato_api_errors(hass, numato_fixture, monkeypatch):
         api.write_output(0, 2, 1)
 
 
-async def test_invalid_port_number(hass, numato_fixture, config):
+async def test_invalid_port_number(hass: HomeAssistant, numato_fixture, config) -> None:
     """Test validation of ADC port number type."""
     sensorports_cfg = config["numato"]["devices"][0]["sensors"]["ports"]
     port1_config = sensorports_cfg["1"]
@@ -72,7 +81,9 @@ async def test_invalid_port_number(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_too_low_adc_port_number(hass, numato_fixture, config):
+async def test_too_low_adc_port_number(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test handling of failing component setup.
 
     Tries setting up an ADC on a port below (0) the allowed range.
@@ -84,7 +95,9 @@ async def test_too_low_adc_port_number(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_too_high_adc_port_number(hass, numato_fixture, config):
+async def test_too_high_adc_port_number(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test handling of failing component setup.
 
     Tries setting up an ADC on a port above (8) the allowed range.
@@ -95,7 +108,9 @@ async def test_too_high_adc_port_number(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_range_value_type(hass, numato_fixture, config):
+async def test_invalid_adc_range_value_type(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range config's types.
 
     Replaces the source range beginning by a string.
@@ -106,7 +121,9 @@ async def test_invalid_adc_range_value_type(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_source_range_length(hass, numato_fixture, config):
+async def test_invalid_adc_source_range_length(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range config's length.
 
     Adds an element to the source range.
@@ -117,7 +134,9 @@ async def test_invalid_adc_source_range_length(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_source_range_order(hass, numato_fixture, config):
+async def test_invalid_adc_source_range_order(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range config's order.
 
     Sets the source range to a decreasing [2, 1].
@@ -128,7 +147,9 @@ async def test_invalid_adc_source_range_order(hass, numato_fixture, config):
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_destination_range_value_type(hass, numato_fixture, config):
+async def test_invalid_adc_destination_range_value_type(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range .
 
     Replaces the destination range beginning by a string.
@@ -139,7 +160,9 @@ async def test_invalid_adc_destination_range_value_type(hass, numato_fixture, co
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_destination_range_length(hass, numato_fixture, config):
+async def test_invalid_adc_destination_range_length(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range config's length.
 
     Adds an element to the destination range.
@@ -150,7 +173,9 @@ async def test_invalid_adc_destination_range_length(hass, numato_fixture, config
     assert not numato_fixture.devices
 
 
-async def test_invalid_adc_destination_range_order(hass, numato_fixture, config):
+async def test_invalid_adc_destination_range_order(
+    hass: HomeAssistant, numato_fixture, config
+) -> None:
     """Test validation of ADC range config's order.
 
     Sets the destination range to a decreasing [2, 1].

--- a/tests/components/numato/test_sensor.py
+++ b/tests/components/numato/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the numato sensor platform."""
 from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -10,7 +11,9 @@ MOCKUP_ENTITY_IDS = {
 }
 
 
-async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
+async def test_failing_setups_no_entities(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
@@ -19,7 +22,9 @@ async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
         assert entity_id not in hass.states.async_entity_ids()
 
 
-async def test_failing_sensor_update(hass, numato_fixture, monkeypatch):
+async def test_failing_sensor_update(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """Test condition when a sensor update fails."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "adc_read", mockup_raise)
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
@@ -27,7 +32,9 @@ async def test_failing_sensor_update(hass, numato_fixture, monkeypatch):
     assert hass.states.get("sensor.numato_adc_mock_port1").state is STATE_UNKNOWN
 
 
-async def test_sensor_setup_without_discovery_info(hass, config, numato_fixture):
+async def test_sensor_setup_without_discovery_info(
+    hass: HomeAssistant, config, numato_fixture
+) -> None:
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
     await discovery.async_load_platform(hass, Platform.SENSOR, "numato", None, config)

--- a/tests/components/numato/test_switch.py
+++ b/tests/components/numato/test_switch.py
@@ -6,6 +6,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -17,7 +18,9 @@ MOCKUP_ENTITY_IDS = {
 }
 
 
-async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
+async def test_failing_setups_no_entities(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """When port setup fails, no entity shall be created."""
     monkeypatch.setattr(numato_fixture.NumatoDeviceMock, "setup", mockup_raise)
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
@@ -26,7 +29,7 @@ async def test_failing_setups_no_entities(hass, numato_fixture, monkeypatch):
         assert entity_id not in hass.states.async_entity_ids()
 
 
-async def test_regular_hass_operations(hass, numato_fixture):
+async def test_regular_hass_operations(hass: HomeAssistant, numato_fixture) -> None:
     """Test regular operations from within Home Assistant."""
     assert await async_setup_component(hass, "numato", NUMATO_CFG)
     await hass.async_block_till_done()  # wait until services are registered
@@ -64,7 +67,9 @@ async def test_regular_hass_operations(hass, numato_fixture):
     assert numato_fixture.devices[0].values[6] == 0
 
 
-async def test_failing_hass_operations(hass, numato_fixture, monkeypatch):
+async def test_failing_hass_operations(
+    hass: HomeAssistant, numato_fixture, monkeypatch
+) -> None:
     """Test failing operations called from within Home Assistant.
 
     Switches remain in their initial 'off' state when the device can't
@@ -108,7 +113,9 @@ async def test_failing_hass_operations(hass, numato_fixture, monkeypatch):
     assert not numato_fixture.devices[0].values[6]
 
 
-async def test_switch_setup_without_discovery_info(hass, config, numato_fixture):
+async def test_switch_setup_without_discovery_info(
+    hass: HomeAssistant, config, numato_fixture
+) -> None:
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
     await discovery.async_load_platform(hass, Platform.SWITCH, "numato", None, config)

--- a/tests/components/number/test_device_action.py
+++ b/tests/components/number/test_device_action.py
@@ -7,7 +7,11 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.number import DOMAIN, device_action
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -20,7 +24,11 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions for an entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -57,12 +65,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -95,7 +103,11 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_get_action_no_state(hass, device_registry, entity_registry):
+async def test_get_action_no_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions for an entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Number component."""
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -236,7 +237,9 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number_4.value is None
 
 
-async def test_deprecation_warnings(hass: HomeAssistant, caplog) -> None:
+async def test_deprecation_warnings(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test overriding the deprecated attributes is possible and warnings are logged."""
     number = MockDefaultNumberEntityDeprecated()
     number.hass = hass
@@ -503,8 +506,8 @@ async def test_deprecated_methods(
     ],
 )
 async def test_temperature_conversion(
-    hass,
-    enable_custom_integrations,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
     unit_system,
     native_unit,
     state_unit,
@@ -518,7 +521,7 @@ async def test_temperature_conversion(
     state_min_value,
     native_step,
     state_step,
-):
+) -> None:
     """Test temperature conversion."""
     hass.config.units = unit_system
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -596,10 +599,10 @@ RESTORE_DATA = {
 
 
 async def test_restore_number_save_state(
-    hass,
-    hass_storage,
-    enable_custom_integrations,
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    enable_custom_integrations: None,
+) -> None:
     """Test RestoreNumber."""
     platform = getattr(hass.components, "test.number")
     platform.init(empty=True)
@@ -659,9 +662,9 @@ async def test_restore_number_save_state(
     ],
 )
 async def test_restore_number_restore_state(
-    hass,
-    enable_custom_integrations,
-    hass_storage,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    hass_storage: dict[str, Any],
     native_max_value,
     native_min_value,
     native_step,
@@ -670,7 +673,7 @@ async def test_restore_number_restore_state(
     extra_data,
     device_class,
     uom,
-):
+) -> None:
     """Test RestoreNumber."""
     mock_restore_cache_with_extra_data(hass, ((State("number.test", ""), extra_data),))
 
@@ -729,15 +732,15 @@ async def test_restore_number_restore_state(
     ],
 )
 async def test_custom_unit(
-    hass,
-    enable_custom_integrations,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
     device_class,
     native_unit,
     custom_unit,
     state_unit,
     native_value,
     custom_value,
-):
+) -> None:
     """Test custom unit."""
     entity_registry = er.async_get(hass)
 
@@ -802,8 +805,8 @@ async def test_custom_unit(
     ],
 )
 async def test_custom_unit_change(
-    hass,
-    enable_custom_integrations,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
     native_unit,
     custom_unit,
     used_custom_unit,
@@ -811,7 +814,7 @@ async def test_custom_unit_change(
     native_value,
     custom_value,
     default_value,
-):
+) -> None:
     """Test custom unit changes are picked up."""
     entity_registry = er.async_get(hass)
     platform = getattr(hass.components, "test.number")

--- a/tests/components/number/test_recorder.py
+++ b/tests/components/number/test_recorder.py
@@ -5,10 +5,11 @@ from datetime import timedelta
 
 from homeassistant.components import number
 from homeassistant.components.number import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_STEP
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -16,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test number registered attributes to be excluded."""
     await async_setup_component(
         hass, number.DOMAIN, {number.DOMAIN: {"platform": "demo"}}

--- a/tests/components/number/test_websocket_api.py
+++ b/tests/components/number/test_websocket_api.py
@@ -5,8 +5,12 @@ from homeassistant.components.number.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.typing import WebSocketGenerator
 
-async def test_device_class_units(hass: HomeAssistant, hass_ws_client) -> None:
+
+async def test_device_class_units(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can get supported units."""
     assert await async_setup_component(hass, DOMAIN, {})
 

--- a/tests/components/nws/test_config_flow.py
+++ b/tests/components/nws/test_config_flow.py
@@ -5,9 +5,10 @@ import aiohttp
 
 from homeassistant import config_entries
 from homeassistant.components.nws.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass, mock_simple_nws_config):
+async def test_form(hass: HomeAssistant, mock_simple_nws_config) -> None:
     """Test we get the form."""
     hass.config.latitude = 35
     hass.config.longitude = -90
@@ -38,7 +39,7 @@ async def test_form(hass, mock_simple_nws_config):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass, mock_simple_nws_config):
+async def test_form_cannot_connect(hass: HomeAssistant, mock_simple_nws_config) -> None:
     """Test we handle cannot connect error."""
     mock_instance = mock_simple_nws_config.return_value
     mock_instance.set_station.side_effect = aiohttp.ClientError
@@ -56,7 +57,7 @@ async def test_form_cannot_connect(hass, mock_simple_nws_config):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknown_error(hass, mock_simple_nws_config):
+async def test_form_unknown_error(hass: HomeAssistant, mock_simple_nws_config) -> None:
     """Test we handle unknown error."""
     mock_instance = mock_simple_nws_config.return_value
     mock_instance.set_station.side_effect = ValueError
@@ -74,7 +75,9 @@ async def test_form_unknown_error(hass, mock_simple_nws_config):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_configured(hass, mock_simple_nws_config):
+async def test_form_already_configured(
+    hass: HomeAssistant, mock_simple_nws_config
+) -> None:
     """Test we handle duplicate entries."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/nws/test_init.py
+++ b/tests/components/nws/test_init.py
@@ -2,13 +2,14 @@
 from homeassistant.components.nws.const import DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 from .const import NWS_CONFIG
 
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass, mock_simple_nws):
+async def test_unload_entry(hass: HomeAssistant, mock_simple_nws) -> None:
     """Test that nws setup with config yaml."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/nws/test_sensor.py
+++ b/tests/components/nws/test_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.nws.const import ATTRIBUTION, DOMAIN
 from homeassistant.components.nws.sensor import SENSOR_TYPES
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
@@ -33,8 +34,13 @@ from tests.common import MockConfigEntry
     ],
 )
 async def test_imperial_metric(
-    hass, units, result_observation, result_forecast, mock_simple_nws, no_weather
-):
+    hass: HomeAssistant,
+    units,
+    result_observation,
+    result_forecast,
+    mock_simple_nws,
+    no_weather,
+) -> None:
     """Test with imperial and metric units."""
     registry = er.async_get(hass)
 
@@ -64,7 +70,7 @@ async def test_imperial_metric(
         assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
 
 
-async def test_none_values(hass, mock_simple_nws, no_weather):
+async def test_none_values(hass: HomeAssistant, mock_simple_nws, no_weather) -> None:
     """Test with no values."""
     instance = mock_simple_nws.return_value
     instance.observation = NONE_OBSERVATION

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -12,6 +12,7 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -42,8 +43,13 @@ from tests.common import MockConfigEntry, async_fire_time_changed
     ],
 )
 async def test_imperial_metric(
-    hass, units, result_observation, result_forecast, mock_simple_nws, no_sensor
-):
+    hass: HomeAssistant,
+    units,
+    result_observation,
+    result_forecast,
+    mock_simple_nws,
+    no_sensor,
+) -> None:
     """Test with imperial and metric units."""
     # enable the hourly entity
     registry = er.async_get(hass)
@@ -91,7 +97,7 @@ async def test_imperial_metric(
         assert forecast[0].get(key) == value
 
 
-async def test_none_values(hass, mock_simple_nws, no_sensor):
+async def test_none_values(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     """Test with none values in observation and forecast dicts."""
     instance = mock_simple_nws.return_value
     instance.observation = NONE_OBSERVATION
@@ -116,7 +122,7 @@ async def test_none_values(hass, mock_simple_nws, no_sensor):
         assert forecast[0].get(key) is None
 
 
-async def test_none(hass, mock_simple_nws, no_sensor):
+async def test_none(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     """Test with None as observation and forecast."""
     instance = mock_simple_nws.return_value
     instance.observation = None
@@ -142,7 +148,7 @@ async def test_none(hass, mock_simple_nws, no_sensor):
     assert forecast is None
 
 
-async def test_error_station(hass, mock_simple_nws, no_sensor):
+async def test_error_station(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     """Test error in setting station."""
 
     instance = mock_simple_nws.return_value
@@ -160,7 +166,7 @@ async def test_error_station(hass, mock_simple_nws, no_sensor):
     assert hass.states.get("weather.abc_daynight") is None
 
 
-async def test_entity_refresh(hass, mock_simple_nws, no_sensor):
+async def test_entity_refresh(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     """Test manual refresh."""
     instance = mock_simple_nws.return_value
 
@@ -189,7 +195,9 @@ async def test_entity_refresh(hass, mock_simple_nws, no_sensor):
     instance.update_forecast_hourly.assert_called_once()
 
 
-async def test_error_observation(hass, mock_simple_nws, no_sensor):
+async def test_error_observation(
+    hass: HomeAssistant, mock_simple_nws, no_sensor
+) -> None:
     """Test error during update observation."""
     utc_time = dt_util.utcnow()
     with patch("homeassistant.components.nws.utcnow") as mock_utc, patch(
@@ -253,7 +261,7 @@ async def test_error_observation(hass, mock_simple_nws, no_sensor):
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_error_forecast(hass, mock_simple_nws, no_sensor):
+async def test_error_forecast(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     """Test error during update forecast."""
     instance = mock_simple_nws.return_value
     instance.update_forecast.side_effect = aiohttp.ClientError
@@ -284,7 +292,9 @@ async def test_error_forecast(hass, mock_simple_nws, no_sensor):
     assert state.state == ATTR_CONDITION_SUNNY
 
 
-async def test_error_forecast_hourly(hass, mock_simple_nws, no_sensor):
+async def test_error_forecast_hourly(
+    hass: HomeAssistant, mock_simple_nws, no_sensor
+) -> None:
     """Test error during update forecast hourly."""
     instance = mock_simple_nws.return_value
     instance.update_forecast_hourly.side_effect = aiohttp.ClientError
@@ -325,7 +335,9 @@ async def test_error_forecast_hourly(hass, mock_simple_nws, no_sensor):
     assert state.state == ATTR_CONDITION_SUNNY
 
 
-async def test_forecast_hourly_disable_enable(hass, mock_simple_nws, no_sensor):
+async def test_forecast_hourly_disable_enable(
+    hass: HomeAssistant, mock_simple_nws, no_sensor
+) -> None:
     """Test error during update forecast hourly."""
     entry = MockConfigEntry(
         domain=nws.DOMAIN,

--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -56,7 +56,9 @@ def client(fake_zones):
 @pytest.mark.usefixtures("client")
 @mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
 @mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
-def test_nx584_sensor_setup_defaults(mock_nx, mock_watcher, hass, fake_zones):
+def test_nx584_sensor_setup_defaults(
+    mock_nx, mock_watcher, hass: HomeAssistant, fake_zones
+) -> None:
     """Test the setup with no configuration."""
     add_entities = mock.MagicMock()
     config = DEFAULT_CONFIG
@@ -70,7 +72,9 @@ def test_nx584_sensor_setup_defaults(mock_nx, mock_watcher, hass, fake_zones):
 @pytest.mark.usefixtures("client")
 @mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
 @mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
-def test_nx584_sensor_setup_full_config(mock_nx, mock_watcher, hass, fake_zones):
+def test_nx584_sensor_setup_full_config(
+    mock_nx, mock_watcher, hass: HomeAssistant, fake_zones
+) -> None:
     """Test the setup with full configuration."""
     config = {
         "host": "foo",
@@ -107,7 +111,7 @@ async def _test_assert_graceful_fail(hass, config):
         ({"zone_types": {"notazone": "motion"}}),
     ],
 )
-async def test_nx584_sensor_setup_bad_config(hass, config):
+async def test_nx584_sensor_setup_bad_config(hass: HomeAssistant, config) -> None:
     """Test the setup with bad configuration."""
     await _test_assert_graceful_fail(hass, config)
 
@@ -120,7 +124,9 @@ async def test_nx584_sensor_setup_bad_config(hass, config):
         pytest.param(IndexError, id="no_partitions"),
     ],
 )
-async def test_nx584_sensor_setup_with_exceptions(hass, exception_type):
+async def test_nx584_sensor_setup_with_exceptions(
+    hass: HomeAssistant, exception_type
+) -> None:
     """Test the setup handles exceptions."""
     nx584_client.Client.return_value.list_zones.side_effect = exception_type
     await _test_assert_graceful_fail(hass, {})
@@ -177,7 +183,7 @@ def test_nx584_zone_sensor_bypassed() -> None:
 
 
 @mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
-def test_nx584_watcher_process_zone_event(mock_update):
+def test_nx584_watcher_process_zone_event(mock_update) -> None:
     """Test the processing of zone events."""
     zone1 = {"number": 1, "name": "foo", "state": True}
     zone2 = {"number": 2, "name": "bar", "state": True}
@@ -192,7 +198,7 @@ def test_nx584_watcher_process_zone_event(mock_update):
 
 
 @mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
-def test_nx584_watcher_process_zone_event_missing_zone(mock_update):
+def test_nx584_watcher_process_zone_event_missing_zone(mock_update) -> None:
     """Test the processing of zone events with missing zones."""
     watcher = nx584.NX584Watcher(None, {})
     watcher._process_zone_event({"zone": 1, "zone_state": False})
@@ -232,7 +238,7 @@ def test_nx584_watcher_run_with_zone_events() -> None:
 
 
 @mock.patch("time.sleep")
-def test_nx584_watcher_run_retries_failures(mock_sleep):
+def test_nx584_watcher_run_retries_failures(mock_sleep) -> None:
     """Test the retries with failures."""
     empty_me = [1, 2]
 

--- a/tests/components/nzbget/test_config_flow.py
+++ b/tests/components/nzbget/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_user_form_single_instance_allowed(hass: HomeAssistant) -> None:
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_options_flow(hass, nzbget_api):
+async def test_options_flow(hass: HomeAssistant, nzbget_api) -> None:
     """Test updating options."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/nzbget/test_init.py
+++ b/tests/components/nzbget/test_init.py
@@ -12,7 +12,7 @@ from . import ENTRY_CONFIG, _patch_version, init_integration
 from tests.common import MockConfigEntry
 
 
-async def test_unload_entry(hass, nzbget_api):
+async def test_unload_entry(hass: HomeAssistant, nzbget_api) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 

--- a/tests/components/nzbget/test_sensor.py
+++ b/tests/components/nzbget/test_sensor.py
@@ -8,13 +8,14 @@ from homeassistant.const import (
     UnitOfDataRate,
     UnitOfInformation,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import init_integration
 
 
-async def test_sensors(hass, nzbget_api) -> None:
+async def test_sensors(hass: HomeAssistant, nzbget_api) -> None:
     """Test the creation and values of the sensors."""
     now = dt_util.utcnow().replace(microsecond=0)
     with patch("homeassistant.components.nzbget.sensor.utcnow", return_value=now):

--- a/tests/components/nzbget/test_switch.py
+++ b/tests/components/nzbget/test_switch.py
@@ -7,13 +7,14 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from . import init_integration
 
 
-async def test_download_switch(hass, nzbget_api) -> None:
+async def test_download_switch(hass: HomeAssistant, nzbget_api) -> None:
     """Test the creation and values of the download switch."""
     instance = nzbget_api.return_value
 
@@ -41,7 +42,7 @@ async def test_download_switch(hass, nzbget_api) -> None:
     assert state.state == STATE_OFF
 
 
-async def test_download_switch_services(hass, nzbget_api) -> None:
+async def test_download_switch_services(hass: HomeAssistant, nzbget_api) -> None:
     """Test download switch services."""
     instance = nzbget_api.return_value
 

--- a/tests/components/octoprint/test_button.py
+++ b/tests/components/octoprint/test_button.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from . import init_integration
 
 
-async def test_pause_job(hass: HomeAssistant):
+async def test_pause_job(hass: HomeAssistant) -> None:
     """Test the pause job button."""
     await init_integration(hass, BUTTON_DOMAIN)
 
@@ -74,7 +74,7 @@ async def test_pause_job(hass: HomeAssistant):
         )
 
 
-async def test_resume_job(hass: HomeAssistant):
+async def test_resume_job(hass: HomeAssistant) -> None:
     """Test the resume job button."""
     await init_integration(hass, BUTTON_DOMAIN)
 
@@ -134,7 +134,7 @@ async def test_resume_job(hass: HomeAssistant):
         )
 
 
-async def test_stop_job(hass: HomeAssistant):
+async def test_stop_job(hass: HomeAssistant) -> None:
     """Test the stop job button."""
     await init_integration(hass, BUTTON_DOMAIN)
 

--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the init."""
+from typing import Any
 from unittest.mock import Mock, patch
 
 from homeassistant.components import onboarding
@@ -12,7 +13,9 @@ from tests.common import MockUser, mock_coro
 # Temporarily: if auth not active, always set onboarded=True
 
 
-async def test_not_setup_views_if_onboarded(hass, hass_storage):
+async def test_not_setup_views_if_onboarded(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test if onboarding is done, we don't setup views."""
     mock_storage(hass_storage, {"done": onboarding.STEPS})
 
@@ -66,7 +69,9 @@ async def test_is_user_onboarded() -> None:
     assert not onboarding.async_is_user_onboarded(hass)
 
 
-async def test_having_owner_finishes_user_step(hass, hass_storage):
+async def test_having_owner_finishes_user_step(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """If owner user already exists, mark user step as complete."""
     MockUser(is_owner=True).add_to_hass(hass)
 
@@ -83,7 +88,7 @@ async def test_having_owner_finishes_user_step(hass, hass_storage):
     assert onboarding.STEP_USER in done
 
 
-async def test_migration(hass, hass_storage):
+async def test_migration(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     """Test migrating onboarding to new version."""
     hass_storage[onboarding.STORAGE_KEY] = {"version": 1, "data": {"done": ["user"]}}
     assert await async_setup_component(hass, "onboarding", {})

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -2,18 +2,27 @@
 import asyncio
 from http import HTTPStatus
 import os
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components import onboarding
 from homeassistant.components.onboarding import const, views
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.setup import async_setup_component
 
 from . import mock_storage
 
-from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, register_auth_provider
+from tests.common import (
+    CLIENT_ID,
+    CLIENT_REDIRECT_URI,
+    MockUser,
+    register_auth_provider,
+)
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -112,7 +121,11 @@ def mock_default_integrations():
         yield
 
 
-async def test_onboarding_progress(hass, hass_storage, hass_client_no_auth):
+async def test_onboarding_progress(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test fetching progress."""
     mock_storage(hass_storage, {"done": ["hello"]})
 
@@ -131,7 +144,11 @@ async def test_onboarding_progress(hass, hass_storage, hass_client_no_auth):
     assert data[1] == {"step": "world", "done": False}
 
 
-async def test_onboarding_user_already_done(hass, hass_storage, hass_client_no_auth):
+async def test_onboarding_user_already_done(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test creating a new user when user step already done."""
     mock_storage(hass_storage, {"done": [views.STEP_USER]})
 
@@ -155,7 +172,11 @@ async def test_onboarding_user_already_done(hass, hass_storage, hass_client_no_a
     assert resp.status == HTTPStatus.FORBIDDEN
 
 
-async def test_onboarding_user(hass, hass_storage, hass_client_no_auth):
+async def test_onboarding_user(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test creating a new user."""
     area_registry = ar.async_get(hass)
 
@@ -221,7 +242,11 @@ async def test_onboarding_user(hass, hass_storage, hass_client_no_auth):
     ]
 
 
-async def test_onboarding_user_invalid_name(hass, hass_storage, hass_client_no_auth):
+async def test_onboarding_user_invalid_name(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test not providing name."""
     mock_storage(hass_storage, {"done": []})
 
@@ -243,7 +268,11 @@ async def test_onboarding_user_invalid_name(hass, hass_storage, hass_client_no_a
     assert resp.status == 400
 
 
-async def test_onboarding_user_race(hass, hass_storage, hass_client_no_auth):
+async def test_onboarding_user_race(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test race condition on creating new user."""
     mock_storage(hass_storage, {"done": ["hello"]})
 
@@ -278,7 +307,12 @@ async def test_onboarding_user_race(hass, hass_storage, hass_client_no_auth):
     assert sorted([res1.status, res2.status]) == [HTTPStatus.OK, HTTPStatus.FORBIDDEN]
 
 
-async def test_onboarding_integration(hass, hass_storage, hass_client, hass_admin_user):
+async def test_onboarding_integration(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+) -> None:
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -320,8 +354,11 @@ async def test_onboarding_integration(hass, hass_storage, hass_client, hass_admi
 
 
 async def test_onboarding_integration_missing_credential(
-    hass, hass_storage, hass_client, hass_access_token
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test that we fail integration step if user is missing credentials."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -342,8 +379,10 @@ async def test_onboarding_integration_missing_credential(
 
 
 async def test_onboarding_integration_invalid_redirect_uri(
-    hass, hass_storage, hass_client
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -374,8 +413,10 @@ async def test_onboarding_integration_invalid_redirect_uri(
 
 
 async def test_onboarding_integration_requires_auth(
-    hass, hass_storage, hass_client_no_auth
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
     """Test finishing integration step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -392,8 +433,11 @@ async def test_onboarding_integration_requires_auth(
 
 
 async def test_onboarding_core_sets_up_met(
-    hass, hass_storage, hass_client, mock_default_integrations
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    mock_default_integrations,
+) -> None:
     """Test finishing the core step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -410,8 +454,11 @@ async def test_onboarding_core_sets_up_met(
 
 
 async def test_onboarding_core_sets_up_radio_browser(
-    hass, hass_storage, hass_client, mock_default_integrations
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    mock_default_integrations,
+) -> None:
     """Test finishing the core step set up the radio browser."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -428,8 +475,13 @@ async def test_onboarding_core_sets_up_radio_browser(
 
 
 async def test_onboarding_core_sets_up_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, rpi, mock_default_integrations
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    rpi,
+    mock_default_integrations,
+) -> None:
     """Test that the core step sets up rpi_power on RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -449,8 +501,13 @@ async def test_onboarding_core_sets_up_rpi_power(
 
 
 async def test_onboarding_core_no_rpi_power(
-    hass, hass_storage, hass_client, aioclient_mock, no_rpi, mock_default_integrations
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    no_rpi,
+    mock_default_integrations,
+) -> None:
     """Test that the core step do not set up rpi_power on non RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -469,7 +526,12 @@ async def test_onboarding_core_no_rpi_power(
     assert not rpi_power_state
 
 
-async def test_onboarding_analytics(hass, hass_storage, hass_client, hass_admin_user):
+async def test_onboarding_analytics(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+) -> None:
     """Test finishing analytics step."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 
@@ -488,7 +550,11 @@ async def test_onboarding_analytics(hass, hass_storage, hass_client, hass_admin_
     assert resp.status == 403
 
 
-async def test_onboarding_installation_type(hass, hass_storage, hass_client):
+async def test_onboarding_installation_type(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test returning installation type during onboarding."""
     mock_storage(hass_storage, {"done": []})
 
@@ -509,7 +575,11 @@ async def test_onboarding_installation_type(hass, hass_storage, hass_client):
         assert resp_content["installation_type"] == "Home Assistant Core"
 
 
-async def test_onboarding_installation_type_after_done(hass, hass_storage, hass_client):
+async def test_onboarding_installation_type_after_done(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test raising for installation type after onboarding."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
 

--- a/tests/components/ondilo_ico/test_config_flow.py
+++ b/tests/components/ondilo_ico/test_config_flow.py
@@ -14,6 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = OAUTH2_CLIENTID
 CLIENT_SECRET = OAUTH2_CLIENTSECRET
@@ -31,8 +33,11 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from . import setup_owproxy_mock_devices
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +40,7 @@ DEVICE_DETAILS = {
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     owproxy: MagicMock,
     device_id: str,
 ) -> None:

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -33,7 +33,7 @@ async def remove_device(
 
 
 @pytest.mark.usefixtures("owproxy_with_connerror")
-async def test_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Test connection failure raises ConfigEntryNotReady."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -45,7 +45,7 @@ async def test_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def test_listing_failure(
     hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock
-):
+) -> None:
     """Test listing failure raises ConfigEntryNotReady."""
     owproxy.return_value.dir.side_effect = protocol.OwnetError()
 
@@ -58,7 +58,7 @@ async def test_listing_failure(
 
 
 @pytest.mark.usefixtures("owproxy")
-async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Test being able to unload an entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import area_registry, device_registry, intent
 from tests.common import MockConfigEntry
 
 
-async def test_default_prompt(hass, mock_init_component):
+async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
     """Test that the default prompt works."""
     device_reg = device_registry.async_get(hass)
     area_reg = area_registry.async_get(hass)
@@ -107,7 +107,7 @@ Smart home: """
     )
 
 
-async def test_error_handling(hass, mock_init_component):
+async def test_error_handling(hass: HomeAssistant, mock_init_component) -> None:
     """Test that the default prompt works."""
     with patch("openai.Completion.acreate", side_effect=error.ServiceUnavailableError):
         result = await conversation.async_converse(hass, "hello", None, Context())

--- a/tests/components/openalpr_cloud/test_image_processing.py
+++ b/tests/components/openalpr_cloud/test_image_processing.py
@@ -11,6 +11,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_capture_events, load_fixture
 from tests.components.image_processing import common
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -118,8 +119,11 @@ async def test_setup_platform_without_region(hass: HomeAssistant) -> None:
 
 
 async def test_openalpr_process_image(
-    alpr_events, setup_openalpr_cloud, hass, aioclient_mock
-):
+    alpr_events,
+    setup_openalpr_cloud,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Set up and scan a picture and test plates from event."""
     aioclient_mock.post(
         OPENALPR_API_URL,
@@ -152,8 +156,11 @@ async def test_openalpr_process_image(
 
 
 async def test_openalpr_process_image_api_error(
-    alpr_events, setup_openalpr_cloud, hass, aioclient_mock
-):
+    alpr_events,
+    setup_openalpr_cloud,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Set up and scan a picture and test api error."""
     aioclient_mock.post(
         OPENALPR_API_URL,
@@ -174,8 +181,11 @@ async def test_openalpr_process_image_api_error(
 
 
 async def test_openalpr_process_image_api_timeout(
-    alpr_events, setup_openalpr_cloud, hass, aioclient_mock
-):
+    alpr_events,
+    setup_openalpr_cloud,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Set up and scan a picture and test api error."""
     aioclient_mock.post(OPENALPR_API_URL, params=PARAMS, exc=asyncio.TimeoutError())
 

--- a/tests/components/openhardwaremonitor/test_sensor.py
+++ b/tests/components/openhardwaremonitor/test_sensor.py
@@ -1,10 +1,13 @@
 """The tests for the Open Hardware Monitor platform."""
+import requests_mock
+
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
 
 
-async def test_setup(hass, requests_mock):
+async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test for successfully setting up the platform."""
     config = {
         "sensor": {

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -13,11 +13,12 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
 )
+from homeassistant.core import HomeAssistant
 
 from .conftest import TEST_API_KEY, TEST_ELEVATION, TEST_LATITUDE, TEST_LONGITUDE
 
 
-async def test_create_entry(hass, client, config, mock_pyopenuv):
+async def test_create_entry(hass: HomeAssistant, client, config, mock_pyopenuv) -> None:
     """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -48,7 +49,9 @@ async def test_create_entry(hass, client, config, mock_pyopenuv):
     }
 
 
-async def test_duplicate_error(hass, config, config_entry, setup_config_entry):
+async def test_duplicate_error(
+    hass: HomeAssistant, config, config_entry, setup_config_entry
+) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -57,7 +60,9 @@ async def test_duplicate_error(hass, config, config_entry, setup_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow(hass, config_entry, setup_config_entry):
+async def test_options_flow(
+    hass: HomeAssistant, config_entry, setup_config_entry
+) -> None:
     """Test config flow options."""
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -95,7 +100,9 @@ async def test_options_flow(hass, config_entry, setup_config_entry):
     }
 
 
-async def test_step_reauth(hass, config, config_entry, setup_config_entry):
+async def test_step_reauth(
+    hass: HomeAssistant, config, config_entry, setup_config_entry
+) -> None:
     """Test that the reauth step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config

--- a/tests/components/openuv/test_diagnostics.py
+++ b/tests/components/openuv/test_diagnostics.py
@@ -1,11 +1,18 @@
 """Test OpenUV diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     await async_setup_component(hass, "homeassistant", {})
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,12 +1,13 @@
 """The tests for the opnsense device tracker platform."""
-
 from unittest import mock
 
 import pytest
 
 from homeassistant.components import opnsense
+from homeassistant.components.device_tracker import legacy
 from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -17,7 +18,9 @@ def mocked_opnsense():
         yield mocked_opn
 
 
-async def test_get_scanner(hass, mocked_opnsense, mock_device_tracker_conf):
+async def test_get_scanner(
+    hass: HomeAssistant, mocked_opnsense, mock_device_tracker_conf: list[legacy.Device]
+) -> None:
     """Test creating an opnsense scanner."""
     interface_client = mock.MagicMock()
     mocked_opnsense.InterfaceClient.return_value = interface_client

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -16,7 +16,7 @@ from tests.components.bluetooth import (
 )
 
 
-async def test_sensors(hass, entity_registry_enabled_by_default):
+async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -46,7 +46,9 @@ async def test_sensors(hass, entity_registry_enabled_by_default):
     await hass.async_block_till_done()
 
 
-async def test_sensors_io_series_4(hass, entity_registry_enabled_by_default):
+async def test_sensors_io_series_4(
+    hass: HomeAssistant, entity_registry_enabled_by_default
+) -> None:
     """Test setting up creates the sensors with an io series 4."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_import_dataset(hass: HomeAssistant):
+async def test_import_dataset(hass: HomeAssistant) -> None:
     """Test the active dataset is imported at setup."""
 
     config_entry = MockConfigEntry(
@@ -37,7 +37,7 @@ async def test_import_dataset(hass: HomeAssistant):
 
 async def test_config_entry_not_ready(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test raising ConfigEntryNotReady ."""
 
     config_entry = MockConfigEntry(
@@ -53,7 +53,7 @@ async def test_config_entry_not_ready(
 
 async def test_remove_entry(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs after removing the config entry."""
 
     aioclient_mock.get(f"{BASE_URL}/node/dataset/active", text="0E")
@@ -69,7 +69,7 @@ async def test_remove_entry(
 
 async def test_get_active_dataset_tlvs(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs."""
 
     mock_response = (
@@ -87,14 +87,14 @@ async def test_get_active_dataset_tlvs(
 
 async def test_get_active_dataset_tlvs_empty(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs."""
 
     aioclient_mock.get(f"{BASE_URL}/node/dataset/active", status=HTTPStatus.NO_CONTENT)
     assert await otbr.async_get_active_dataset_tlvs(hass) is None
 
 
-async def test_get_active_dataset_tlvs_addon_not_installed(hass: HomeAssistant):
+async def test_get_active_dataset_tlvs_addon_not_installed(hass: HomeAssistant) -> None:
     """Test async_get_active_dataset_tlvs when the multi-PAN addon is not installed."""
 
     with pytest.raises(HomeAssistantError):
@@ -103,7 +103,7 @@ async def test_get_active_dataset_tlvs_addon_not_installed(hass: HomeAssistant):
 
 async def test_get_active_dataset_tlvs_404(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs with error."""
 
     aioclient_mock.get(f"{BASE_URL}/node/dataset/active", status=HTTPStatus.NOT_FOUND)
@@ -113,7 +113,7 @@ async def test_get_active_dataset_tlvs_404(
 
 async def test_get_active_dataset_tlvs_201(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs with error."""
 
     aioclient_mock.get(f"{BASE_URL}/node/dataset/active", status=HTTPStatus.CREATED)
@@ -123,7 +123,7 @@ async def test_get_active_dataset_tlvs_201(
 
 async def test_get_active_dataset_tlvs_invalid(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_config_entry
-):
+) -> None:
     """Test async_get_active_dataset_tlvs with error."""
 
     aioclient_mock.get(f"{BASE_URL}/node/dataset/active", text="unexpected")

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -23,7 +23,7 @@ async def test_get_info(
     aioclient_mock: AiohttpClientMocker,
     otbr_config_entry,
     websocket_client,
-):
+) -> None:
     """Test async_get_info."""
 
     mock_response = (
@@ -54,7 +54,7 @@ async def test_get_info_no_entry(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     websocket_client,
-):
+) -> None:
     """Test async_get_info."""
     await async_setup_component(hass, "otbr", {})
     await websocket_client.send_json(
@@ -75,7 +75,7 @@ async def test_get_info_fetch_fails(
     aioclient_mock: AiohttpClientMocker,
     otbr_config_entry,
     websocket_client,
-):
+) -> None:
     """Test async_get_info."""
     await async_setup_component(hass, "otbr", {})
 

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -60,7 +60,7 @@ async def init_config_flow(hass):
     return flow
 
 
-async def test_user(hass, webhook_id, secret):
+async def test_user(hass: HomeAssistant, webhook_id, secret) -> None:
     """Test user step."""
     flow = await init_config_flow(hass)
 
@@ -103,7 +103,9 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_user_not_supports_encryption(hass, not_supports_encryption):
+async def test_user_not_supports_encryption(
+    hass: HomeAssistant, not_supports_encryption
+) -> None:
     """Test user step."""
     flow = await init_config_flow(hass)
 

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -401,14 +401,14 @@ def assert_mobile_tracker_accuracy(hass, accuracy, beacon=IBEACON_DEVICE):
     assert state.attributes.get("gps_accuracy") == accuracy
 
 
-async def test_location_invalid_devid(hass, context):
+async def test_location_invalid_devid(hass: HomeAssistant, context) -> None:
     """Test the update of a location."""
     await send_message(hass, "owntracks/paulus/nexus-5x", LOCATION_MESSAGE)
     state = hass.states.get("device_tracker.paulus_nexus_5x")
     assert state.state == "outer"
 
 
-async def test_location_update(hass, context):
+async def test_location_update(hass: HomeAssistant, context) -> None:
     """Test the update of a location."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
 
@@ -418,7 +418,7 @@ async def test_location_update(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_location_update_no_t_key(hass, context):
+async def test_location_update_no_t_key(hass: HomeAssistant, context) -> None:
     """Test the update of a location when message does not contain 't'."""
     message = LOCATION_MESSAGE.copy()
     message.pop("t")
@@ -430,7 +430,7 @@ async def test_location_update_no_t_key(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_location_inaccurate_gps(hass, context):
+async def test_location_inaccurate_gps(hass: HomeAssistant, context) -> None:
     """Test the location for inaccurate GPS information."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_INACCURATE)
@@ -440,7 +440,7 @@ async def test_location_inaccurate_gps(hass, context):
     assert_location_longitude(hass, LOCATION_MESSAGE["lon"])
 
 
-async def test_location_zero_accuracy_gps(hass, context):
+async def test_location_zero_accuracy_gps(hass: HomeAssistant, context) -> None:
     """Ignore the location for zero accuracy GPS information."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_ZERO_ACCURACY)
@@ -452,7 +452,7 @@ async def test_location_zero_accuracy_gps(hass, context):
 
 # ------------------------------------------------------------------------
 # GPS based event entry / exit testing
-async def test_event_gps_entry_exit(hass, context):
+async def test_event_gps_entry_exit(hass: HomeAssistant, context) -> None:
     """Test the entry event."""
     # Entering the owntracks circular region named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -490,7 +490,7 @@ async def test_event_gps_entry_exit(hass, context):
     assert_location_accuracy(hass, LOCATION_MESSAGE["acc"])
 
 
-async def test_event_gps_with_spaces(hass, context):
+async def test_event_gps_with_spaces(hass: HomeAssistant, context) -> None:
     """Test the entry event."""
     message = build_message({"desc": "inner 2"}, REGION_GPS_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
@@ -503,7 +503,7 @@ async def test_event_gps_with_spaces(hass, context):
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_entry_inaccurate(hass, context):
+async def test_event_gps_entry_inaccurate(hass: HomeAssistant, context) -> None:
     """Test the event for inaccurate entry."""
     # Set location to the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -516,7 +516,7 @@ async def test_event_gps_entry_inaccurate(hass, context):
     assert_location_state(hass, "inner")
 
 
-async def test_event_gps_entry_exit_inaccurate(hass, context):
+async def test_event_gps_entry_exit_inaccurate(hass: HomeAssistant, context) -> None:
     """Test the event for inaccurate exit."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
 
@@ -536,7 +536,7 @@ async def test_event_gps_entry_exit_inaccurate(hass, context):
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_entry_exit_zero_accuracy(hass, context):
+async def test_event_gps_entry_exit_zero_accuracy(hass: HomeAssistant, context) -> None:
     """Test entry/exit events with accuracy zero."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE_ZERO)
 
@@ -556,7 +556,9 @@ async def test_event_gps_entry_exit_zero_accuracy(hass, context):
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_exit_outside_zone_sets_away(hass, context):
+async def test_event_gps_exit_outside_zone_sets_away(
+    hass: HomeAssistant, context
+) -> None:
     """Test the event for exit zone."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
     assert_location_state(hass, "inner")
@@ -569,7 +571,7 @@ async def test_event_gps_exit_outside_zone_sets_away(hass, context):
     assert_location_state(hass, STATE_NOT_HOME)
 
 
-async def test_event_gps_entry_exit_right_order(hass, context):
+async def test_event_gps_entry_exit_right_order(hass: HomeAssistant, context) -> None:
     """Test the event for ordering."""
     # Enter inner zone
     # Set location to the outer zone.
@@ -594,7 +596,7 @@ async def test_event_gps_entry_exit_right_order(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_event_gps_entry_exit_wrong_order(hass, context):
+async def test_event_gps_entry_exit_wrong_order(hass: HomeAssistant, context) -> None:
     """Test the event for wrong order."""
     # Enter inner zone
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -617,7 +619,7 @@ async def test_event_gps_entry_exit_wrong_order(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_event_gps_entry_unknown_zone(hass, context):
+async def test_event_gps_entry_unknown_zone(hass: HomeAssistant, context) -> None:
     """Test the event for unknown zone."""
     # Just treat as location update
     message = build_message({"desc": "unknown"}, REGION_GPS_ENTER_MESSAGE)
@@ -626,7 +628,7 @@ async def test_event_gps_entry_unknown_zone(hass, context):
     assert_location_state(hass, "inner")
 
 
-async def test_event_gps_exit_unknown_zone(hass, context):
+async def test_event_gps_exit_unknown_zone(hass: HomeAssistant, context) -> None:
     """Test the event for unknown zone."""
     # Just treat as location update
     message = build_message({"desc": "unknown"}, REGION_GPS_LEAVE_MESSAGE)
@@ -635,7 +637,7 @@ async def test_event_gps_exit_unknown_zone(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_event_entry_zone_loading_dash(hass, context):
+async def test_event_entry_zone_loading_dash(hass: HomeAssistant, context) -> None:
     """Test the event for zone landing."""
     # Make sure the leading - is ignored
     # Owntracks uses this to switch on hold
@@ -644,7 +646,7 @@ async def test_event_entry_zone_loading_dash(hass, context):
     assert_location_state(hass, "inner")
 
 
-async def test_events_only_on(hass, context):
+async def test_events_only_on(hass: HomeAssistant, context) -> None:
     """Test events_only config suppresses location updates."""
     # Sending a location message that is not home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
@@ -665,7 +667,7 @@ async def test_events_only_on(hass, context):
     assert_location_state(hass, STATE_NOT_HOME)
 
 
-async def test_events_only_off(hass, context):
+async def test_events_only_off(hass: HomeAssistant, context) -> None:
     """Test when events_only is False."""
     # Sending a location message that is not home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
@@ -686,7 +688,7 @@ async def test_events_only_off(hass, context):
     assert_location_state(hass, "outer")
 
 
-async def test_event_source_type_entry_exit(hass, context):
+async def test_event_source_type_entry_exit(hass: HomeAssistant, context) -> None:
     """Test the entry and exit events of source type."""
     # Entering the owntracks circular region named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -716,7 +718,7 @@ async def test_event_source_type_entry_exit(hass, context):
 
 
 # Region Beacon based event entry / exit testing
-async def test_event_region_entry_exit(hass, context):
+async def test_event_region_entry_exit(hass: HomeAssistant, context) -> None:
     """Test the entry event."""
     # Seeing a beacon named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_BEACON_ENTER_MESSAGE)
@@ -755,7 +757,7 @@ async def test_event_region_entry_exit(hass, context):
     assert_location_accuracy(hass, LOCATION_MESSAGE["acc"])
 
 
-async def test_event_region_with_spaces(hass, context):
+async def test_event_region_with_spaces(hass: HomeAssistant, context) -> None:
     """Test the entry event."""
     message = build_message({"desc": "inner 2"}, REGION_BEACON_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
@@ -768,7 +770,9 @@ async def test_event_region_with_spaces(hass, context):
     assert not context().regions_entered[USER]
 
 
-async def test_event_region_entry_exit_right_order(hass, context):
+async def test_event_region_entry_exit_right_order(
+    hass: HomeAssistant, context
+) -> None:
     """Test the event for ordering."""
     # Enter inner zone
     # Set location to the outer zone.
@@ -799,7 +803,9 @@ async def test_event_region_entry_exit_right_order(hass, context):
     assert_location_state(hass, "inner")
 
 
-async def test_event_region_entry_exit_wrong_order(hass, context):
+async def test_event_region_entry_exit_wrong_order(
+    hass: HomeAssistant, context
+) -> None:
     """Test the event for wrong order."""
     # Enter inner zone
     await send_message(hass, EVENT_TOPIC, REGION_BEACON_ENTER_MESSAGE)
@@ -826,7 +832,9 @@ async def test_event_region_entry_exit_wrong_order(hass, context):
     assert_location_state(hass, "inner_2")
 
 
-async def test_event_beacon_unknown_zone_no_location(hass, context):
+async def test_event_beacon_unknown_zone_no_location(
+    hass: HomeAssistant, context
+) -> None:
     """Test the event for unknown zone."""
     # A beacon which does not match a HA zone is the
     # definition of a mobile beacon. In this case, "unknown"
@@ -851,7 +859,7 @@ async def test_event_beacon_unknown_zone_no_location(hass, context):
     assert_mobile_tracker_state(hass, "unknown", "unknown")
 
 
-async def test_event_beacon_unknown_zone(hass, context):
+async def test_event_beacon_unknown_zone(hass: HomeAssistant, context) -> None:
     """Test the event for unknown zone."""
     # A beacon which does not match a HA zone is the
     # definition of a mobile beacon. In this case, "unknown"
@@ -871,7 +879,9 @@ async def test_event_beacon_unknown_zone(hass, context):
     assert_mobile_tracker_state(hass, "outer", "unknown")
 
 
-async def test_event_beacon_entry_zone_loading_dash(hass, context):
+async def test_event_beacon_entry_zone_loading_dash(
+    hass: HomeAssistant, context
+) -> None:
     """Test the event for beacon zone landing."""
     # Make sure the leading - is ignored
     # Owntracks uses this to switch on hold
@@ -883,7 +893,7 @@ async def test_event_beacon_entry_zone_loading_dash(hass, context):
 
 # ------------------------------------------------------------------------
 # Mobile Beacon based event entry / exit testing
-async def test_mobile_enter_move_beacon(hass, context):
+async def test_mobile_enter_move_beacon(hass: HomeAssistant, context) -> None:
     """Test the movement of a beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -907,7 +917,7 @@ async def test_mobile_enter_move_beacon(hass, context):
     assert_mobile_tracker_latitude(hass, not_home_lat)
 
 
-async def test_mobile_enter_exit_region_beacon(hass, context):
+async def test_mobile_enter_exit_region_beacon(hass: HomeAssistant, context) -> None:
     """Test the enter and the exit of a mobile beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -930,7 +940,7 @@ async def test_mobile_enter_exit_region_beacon(hass, context):
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_mobile_exit_move_beacon(hass, context):
+async def test_mobile_exit_move_beacon(hass: HomeAssistant, context) -> None:
     """Test the exit move of a beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -952,7 +962,7 @@ async def test_mobile_exit_move_beacon(hass, context):
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_mobile_multiple_async_enter_exit(hass, context):
+async def test_mobile_multiple_async_enter_exit(hass: HomeAssistant, context) -> None:
     """Test the multiple entering."""
     # Test race condition
     for _ in range(0, 20):
@@ -972,7 +982,7 @@ async def test_mobile_multiple_async_enter_exit(hass, context):
     assert len(context().mobile_beacons_active["greg_phone"]) == 0
 
 
-async def test_mobile_multiple_enter_exit(hass, context):
+async def test_mobile_multiple_enter_exit(hass: HomeAssistant, context) -> None:
     """Test the multiple entering."""
     await send_message(hass, EVENT_TOPIC, MOBILE_BEACON_ENTER_EVENT_MESSAGE)
     await send_message(hass, EVENT_TOPIC, MOBILE_BEACON_ENTER_EVENT_MESSAGE)
@@ -981,7 +991,7 @@ async def test_mobile_multiple_enter_exit(hass, context):
     assert len(context().mobile_beacons_active["greg_phone"]) == 0
 
 
-async def test_complex_movement(hass, context):
+async def test_complex_movement(hass: HomeAssistant, context) -> None:
     """Test a complex sequence representative of real-world use."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -1103,7 +1113,9 @@ async def test_complex_movement(hass, context):
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_complex_movement_sticky_keys_beacon(hass, context):
+async def test_complex_movement_sticky_keys_beacon(
+    hass: HomeAssistant, context
+) -> None:
     """Test a complex sequence which was previously broken."""
     # I am not_home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -1215,7 +1227,7 @@ async def test_complex_movement_sticky_keys_beacon(hass, context):
     assert_mobile_tracker_latitude(hass, INNER_ZONE["latitude"])
 
 
-async def test_waypoint_import_simple(hass, context):
+async def test_waypoint_import_simple(hass: HomeAssistant, context) -> None:
     """Test a simple import of list of waypoints."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message)
@@ -1226,7 +1238,7 @@ async def test_waypoint_import_simple(hass, context):
     assert wayp is not None
 
 
-async def test_waypoint_import_block(hass, context):
+async def test_waypoint_import_block(hass: HomeAssistant, context) -> None:
     """Test import of list of waypoints for blocked user."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC_BLOCKED, waypoints_message)
@@ -1237,7 +1249,7 @@ async def test_waypoint_import_block(hass, context):
     assert wayp is None
 
 
-async def test_waypoint_import_no_whitelist(hass, setup_comp):
+async def test_waypoint_import_no_whitelist(hass: HomeAssistant, setup_comp) -> None:
     """Test import of list of waypoints with no whitelist set."""
     await setup_owntracks(
         hass,
@@ -1257,7 +1269,7 @@ async def test_waypoint_import_no_whitelist(hass, setup_comp):
     assert wayp is not None
 
 
-async def test_waypoint_import_bad_json(hass, context):
+async def test_waypoint_import_bad_json(hass: HomeAssistant, context) -> None:
     """Test importing a bad JSON payload."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message, True)
@@ -1268,7 +1280,7 @@ async def test_waypoint_import_bad_json(hass, context):
     assert wayp is None
 
 
-async def test_waypoint_import_existing(hass, context):
+async def test_waypoint_import_existing(hass: HomeAssistant, context) -> None:
     """Test importing a zone that exists."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message)
@@ -1281,7 +1293,7 @@ async def test_waypoint_import_existing(hass, context):
     assert wayp == new_wayp
 
 
-async def test_single_waypoint_import(hass, context):
+async def test_single_waypoint_import(hass: HomeAssistant, context) -> None:
     """Test single waypoint message."""
     waypoint_message = WAYPOINT_MESSAGE.copy()
     await send_message(hass, WAYPOINT_TOPIC, waypoint_message)
@@ -1289,7 +1301,7 @@ async def test_single_waypoint_import(hass, context):
     assert wayp is not None
 
 
-async def test_not_implemented_message(hass, context):
+async def test_not_implemented_message(hass: HomeAssistant, context) -> None:
     """Handle not implemented message type."""
     patch_handler = patch(
         "homeassistant.components.owntracks.messages.async_handle_not_impl_msg",
@@ -1300,7 +1312,7 @@ async def test_not_implemented_message(hass, context):
     patch_handler.stop()
 
 
-async def test_unsupported_message(hass, context):
+async def test_unsupported_message(hass: HomeAssistant, context) -> None:
     """Handle not implemented message type."""
     patch_handler = patch(
         "homeassistant.components.owntracks.messages.async_handle_unsupported_msg",
@@ -1418,7 +1430,7 @@ def mock_get_cipher_error():
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload(hass, setup_comp):
+async def test_encrypted_payload(hass: HomeAssistant, setup_comp) -> None:
     """Test encrypted payload."""
     await setup_owntracks(hass, {CONF_SECRET: TEST_SECRET_KEY})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
@@ -1426,7 +1438,7 @@ async def test_encrypted_payload(hass, setup_comp):
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload_topic_key(hass, setup_comp):
+async def test_encrypted_payload_topic_key(hass: HomeAssistant, setup_comp) -> None:
     """Test encrypted payload with a topic key."""
     await setup_owntracks(hass, {CONF_SECRET: {LOCATION_TOPIC: TEST_SECRET_KEY}})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
@@ -1434,15 +1446,17 @@ async def test_encrypted_payload_topic_key(hass, setup_comp):
 
 
 async def test_encrypted_payload_not_supports_encryption(
-    hass, setup_comp, not_supports_encryption
-):
+    hass: HomeAssistant, setup_comp, not_supports_encryption
+) -> None:
     """Test encrypted payload with no supported encryption."""
     await setup_owntracks(hass, {CONF_SECRET: TEST_SECRET_KEY})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
     assert hass.states.get(DEVICE_TRACKER_STATE) is None
 
 
-async def test_encrypted_payload_get_cipher_error(hass, setup_comp, get_cipher_error):
+async def test_encrypted_payload_get_cipher_error(
+    hass: HomeAssistant, setup_comp, get_cipher_error
+) -> None:
     """Test encrypted payload with no supported encryption."""
     await setup_owntracks(hass, {CONF_SECRET: TEST_SECRET_KEY})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
@@ -1450,7 +1464,7 @@ async def test_encrypted_payload_get_cipher_error(hass, setup_comp, get_cipher_e
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload_no_key(hass, setup_comp):
+async def test_encrypted_payload_no_key(hass: HomeAssistant, setup_comp) -> None:
     """Test encrypted payload with no key, ."""
     assert hass.states.get(DEVICE_TRACKER_STATE) is None
     await setup_owntracks(hass, {CONF_SECRET: {}})
@@ -1459,7 +1473,7 @@ async def test_encrypted_payload_no_key(hass, setup_comp):
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload_wrong_key(hass, setup_comp):
+async def test_encrypted_payload_wrong_key(hass: HomeAssistant, setup_comp) -> None:
     """Test encrypted payload with wrong key."""
     await setup_owntracks(hass, {CONF_SECRET: "wrong key"})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
@@ -1467,7 +1481,9 @@ async def test_encrypted_payload_wrong_key(hass, setup_comp):
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload_wrong_topic_key(hass, setup_comp):
+async def test_encrypted_payload_wrong_topic_key(
+    hass: HomeAssistant, setup_comp
+) -> None:
     """Test encrypted payload with wrong  topic key."""
     await setup_owntracks(hass, {CONF_SECRET: {LOCATION_TOPIC: "wrong key"}})
     await send_message(hass, LOCATION_TOPIC, MOCK_ENCRYPTED_LOCATION_MESSAGE)
@@ -1475,7 +1491,7 @@ async def test_encrypted_payload_wrong_topic_key(hass, setup_comp):
 
 
 @patch("homeassistant.components.owntracks.messages.get_cipher", mock_cipher)
-async def test_encrypted_payload_no_topic_key(hass, setup_comp):
+async def test_encrypted_payload_no_topic_key(hass: HomeAssistant, setup_comp) -> None:
     """Test encrypted payload with no topic key."""
     await setup_owntracks(
         hass, {CONF_SECRET: {"owntracks/{}/{}".format(USER, "otherdevice"): "foobar"}}
@@ -1484,7 +1500,7 @@ async def test_encrypted_payload_no_topic_key(hass, setup_comp):
     assert hass.states.get(DEVICE_TRACKER_STATE) is None
 
 
-async def test_encrypted_payload_libsodium(hass, setup_comp):
+async def test_encrypted_payload_libsodium(hass: HomeAssistant, setup_comp) -> None:
     """Test sending encrypted message payload."""
     try:
         import nacl  # noqa: F401 pylint: disable=unused-import
@@ -1498,7 +1514,7 @@ async def test_encrypted_payload_libsodium(hass, setup_comp):
     assert_location_latitude(hass, LOCATION_MESSAGE["lat"])
 
 
-async def test_customized_mqtt_topic(hass, setup_comp):
+async def test_customized_mqtt_topic(hass: HomeAssistant, setup_comp) -> None:
     """Test subscribing to a custom mqtt topic."""
     await setup_owntracks(hass, {CONF_MQTT_TOPIC: "mytracks/#"})
 
@@ -1508,7 +1524,7 @@ async def test_customized_mqtt_topic(hass, setup_comp):
     assert_location_latitude(hass, LOCATION_MESSAGE["lat"])
 
 
-async def test_region_mapping(hass, setup_comp):
+async def test_region_mapping(hass: HomeAssistant, setup_comp) -> None:
     """Test region to zone mapping."""
     await setup_owntracks(hass, {CONF_REGION_MAPPING: {"foo": "inner"}})
 

--- a/tests/components/owntracks/test_helper.py
+++ b/tests/components/owntracks/test_helper.py
@@ -20,11 +20,11 @@ def mock_nacl_not_imported():
         yield
 
 
-def test_supports_encryption(nacl_imported):
+def test_supports_encryption(nacl_imported) -> None:
     """Test if env supports encryption."""
     assert helper.supports_encryption()
 
 
-def test_supports_encryption_failed(nacl_not_imported):
+def test_supports_encryption_failed(nacl_not_imported) -> None:
     """Test if env does not support encryption."""
     assert not helper.supports_encryption()

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -52,7 +52,7 @@ def mock_client(hass, hass_client_no_auth):
     return hass.loop.run_until_complete(hass_client_no_auth())
 
 
-async def test_handle_valid_message(mock_client):
+async def test_handle_valid_message(mock_client) -> None:
     """Test that we forward messages correctly to OwnTracks."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test",
@@ -66,7 +66,7 @@ async def test_handle_valid_message(mock_client):
     assert json == []
 
 
-async def test_handle_valid_minimal_message(mock_client):
+async def test_handle_valid_minimal_message(mock_client) -> None:
     """Test that we forward messages correctly to OwnTracks."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test",
@@ -80,7 +80,7 @@ async def test_handle_valid_minimal_message(mock_client):
     assert json == []
 
 
-async def test_handle_value_error(mock_client):
+async def test_handle_value_error(mock_client) -> None:
     """Test we don't disclose that this is a valid webhook."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test",
@@ -94,7 +94,9 @@ async def test_handle_value_error(mock_client):
     assert json == ""
 
 
-async def test_returns_error_missing_username(mock_client, caplog):
+async def test_returns_error_missing_username(
+    mock_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an error is returned when username is missing."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test",
@@ -109,7 +111,9 @@ async def test_returns_error_missing_username(mock_client, caplog):
     assert "No topic or user found" in caplog.text
 
 
-async def test_returns_error_incorrect_json(mock_client, caplog):
+async def test_returns_error_incorrect_json(
+    mock_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that an error is returned when username is missing."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test", data="not json", headers={"X-Limit-d": "Pixel"}
@@ -122,7 +126,7 @@ async def test_returns_error_incorrect_json(mock_client, caplog):
     assert "invalid JSON" in caplog.text
 
 
-async def test_returns_error_missing_device(mock_client):
+async def test_returns_error_missing_device(mock_client) -> None:
     """Test that an error is returned when device name is missing."""
     resp = await mock_client.post(
         "/api/webhook/owntracks_test",

--- a/tests/components/p1_monitor/test_diagnostics.py
+++ b/tests/components/p1_monitor/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -22,7 +22,7 @@ from .conftest import (
 from tests.common import MockConfigEntry
 
 
-async def test_setup_entry_encrypted(hass, mock_remote):
+async def test_setup_entry_encrypted(hass: HomeAssistant, mock_remote) -> None:
     """Test setup with encrypted config entry."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -45,7 +45,9 @@ async def test_setup_entry_encrypted(hass, mock_remote):
     assert state_remote.name == DEFAULT_NAME
 
 
-async def test_setup_entry_encrypted_missing_device_info(hass, mock_remote):
+async def test_setup_entry_encrypted_missing_device_info(
+    hass: HomeAssistant, mock_remote
+) -> None:
     """Test setup with encrypted config entry and missing device info."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -105,7 +107,7 @@ async def test_setup_entry_encrypted_missing_device_info_none(
         assert state_remote.name == DEFAULT_NAME
 
 
-async def test_setup_entry_unencrypted(hass, mock_remote):
+async def test_setup_entry_unencrypted(hass: HomeAssistant, mock_remote) -> None:
     """Test setup with unencrypted config entry."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -128,7 +130,9 @@ async def test_setup_entry_unencrypted(hass, mock_remote):
     assert state_remote.name == DEFAULT_NAME
 
 
-async def test_setup_entry_unencrypted_missing_device_info(hass, mock_remote):
+async def test_setup_entry_unencrypted_missing_device_info(
+    hass: HomeAssistant, mock_remote
+) -> None:
     """Test setup with unencrypted config entry and missing device info."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -209,7 +213,7 @@ async def test_setup_config_flow_initiated(hass: HomeAssistant) -> None:
     assert len(hass.config_entries.flow.async_progress()) == 1
 
 
-async def test_setup_unload_entry(hass, mock_remote):
+async def test_setup_unload_entry(hass: HomeAssistant, mock_remote) -> None:
     """Test if config entry is unloaded."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/panasonic_viera/test_remote.py
+++ b/tests/components/panasonic_viera/test_remote.py
@@ -1,5 +1,4 @@
 """Test the Panasonic Viera remote entity."""
-
 from unittest.mock import Mock, call
 
 from panasonic_viera import Keys, SOAPError
@@ -11,6 +10,7 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 
 from .conftest import MOCK_CONFIG_DATA, MOCK_DEVICE_INFO, MOCK_ENCRYPTION_DATA
 
@@ -31,7 +31,7 @@ async def setup_panasonic_viera(hass):
     await hass.async_block_till_done()
 
 
-async def test_onoff(hass, mock_remote):
+async def test_onoff(hass: HomeAssistant, mock_remote) -> None:
     """Test the on/off service calls."""
 
     await setup_panasonic_viera(hass)
@@ -49,7 +49,7 @@ async def test_onoff(hass, mock_remote):
     assert mock_remote.send_key.call_args_list == [call(power), call(power)]
 
 
-async def test_send_command(hass, mock_remote):
+async def test_send_command(hass: HomeAssistant, mock_remote) -> None:
     """Test the send_command service call."""
 
     await setup_panasonic_viera(hass)

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.setup import async_setup_component
         {"router": {"url": "not-a-url"}},
     ),
 )
-async def test_wrong_config(hass, config_to_try):
+async def test_wrong_config(hass: HomeAssistant, config_to_try) -> None:
     """Test setup with wrong configuration."""
     assert not await async_setup_component(
         hass, "panel_iframe", {"panel_iframe": config_to_try}

--- a/tests/components/peco/test_init.py
+++ b/tests/components/peco/test_init.py
@@ -57,7 +57,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         "bucks_customers_served",
     ],
 )
-async def test_update_timeout(hass: HomeAssistant, sensor):
+async def test_update_timeout(hass: HomeAssistant, sensor) -> None:
     """Test if it raises an error when there is a timeout."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=COUNTY_ENTRY_DATA)
@@ -83,7 +83,7 @@ async def test_update_timeout(hass: HomeAssistant, sensor):
         "total_customers_served",
     ],
 )
-async def test_total_update_timeout(hass: HomeAssistant, sensor):
+async def test_total_update_timeout(hass: HomeAssistant, sensor) -> None:
     """Test if it raises an error when there is a timeout."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRY_DATA)
@@ -108,7 +108,7 @@ async def test_total_update_timeout(hass: HomeAssistant, sensor):
         "bucks_customers_served",
     ],
 )
-async def test_http_error(hass: HomeAssistant, sensor: str):
+async def test_http_error(hass: HomeAssistant, sensor: str) -> None:
     """Test if it raises an error when an abnormal status code is returned."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=COUNTY_ENTRY_DATA)
@@ -134,7 +134,7 @@ async def test_http_error(hass: HomeAssistant, sensor: str):
         "bucks_customers_served",
     ],
 )
-async def test_bad_json(hass: HomeAssistant, sensor: str):
+async def test_bad_json(hass: HomeAssistant, sensor: str) -> None:
     """Test if it raises an error when abnormal JSON is returned."""
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=COUNTY_ENTRY_DATA)

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the person component."""
 import logging
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +22,8 @@ from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import collection, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_component, mock_restore_cache
+from tests.common import MockUser, mock_component, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 DEVICE_TRACKER = "device_tracker.test_tracker"
 DEVICE_TRACKER_2 = "device_tracker.test_tracker_2"
@@ -87,7 +89,7 @@ async def test_setup_no_name(hass: HomeAssistant) -> None:
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_setup_user_id(hass, hass_admin_user):
+async def test_setup_user_id(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test config with user id."""
     user_id = hass_admin_user.id
     config = {DOMAIN: {"id": "1234", "name": "test person", "user_id": user_id}}
@@ -102,7 +104,9 @@ async def test_setup_user_id(hass, hass_admin_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_valid_invalid_user_ids(hass, hass_admin_user):
+async def test_valid_invalid_user_ids(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test a person with valid user id and a person with invalid user id ."""
     user_id = hass_admin_user.id
     config = {
@@ -124,7 +128,7 @@ async def test_valid_invalid_user_ids(hass, hass_admin_user):
     assert state is None
 
 
-async def test_setup_tracker(hass, hass_admin_user):
+async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test set up person with one device tracker."""
     hass.state = CoreState.not_running
     user_id = hass_admin_user.id
@@ -180,7 +184,9 @@ async def test_setup_tracker(hass, hass_admin_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_setup_two_trackers(hass, hass_admin_user):
+async def test_setup_two_trackers(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test set up person with two device trackers."""
     hass.state = CoreState.not_running
     user_id = hass_admin_user.id
@@ -258,7 +264,9 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
 
 
-async def test_ignore_unavailable_states(hass, hass_admin_user):
+async def test_ignore_unavailable_states(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test set up person with two device trackers, one unavailable."""
     hass.state = CoreState.not_running
     user_id = hass_admin_user.id
@@ -301,7 +309,9 @@ async def test_ignore_unavailable_states(hass, hass_admin_user):
     assert state.state == "not_home"
 
 
-async def test_restore_home_state(hass, hass_admin_user):
+async def test_restore_home_state(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
     """Test that the state is restored for a person on startup."""
     user_id = hass_admin_user.id
     attrs = {
@@ -337,7 +347,7 @@ async def test_restore_home_state(hass, hass_admin_user):
     assert state.attributes.get(ATTR_ENTITY_PICTURE) == "/bla"
 
 
-async def test_duplicate_ids(hass, hass_admin_user):
+async def test_duplicate_ids(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test we don't allow duplicate IDs."""
     config = {
         DOMAIN: [
@@ -368,7 +378,9 @@ async def test_create_person_during_run(hass: HomeAssistant) -> None:
     assert state.state == "home"
 
 
-async def test_load_person_storage(hass, hass_admin_user, storage_setup):
+async def test_load_person_storage(
+    hass: HomeAssistant, hass_admin_user: MockUser, storage_setup
+) -> None:
     """Test set up person from storage."""
     state = hass.states.get("person.tracked_person")
     assert state.state == STATE_UNKNOWN
@@ -392,7 +404,9 @@ async def test_load_person_storage(hass, hass_admin_user, storage_setup):
     assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
 
 
-async def test_load_person_storage_two_nonlinked(hass, hass_storage):
+async def test_load_person_storage_two_nonlinked(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test loading two users with both not having a user linked."""
     hass_storage[DOMAIN] = {
         "key": DOMAIN,
@@ -421,7 +435,9 @@ async def test_load_person_storage_two_nonlinked(hass, hass_storage):
     assert hass.states.get("person.tracked_person_2") is not None
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     manager = hass.data[DOMAIN][1]
 
@@ -435,7 +451,12 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert len(resp["result"]["config"]) == 0
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup, hass_read_only_user):
+async def test_ws_create(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    hass_read_only_user: MockUser,
+) -> None:
     """Test creating via WS."""
     manager = hass.data[DOMAIN][1]
 
@@ -461,8 +482,12 @@ async def test_ws_create(hass, hass_ws_client, storage_setup, hass_read_only_use
 
 
 async def test_ws_create_requires_admin(
-    hass, hass_ws_client, storage_setup, hass_admin_user, hass_read_only_user
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
+) -> None:
     """Test creating via WS requires admin."""
     hass_admin_user.groups = []
     manager = hass.data[DOMAIN][1]
@@ -486,7 +511,9 @@ async def test_ws_create_requires_admin(
     assert not resp["success"]
 
 
-async def test_ws_update(hass, hass_ws_client, storage_setup):
+async def test_ws_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating via WS."""
     manager = hass.data[DOMAIN][1]
 
@@ -534,8 +561,11 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
 
 
 async def test_ws_update_require_admin(
-    hass, hass_ws_client, storage_setup, hass_admin_user
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    hass_admin_user: MockUser,
+) -> None:
     """Test updating via WS requires admin."""
     hass_admin_user.groups = []
     manager = hass.data[DOMAIN][1]
@@ -560,7 +590,9 @@ async def test_ws_update_require_admin(
     assert original == not_updated
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test deleting via WS."""
     manager = hass.data[DOMAIN][1]
 
@@ -582,8 +614,11 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
 
 async def test_ws_delete_require_admin(
-    hass, hass_ws_client, storage_setup, hass_admin_user
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    storage_setup,
+    hass_admin_user: MockUser,
+) -> None:
     """Test deleting via WS requires admin."""
     hass_admin_user.groups = []
     manager = hass.data[DOMAIN][1]
@@ -607,7 +642,7 @@ async def test_ws_delete_require_admin(
     assert len(persons) == 1
 
 
-async def test_create_invalid_user_id(hass, storage_collection):
+async def test_create_invalid_user_id(hass: HomeAssistant, storage_collection) -> None:
     """Test we do not allow invalid user ID during creation."""
     with pytest.raises(ValueError):
         await storage_collection.async_create_item(
@@ -615,7 +650,9 @@ async def test_create_invalid_user_id(hass, storage_collection):
         )
 
 
-async def test_create_duplicate_user_id(hass, hass_admin_user, storage_collection):
+async def test_create_duplicate_user_id(
+    hass: HomeAssistant, hass_admin_user: MockUser, storage_collection
+) -> None:
     """Test we do not allow duplicate user ID during creation."""
     await storage_collection.async_create_item(
         {"name": "Hello", "user_id": hass_admin_user.id}
@@ -627,7 +664,9 @@ async def test_create_duplicate_user_id(hass, hass_admin_user, storage_collectio
         )
 
 
-async def test_update_double_user_id(hass, hass_admin_user, storage_collection):
+async def test_update_double_user_id(
+    hass: HomeAssistant, hass_admin_user: MockUser, storage_collection
+) -> None:
     """Test we do not allow double user ID during update."""
     await storage_collection.async_create_item(
         {"name": "Hello", "user_id": hass_admin_user.id}
@@ -640,7 +679,7 @@ async def test_update_double_user_id(hass, hass_admin_user, storage_collection):
         )
 
 
-async def test_update_invalid_user_id(hass, storage_collection):
+async def test_update_invalid_user_id(hass: HomeAssistant, storage_collection) -> None:
     """Test updating to invalid user ID."""
     person = await storage_collection.async_create_item({"name": "Hello"})
 
@@ -651,8 +690,8 @@ async def test_update_invalid_user_id(hass, storage_collection):
 
 
 async def test_update_person_when_user_removed(
-    hass, storage_setup, hass_read_only_user
-):
+    hass: HomeAssistant, storage_setup, hass_read_only_user: MockUser
+) -> None:
     """Update person when user is removed."""
     storage_collection = hass.data[DOMAIN][1]
 
@@ -666,7 +705,7 @@ async def test_update_person_when_user_removed(
     assert storage_collection.data[person["id"]]["user_id"] is None
 
 
-async def test_removing_device_tracker(hass, storage_setup):
+async def test_removing_device_tracker(hass: HomeAssistant, storage_setup) -> None:
     """Test we automatically remove removed device trackers."""
     storage_collection = hass.data[DOMAIN][1]
     reg = er.async_get(hass)
@@ -684,7 +723,9 @@ async def test_removing_device_tracker(hass, storage_setup):
     assert storage_collection.data[person["id"]]["device_trackers"] == []
 
 
-async def test_add_user_device_tracker(hass, storage_setup, hass_read_only_user):
+async def test_add_user_device_tracker(
+    hass: HomeAssistant, storage_setup, hass_read_only_user: MockUser
+) -> None:
     """Test adding a device tracker to a person tied to a user."""
     storage_collection = hass.data[DOMAIN][1]
     pers = await storage_collection.async_create_item(
@@ -705,7 +746,7 @@ async def test_add_user_device_tracker(hass, storage_setup, hass_read_only_user)
     ]
 
 
-async def test_reload(hass, hass_admin_user):
+async def test_reload(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test reloading the YAML config."""
     assert await async_setup_component(
         hass,
@@ -761,7 +802,7 @@ async def test_reload(hass, hass_admin_user):
     assert state_3.name == "Person 3"
 
 
-async def test_person_storage_fixing_device_trackers(storage_collection):
+async def test_person_storage_fixing_device_trackers(storage_collection) -> None:
     """Test None device trackers become lists."""
     with patch.object(
         storage_collection.store,

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -45,7 +45,7 @@ async def mock_tv_pairable(mock_tv):
     return mock_tv
 
 
-async def test_form(hass, mock_setup_entry):
+async def test_form(hass: HomeAssistant, mock_setup_entry) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -65,7 +65,7 @@ async def test_form(hass, mock_setup_entry):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass, mock_tv):
+async def test_form_cannot_connect(hass: HomeAssistant, mock_tv) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -80,7 +80,7 @@ async def test_form_cannot_connect(hass, mock_tv):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unexpected_error(hass, mock_tv):
+async def test_form_unexpected_error(hass: HomeAssistant, mock_tv) -> None:
     """Test we handle unexpected exceptions."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -95,7 +95,7 @@ async def test_form_unexpected_error(hass, mock_tv):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_pairing(hass, mock_tv_pairable, mock_setup_entry):
+async def test_pairing(hass: HomeAssistant, mock_tv_pairable, mock_setup_entry) -> None:
     """Test we get the form."""
     mock_tv = mock_tv_pairable
 
@@ -138,7 +138,9 @@ async def test_pairing(hass, mock_tv_pairable, mock_setup_entry):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_pair_request_failed(hass, mock_tv_pairable, mock_setup_entry):
+async def test_pair_request_failed(
+    hass: HomeAssistant, mock_tv_pairable, mock_setup_entry
+) -> None:
     """Test we get the form."""
     mock_tv = mock_tv_pairable
     mock_tv.pairRequest.side_effect = PairingFailure({})
@@ -163,7 +165,9 @@ async def test_pair_request_failed(hass, mock_tv_pairable, mock_setup_entry):
     }
 
 
-async def test_pair_grant_failed(hass, mock_tv_pairable, mock_setup_entry):
+async def test_pair_grant_failed(
+    hass: HomeAssistant, mock_tv_pairable, mock_setup_entry
+) -> None:
     """Test we get the form."""
     mock_tv = mock_tv_pairable
 

--- a/tests/components/philips_js/test_device_trigger.py
+++ b/tests/components/philips_js/test_device_trigger.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.philips_js.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -20,7 +21,7 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, mock_device):
+async def test_get_triggers(hass: HomeAssistant, mock_device) -> None:
     """Test we get the expected triggers."""
     expected_triggers = [
         {
@@ -39,8 +40,8 @@ async def test_get_triggers(hass, mock_device):
 
 
 async def test_if_fires_on_turn_on_request(
-    hass, calls, mock_tv, mock_entity, mock_device
-):
+    hass: HomeAssistant, calls, mock_tv, mock_entity, mock_device
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
 
     mock_tv.on = False

--- a/tests/components/pi_hole/test_config_flow.py
+++ b/tests/components/pi_hole/test_config_flow.py
@@ -23,7 +23,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_flow_user_with_api_key(hass: HomeAssistant):
+async def test_flow_user_with_api_key(hass: HomeAssistant) -> None:
     """Test user initialized flow with api key needed."""
     mocked_hole = _create_mocked_hole(has_data=False)
     with _patch_config_flow_hole(mocked_hole), _patch_setup_hole() as mock_setup:
@@ -71,7 +71,7 @@ async def test_flow_user_with_api_key(hass: HomeAssistant):
         assert result["reason"] == "already_configured"
 
 
-async def test_flow_user_without_api_key(hass: HomeAssistant):
+async def test_flow_user_without_api_key(hass: HomeAssistant) -> None:
     """Test user initialized flow without api key needed."""
     mocked_hole = _create_mocked_hole()
     with _patch_config_flow_hole(mocked_hole), _patch_setup_hole() as mock_setup:
@@ -93,7 +93,7 @@ async def test_flow_user_without_api_key(hass: HomeAssistant):
         mock_setup.assert_called_once()
 
 
-async def test_flow_user_invalid(hass: HomeAssistant):
+async def test_flow_user_invalid(hass: HomeAssistant) -> None:
     """Test user initialized flow with invalid server."""
     mocked_hole = _create_mocked_hole(True)
     with _patch_config_flow_hole(mocked_hole):
@@ -105,7 +105,7 @@ async def test_flow_user_invalid(hass: HomeAssistant):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_flow_reauth(hass: HomeAssistant):
+async def test_flow_reauth(hass: HomeAssistant) -> None:
     """Test reauth flow."""
     mocked_hole = _create_mocked_hole(has_data=False)
     entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONFIG_DATA_DEFAULTS)

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -3,6 +3,7 @@ import logging
 from unittest.mock import AsyncMock
 
 from hole.exceptions import HoleError
+import pytest
 
 from homeassistant.components import pi_hole, switch
 from homeassistant.components.pi_hole.const import (
@@ -24,7 +25,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_setup_with_defaults(hass: HomeAssistant):
+async def test_setup_with_defaults(hass: HomeAssistant) -> None:
     """Tests component setup with default config."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(
@@ -75,7 +76,7 @@ async def test_setup_with_defaults(hass: HomeAssistant):
     assert state.state == "off"
 
 
-async def test_setup_name_config(hass: HomeAssistant):
+async def test_setup_name_config(hass: HomeAssistant) -> None:
     """Tests component setup with a custom name."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(
@@ -93,7 +94,7 @@ async def test_setup_name_config(hass: HomeAssistant):
     )
 
 
-async def test_switch(hass: HomeAssistant, caplog):
+async def test_switch(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test Pi-hole switch."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONFIG_DATA)
@@ -140,7 +141,7 @@ async def test_switch(hass: HomeAssistant, caplog):
         assert errors[-1].message == "Unable to disable Pi-hole: Error2"
 
 
-async def test_disable_service_call(hass: HomeAssistant):
+async def test_disable_service_call(hass: HomeAssistant) -> None:
     """Test disable service call with no Pi-hole named."""
 
     mocked_hole = _create_mocked_hole()
@@ -169,7 +170,7 @@ async def test_disable_service_call(hass: HomeAssistant):
         mocked_hole.disable.assert_called_with(1)
 
 
-async def test_unload(hass: HomeAssistant):
+async def test_unload(hass: HomeAssistant) -> None:
     """Test unload entities."""
     entry = MockConfigEntry(
         domain=pi_hole.DOMAIN,
@@ -188,7 +189,7 @@ async def test_unload(hass: HomeAssistant):
     assert entry.entry_id not in hass.data[pi_hole.DOMAIN]
 
 
-async def test_remove_obsolete(hass: HomeAssistant):
+async def test_remove_obsolete(hass: HomeAssistant) -> None:
     """Test removing obsolete config entry parameters."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(

--- a/tests/components/pi_hole/test_update.py
+++ b/tests/components/pi_hole/test_update.py
@@ -9,7 +9,7 @@ from . import CONFIG_DATA_DEFAULTS, _create_mocked_hole, _patch_init_hole
 from tests.common import MockConfigEntry
 
 
-async def test_update(hass: HomeAssistant):
+async def test_update(hass: HomeAssistant) -> None:
     """Tests update entity."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONFIG_DATA_DEFAULTS)
@@ -50,7 +50,7 @@ async def test_update(hass: HomeAssistant):
     )
 
 
-async def test_update_no_versions(hass: HomeAssistant):
+async def test_update_no_versions(hass: HomeAssistant) -> None:
     """Tests update entity when no version data available."""
     mocked_hole = _create_mocked_hole(has_versions=False)
     entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=CONFIG_DATA_DEFAULTS)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
