### PR TITLE
Fix apprise tests for python 3.11

### DIFF
--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -15,7 +15,10 @@ async def test_apprise_config_load_fail01(hass: HomeAssistant) -> None:
         BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": "/path/"}
     }
 
-    with patch("apprise.AppriseConfig.add", return_value=False):
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.AppriseConfig.add",
+        return_value=False,
+    ):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
 
@@ -30,8 +33,12 @@ async def test_apprise_config_load_fail02(hass: HomeAssistant) -> None:
         BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": "/path/"}
     }
 
-    with patch("apprise.Apprise.add", return_value=False), patch(
-        "apprise.AppriseConfig.add", return_value=True
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise.add",
+        return_value=False,
+    ), patch(
+        "homeassistant.components.apprise.notify.apprise.AppriseConfig.add",
+        return_value=True,
     ):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
@@ -68,7 +75,10 @@ async def test_apprise_url_load_fail(hass: HomeAssistant) -> None:
             "url": "mailto://user:pass@example.com",
         }
     }
-    with patch("apprise.Apprise.add", return_value=False):
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise.add",
+        return_value=False,
+    ):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
 
@@ -90,7 +100,9 @@ async def test_apprise_notification(hass: HomeAssistant) -> None:
     # Our Message
     data = {"title": "Test Title", "message": "Test Message"}
 
-    with patch("apprise.Apprise") as mock_apprise:
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise"
+    ) as mock_apprise:
         obj = MagicMock()
         obj.add.return_value = True
         obj.notify.return_value = True
@@ -131,7 +143,9 @@ async def test_apprise_notification_with_target(
     # Our Message, only notify the services tagged with "devops"
     data = {"title": "Test Title", "message": "Test Message", "target": ["devops"]}
 
-    with patch("apprise.Apprise") as mock_apprise:
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise"
+    ) as mock_apprise:
         apprise_obj = MagicMock()
         apprise_obj.add.return_value = True
         apprise_obj.notify.return_value = True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The patch targets were trying to patch a file with an object of the same name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
