### PR TITLE
Do not reload Shelly TRV entry when not needed

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -161,6 +161,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         self._last_mode: str | None = None
         self._last_effect: int | None = None
         self._last_input_events_count: dict = {}
+        self._last_target_temp: float | None = None
 
         entry.async_on_unload(
             self.async_add_listener(self._async_device_updates_handler)
@@ -193,6 +194,13 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         for block in self.device.blocks:
             if block.type == "device":
                 cfg_changed = block.cfgChanged
+
+            # Reloading the entry is not needed when the target temperature changes
+            if self.model == "SHTRV-01":
+                if "targetTemp" in block.sensor_ids:
+                    if self._last_target_temp != block.targetTemp:
+                        self._last_cfg_changed = None
+                    self._last_target_temp = block.targetTemp
 
             # For dual mode bulbs ignore change if it is due to mode/effect change
             if self.model in DUAL_MODE_LIGHT_MODELS:

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -195,12 +195,17 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
             if block.type == "device":
                 cfg_changed = block.cfgChanged
 
-            # Reloading the entry is not needed when the target temperature changes
             if self.model == "SHTRV-01":
+                # Reloading the entry is not needed when the target temperature changes
                 if "targetTemp" in block.sensor_ids:
                     if self._last_target_temp != block.targetTemp:
                         self._last_cfg_changed = None
                     self._last_target_temp = block.targetTemp
+                # Reloading the entry is not needed when the mode changes
+                if "mode" in block.sensor_ids:
+                    if self._last_mode != block.mode:
+                        self._last_cfg_changed = None
+                    self._last_mode = block.mode
 
             # For dual mode bulbs ignore change if it is due to mode/effect change
             if self.model in DUAL_MODE_LIGHT_MODELS:

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -35,8 +35,13 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.test_name"
 async def test_climate_hvac_mode(hass, mock_block_device, monkeypatch):
     """Test climate hvac mode service."""
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
+    monkeypatch.setattr(
+        mock_block_device.blocks[SENSOR_BLOCK_ID],
+        "sensor_ids",
+        {"battery": 98, "valvePos": 50, "targetTemp": 21.0},
+    )
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
-    await init_integration(hass, 1, sleep_period=1000)
+    await init_integration(hass, 1, sleep_period=1000, model="SHTRV-01")
 
     # Make device online
     mock_block_device.mock_update()

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -131,7 +131,7 @@ async def test_climate_set_preset_mode(hass, mock_block_device, monkeypatch):
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "mode", None)
-    await init_integration(hass, 1, sleep_period=1000)
+    await init_integration(hass, 1, sleep_period=1000, model="SHTRV-01")
 
     # Make device online
     mock_block_device.mock_update()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Temporarily changing the state of the climate entity to `unavailable` is the result of reloading the entry. Reloading the entry is not needed when changing the target temperature or mode (preset). With this change, `cfgChanged` events are skipped if the target temperature or mode has changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86641
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
