### PR TITLE
Upload KNX Keyfile from Config/Options Flow directly

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Final
 
 import voluptuous as vol
@@ -333,6 +334,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update a given config entry."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove a config entry."""
+
+    def remove_keyring_files(file_path: Path) -> None:
+        """Remove keyring files."""
+        if file_path.exists():
+            file_path.unlink()
+
+    if (_knxkeys_file := entry.data.get(CONF_KNX_KNXKEY_FILENAME)) is not None:
+        file_path = Path(hass.config.path(STORAGE_DIR)) / _knxkeys_file
+        await hass.async_add_executor_job(remove_keyring_files, file_path)
 
 
 class KNXModule:

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from pathlib import Path
 from typing import Final
@@ -341,8 +342,10 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     def remove_keyring_files(file_path: Path) -> None:
         """Remove keyring files."""
-        if file_path.exists():
+        with contextlib.suppress(FileNotFoundError):
             file_path.unlink()
+        with contextlib.suppress(FileNotFoundError, OSError):
+            file_path.parent.rmdir()
 
     if (_knxkeys_file := entry.data.get(CONF_KNX_KNXKEY_FILENAME)) is not None:
         file_path = Path(hass.config.path(STORAGE_DIR)) / _knxkeys_file

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Final
 
 import voluptuous as vol
@@ -43,7 +44,6 @@ from .const import (
     CONF_KNX_CONNECTION_TYPE,
     CONF_KNX_EXPOSE,
     CONF_KNX_INDIVIDUAL_ADDRESS,
-    CONF_KNX_KNXKEY_FILENAME,
     CONF_KNX_KNXKEY_PASSWORD,
     CONF_KNX_LOCAL_IP,
     CONF_KNX_MCAST_GRP,
@@ -65,6 +65,7 @@ from .const import (
     DATA_KNX_CONFIG,
     DOMAIN,
     KNX_ADDRESS,
+    KNX_KEYRING_FILENAME,
     SUPPORTED_PLATFORMS,
 )
 from .expose import KNXExposeSensor, KNXExposeTime, create_knx_exposure
@@ -219,6 +220,39 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     conf = dict(conf)
     hass.data[DATA_KNX_CONFIG] = conf
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Migrate the config entry upon new versions."""
+    version = entry.version
+    data = {**entry.data}
+
+    _LOGGER.debug("Migrating from version %s", version)
+
+    if version == 1:
+        # - rename .knxkeys file from user specified path to default path
+        # - remove "knxkeys_filename" from config entry data
+        def _move_keyfile(user_keyfile_path: Path) -> None:
+            """Move keyfile to default path."""
+            dest_path = Path(hass.config.path(STORAGE_DIR, DOMAIN))
+            dest_path.mkdir(exist_ok=True)
+            user_keyfile_path.rename(dest_path / KNX_KEYRING_FILENAME)
+
+        knxkeys_filename = data.pop("knxkeys_filename", None)
+        if knxkeys_filename is not None:
+            user_keyfile_path = Path(
+                hass.config.path(
+                    STORAGE_DIR,
+                    knxkeys_filename,
+                )
+            )
+            await hass.async_add_executor_job(_move_keyfile, user_keyfile_path)
+
+        version = entry.version = 2
+        hass.config_entries.async_update_entry(entry, data=data)
+
+    _LOGGER.info("Migration to version %s successful", version)
     return True
 
 
@@ -384,6 +418,11 @@ class KNXModule:
     def connection_config(self) -> ConnectionConfig:
         """Return the connection_config."""
         _conn_type: str = self.entry.data[CONF_KNX_CONNECTION_TYPE]
+        _knxkeys_path = (
+            Path(self.hass.config.path(STORAGE_DIR, DOMAIN)) / KNX_KEYRING_FILENAME
+        )
+        knxkeys_file = _knxkeys_path if _knxkeys_path.exists() else None
+
         if _conn_type == CONF_KNX_ROUTING:
             return ConnectionConfig(
                 connection_type=ConnectionType.ROUTING,
@@ -392,6 +431,10 @@ class KNXModule:
                 multicast_port=self.entry.data[CONF_KNX_MCAST_PORT],
                 local_ip=self.entry.data.get(CONF_KNX_LOCAL_IP),
                 auto_reconnect=True,
+                secure_config=SecureConfig(
+                    knxkeys_file_path=knxkeys_file,
+                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
+                ),
                 threaded=True,
             )
         if _conn_type == CONF_KNX_TUNNELING:
@@ -402,6 +445,10 @@ class KNXModule:
                 local_ip=self.entry.data.get(CONF_KNX_LOCAL_IP),
                 route_back=self.entry.data.get(CONF_KNX_ROUTE_BACK, False),
                 auto_reconnect=True,
+                secure_config=SecureConfig(
+                    knxkeys_file_path=knxkeys_file,
+                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
+                ),
                 threaded=True,
             )
         if _conn_type == CONF_KNX_TUNNELING_TCP:
@@ -410,16 +457,12 @@ class KNXModule:
                 gateway_ip=self.entry.data[CONF_HOST],
                 gateway_port=self.entry.data[CONF_PORT],
                 auto_reconnect=True,
+                secure_config=SecureConfig(
+                    knxkeys_file_path=knxkeys_file,
+                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
+                ),
                 threaded=True,
             )
-        knxkeys_file: str | None = (
-            self.hass.config.path(
-                STORAGE_DIR,
-                self.entry.data[CONF_KNX_KNXKEY_FILENAME],
-            )
-            if self.entry.data.get(CONF_KNX_KNXKEY_FILENAME) is not None
-            else None
-        )
         if _conn_type == CONF_KNX_TUNNELING_TCP_SECURE:
             return ConnectionConfig(
                 connection_type=ConnectionType.TUNNELING_TCP_SECURE,
@@ -431,8 +474,8 @@ class KNXModule:
                     device_authentication_password=self.entry.data.get(
                         CONF_KNX_SECURE_DEVICE_AUTHENTICATION
                     ),
-                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
                     knxkeys_file_path=knxkeys_file,
+                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
                 ),
                 auto_reconnect=True,
                 threaded=True,
@@ -449,14 +492,18 @@ class KNXModule:
                     latency_ms=self.entry.data.get(
                         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE
                     ),
-                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
                     knxkeys_file_path=knxkeys_file,
+                    knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
                 ),
                 auto_reconnect=True,
                 threaded=True,
             )
         return ConnectionConfig(
             auto_reconnect=True,
+            secure_config=SecureConfig(
+                knxkeys_file_path=knxkeys_file,
+                knxkeys_password=self.entry.data.get(CONF_KNX_KNXKEY_PASSWORD),
+            ),
             threaded=True,
         )
 

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
     CONF_KNX_TUNNELING_TCP_SECURE,
     DEFAULT_ROUTING_IA,
     DOMAIN,
+    KNX_KEYRING_FILENAME,
     KNXConfigEntryData,
 )
 from .schema import ia_validator, ip_v4_validator
@@ -706,7 +707,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                 else:
                     dest_path = Path(self.hass.config.path(STORAGE_DIR, DOMAIN))
                     dest_path.mkdir(exist_ok=True)
-                    file_path.rename(dest_path / "keyfile.knxkeys")
+                    file_path.rename(dest_path / KNX_KEYRING_FILENAME)
             return keyring, errors
 
         keyring, errors = await self.hass.async_add_executor_job(_process_upload)
@@ -717,7 +718,7 @@ class KNXCommonFlow(ABC, FlowHandler):
 class KNXConfigFlow(KNXCommonFlow, ConfigFlow, domain=DOMAIN):
     """Handle a KNX config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize KNX options flow."""

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -67,7 +67,7 @@ DEFAULT_ENTRY_DATA = KNXConfigEntryData(
 )
 
 CONF_KEYRING_FILE: Final = "knxkeys_file"
-DEFAULT_KNX_KEYRING_FILENAME: Final = "keyfile.knxkeys"
+DEFAULT_KNX_KEYRING_FILENAME: Final = "keyring.knxkeys"
 
 CONF_KNX_TUNNELING_TYPE: Final = "tunneling_type"
 CONF_KNX_TUNNELING_TYPE_LABELS: Final = {

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -229,7 +229,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             if connection_type == CONF_KNX_TUNNELING_TCP_SECURE:
                 return self.async_show_menu(
                     step_id="secure_key_source",
-                    menu_options=["knxkeys_upload", "secure_tunnel_manual"],
+                    menu_options=["secure_knxkeys", "secure_tunnel_manual"],
                 )
             self.new_title = f"Tunneling @ {self._selected_tunnel}"
             return self.finish_flow()
@@ -305,7 +305,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                 if selected_tunnelling_type == CONF_KNX_TUNNELING_TCP_SECURE:
                     return self.async_show_menu(
                         step_id="secure_key_source",
-                        menu_options=["knxkeys_upload", "secure_tunnel_manual"],
+                        menu_options=["secure_knxkeys", "secure_tunnel_manual"],
                     )
                 self.new_title = (
                     "Tunneling "
@@ -473,7 +473,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             errors=errors,
         )
 
-    async def async_step_knxkeys_upload(
+    async def async_step_secure_knxkeys(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage upload of new KNX Keyring file."""
@@ -515,7 +515,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             ): selector.TextSelector(),
         }
         return self.async_show_form(
-            step_id="knxkeys_upload",
+            step_id="secure_knxkeys",
             data_schema=vol.Schema(fields),
             errors=errors,
         )
@@ -555,7 +555,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             )
             return self.finish_flow()
 
-        # this step is only called from async_step_knxkeys_upload so self._keyring is always set
+        # this step is only called from async_step_secure_knxkeys so self._keyring is always set
         assert self._keyring
 
         # Filter for selected tunnel
@@ -659,7 +659,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                     self.new_title = f"Secure Routing as {_individual_address}"
                     return self.async_show_menu(
                         step_id="secure_key_source",
-                        menu_options=["knxkeys_upload", "secure_routing_manual"],
+                        menu_options=["secure_knxkeys", "secure_routing_manual"],
                     )
                 self.new_title = f"Routing as {_individual_address}"
                 return self.finish_flow()
@@ -777,7 +777,7 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
             menu_options=[
                 "connection_type",
                 "communication_settings",
-                "knxkeys_upload",
+                "secure_knxkeys",
             ],
         )
 

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import Any, Final
 
 import voluptuous as vol
@@ -11,8 +12,9 @@ from xknx.exceptions.exception import CommunicationError, InvalidSecureConfigura
 from xknx.io import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.io.gateway_scanner import GatewayDescriptor, GatewayScanner
 from xknx.io.self_description import request_description
-from xknx.secure.keyring import XMLInterface, load_keyring
+from xknx.secure.keyring import Keyring, XMLInterface, sync_load_keyring
 
+from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
@@ -27,7 +29,6 @@ from .const import (
     CONF_KNX_DEFAULT_RATE_LIMIT,
     CONF_KNX_DEFAULT_STATE_UPDATER,
     CONF_KNX_INDIVIDUAL_ADDRESS,
-    CONF_KNX_KNXKEY_FILENAME,
     CONF_KNX_KNXKEY_PASSWORD,
     CONF_KNX_LOCAL_IP,
     CONF_KNX_MCAST_GRP,
@@ -42,10 +43,10 @@ from .const import (
     CONF_KNX_SECURE_USER_ID,
     CONF_KNX_SECURE_USER_PASSWORD,
     CONF_KNX_STATE_UPDATER,
+    CONF_KNX_TUNNEL_ENDPOINT_IA,
     CONF_KNX_TUNNELING,
     CONF_KNX_TUNNELING_TCP,
     CONF_KNX_TUNNELING_TCP_SECURE,
-    CONST_KNX_STORAGE_KEY,
     DEFAULT_ROUTING_IA,
     DOMAIN,
     KNXConfigEntryData,
@@ -64,6 +65,8 @@ DEFAULT_ENTRY_DATA = KNXConfigEntryData(
     route_back=False,
     state_updater=CONF_KNX_DEFAULT_STATE_UPDATER,
 )
+
+CONF_KEYRING_FILE: Final = "knxkeys_file"
 
 CONF_KNX_TUNNELING_TYPE: Final = "tunneling_type"
 CONF_KNX_TUNNELING_TYPE_LABELS: Final = {
@@ -93,6 +96,9 @@ class KNXCommonFlow(ABC, FlowHandler):
         """Initialize KNXCommonFlow."""
         self.initial_data = initial_data
         self.new_entry_data = KNXConfigEntryData()
+        self.new_title: str | None = None
+
+        self._keyring: Keyring | None = None
         self._found_gateways: list[GatewayDescriptor] = []
         self._found_tunnels: list[GatewayDescriptor] = []
         self._selected_tunnel: GatewayDescriptor | None = None
@@ -102,8 +108,24 @@ class KNXCommonFlow(ABC, FlowHandler):
         self._async_scan_gen: AsyncGenerator[GatewayDescriptor, None] | None = None
 
     @abstractmethod
-    def finish_flow(self, title: str) -> FlowResult:
+    def finish_flow(self) -> FlowResult:
         """Finish the flow."""
+
+    @property
+    def connection_type(self) -> str:
+        """Return the configured connection type."""
+        _new_type = self.new_entry_data.get(CONF_KNX_CONNECTION_TYPE)
+        if _new_type is None:
+            return self.initial_data[CONF_KNX_CONNECTION_TYPE]
+        return _new_type
+
+    @property
+    def tunnel_endpoint_ia(self) -> str | None:
+        """Return the configured tunnel endpoint individual address."""
+        return self.new_entry_data.get(
+            CONF_KNX_TUNNEL_ENDPOINT_IA,
+            self.initial_data.get(CONF_KNX_TUNNEL_ENDPOINT_IA),
+        )
 
     async def async_step_connection_type(
         self, user_input: dict | None = None
@@ -135,8 +157,12 @@ class KNXCommonFlow(ABC, FlowHandler):
                 return await self.async_step_tunnel()
 
             # Automatic connection type
-            self.new_entry_data = KNXConfigEntryData(connection_type=CONF_KNX_AUTOMATIC)
-            return self.finish_flow(title=CONF_KNX_AUTOMATIC.capitalize())
+            self.new_entry_data = KNXConfigEntryData(
+                connection_type=CONF_KNX_AUTOMATIC,
+                tunnel_endpoint_ia=None,
+            )
+            self.new_title = CONF_KNX_AUTOMATIC.capitalize()
+            return self.finish_flow()
 
         supported_connection_types = {
             CONF_KNX_TUNNELING: CONF_KNX_TUNNELING.capitalize(),
@@ -194,13 +220,18 @@ class KNXCommonFlow(ABC, FlowHandler):
                 port=self._selected_tunnel.port,
                 route_back=False,
                 connection_type=connection_type,
+                device_authentication=None,
+                user_id=None,
+                user_password=None,
+                tunnel_endpoint_ia=None,
             )
             if connection_type == CONF_KNX_TUNNELING_TCP_SECURE:
                 return self.async_show_menu(
                     step_id="secure_key_source",
-                    menu_options=["secure_knxkeys", "secure_tunnel_manual"],
+                    menu_options=["knxkeys_upload", "secure_tunnel_manual"],
                 )
-            return self.finish_flow(title=f"Tunneling @ {self._selected_tunnel}")
+            self.new_title = f"Tunneling @ {self._selected_tunnel}"
+            return self.finish_flow()
 
         if not self._found_tunnels:
             return await self.async_step_manual_tunnel()
@@ -264,14 +295,23 @@ class KNXCommonFlow(ABC, FlowHandler):
                     port=user_input[CONF_PORT],
                     route_back=user_input[CONF_KNX_ROUTE_BACK],
                     local_ip=_local_ip,
+                    device_authentication=None,
+                    user_id=None,
+                    user_password=None,
+                    tunnel_endpoint_ia=None,
                 )
 
                 if selected_tunnelling_type == CONF_KNX_TUNNELING_TCP_SECURE:
                     return self.async_show_menu(
                         step_id="secure_key_source",
-                        menu_options=["secure_knxkeys", "secure_tunnel_manual"],
+                        menu_options=["knxkeys_upload", "secure_tunnel_manual"],
                     )
-                return self.finish_flow(title=f"Tunneling @ {_host}")
+                self.new_title = (
+                    "Tunneling "
+                    f"{'UDP' if selected_tunnelling_type == CONF_KNX_TUNNELING else 'TCP'} "
+                    f"@ {_host}"
+                )
+                return self.finish_flow()
 
         _reconfiguring_existing_tunnel = (
             self.initial_data.get(CONF_KNX_CONNECTION_TYPE)
@@ -342,10 +382,10 @@ class KNXCommonFlow(ABC, FlowHandler):
                 device_authentication=user_input[CONF_KNX_SECURE_DEVICE_AUTHENTICATION],
                 user_id=user_input[CONF_KNX_SECURE_USER_ID],
                 user_password=user_input[CONF_KNX_SECURE_USER_PASSWORD],
+                tunnel_endpoint_ia=None,
             )
-            return self.finish_flow(
-                title=f"Secure Tunneling @ {self.new_entry_data[CONF_HOST]}"
-            )
+            self.new_title = f"Secure Tunneling @ {self.new_entry_data[CONF_HOST]}"
+            return self.finish_flow()
 
         fields = {
             vol.Required(
@@ -399,12 +439,8 @@ class KNXCommonFlow(ABC, FlowHandler):
                         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE
                     ],
                 )
-                return self.finish_flow(
-                    title=(
-                        "Secure Routing as"
-                        f" {self.new_entry_data[CONF_KNX_INDIVIDUAL_ADDRESS]}"
-                    )
-                )
+                self.new_title = f"Secure Routing as {self.new_entry_data[CONF_KNX_INDIVIDUAL_ADDRESS]}"
+                return self.finish_flow()
 
         fields = {
             vol.Required(
@@ -436,93 +472,101 @@ class KNXCommonFlow(ABC, FlowHandler):
             errors=errors,
         )
 
-    async def async_step_secure_knxkeys(
-        self, user_input: dict | None = None
+    async def async_step_knxkeys_upload(
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Configure secure knxkeys used to authenticate."""
-        errors = {}
-        description_placeholders = {}
+        """Manage upload of new KNX Keyring file."""
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            connection_type = self.new_entry_data[CONF_KNX_CONNECTION_TYPE]
-            storage_key = CONST_KNX_STORAGE_KEY + user_input[CONF_KNX_KNXKEY_FILENAME]
-            try:
-                keyring = await load_keyring(
-                    path=self.hass.config.path(STORAGE_DIR, storage_key),
-                    password=user_input[CONF_KNX_KNXKEY_PASSWORD],
-                )
-            except FileNotFoundError:
-                errors[CONF_KNX_KNXKEY_FILENAME] = "keyfile_not_found"
-            except InvalidSecureConfiguration:
-                errors[CONF_KNX_KNXKEY_PASSWORD] = "keyfile_invalid_signature"
-            else:
-                if (
-                    connection_type == CONF_KNX_TUNNELING_TCP_SECURE
-                    and self._selected_tunnel is not None
-                ):
-                    if host_ia := self._selected_tunnel.individual_address:
-                        self._tunnel_endpoints = keyring.get_tunnel_interfaces_by_host(
-                            host=host_ia
-                        )
-                    if not self._tunnel_endpoints:
-                        errors["base"] = "keyfile_no_tunnel_for_host"
-                        description_placeholders = {CONF_HOST: str(host_ia)}
-
-                if connection_type == CONF_KNX_ROUTING_SECURE:
-                    if not (keyring.backbone is not None and keyring.backbone.key):
-                        errors["base"] = "keyfile_no_backbone_key"
-
-            if not errors:
+            password = user_input[CONF_KNX_KNXKEY_PASSWORD]
+            errors = await self._save_uploaded_knxkeys_file(
+                uploaded_file_id=user_input[CONF_KEYRING_FILE],
+                password=password,
+            )
+            if not errors and self._keyring:
                 self.new_entry_data |= KNXConfigEntryData(
-                    knxkeys_filename=storage_key,
-                    knxkeys_password=user_input[CONF_KNX_KNXKEY_PASSWORD],
+                    knxkeys_password=password,
                     backbone_key=None,
                     sync_latency_tolerance=None,
-                    device_authentication=None,
-                    user_id=None,
-                    user_password=None,
                 )
-                if connection_type == CONF_KNX_ROUTING_SECURE:
-                    return self.finish_flow(
-                        title=(
-                            "Secure Routing as"
-                            f" {self.new_entry_data[CONF_KNX_INDIVIDUAL_ADDRESS]}"
-                        )
-                    )
-                return await self.async_step_knxkeys_tunnel_select()
+                # Routing
+                if self.connection_type in (CONF_KNX_ROUTING, CONF_KNX_ROUTING_SECURE):
+                    return self.finish_flow()
 
-        if _default_filename := self.initial_data.get(CONF_KNX_KNXKEY_FILENAME):
-            _default_filename = _default_filename.lstrip(CONST_KNX_STORAGE_KEY)
+                # Tunneling / Automatic
+                # skip selection step if we have a keyfile update that includes a configured tunnel
+                if self.tunnel_endpoint_ia is not None and self.tunnel_endpoint_ia in [
+                    str(_if.individual_address) for _if in self._keyring.interfaces
+                ]:
+                    return self.finish_flow()
+                if not errors:
+                    return await self.async_step_knxkeys_tunnel_select()
+
         fields = {
-            vol.Required(
-                CONF_KNX_KNXKEY_FILENAME, default=_default_filename
-            ): selector.TextSelector(),
+            vol.Required(CONF_KEYRING_FILE): selector.FileSelector(
+                config=selector.FileSelectorConfig(accept=".knxkeys")
+            ),
             vol.Required(
                 CONF_KNX_KNXKEY_PASSWORD,
                 default=self.initial_data.get(CONF_KNX_KNXKEY_PASSWORD),
             ): selector.TextSelector(),
         }
-
         return self.async_show_form(
-            step_id="secure_knxkeys",
+            step_id="knxkeys_upload",
             data_schema=vol.Schema(fields),
             errors=errors,
-            description_placeholders=description_placeholders,
         )
 
     async def async_step_knxkeys_tunnel_select(
         self, user_input: dict | None = None
     ) -> FlowResult:
         """Select if a specific tunnel should be used from knxkeys file."""
+        errors = {}
+        description_placeholders = {}
         if user_input is not None:
-            if user_input[CONF_KNX_SECURE_USER_ID] == CONF_KNX_AUTOMATIC:
-                selected_user_id = None
+            selected_tunnel_ia: str | None = None
+            _if_user_id: int | None = None
+            if user_input[CONF_KNX_TUNNEL_ENDPOINT_IA] == CONF_KNX_AUTOMATIC:
+                self.new_entry_data |= KNXConfigEntryData(
+                    tunnel_endpoint_ia=None,
+                )
             else:
-                selected_user_id = int(user_input[CONF_KNX_SECURE_USER_ID])
-            self.new_entry_data |= KNXConfigEntryData(user_id=selected_user_id)
-            return self.finish_flow(
-                title=f"Secure Tunneling @ {self.new_entry_data[CONF_HOST]}"
+                selected_tunnel_ia = user_input[CONF_KNX_TUNNEL_ENDPOINT_IA]
+                self.new_entry_data |= KNXConfigEntryData(
+                    tunnel_endpoint_ia=selected_tunnel_ia,
+                    user_id=None,
+                    user_password=None,
+                    device_authentication=None,
+                )
+                _if_user_id = next(
+                    (
+                        _if.user_id
+                        for _if in self._tunnel_endpoints
+                        if str(_if.individual_address) == selected_tunnel_ia
+                    ),
+                    None,
+                )
+            self.new_title = (
+                f"{'Secure ' if _if_user_id else ''}"
+                f"Tunneling @ {selected_tunnel_ia or self.new_entry_data[CONF_HOST]}"
             )
+            return self.finish_flow()
+
+        # this step is only called from async_step_knxkeys_upload so self._keyring is always set
+        assert self._keyring
+
+        # Filter for selected tunnel
+        if self._selected_tunnel is not None:
+            if host_ia := self._selected_tunnel.individual_address:
+                self._tunnel_endpoints = self._keyring.get_tunnel_interfaces_by_host(
+                    host=host_ia
+                )
+            if not self._tunnel_endpoints:
+                errors["base"] = "keyfile_no_tunnel_for_host"
+                description_placeholders = {CONF_HOST: str(host_ia)}
+        else:
+            self._tunnel_endpoints = self._keyring.interfaces
 
         tunnel_endpoint_options = [
             selector.SelectOptionDict(
@@ -532,8 +576,12 @@ class KNXCommonFlow(ABC, FlowHandler):
         for endpoint in self._tunnel_endpoints:
             tunnel_endpoint_options.append(
                 selector.SelectOptionDict(
-                    value=str(endpoint.user_id),
-                    label=f"{endpoint.individual_address} (User ID: {endpoint.user_id})",
+                    value=str(endpoint.individual_address),
+                    label=(
+                        f"{endpoint.individual_address} "
+                        f"{'🔐 ' if endpoint.user_id else ''}"
+                        f"(Data Secure GAs: {len(endpoint.group_addresses)})"
+                    ),
                 )
             )
         return self.async_show_form(
@@ -541,7 +589,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_KNX_SECURE_USER_ID, default=CONF_KNX_AUTOMATIC
+                        CONF_KNX_TUNNEL_ENDPOINT_IA, default=CONF_KNX_AUTOMATIC
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=tunnel_endpoint_options,
@@ -550,6 +598,8 @@ class KNXCommonFlow(ABC, FlowHandler):
                     ),
                 }
             ),
+            errors=errors,
+            description_placeholders=description_placeholders,
         )
 
     async def async_step_routing(self, user_input: dict | None = None) -> FlowResult:
@@ -598,13 +648,19 @@ class KNXCommonFlow(ABC, FlowHandler):
                     multicast_group=_multicast_group,
                     multicast_port=_multicast_port,
                     local_ip=_local_ip,
+                    device_authentication=None,
+                    user_id=None,
+                    user_password=None,
+                    tunnel_endpoint_ia=None,
                 )
                 if connection_type == CONF_KNX_ROUTING_SECURE:
+                    self.new_title = f"Secure Routing as {_individual_address}"
                     return self.async_show_menu(
                         step_id="secure_key_source",
-                        menu_options=["secure_knxkeys", "secure_routing_manual"],
+                        menu_options=["knxkeys_upload", "secure_routing_manual"],
                     )
-                return self.finish_flow(title=f"Routing as {_individual_address}")
+                self.new_title = f"Routing as {_individual_address}"
+                return self.finish_flow()
 
         routers = [router for router in self._found_gateways if router.supports_routing]
         if not routers:
@@ -631,6 +687,32 @@ class KNXCommonFlow(ABC, FlowHandler):
             step_id="routing", data_schema=vol.Schema(fields), errors=errors
         )
 
+    async def _save_uploaded_knxkeys_file(
+        self, uploaded_file_id: str, password: str
+    ) -> dict[str, str]:
+        """Validate the uploaded file and move it to the storage directory. Return errors."""
+
+        def _process_upload() -> tuple[Keyring | None, dict[str, str]]:
+            keyring: Keyring | None = None
+            errors = {}
+            with process_uploaded_file(self.hass, uploaded_file_id) as file_path:
+                try:
+                    keyring = sync_load_keyring(
+                        path=file_path,
+                        password=password,
+                    )
+                except InvalidSecureConfiguration:
+                    errors[CONF_KNX_KNXKEY_PASSWORD] = "keyfile_invalid_signature"
+                else:
+                    dest_path = Path(self.hass.config.path(STORAGE_DIR, DOMAIN))
+                    dest_path.mkdir(exist_ok=True)
+                    file_path.rename(dest_path / "keyfile.knxkeys")
+            return keyring, errors
+
+        keyring, errors = await self.hass.async_add_executor_job(_process_upload)
+        self._keyring = keyring
+        return errors
+
 
 class KNXConfigFlow(KNXCommonFlow, ConfigFlow, domain=DOMAIN):
     """Handle a KNX config flow."""
@@ -648,8 +730,9 @@ class KNXConfigFlow(KNXCommonFlow, ConfigFlow, domain=DOMAIN):
         return KNXOptionsFlow(config_entry)
 
     @callback
-    def finish_flow(self, title: str) -> FlowResult:
+    def finish_flow(self) -> FlowResult:
         """Create the ConfigEntry."""
+        title = self.new_title or f"KNX {self.new_entry_data[CONF_KNX_CONNECTION_TYPE]}"
         return self.async_create_entry(
             title=title,
             data=DEFAULT_ENTRY_DATA | self.new_entry_data,
@@ -673,13 +756,13 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
         super().__init__(initial_data=config_entry.data)  # type: ignore[arg-type]
 
     @callback
-    def finish_flow(self, title: str | None) -> FlowResult:
+    def finish_flow(self) -> FlowResult:
         """Update the ConfigEntry and finish the flow."""
         new_data = DEFAULT_ENTRY_DATA | self.initial_data | self.new_entry_data
         self.hass.config_entries.async_update_entry(
             self.config_entry,
             data=new_data,
-            title=title or UNDEFINED,
+            title=self.new_title or UNDEFINED,
         )
         return self.async_create_entry(title="", data={})
 
@@ -689,7 +772,11 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
         """Manage KNX options."""
         return self.async_show_menu(
             step_id="options_init",
-            menu_options=["connection_type", "communication_settings"],
+            menu_options=[
+                "connection_type",
+                "communication_settings",
+                "knxkeys_upload",
+            ],
         )
 
     async def async_step_communication_settings(
@@ -701,7 +788,7 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
                 state_updater=user_input[CONF_KNX_STATE_UPDATER],
                 rate_limit=user_input[CONF_KNX_RATE_LIMIT],
             )
-            return self.finish_flow(title=None)
+            return self.finish_flow()
 
         data_schema = {
             vol.Required(

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -49,7 +49,6 @@ from .const import (
     CONF_KNX_TUNNELING_TCP_SECURE,
     DEFAULT_ROUTING_IA,
     DOMAIN,
-    KNX_KEYRING_FILENAME,
     KNXConfigEntryData,
 )
 from .schema import ia_validator, ip_v4_validator
@@ -68,6 +67,7 @@ DEFAULT_ENTRY_DATA = KNXConfigEntryData(
 )
 
 CONF_KEYRING_FILE: Final = "knxkeys_file"
+DEFAULT_KNX_KEYRING_FILENAME: Final = "keyfile.knxkeys"
 
 CONF_KNX_TUNNELING_TYPE: Final = "tunneling_type"
 CONF_KNX_TUNNELING_TYPE_LABELS: Final = {
@@ -487,6 +487,7 @@ class KNXCommonFlow(ABC, FlowHandler):
             )
             if not errors and self._keyring:
                 self.new_entry_data |= KNXConfigEntryData(
+                    knxkeys_filename=f"{DOMAIN}/{DEFAULT_KNX_KEYRING_FILENAME}",
                     knxkeys_password=password,
                     backbone_key=None,
                     sync_latency_tolerance=None,
@@ -707,7 +708,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                 else:
                     dest_path = Path(self.hass.config.path(STORAGE_DIR, DOMAIN))
                     dest_path.mkdir(exist_ok=True)
-                    file_path.rename(dest_path / KNX_KEYRING_FILENAME)
+                    file_path.rename(dest_path / DEFAULT_KNX_KEYRING_FILENAME)
             return keyring, errors
 
         keyring, errors = await self.hass.async_add_executor_job(_process_upload)
@@ -718,7 +719,7 @@ class KNXCommonFlow(ABC, FlowHandler):
 class KNXConfigFlow(KNXCommonFlow, ConfigFlow, domain=DOMAIN):
     """Handle a KNX config flow."""
 
-    VERSION = 2
+    VERSION = 1
 
     def __init__(self) -> None:
         """Initialize KNX options flow."""

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -39,6 +39,7 @@ CONF_KNX_TUNNELING_TCP_SECURE: Final = "tunneling_tcp_secure"
 CONF_KNX_LOCAL_IP: Final = "local_ip"
 CONF_KNX_MCAST_GRP: Final = "multicast_group"
 CONF_KNX_MCAST_PORT: Final = "multicast_port"
+CONF_KNX_TUNNEL_ENDPOINT_IA: Final = "tunnel_endpoint_ia"
 
 CONF_KNX_RATE_LIMIT: Final = "rate_limit"
 CONF_KNX_ROUTE_BACK: Final = "route_back"
@@ -89,6 +90,7 @@ class KNXConfigEntryData(TypedDict, total=False):
     rate_limit: int
     host: str
     port: int
+    tunnel_endpoint_ia: str | None
 
     user_id: int | None
     user_password: str | None

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -20,6 +20,8 @@ DOMAIN: Final = "knx"
 # Address is used for configuration and services by the same functions so the key has to match
 KNX_ADDRESS: Final = "address"
 
+KNX_KEYRING_FILENAME: Final = "keyfile.knxkeys"
+
 CONF_INVERT: Final = "invert"
 CONF_KNX_EXPOSE: Final = "expose"
 CONF_KNX_INDIVIDUAL_ADDRESS: Final = "individual_address"

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -20,8 +20,6 @@ DOMAIN: Final = "knx"
 # Address is used for configuration and services by the same functions so the key has to match
 KNX_ADDRESS: Final = "address"
 
-KNX_KEYRING_FILENAME: Final = "keyfile.knxkeys"
-
 CONF_INVERT: Final = "invert"
 CONF_KNX_EXPOSE: Final = "expose"
 CONF_KNX_INDIVIDUAL_ADDRESS: Final = "individual_address"

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,6 +3,7 @@
   "name": "KNX",
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "config_flow": true,
+  "dependencies": ["file_upload"],
   "documentation": "https://www.home-assistant.io/integrations/knx",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -36,20 +36,19 @@
         "title": "KNX IP-Secure",
         "description": "Select how you want to configure KNX/IP Secure.",
         "menu_options": {
-          "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
+          "knxkeys_upload": "Use a `.knxkeys` file containing IP secure keys",
           "secure_tunnel_manual": "Configure IP secure credentials manually",
           "secure_routing_manual": "Configure IP secure backbone key manually"
         }
       },
-      "secure_knxkeys": {
-        "title": "Keyfile",
-        "description": "Please enter the information for your `.knxkeys` file.",
+      "knxkeys_upload": {
+        "title": "Import KNX Keyring",
+        "description": "Please select a `.knxkeys` file to import.",
         "data": {
-          "knxkeys_filename": "The filename of your `.knxkeys` file (including extension)",
+          "knxkeys_file": "Keyring file",
           "knxkeys_password": "The password to decrypt the `.knxkeys` file"
         },
         "data_description": {
-          "knxkeys_filename": "The file is expected to be found in your config directory in `.storage/knx/`.\nIn Home Assistant OS this would be `/config/.storage/knx/`\nExample: `my_project.knxkeys`",
           "knxkeys_password": "This was set when exporting the file from ETS."
         }
       },
@@ -126,7 +125,8 @@
         "title": "KNX Settings",
         "menu_options": {
           "connection_type": "Configure KNX interface",
-          "communication_settings": "Communication settings"
+          "communication_settings": "Communication settings",
+          "knxkeys_upload": "Import a `.knxkeys` file"
         }
       },
       "communication_settings": {
@@ -175,21 +175,20 @@
         "title": "[%key:component::knx::config::step::secure_key_source::title%]",
         "description": "[%key:component::knx::config::step::secure_key_source::description%]",
         "menu_options": {
-          "secure_knxkeys": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_knxkeys%]",
+          "knxkeys_upload": "[%key:component::knx::config::step::secure_key_source::menu_options::knxkeys_upload%]",
           "secure_tunnel_manual": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_tunnel_manual%]",
           "secure_routing_manual": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_routing_manual%]"
         }
       },
-      "secure_knxkeys": {
-        "title": "[%key:component::knx::config::step::secure_knxkeys::title%]",
-        "description": "[%key:component::knx::config::step::secure_knxkeys::description%]",
+      "knxkeys_upload": {
+        "title": "[%key:component::knx::config::step::knxkeys_upload::title%]",
+        "description": "[%key:component::knx::config::step::knxkeys_upload::description%]",
         "data": {
-          "knxkeys_filename": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_filename%]",
-          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_password%]"
+          "knxkeys_file": "[%key:component::knx::config::step::knxkeys_upload::data::knxkeys_file%]",
+          "knxkeys_password": "[%key:component::knx::config::step::knxkeys_upload::data::knxkeys_password%]"
         },
         "data_description": {
-          "knxkeys_filename": "[%key:component::knx::config::step::secure_knxkeys::data_description::knxkeys_filename%]",
-          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data_description::knxkeys_password%]"
+          "knxkeys_password": "[%key:component::knx::config::step::knxkeys_upload::data_description::knxkeys_password%]"
         }
       },
       "knxkeys_tunnel_select": {

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -36,12 +36,12 @@
         "title": "KNX IP-Secure",
         "description": "Select how you want to configure KNX/IP Secure.",
         "menu_options": {
-          "knxkeys_upload": "Use a `.knxkeys` file containing IP secure keys",
+          "secure_knxkeys": "Use a `.knxkeys` file containing IP secure keys",
           "secure_tunnel_manual": "Configure IP secure credentials manually",
           "secure_routing_manual": "Configure IP secure backbone key manually"
         }
       },
-      "knxkeys_upload": {
+      "secure_knxkeys": {
         "title": "Import KNX Keyring",
         "description": "Please select a `.knxkeys` file to import.",
         "data": {
@@ -126,7 +126,7 @@
         "menu_options": {
           "connection_type": "Configure KNX interface",
           "communication_settings": "Communication settings",
-          "knxkeys_upload": "Import a `.knxkeys` file"
+          "secure_knxkeys": "Import a `.knxkeys` file"
         }
       },
       "communication_settings": {
@@ -175,20 +175,20 @@
         "title": "[%key:component::knx::config::step::secure_key_source::title%]",
         "description": "[%key:component::knx::config::step::secure_key_source::description%]",
         "menu_options": {
-          "knxkeys_upload": "[%key:component::knx::config::step::secure_key_source::menu_options::knxkeys_upload%]",
+          "secure_knxkeys": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_knxkeys%]",
           "secure_tunnel_manual": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_tunnel_manual%]",
           "secure_routing_manual": "[%key:component::knx::config::step::secure_key_source::menu_options::secure_routing_manual%]"
         }
       },
-      "knxkeys_upload": {
-        "title": "[%key:component::knx::config::step::knxkeys_upload::title%]",
-        "description": "[%key:component::knx::config::step::knxkeys_upload::description%]",
+      "secure_knxkeys": {
+        "title": "[%key:component::knx::config::step::secure_knxkeys::title%]",
+        "description": "[%key:component::knx::config::step::secure_knxkeys::description%]",
         "data": {
-          "knxkeys_file": "[%key:component::knx::config::step::knxkeys_upload::data::knxkeys_file%]",
-          "knxkeys_password": "[%key:component::knx::config::step::knxkeys_upload::data::knxkeys_password%]"
+          "knxkeys_file": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_file%]",
+          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data::knxkeys_password%]"
         },
         "data_description": {
-          "knxkeys_password": "[%key:component::knx::config::step::knxkeys_upload::data_description::knxkeys_password%]"
+          "knxkeys_password": "[%key:component::knx::config::step::secure_knxkeys::data_description::knxkeys_password%]"
         }
       },
       "knxkeys_tunnel_select": {

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -414,7 +414,7 @@ async def test_routing_secure_keyfile(
     assert routing_secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1073,7 +1073,7 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     assert secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1293,7 +1293,7 @@ async def test_options_flow_secure_manual_to_keyfile(
     assert mock_config_entry.data == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
         CONF_KNX_SECURE_USER_ID: None,
@@ -1389,7 +1389,7 @@ async def test_options_update_keyfile(hass: HomeAssistant, knx_setup) -> None:
     assert not result2.get("data")
     assert mock_config_entry.data == {
         **start_data,
-        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1447,7 +1447,7 @@ async def test_options_keyfile_upload(hass: HomeAssistant, knx_setup) -> None:
     assert not result3.get("data")
     assert mock_config_entry.data == {
         **start_data,
-        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
         CONF_KNX_SECURE_USER_ID: None,

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the KNX config flow."""
+from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from xknx.telegram import IndividualAddress
 
 from homeassistant import config_entries
 from homeassistant.components.knx.config_flow import (
+    CONF_KEYRING_FILE,
     CONF_KNX_GATEWAY,
     CONF_KNX_TUNNELING_TYPE,
     DEFAULT_ENTRY_DATA,
@@ -35,6 +37,7 @@ from homeassistant.components.knx.const import (
     CONF_KNX_SECURE_USER_ID,
     CONF_KNX_SECURE_USER_PASSWORD,
     CONF_KNX_STATE_UPDATER,
+    CONF_KNX_TUNNEL_ENDPOINT_IA,
     CONF_KNX_TUNNELING,
     CONF_KNX_TUNNELING_TCP,
     CONF_KNX_TUNNELING_TCP_SECURE,
@@ -47,6 +50,10 @@ from homeassistant.data_entry_flow import FlowResult, FlowResultType
 from tests.common import MockConfigEntry, get_fixture_path
 
 FIXTURE_KNXKEYS_PASSWORD = "test"
+FIXTURE_KEYRING = sync_load_keyring(
+    get_fixture_path("fixture.knxkeys", DOMAIN), FIXTURE_KNXKEYS_PASSWORD
+)
+FIXTURE_UPLOAD_UUID = "0123456789abcdef0123456789abcdef"
 GATEWAY_INDIVIDUAL_ADDRESS = IndividualAddress("1.0.0")
 
 
@@ -57,6 +64,29 @@ def fixture_knx_setup():
         "homeassistant.components.knx.async_setup_entry", return_value=True
     ) as mock_async_setup_entry:
         yield mock_async_setup_entry
+
+
+@contextmanager
+def patch_file_upload(return_value=FIXTURE_KEYRING, side_effect=None):
+    """Patch file upload. Yields the Keyring instance (return_value)."""
+    with patch(
+        "homeassistant.components.knx.config_flow.process_uploaded_file"
+    ) as file_upload_mock, patch(
+        "homeassistant.components.knx.config_flow.sync_load_keyring",
+        return_value=return_value,
+        side_effect=side_effect,
+    ), patch(
+        "pathlib.Path.mkdir"
+    ) as mkdir_mock:
+        file_path_mock = Mock()
+        file_upload_mock.return_value.__enter__.return_value = file_path_mock
+        yield return_value
+        if side_effect:
+            mkdir_mock.assert_not_called()
+            file_path_mock.rename.assert_not_called()
+        else:
+            mkdir_mock.assert_called_once()
+            file_path_mock.rename.assert_called_once()
 
 
 def _gateway_descriptor(
@@ -153,6 +183,10 @@ async def test_routing_setup(
         CONF_KNX_MCAST_PORT: 3675,
         CONF_KNX_LOCAL_IP: None,
         CONF_KNX_INDIVIDUAL_ADDRESS: "1.1.110",
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
     }
     knx_setup.assert_called_once()
 
@@ -224,6 +258,10 @@ async def test_routing_setup_advanced(
         CONF_KNX_MCAST_PORT: 3675,
         CONF_KNX_LOCAL_IP: "192.168.1.112",
         CONF_KNX_INDIVIDUAL_ADDRESS: "1.1.110",
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
     }
     knx_setup.assert_called_once()
 
@@ -310,6 +348,10 @@ async def test_routing_secure_manual_setup(
         CONF_KNX_ROUTING_BACKBONE_KEY: "bbaacc44bbaacc44bbaacc44bbaacc44",
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: 2000,
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.123",
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
     }
     knx_setup.assert_called_once()
 
@@ -352,35 +394,17 @@ async def test_routing_secure_keyfile(
 
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
+        {"next_step_id": "knxkeys_upload"},
     )
     assert result4["type"] == FlowResultType.FORM
-    assert result4["step_id"] == "secure_knxkeys"
+    assert result4["step_id"] == "knxkeys_upload"
     assert not result4["errors"]
 
-    # test file without backbone key
-    with patch(
-        "homeassistant.components.knx.config_flow.load_keyring"
-    ) as mock_load_keyring:
-        mock_keyring = Mock()
-        mock_keyring.backbone.key = None
-        mock_load_keyring.return_value = mock_keyring
-        secure_knxkeys = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
-                CONF_KNX_KNXKEY_PASSWORD: "password",
-            },
-        )
-        assert secure_knxkeys["type"] == FlowResultType.FORM
-        assert secure_knxkeys["errors"] == {"base": "keyfile_no_backbone_key"}
-
-    # test valid file
-    with patch("homeassistant.components.knx.config_flow.load_keyring"):
+    with patch_file_upload():
         routing_secure_knxkeys = await hass.config_entries.flow.async_configure(
             result4["flow_id"],
             {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
@@ -390,20 +414,20 @@ async def test_routing_secure_keyfile(
     assert routing_secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/testcase.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
         CONF_KNX_SECURE_USER_ID: None,
         CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.123",
     }
     knx_setup.assert_called_once()
 
 
 @pytest.mark.parametrize(
-    ("user_input", "config_entry_data"),
+    ("user_input", "title", "config_entry_data"),
     [
         (
             {
@@ -412,6 +436,7 @@ async def test_routing_secure_keyfile(
                 CONF_PORT: 3675,
                 CONF_KNX_ROUTE_BACK: False,
             },
+            "Tunneling UDP @ 192.168.0.1",
             {
                 **DEFAULT_ENTRY_DATA,
                 CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
@@ -420,6 +445,10 @@ async def test_routing_secure_keyfile(
                 CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
                 CONF_KNX_ROUTE_BACK: False,
                 CONF_KNX_LOCAL_IP: None,
+                CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+                CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+                CONF_KNX_SECURE_USER_ID: None,
+                CONF_KNX_SECURE_USER_PASSWORD: None,
             },
         ),
         (
@@ -429,6 +458,7 @@ async def test_routing_secure_keyfile(
                 CONF_PORT: 3675,
                 CONF_KNX_ROUTE_BACK: False,
             },
+            "Tunneling TCP @ 192.168.0.1",
             {
                 **DEFAULT_ENTRY_DATA,
                 CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP,
@@ -437,6 +467,10 @@ async def test_routing_secure_keyfile(
                 CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
                 CONF_KNX_ROUTE_BACK: False,
                 CONF_KNX_LOCAL_IP: None,
+                CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+                CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+                CONF_KNX_SECURE_USER_ID: None,
+                CONF_KNX_SECURE_USER_PASSWORD: None,
             },
         ),
         (
@@ -446,6 +480,7 @@ async def test_routing_secure_keyfile(
                 CONF_PORT: 3675,
                 CONF_KNX_ROUTE_BACK: True,
             },
+            "Tunneling UDP @ 192.168.0.1",
             {
                 **DEFAULT_ENTRY_DATA,
                 CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
@@ -454,6 +489,10 @@ async def test_routing_secure_keyfile(
                 CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
                 CONF_KNX_ROUTE_BACK: True,
                 CONF_KNX_LOCAL_IP: None,
+                CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+                CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+                CONF_KNX_SECURE_USER_ID: None,
+                CONF_KNX_SECURE_USER_PASSWORD: None,
             },
         ),
     ],
@@ -467,6 +506,7 @@ async def test_tunneling_setup_manual(
     hass: HomeAssistant,
     knx_setup,
     user_input,
+    title,
     config_entry_data,
 ) -> None:
     """Test tunneling if no gateway was found found (or `manual` option was chosen)."""
@@ -502,7 +542,7 @@ async def test_tunneling_setup_manual(
         )
         await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Tunneling @ 192.168.0.1"
+    assert result3["title"] == title
     assert result3["data"] == config_entry_data
     knx_setup.assert_called_once()
 
@@ -631,12 +671,16 @@ async def test_tunneling_setup_manual_request_description_error(
         )
         await hass.async_block_till_done()
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Tunneling @ 192.168.0.1"
+    assert result["title"] == "Tunneling TCP @ 192.168.0.1"
     assert result["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP,
         CONF_HOST: "192.168.0.1",
         CONF_PORT: 3671,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
     }
     knx_setup.assert_called_once()
 
@@ -718,7 +762,7 @@ async def test_tunneling_setup_for_local_ip(
     )
     await hass.async_block_till_done()
     assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Tunneling @ 192.168.0.2"
+    assert result3["title"] == "Tunneling UDP @ 192.168.0.2"
     assert result3["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
@@ -727,6 +771,10 @@ async def test_tunneling_setup_for_local_ip(
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
         CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_LOCAL_IP: "192.168.1.112",
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
     }
     knx_setup.assert_called_once()
 
@@ -771,6 +819,10 @@ async def test_tunneling_setup_for_multiple_found_gateways(
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
         CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_LOCAL_IP: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
     }
     knx_setup.assert_called_once()
 
@@ -848,11 +900,12 @@ async def test_form_with_automatic_connection_handling(
     assert result2["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
     }
     knx_setup.assert_called_once()
 
 
-async def _get_menu_step(hass: HomeAssistant) -> FlowResult:
+async def _get_menu_step_secure_tunnel(hass: HomeAssistant) -> FlowResult:
     """Return flow in secure_tunnelling menu step."""
     gateway = _gateway_descriptor(
         "192.168.0.1",
@@ -950,7 +1003,7 @@ async def test_get_secure_menu_step_manual_tunnelling(
 
 async def test_configure_secure_tunnel_manual(hass: HomeAssistant, knx_setup) -> None:
     """Test configure tunnelling secure keys manually."""
-    menu_step = await _get_menu_step(hass)
+    menu_step = await _get_menu_step_secure_tunnel(hass)
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
@@ -981,33 +1034,28 @@ async def test_configure_secure_tunnel_manual(hass: HomeAssistant, knx_setup) ->
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
         CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_LOCAL_IP: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
     }
     knx_setup.assert_called_once()
 
 
 async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     """Test configure secure knxkeys."""
-    menu_step = await _get_menu_step(hass)
+    menu_step = await _get_menu_step_secure_tunnel(hass)
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
+        {"next_step_id": "knxkeys_upload"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "secure_knxkeys"
+    assert result["step_id"] == "knxkeys_upload"
     assert not result["errors"]
 
-    with patch(
-        "xknx.secure.keyring.sync_load_keyring",
-        return_value=sync_load_keyring(
-            str(get_fixture_path("fixture.knxkeys", DOMAIN).absolute()),
-            FIXTURE_KNXKEYS_PASSWORD,
-        ),
-    ):
+    with patch_file_upload():
         secure_knxkeys = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
                 CONF_KNX_KNXKEY_PASSWORD: "test",
             },
         )
@@ -1016,7 +1064,7 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     assert not result["errors"]
     secure_knxkeys = await hass.config_entries.flow.async_configure(
         secure_knxkeys["flow_id"],
-        {CONF_KNX_SECURE_USER_ID: CONF_KNX_AUTOMATIC},
+        {CONF_KNX_TUNNEL_ENDPOINT_IA: CONF_KNX_AUTOMATIC},
     )
 
     await hass.async_block_till_done()
@@ -1024,13 +1072,13 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     assert secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/testcase.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
         CONF_KNX_SECURE_USER_ID: None,
         CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: None,
         CONF_HOST: "192.168.0.1",
         CONF_PORT: 3675,
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
@@ -1040,54 +1088,25 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     knx_setup.assert_called_once()
 
 
-async def test_configure_secure_knxkeys_file_not_found(hass: HomeAssistant) -> None:
-    """Test configure secure knxkeys but file was not found."""
-    menu_step = await _get_menu_step(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        menu_step["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "secure_knxkeys"
-    assert not result["errors"]
-
-    with patch(
-        "homeassistant.components.knx.config_flow.load_keyring",
-        side_effect=FileNotFoundError(),
-    ):
-        secure_knxkeys = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
-                CONF_KNX_KNXKEY_PASSWORD: "password",
-            },
-        )
-        assert secure_knxkeys["type"] == FlowResultType.FORM
-        assert secure_knxkeys["errors"]
-        assert secure_knxkeys["errors"][CONF_KNX_KNXKEY_FILENAME] == "keyfile_not_found"
-
-
 async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant) -> None:
     """Test configure secure knxkeys but file was not found."""
-    menu_step = await _get_menu_step(hass)
+    menu_step = await _get_menu_step_secure_tunnel(hass)
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
+        {"next_step_id": "knxkeys_upload"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "secure_knxkeys"
+    assert result["step_id"] == "knxkeys_upload"
     assert not result["errors"]
 
-    with patch(
-        "homeassistant.components.knx.config_flow.load_keyring",
+    with patch_file_upload(
         side_effect=InvalidSecureConfiguration(),
     ):
         secure_knxkeys = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
@@ -1101,26 +1120,22 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant) -
 
 async def test_configure_secure_knxkeys_no_tunnel_for_host(hass: HomeAssistant) -> None:
     """Test configure secure knxkeys but file was not found."""
-    menu_step = await _get_menu_step(hass)
+    menu_step = await _get_menu_step_secure_tunnel(hass)
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
+        {"next_step_id": "knxkeys_upload"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "secure_knxkeys"
+    assert result["step_id"] == "knxkeys_upload"
     assert not result["errors"]
 
-    with patch(
-        "homeassistant.components.knx.config_flow.load_keyring"
-    ) as mock_load_keyring:
-        mock_keyring = Mock()
+    with patch_file_upload(return_value=Mock()) as mock_keyring:
         mock_keyring.get_tunnel_interfaces_by_host.return_value = []
-        mock_load_keyring.return_value = mock_keyring
         secure_knxkeys = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
         )
@@ -1180,6 +1195,10 @@ async def test_options_flow_connection_type(
             CONF_KNX_RATE_LIMIT: 0,
             CONF_KNX_STATE_UPDATER: CONF_KNX_DEFAULT_STATE_UPDATER,
             CONF_KNX_ROUTE_BACK: False,
+            CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+            CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+            CONF_KNX_SECURE_USER_ID: None,
+            CONF_KNX_SECURE_USER_PASSWORD: None,
         }
 
 
@@ -1245,23 +1264,17 @@ async def test_options_flow_secure_manual_to_keyfile(
 
     result4 = await hass.config_entries.options.async_configure(
         result3["flow_id"],
-        {"next_step_id": "secure_knxkeys"},
+        {"next_step_id": "knxkeys_upload"},
     )
     assert result4["type"] == FlowResultType.FORM
-    assert result4["step_id"] == "secure_knxkeys"
+    assert result4["step_id"] == "knxkeys_upload"
     assert not result4["errors"]
 
-    with patch(
-        "xknx.secure.keyring.sync_load_keyring",
-        return_value=sync_load_keyring(
-            str(get_fixture_path("fixture.knxkeys", DOMAIN).absolute()),
-            FIXTURE_KNXKEYS_PASSWORD,
-        ),
-    ):
+    with patch_file_upload():
         secure_knxkeys = await hass.config_entries.options.async_configure(
             result4["flow_id"],
             {
-                CONF_KNX_KNXKEY_FILENAME: "testcase.knxkeys",
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
                 CONF_KNX_KNXKEY_PASSWORD: "test",
             },
         )
@@ -1270,7 +1283,7 @@ async def test_options_flow_secure_manual_to_keyfile(
     assert not result["errors"]
     secure_knxkeys = await hass.config_entries.options.async_configure(
         secure_knxkeys["flow_id"],
-        {CONF_KNX_SECURE_USER_ID: "2"},
+        {CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1"},
     )
 
     await hass.async_block_till_done()
@@ -1281,8 +1294,9 @@ async def test_options_flow_secure_manual_to_keyfile(
         CONF_KNX_KNXKEY_FILENAME: "knx/testcase.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
-        CONF_KNX_SECURE_USER_ID: 2,
+        CONF_KNX_SECURE_USER_ID: None,
         CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
         CONF_HOST: "192.168.0.1",
@@ -1324,5 +1338,118 @@ async def test_options_communication_settings(
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
         CONF_KNX_STATE_UPDATER: False,
         CONF_KNX_RATE_LIMIT: 40,
+    }
+    knx_setup.assert_called_once()
+
+
+async def test_options_update_keyfile(hass: HomeAssistant, knx_setup) -> None:
+    """Test options flow updating keyfile when tunnel endpoint is already configured."""
+    start_data = {
+        **DEFAULT_ENTRY_DATA,
+        CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
+        CONF_KNX_SECURE_USER_ID: 2,
+        CONF_KNX_SECURE_USER_PASSWORD: "password",
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: "device_auth",
+        CONF_KNX_KNXKEY_PASSWORD: "old_password",
+        CONF_HOST: "192.168.0.1",
+        CONF_PORT: 3675,
+        CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
+        CONF_KNX_ROUTE_BACK: False,
+        CONF_KNX_LOCAL_IP: None,
+        CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
+    }
+    mock_config_entry = MockConfigEntry(
+        title="KNX",
+        domain="knx",
+        data=start_data,
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    menu_step = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_configure(
+        menu_step["flow_id"],
+        {"next_step_id": "knxkeys_upload"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "knxkeys_upload"
+
+    with patch_file_upload():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
+                CONF_KNX_KNXKEY_PASSWORD: "password",
+            },
+        )
+        await hass.async_block_till_done()
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert not result2.get("data")
+    assert mock_config_entry.data == {
+        **start_data,
+        CONF_KNX_KNXKEY_PASSWORD: "password",
+        CONF_KNX_ROUTING_BACKBONE_KEY: None,
+        CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
+    }
+    knx_setup.assert_called_once()
+
+
+async def test_options_keyfile_upload(hass: HomeAssistant, knx_setup) -> None:
+    """Test options flow uploading a keyfile for the first time."""
+    start_data = {
+        **DEFAULT_ENTRY_DATA,
+        CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP,
+        CONF_HOST: "192.168.0.1",
+        CONF_PORT: 3675,
+        CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
+        CONF_KNX_ROUTE_BACK: False,
+        CONF_KNX_LOCAL_IP: None,
+    }
+    mock_config_entry = MockConfigEntry(
+        title="KNX",
+        domain="knx",
+        data=start_data,
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    menu_step = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_configure(
+        menu_step["flow_id"],
+        {"next_step_id": "knxkeys_upload"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "knxkeys_upload"
+
+    with patch_file_upload():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_KEYRING_FILE: FIXTURE_UPLOAD_UUID,
+                CONF_KNX_KNXKEY_PASSWORD: "password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "knxkeys_tunnel_select"
+
+    result3 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert not result3.get("data")
+    assert mock_config_entry.data == {
+        **start_data,
+        CONF_KNX_KNXKEY_PASSWORD: "password",
+        CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
+        CONF_KNX_SECURE_USER_ID: None,
+        CONF_KNX_SECURE_USER_PASSWORD: None,
+        CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
+        CONF_KNX_ROUTING_BACKBONE_KEY: None,
+        CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
     }
     knx_setup.assert_called_once()

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -414,6 +414,7 @@ async def test_routing_secure_keyfile(
     assert routing_secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_ROUTING_SECURE,
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1072,6 +1073,7 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
     assert secure_knxkeys["data"] == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1291,7 +1293,7 @@ async def test_options_flow_secure_manual_to_keyfile(
     assert mock_config_entry.data == {
         **DEFAULT_ENTRY_DATA,
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
-        CONF_KNX_KNXKEY_FILENAME: "knx/testcase.knxkeys",
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "test",
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
         CONF_KNX_SECURE_USER_ID: None,
@@ -1387,6 +1389,7 @@ async def test_options_update_keyfile(hass: HomeAssistant, knx_setup) -> None:
     assert not result2.get("data")
     assert mock_config_entry.data == {
         **start_data,
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_ROUTING_BACKBONE_KEY: None,
         CONF_KNX_ROUTING_SYNC_LATENCY_TOLERANCE: None,
@@ -1444,6 +1447,7 @@ async def test_options_keyfile_upload(hass: HomeAssistant, knx_setup) -> None:
     assert not result3.get("data")
     assert mock_config_entry.data == {
         **start_data,
+        CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
         CONF_KNX_KNXKEY_PASSWORD: "password",
         CONF_KNX_TUNNEL_ENDPOINT_IA: "1.0.1",
         CONF_KNX_SECURE_USER_ID: None,

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -394,10 +394,10 @@ async def test_routing_secure_keyfile(
 
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result4["type"] == FlowResultType.FORM
-    assert result4["step_id"] == "knxkeys_upload"
+    assert result4["step_id"] == "secure_knxkeys"
     assert not result4["errors"]
 
     with patch_file_upload():
@@ -1046,10 +1046,10 @@ async def test_configure_secure_knxkeys(hass: HomeAssistant, knx_setup) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "knxkeys_upload"
+    assert result["step_id"] == "secure_knxkeys"
     assert not result["errors"]
 
     with patch_file_upload():
@@ -1096,10 +1096,10 @@ async def test_configure_secure_knxkeys_invalid_signature(hass: HomeAssistant) -
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "knxkeys_upload"
+    assert result["step_id"] == "secure_knxkeys"
     assert not result["errors"]
 
     with patch_file_upload(
@@ -1126,10 +1126,10 @@ async def test_configure_secure_knxkeys_no_tunnel_for_host(hass: HomeAssistant) 
 
     result = await hass.config_entries.flow.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "knxkeys_upload"
+    assert result["step_id"] == "secure_knxkeys"
     assert not result["errors"]
 
     with patch_file_upload(return_value=Mock()) as mock_keyring:
@@ -1266,10 +1266,10 @@ async def test_options_flow_secure_manual_to_keyfile(
 
     result4 = await hass.config_entries.options.async_configure(
         result3["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result4["type"] == FlowResultType.FORM
-    assert result4["step_id"] == "knxkeys_upload"
+    assert result4["step_id"] == "secure_knxkeys"
     assert not result4["errors"]
 
     with patch_file_upload():
@@ -1371,10 +1371,10 @@ async def test_options_update_keyfile(hass: HomeAssistant, knx_setup) -> None:
 
     result = await hass.config_entries.options.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "knxkeys_upload"
+    assert result["step_id"] == "secure_knxkeys"
 
     with patch_file_upload():
         result2 = await hass.config_entries.options.async_configure(
@@ -1419,10 +1419,10 @@ async def test_options_keyfile_upload(hass: HomeAssistant, knx_setup) -> None:
 
     result = await hass.config_entries.options.async_configure(
         menu_step["flow_id"],
-        {"next_step_id": "knxkeys_upload"},
+        {"next_step_id": "secure_knxkeys"},
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "knxkeys_upload"
+    assert result["step_id"] == "secure_knxkeys"
 
     with patch_file_upload():
         result2 = await hass.config_entries.options.async_configure(

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -113,7 +113,7 @@ from tests.common import MockConfigEntry
                 CONF_KNX_MCAST_PORT: DEFAULT_MCAST_PORT,
                 CONF_KNX_MCAST_GRP: DEFAULT_MCAST_GRP,
                 CONF_KNX_INDIVIDUAL_ADDRESS: DEFAULT_ROUTING_IA,
-                CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+                CONF_KNX_KNXKEY_FILENAME: "knx/keyring.knxkeys",
                 CONF_KNX_KNXKEY_PASSWORD: "password",
             },
             ConnectionConfig(
@@ -122,7 +122,7 @@ from tests.common import MockConfigEntry
                 gateway_port=3675,
                 auto_reconnect=True,
                 secure_config=SecureConfig(
-                    knxkeys_file_path="keyfile.knxkeys", knxkeys_password="password"
+                    knxkeys_file_path="keyring.knxkeys", knxkeys_password="password"
                 ),
                 threaded=True,
             ),

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -1,6 +1,4 @@
 """Test KNX init."""
-from unittest.mock import patch
-
 import pytest
 from xknx.io import (
     DEFAULT_MCAST_GRP,
@@ -10,7 +8,6 @@ from xknx.io import (
     SecureConfig,
 )
 
-from homeassistant.components.knx import async_migrate_entry
 from homeassistant.components.knx.config_flow import DEFAULT_ROUTING_IA
 from homeassistant.components.knx.const import (
     CONF_KNX_AUTOMATIC,
@@ -113,12 +110,17 @@ from tests.common import MockConfigEntry
                 CONF_KNX_MCAST_PORT: DEFAULT_MCAST_PORT,
                 CONF_KNX_MCAST_GRP: DEFAULT_MCAST_GRP,
                 CONF_KNX_INDIVIDUAL_ADDRESS: DEFAULT_ROUTING_IA,
+                CONF_KNX_KNXKEY_FILENAME: "knx/keyfile.knxkeys",
+                CONF_KNX_KNXKEY_PASSWORD: "password",
             },
             ConnectionConfig(
                 connection_type=ConnectionType.TUNNELING_TCP,
                 gateway_ip="192.168.0.2",
                 gateway_port=3675,
                 auto_reconnect=True,
+                secure_config=SecureConfig(
+                    knxkeys_file_path="keyfile.knxkeys", knxkeys_password="password"
+                ),
                 threaded=True,
             ),
         ),
@@ -247,51 +249,10 @@ async def test_init_connection_handling(
             .secure_config.device_authentication_password
             == connection_config.secure_config.device_authentication_password
         )
-
-
-@pytest.mark.parametrize(
-    "config_entry_data",
-    [
-        {
-            CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
-            CONF_KNX_RATE_LIMIT: CONF_KNX_DEFAULT_RATE_LIMIT,
-            CONF_KNX_STATE_UPDATER: CONF_KNX_DEFAULT_STATE_UPDATER,
-            CONF_KNX_MCAST_PORT: DEFAULT_MCAST_PORT,
-            CONF_KNX_MCAST_GRP: DEFAULT_MCAST_GRP,
-            CONF_KNX_INDIVIDUAL_ADDRESS: DEFAULT_ROUTING_IA,
-        },
-        {
-            CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING_TCP_SECURE,
-            CONF_KNX_SECURE_USER_ID: 2,
-            CONF_KNX_SECURE_USER_PASSWORD: "password",
-            CONF_KNX_SECURE_DEVICE_AUTHENTICATION: "device_auth",
-            CONF_KNX_KNXKEY_FILENAME: "knx/testcase.knxkeys",
-            CONF_KNX_KNXKEY_PASSWORD: "password",
-            CONF_HOST: "192.168.0.1",
-            CONF_PORT: 3675,
-            CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
-            CONF_KNX_ROUTE_BACK: False,
-            CONF_KNX_LOCAL_IP: None,
-        },
-    ],
-)
-async def test_config_entry_migration(
-    hass: HomeAssistant,
-    config_entry_data: KNXConfigEntryData,
-):
-    """Test config entry migration."""
-    mock_config_entry = MockConfigEntry(
-        title="KNX",
-        domain=KNX_DOMAIN,
-        data=config_entry_data,
-        version=1,
-    )
-    keyfile_to_move = CONF_KNX_KNXKEY_FILENAME in config_entry_data
-    with patch("pathlib.Path.mkdir") as mkdir_mock, patch(
-        "pathlib.Path.rename"
-    ) as rename_mock:
-        await async_migrate_entry(hass, mock_config_entry)
-        assert mkdir_mock.call_count == keyfile_to_move
-        assert rename_mock.call_count == keyfile_to_move
-    assert mock_config_entry.version == 2
-    assert CONF_KNX_KNXKEY_FILENAME not in mock_config_entry.data
+        if connection_config.secure_config.knxkeys_file_path is not None:
+            assert (
+                connection_config.secure_config.knxkeys_file_path
+                in hass.data[KNX_DOMAIN]
+                .connection_config()
+                .secure_config.knxkeys_file_path
+            )

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -276,12 +276,12 @@ async def test_async_remove_entry(
     knx.mock_config_entry = config_entry
     await knx.setup_integration({})
 
-    with patch("pathlib.Path.exists", return_value=True) as exists_mock, patch(
-        "pathlib.Path.unlink"
-    ) as unlink_mock:
+    with patch("pathlib.Path.unlink") as unlink_mock, patch(
+        "pathlib.Path.rmdir"
+    ) as rmdir_mock:
         assert await hass.config_entries.async_remove(config_entry.entry_id)
-        exists_mock.assert_called_once()
         unlink_mock.assert_called_once()
+        rmdir_mock.assert_called_once()
     await hass.async_block_till_done()
 
     assert hass.config_entries.async_entries() == []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upload KNX Keyfile from Config/Options Flow directly

Previously we asked users to store it in `<config>/.storage/knx/` and configure the filename. Now we make use of the `file_upload` integration in our flow to make that easier.
It's also possible to update (replace) the keyfile from the options flow so new keys can be provided without changing connections settings. This is especially useful for Data Secure.

The uploaded file will be deleted when the integration (config entry) is removed.

### Release note hints

> KNX Data Secure is now supported. 

Depending on how long the text shall be this could also be added:
>Assign your GAs to the interface used by HA and export a Keyring file from ETS to start using it. 

Support was actually added with a dependency upgrade #87502 - here are the needed steps to make use of it. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26269

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
