### PR TITLE
Lock entity options

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     STATE_UNLOCKED,
     STATE_UNLOCKING,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -39,6 +39,7 @@ from homeassistant.helpers.typing import ConfigType, StateType
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANGED_BY = "changed_by"
+CONF_DEFAULT_CODE = "default_code"
 
 DOMAIN = "lock"
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -88,7 +89,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Lock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
+    code: str = service_call.data.get(
+        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
+    )
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
@@ -98,7 +101,9 @@ async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
     """Unlock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
+    code: str = service_call.data.get(
+        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
+    )
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for unlocking {entity.entity_id} doesn't match pattern {entity.code_format}"
@@ -108,7 +113,9 @@ async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
 
 async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
     """Open the door latch."""
-    code: str = service_call.data.get(ATTR_CODE, "")
+    code: str = service_call.data.get(
+        ATTR_CODE, entity._lock_option_default_code  # pylint: disable=protected-access
+    )
     if entity.code_format_cmp and not entity.code_format_cmp.match(code):
         raise ValueError(
             f"Code '{code}' for opening {entity.entity_id} doesn't match pattern {entity.code_format}"
@@ -145,6 +152,7 @@ class LockEntity(Entity):
     _attr_is_jammed: bool | None = None
     _attr_state: None = None
     _attr_supported_features: LockEntityFeature = LockEntityFeature(0)
+    _lock_option_default_code: str | None = None
     __code_format_cmp: re.Pattern[str] | None = None
 
     @property
@@ -243,3 +251,18 @@ class LockEntity(Entity):
     def supported_features(self) -> LockEntityFeature:
         """Return the list of supported features."""
         return self._attr_supported_features
+
+    @callback
+    def async_registry_entry_updated(self) -> None:
+        """Run when the entity registry entry has been updated."""
+        assert self.registry_entry
+        if (lock_options := self.registry_entry.options.get(DOMAIN)) and (
+            custom_default_lock_code := lock_options.get(CONF_DEFAULT_CODE)
+        ):
+            if self.code_format_cmp and self.code_format_cmp.match(
+                custom_default_lock_code
+            ):
+                self._lock_option_default_code = custom_default_lock_code
+            return
+
+        self._lock_option_default_code = None

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -152,7 +152,7 @@ class LockEntity(Entity):
     _attr_is_jammed: bool | None = None
     _attr_state: None = None
     _attr_supported_features: LockEntityFeature = LockEntityFeature(0)
-    _lock_option_default_code: str | None = None
+    _lock_option_default_code: str = ""
     __code_format_cmp: re.Pattern[str] | None = None
 
     @property
@@ -265,4 +265,4 @@ class LockEntity(Entity):
                 self._lock_option_default_code = custom_default_lock_code
             return
 
-        self._lock_option_default_code = None
+        self._lock_option_default_code = ""

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -252,9 +252,25 @@ class LockEntity(Entity):
         """Return the list of supported features."""
         return self._attr_supported_features
 
+    async def async_internal_added_to_hass(self) -> None:
+        """Call when the sensor entity is added to hass."""
+        await super().async_internal_added_to_hass()
+        if not self.registry_entry:
+            return
+        self._async_read_entity_options()
+
     @callback
     def async_registry_entry_updated(self) -> None:
         """Run when the entity registry entry has been updated."""
+        self._async_read_entity_options()
+
+    @callback
+    def _async_read_entity_options(self) -> None:
+        """Read entity options from entity registry.
+
+        Called when the entity registry entry has been updated and before the lock is
+        added to the state machine.
+        """
         assert self.registry_entry
         if (lock_options := self.registry_entry.options.get(DOMAIN)) and (
             custom_default_lock_code := lock_options.get(CONF_DEFAULT_CODE)

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -64,7 +64,6 @@ class MockLockEntity(LockEntity):
     @callback
     def async_registry_entry_updated(self) -> None:
         """Run when the entity registry entry has been updated."""
-        self._lock_option_default_code = self._lock_option_default_code
 
 
 async def test_lock_default(hass: HomeAssistant) -> None:

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -32,7 +32,7 @@ class MockLockEntity(LockEntity):
     def __init__(
         self,
         code_format: str | None = None,
-        lock_option_default_code: str | None = None,
+        lock_option_default_code: str = "",
         supported_features: LockEntityFeature = LockEntityFeature(0),
     ) -> None:
         """Initialize mock lock entity."""
@@ -40,7 +40,7 @@ class MockLockEntity(LockEntity):
         self.calls_open = MagicMock()
         if code_format is not None:
             self._attr_code_format = code_format
-        self.lock_option_default_code = lock_option_default_code
+        self._lock_option_default_code = lock_option_default_code
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
@@ -59,7 +59,7 @@ class MockLockEntity(LockEntity):
     @callback
     def async_registry_entry_updated(self) -> None:
         """Run when the entity registry entry has been updated."""
-        self._lock_option_default_code = self.lock_option_default_code
+        self._lock_option_default_code = self._lock_option_default_code
 
 
 async def test_lock_default(hass: HomeAssistant) -> None:
@@ -169,11 +169,8 @@ async def test_lock_with_default_code(hass: HomeAssistant) -> None:
     lock.hass = hass
 
     assert lock.state_attributes == {"code_format": r"^\d{4}$"}
+    assert lock._lock_option_default_code == "1234"
 
     await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {}))
     await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {}))
     await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {}))
-
-    await _async_open(lock, ServiceCall(DOMAIN, SERVICE_OPEN, {ATTR_CODE: ""}))
-    await _async_lock(lock, ServiceCall(DOMAIN, SERVICE_LOCK, {ATTR_CODE: ""}))
-    await _async_unlock(lock, ServiceCall(DOMAIN, SERVICE_UNLOCK, {ATTR_CODE: ""}))

--- a/tests/testing_config/custom_components/test/lock.py
+++ b/tests/testing_config/custom_components/test/lock.py
@@ -44,6 +44,11 @@ class MockLock(MockEntity, LockEntity):
     """Mock Lock class."""
 
     @property
+    def code_format(self) -> str | None:
+        """Return code format."""
+        return self._handle("code_format")
+
+    @property
     def is_locked(self):
         """Return true if the lock is locked."""
         return self._handle("is_locked")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity option to `lock` for providing a default `code`
As described in https://github.com/home-assistant/architecture/discussions/870
Frontend PR: https://github.com/home-assistant/frontend/pull/16344

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
