### PR TITLE
Inverse json import logic (alternative)

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -28,9 +28,10 @@ import homeassistant.core as ha
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotFound, TemplateError, Unauthorized
 from homeassistant.helpers import template
-from homeassistant.helpers.json import json_dumps, json_loads
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.json_decode import json_loads
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -24,7 +24,7 @@ from homeassistant.helpers import (
     template,
     translation,
 )
-from homeassistant.helpers.json import JsonObjectType, json_loads_object
+from homeassistant.util.json_decode import JsonObjectType, json_loads_object
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
 from .const import DOMAIN

--- a/homeassistant/components/mobile_app/helpers.py
+++ b/homeassistant/components/mobile_app/helpers.py
@@ -14,7 +14,8 @@ from nacl.secret import SecretBox
 from homeassistant.const import ATTR_DEVICE_ID, CONTENT_TYPE_JSON
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.json import JSONEncoder, JsonObjectType, json_loads_object
+from homeassistant.helpers.json import JSONEncoder
+from homeassistant.util.json_decode import JsonObjectType, json_loads_object
 
 from .const import (
     ATTR_APP_DATA,

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_dumps, json_loads
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.selector import (
     BooleanSelector,
     FileSelector,
@@ -44,6 +44,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads
 
 from .client import MqttClientSetup
 from .config_integration import CONFIG_SCHEMA_ENTRY

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -31,9 +31,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads
 
 from . import subscription
 from .config import MQTT_BASE_SCHEMA

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -18,10 +18,10 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.json import json_loads_object
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.loader import async_get_mqtt
+from homeassistant.util.json_decode import json_loads_object
 
 from .. import mqtt
 from .abbreviations import ABBREVIATIONS, DEVICE_ABBREVIATIONS

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -47,10 +47,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import json_dumps, json_loads_object
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.color as color_util
+from homeassistant.util.json_decode import json_loads_object
 
 from .. import subscription
 from ..config import DEFAULT_QOS, DEFAULT_RETAIN, MQTT_RW_SCHEMA

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -51,8 +51,8 @@ from homeassistant.helpers.entity import (
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.json import json_loads
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.json_decode import json_loads
 
 from . import debug_info, subscription
 from .client import async_publish

--- a/homeassistant/components/mqtt/siren.py
+++ b/homeassistant/components/mqtt/siren.py
@@ -31,13 +31,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import (
-    JSON_DECODE_EXCEPTIONS,
-    json_dumps,
-    json_loads_object,
-)
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, TemplateVarsType
+from homeassistant.util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads_object
 
 from . import subscription
 from .config import MQTT_RW_SCHEMA

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -11,10 +11,10 @@ import voluptuous as vol
 from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM, CONF_VALUE_TEMPLATE
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.json import json_loads
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger import TriggerActionType, TriggerData, TriggerInfo
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+from homeassistant.util.json_decode import json_loads
 
 from .. import mqtt
 from .const import CONF_ENCODING, CONF_QOS, CONF_TOPIC, DEFAULT_ENCODING, DEFAULT_QOS

--- a/homeassistant/components/mqtt/update.py
+++ b/homeassistant/components/mqtt/update.py
@@ -18,9 +18,9 @@ from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_VALUE_TEMPLAT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads
 
 from . import subscription
 from .config import DEFAULT_RETAIN, MQTT_RO_SCHEMA

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -25,8 +25,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import json_dumps, json_loads_object
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.json_decode import json_loads_object
 
 from .. import subscription
 from ..config import MQTT_BASE_SCHEMA

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -41,15 +41,13 @@ from homeassistant.const import (
     MAX_LENGTH_STATE_STATE,
 )
 from homeassistant.core import Context, Event, EventOrigin, State, split_entity_id
-from homeassistant.helpers.json import (
+from homeassistant.helpers.json import JSON_DUMP, json_bytes, json_bytes_strip_null
+import homeassistant.util.dt as dt_util
+from homeassistant.util.json_decode import (
     JSON_DECODE_EXCEPTIONS,
-    JSON_DUMP,
-    json_bytes,
-    json_bytes_strip_null,
     json_loads,
     json_loads_object,
 )
-import homeassistant.util.dt as dt_util
 
 from .const import ALL_DOMAIN_EXCLUDE_ATTRS, SupportedDialect
 from .models import (

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -16,8 +16,8 @@ from homeassistant.const import (
     COMPRESSED_STATE_STATE,
 )
 from homeassistant.core import Context, State
-from homeassistant.helpers.json import json_loads_object
 import homeassistant.util.dt as dt_util
+from homeassistant.util.json_decode import json_loads_object
 
 from .const import SupportedDialect
 

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -25,10 +25,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.json import json_dumps, json_loads
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.template_entity import TemplateSensor
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.json_decode import json_loads
 
 from . import async_get_config_and_coordinator, create_rest_data_from_config
 from .const import CONF_JSON_ATTRS, CONF_JSON_ATTRS_PATH, DEFAULT_SENSOR_NAME

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -16,7 +16,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.json import json_loads
+from homeassistant.util.json_decode import json_loads
 
 from .auth import AuthPhase, auth_required_message
 from .const import (

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -20,9 +20,10 @@ from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __v
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util import ssl as ssl_util
+from homeassistant.util.json_decode import json_loads
 
 from .frame import warn_use
-from .json import json_dumps, json_loads
+from .json import json_dumps
 
 if TYPE_CHECKING:
     from aiohttp.typedefs import JSONDecoder

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -7,12 +7,7 @@ from typing import Any, Final
 
 import orjson
 
-JsonValueType = (
-    dict[str, "JsonValueType"] | list["JsonValueType"] | str | int | float | bool | None
-)
-"""Any data that can be returned by the standard JSON deserializing process."""
-JsonObjectType = dict[str, JsonValueType]
-"""Dictionary that can be returned by the standard JSON deserializing process."""
+from homeassistant.util.json import JsonObjectType, JsonValueType
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -1,5 +1,4 @@
 """Helpers to help with encoding Home Assistant objects in JSON."""
-from collections.abc import Callable
 import datetime
 import json
 from pathlib import Path
@@ -7,10 +6,12 @@ from typing import Any, Final
 
 import orjson
 
-from homeassistant.util.json import JsonObjectType, JsonValueType
+from homeassistant.util.json_decode import (  # pylint: disable=unused-import # noqa: F401
+    JSON_DECODE_EXCEPTIONS,
+    json_loads,
+)
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
-JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -133,20 +134,6 @@ def json_dumps_sorted(data: Any) -> str:
         option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
         default=json_encoder_default,
     ).decode("utf-8")
-
-
-json_loads: Callable[[bytes | bytearray | memoryview | str], JsonValueType]
-json_loads = orjson.loads
-"""Parse JSON data."""
-
-
-def json_loads_object(__obj: bytes | bytearray | memoryview | str) -> JsonObjectType:
-    """Parse JSON data and ensure result is a dictionary."""
-    value: JsonValueType = json_loads(__obj)
-    # Avoid isinstance overhead as we are not interested in dict subclasses
-    if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
-        return value
-    raise ValueError(f"Expected JSON to be parsed as a dict got {type(value)}")
 
 
 JSON_DUMP: Final = json_dumps

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -68,11 +68,11 @@ from homeassistant.util import (
     slugify as slugify_util,
 )
 from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads
 from homeassistant.util.read_only_dict import ReadOnlyDict
 from homeassistant.util.thread import ThreadWithException
 
 from . import area_registry, device_registry, entity_registry, location as loc_helper
-from .json import JSON_DECODE_EXCEPTIONS, json_loads
 from .typing import TemplateVarsType
 
 # mypy: allow-untyped-defs, no-check-untyped-defs

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -30,7 +30,7 @@ from .generated.mqtt import MQTT
 from .generated.ssdp import SSDP
 from .generated.usb import USB
 from .generated.zeroconf import HOMEKIT, ZEROCONF
-from .helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
+from .util.json_decode import JSON_DECODE_EXCEPTIONS, json_loads
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -11,17 +11,14 @@ import orjson
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.json import (
+    JSONEncoder as DefaultHASSJSONEncoder,
+    json_encoder_default as default_hass_orjson_encoder,
+)
 
 from .file import write_utf8_file, write_utf8_file_atomic
 
 _LOGGER = logging.getLogger(__name__)
-
-JsonValueType = (
-    dict[str, "JsonValueType"] | list["JsonValueType"] | str | int | float | bool | None
-)
-"""Any data that can be returned by the standard JSON deserializing process."""
-JsonObjectType = dict[str, JsonValueType]
-"""Dictionary that can be returned by the standard JSON deserializing process."""
 
 
 class SerializationError(HomeAssistantError):
@@ -54,11 +51,6 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
 
 def _orjson_default_encoder(data: Any) -> str:
     """JSON encoder that uses orjson with hass defaults."""
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.helpers.json import (
-        json_encoder_default as default_hass_orjson_encoder,
-    )
-
     return orjson.dumps(
         data,
         option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
@@ -78,9 +70,6 @@ def save_json(
 
     Returns True on success.
     """
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.helpers.json import JSONEncoder as DefaultHASSJSONEncoder
-
     dump: Callable[[Any], Any]
     try:
         # For backwards compatibility, if they pass in the

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -11,14 +11,17 @@ import orjson
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.json import (
-    JSONEncoder as DefaultHASSJSONEncoder,
-    json_encoder_default as default_hass_orjson_encoder,
-)
 
 from .file import write_utf8_file, write_utf8_file_atomic
 
 _LOGGER = logging.getLogger(__name__)
+
+JsonValueType = (
+    dict[str, "JsonValueType"] | list["JsonValueType"] | str | int | float | bool | None
+)
+"""Any data that can be returned by the standard JSON deserializing process."""
+JsonObjectType = dict[str, JsonValueType]
+"""Dictionary that can be returned by the standard JSON deserializing process."""
 
 
 class SerializationError(HomeAssistantError):
@@ -51,6 +54,11 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
 
 def _orjson_default_encoder(data: Any) -> str:
     """JSON encoder that uses orjson with hass defaults."""
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.helpers.json import (
+        json_encoder_default as default_hass_orjson_encoder,
+    )
+
     return orjson.dumps(
         data,
         option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
@@ -70,6 +78,9 @@ def save_json(
 
     Returns True on success.
     """
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.helpers.json import JSONEncoder as DefaultHASSJSONEncoder
+
     dump: Callable[[Any], Any]
     try:
         # For backwards compatibility, if they pass in the

--- a/homeassistant/util/json_decode.py
+++ b/homeassistant/util/json_decode.py
@@ -1,0 +1,29 @@
+"""JSON decode utility functions."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import orjson
+
+JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
+
+JsonValueType = (
+    dict[str, "JsonValueType"] | list["JsonValueType"] | str | int | float | bool | None
+)
+"""Any data that can be returned by the standard JSON deserializing process."""
+JsonObjectType = dict[str, JsonValueType]
+"""Dictionary that can be returned by the standard JSON deserializing process."""
+
+
+json_loads: Callable[[bytes | bytearray | memoryview | str], JsonValueType]
+json_loads = orjson.loads
+"""Parse JSON data."""
+
+
+def json_loads_object(__obj: bytes | bytearray | memoryview | str) -> JsonObjectType:
+    """Parse JSON data and ensure result is a dictionary."""
+    value: JsonValueType = json_loads(__obj)
+    # Avoid isinstance overhead as we are not interested in dict subclasses
+    if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
+        return value
+    raise ValueError(f"Expected JSON to be parsed as a dict got {type(value)}")

--- a/tests/components/diagnostics/__init__.py
+++ b/tests/components/diagnostics/__init__.py
@@ -5,8 +5,8 @@ from typing import cast
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.json import JsonObjectType
 from homeassistant.setup import async_setup_component
+from homeassistant.util.json_decode import JsonObjectType
 
 from tests.typing import ClientSessionGenerator
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -97,8 +97,8 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers.json import JsonValueType, json_loads
 from homeassistant.setup import async_setup_component
+from homeassistant.util.json_decode import JsonValueType, json_loads
 
 from .test_common import (
     help_test_availability_when_connection_lost,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #88099

### The problem
- the `helpers` section refers to helpers directly related to Home Assistant
- the `util` section refers to utilities not directly related to Home Assistant

In the case of `json`, it seems the logic has been inverted and we have ended up with `util` referencing Home Assistant internals, and `helpers` not referencing any Home Assistant internals.

### Options
- this PR attempts to avoid breaking change by refactoring into a new file and deprecating the old file
- #88099 attempts to avoid breaking change by using late-import

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
