### PR TITLE
Use blocking in intent service calls and verify results

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -63,7 +63,7 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
 
     async def async_call_service(
         self, intent_obj: intent.Intent, state: State
-    ) -> tuple[bool, State]:
+    ) -> tuple[bool | None, State]:
         """Call service on entity with special case for covers."""
         hass = intent_obj.hass
 
@@ -78,9 +78,10 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
                 {ATTR_ENTITY_ID: state.entity_id},
                 context=intent_obj.context,
                 blocking=True,
+                limit=self.service_timeout,
             )
 
-            return result is True, state
+            return result, state
 
         if not hass.services.has_service(state.domain, self.service):
             _LOGGER.warning(

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -61,16 +61,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class OnOffIntentHandler(intent.ServiceIntentHandler):
     """Intent handler for on/off that handles covers too."""
 
-    async def async_call_service(
-        self, intent_obj: intent.Intent, state: State
-    ) -> tuple[bool | None, State]:
+    async def async_call_service(self, intent_obj: intent.Intent, state: State) -> None:
         """Call service on entity with special case for covers."""
         hass = intent_obj.hass
 
         if state.domain == COVER_DOMAIN:
             # on = open
             # off = close
-            result = await hass.services.async_call(
+            await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_OPEN_COVER
                 if self.service == SERVICE_TURN_ON
@@ -81,16 +79,13 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
                 limit=self.service_timeout,
             )
 
-            return result, state
-
-        if not hass.services.has_service(state.domain, self.service):
-            _LOGGER.warning(
-                "Service %s does not support entity %s", self.service, state.entity_id
+        elif not hass.services.has_service(state.domain, self.service):
+            raise intent.IntentHandleError(
+                f"Service {self.service} does not support entity {state.entity_id}"
             )
-            return False, state
 
         # Fall back to homeassistant.turn_on/off
-        return await super().async_call_service(intent_obj, state)
+        await super().async_call_service(intent_obj, state)
 
 
 class GetStateIntentHandler(intent.IntentHandler):

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -44,15 +44,3 @@ async def test_hidden_entities_skipped(
     assert len(calls) == 0
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
-
-
-async def test_cant_turn_on_sun(hass: HomeAssistant, init_components) -> None:
-    """Test we can't turn on entities that don't support it."""
-
-    assert await async_setup_component(hass, "sun", {})
-    result = await conversation.async_converse(
-        hass, "turn on sun", None, Context(), None
-    )
-
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -44,3 +44,15 @@ async def test_hidden_entities_skipped(
     assert len(calls) == 0
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+
+
+async def test_cant_turn_on_sun(hass: HomeAssistant, init_components) -> None:
+    """Test we can't turn on entities that don't support it."""
+
+    assert await async_setup_component(hass, "sun", {})
+    result = await conversation.async_converse(
+        hass, "turn on sun", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When handing HassTurnOn/HassTurnOff intents, check that an entity supports the service and return a failure otherwise. This prevents "turn on the sun".

Use `blocking=True` in service calls so results can be retrieved and checked. Partial failures are now possible. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
