### PR TITLE
Restore original aiohttp cancelation behavior

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -77,6 +77,7 @@ from .exceptions import (
     ServiceNotFound,
     Unauthorized,
 )
+from .helpers.aiohttp_compat import restore_original_aiohttp_cancel_behavior
 from .util import dt as dt_util, location, ulid as ulid_util
 from .util.async_ import (
     fire_coroutine_threadsafe,
@@ -105,6 +106,7 @@ STAGE_2_SHUTDOWN_TIMEOUT = 60
 STAGE_3_SHUTDOWN_TIMEOUT = 30
 
 block_async_io.enable()
+restore_original_aiohttp_cancel_behavior()
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")

--- a/homeassistant/helpers/aiohttp_compat.py
+++ b/homeassistant/helpers/aiohttp_compat.py
@@ -1,7 +1,7 @@
 """Helper to restore old aiohttp behavior."""
 from __future__ import annotations
 
-from aiohttp import web_protocol
+from aiohttp import web_protocol, web_server
 
 
 class CancelOnDisconnectRequestHandler(web_protocol.RequestHandler):
@@ -22,3 +22,4 @@ def restore_original_aiohttp_cancel_behavior() -> None:
     https://github.com/aio-libs/aiohttp/pull/7128
     """
     web_protocol.RequestHandler = CancelOnDisconnectRequestHandler  # type: ignore[misc]
+    web_server.RequestHandler = CancelOnDisconnectRequestHandler  # type: ignore[misc]

--- a/homeassistant/helpers/aiohttp_compat.py
+++ b/homeassistant/helpers/aiohttp_compat.py
@@ -1,0 +1,24 @@
+"""Helper to restore old aiohttp behavior."""
+from __future__ import annotations
+
+from aiohttp import web_protocol
+
+
+class CancelOnDisconnectRequestHandler(web_protocol.RequestHandler):
+    """Request handler that cancels tasks on disconnect."""
+
+    def connection_lost(self, exc: BaseException | None) -> None:
+        """Handle connection lost."""
+        task_handler = self._task_handler
+        super().connection_lost(exc)
+        if task_handler is not None:
+            task_handler.cancel()
+
+
+def restore_original_aiohttp_cancel_behavior() -> None:
+    """Patch aiohttp to restore cancel behavior.
+
+    Remove this once aiohttp 3.9 is released as we can use
+    https://github.com/aio-libs/aiohttp/pull/7128
+    """
+    web_protocol.RequestHandler = CancelOnDisconnectRequestHandler  # type: ignore[misc]

--- a/tests/helpers/test_aiohttp_compat.py
+++ b/tests/helpers/test_aiohttp_compat.py
@@ -1,0 +1,49 @@
+"""Test the aiohttp compatibility shim."""
+
+import asyncio
+from contextlib import suppress
+
+from aiohttp import client, web
+import pytest
+
+
+@pytest.mark.allow_hosts(["127.0.0.1"])
+async def test_handler_cancellation(socket_enabled, aiohttp_unused_port) -> None:
+    """Test that handler cancels the request on disconnect.
+
+    From aiohttp tests/test_web_server.py
+    """
+    timeout_event = asyncio.Event()
+    done_event = asyncio.Event()
+    port = aiohttp_unused_port()
+
+    async def on_request(_: web.Request) -> web.Response:
+        nonlocal done_event, timeout_event
+        await asyncio.wait_for(timeout_event.wait(), timeout=5)
+        done_event.set()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", on_request)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    site = web.TCPSite(runner, host="127.0.0.1", port=port)
+
+    await site.start()
+
+    try:
+        async with client.ClientSession(
+            timeout=client.ClientTimeout(total=0.1)
+        ) as sess:
+            with pytest.raises(asyncio.TimeoutError):
+                await sess.get(f"http://127.0.0.1:{port}/")
+        await asyncio.sleep(0.1)
+        timeout_event.set()
+
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(done_event.wait(), timeout=1)
+        assert done_event.is_set()
+    finally:
+        await asyncio.gather(runner.shutdown(), site.stop())

--- a/tests/helpers/test_aiohttp_compat.py
+++ b/tests/helpers/test_aiohttp_compat.py
@@ -4,7 +4,6 @@ import asyncio
 from contextlib import suppress
 
 from aiohttp import client, web
-import aiohttp.client_exceptions
 import pytest
 
 from homeassistant.helpers.aiohttp_compat import (
@@ -46,9 +45,7 @@ async def test_handler_cancellation(socket_enabled, aiohttp_unused_port) -> None
         async with client.ClientSession(
             timeout=client.ClientTimeout(total=0.1)
         ) as sess:
-            with pytest.raises(
-                (asyncio.TimeoutError, aiohttp.client_exceptions.ClientOSError)
-            ):
+            with pytest.raises(asyncio.TimeoutError):
                 await sess.get(f"http://127.0.0.1:{port}/")
 
         with suppress(asyncio.TimeoutError):

--- a/tests/helpers/test_aiohttp_compat.py
+++ b/tests/helpers/test_aiohttp_compat.py
@@ -3,7 +3,7 @@
 import asyncio
 from contextlib import suppress
 
-from aiohttp import client, web, web_protocol
+from aiohttp import client, web, web_protocol, web_server
 import pytest
 
 from homeassistant.helpers.aiohttp_compat import CancelOnDisconnectRequestHandler
@@ -16,6 +16,8 @@ async def test_handler_cancellation(socket_enabled, unused_tcp_port_factory) -> 
     From aiohttp tests/test_web_server.py
     """
     assert web_protocol.RequestHandler is CancelOnDisconnectRequestHandler
+    assert web_server.RequestHandler is CancelOnDisconnectRequestHandler
+
     event = asyncio.Event()
     port = unused_tcp_port_factory()
 

--- a/tests/helpers/test_aiohttp_compat.py
+++ b/tests/helpers/test_aiohttp_compat.py
@@ -4,7 +4,12 @@ import asyncio
 from contextlib import suppress
 
 from aiohttp import client, web
+import aiohttp.client_exceptions
 import pytest
+
+from homeassistant.helpers.aiohttp_compat import (
+    restore_original_aiohttp_cancel_behavior,
+)
 
 
 @pytest.mark.allow_hosts(["127.0.0.1"])
@@ -13,20 +18,24 @@ async def test_handler_cancellation(socket_enabled, aiohttp_unused_port) -> None
 
     From aiohttp tests/test_web_server.py
     """
-    timeout_event = asyncio.Event()
-    done_event = asyncio.Event()
+    restore_original_aiohttp_cancel_behavior()
+    event = asyncio.Event()
     port = aiohttp_unused_port()
 
     async def on_request(_: web.Request) -> web.Response:
-        nonlocal done_event, timeout_event
-        await asyncio.wait_for(timeout_event.wait(), timeout=5)
-        done_event.set()
-        return web.Response()
+        nonlocal event
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            event.set()
+            raise
+        else:
+            raise web.HTTPInternalServerError()
 
     app = web.Application()
     app.router.add_route("GET", "/", on_request)
 
-    runner = web.AppRunner(app)
+    runner = web.AppRunner(app, handler_cancellation=True)
     await runner.setup()
 
     site = web.TCPSite(runner, host="127.0.0.1", port=port)
@@ -37,13 +46,13 @@ async def test_handler_cancellation(socket_enabled, aiohttp_unused_port) -> None
         async with client.ClientSession(
             timeout=client.ClientTimeout(total=0.1)
         ) as sess:
-            with pytest.raises(asyncio.TimeoutError):
+            with pytest.raises(
+                (asyncio.TimeoutError, aiohttp.client_exceptions.ClientOSError)
+            ):
                 await sess.get(f"http://127.0.0.1:{port}/")
-        await asyncio.sleep(0.1)
-        timeout_event.set()
 
         with suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(done_event.wait(), timeout=1)
-        assert done_event.is_set()
+            await asyncio.wait_for(event.wait(), timeout=1)
+        assert event.is_set(), "Request handler hasn't been cancelled"
     finally:
         await asyncio.gather(runner.shutdown(), site.stop())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

aiohttp will now preserve the 3.8.1 handler cancellation on disconnect behavior which is now the unreleased 3.9.x version behavior of setting `handler_cancellation` to `True` (docs: https://github.com/aio-libs/aiohttp/pull/7128)

This shim can be removed when 3.9.x is released and replaced with setting `handler_cancellation` to `True`

https://github.com/home-assistant/core/pull/88032#issuecomment-1428974031

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
