### PR TITLE
Update orjson to resolve segmentation fault during JSON serialisation

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -30,7 +30,7 @@ ifaddr==0.1.7
 janus==1.0.0
 jinja2==3.1.2
 lru-dict==1.1.8
-orjson==3.8.5
+orjson==3.8.6
 paho-mqtt==1.6.1
 pillow==9.4.0
 pip>=21.0,<23.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies    = [
     "cryptography==39.0.1",
     # pyOpenSSL 23.0.0 is required to work with cryptography 39+
     "pyOpenSSL==23.0.0",
-    "orjson==3.8.5",
+    "orjson==3.8.6",
     "pip>=21.0,<23.1",
     "python-slugify==4.0.1",
     "pyyaml==6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ lru-dict==1.1.8
 PyJWT==2.5.0
 cryptography==39.0.1
 pyOpenSSL==23.0.0
-orjson==3.8.5
+orjson==3.8.6
 pip>=21.0,<23.1
 python-slugify==4.0.1
 pyyaml==6.0


### PR DESCRIPTION
Home Assistant uses orjson 3.8.5 that contains an issue[1] on musl libc platforms that causes a segmentation fault.  This particularly affect Home Assistant container installations and is reported in #87283 and #87522.

This updates the version to 3.8.6 that resolves the segmentation fault during json serialisation.

orjson changelog - https://github.com/ijl/orjson/releases/tag/3.8.6

[1] https://github.com/ijl/orjson/issues/335

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the orison library dependancy to 3.8.6 that has a single fix for a segmentation fault on muse libc based installations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #87283 & #87522
- Please consider this change for stable as it makes 2023.02.x unusable for some installations.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ X] The code change is tested and works locally.
- [ X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ X] There is no commented out code in this PR.
- [ X] I have followed the [development checklist][dev-checklist]
- [ X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
