### PR TITLE
Account for changed python3.11 enum.IntFlag 0 behavior in zha

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -443,7 +443,7 @@ class SmartEnergyMetering(Sensor):
             attrs["device_type"] = self._channel.device_type
         if (status := self._channel.status) is not None:
             if isinstance(status, enum.IntFlag):
-                attrs["status"] = str(status.name)
+                attrs["status"] = str(status).split(".", 1)[-1]
             else:
                 attrs["status"] = str(status)[len(status.__class__.__name__) + 1 :]
         return attrs

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import enum
 import functools
 import numbers
+import sys
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self
@@ -442,8 +443,10 @@ class SmartEnergyMetering(Sensor):
         if self._channel.device_type is not None:
             attrs["device_type"] = self._channel.device_type
         if (status := self._channel.status) is not None:
-            if isinstance(status, enum.IntFlag):
-                attrs["status"] = str(status).split(".", 1)[-1]
+            if isinstance(status, enum.IntFlag) and sys.version_info >= (3, 11):
+                attrs["status"] = str(
+                    status.name if status.name is not None else status.value
+                )
             else:
                 attrs["status"] = str(status)[len(status.__class__.__name__) + 1 :]
         return attrs

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -442,7 +442,10 @@ class SmartEnergyMetering(Sensor):
         if self._channel.device_type is not None:
             attrs["device_type"] = self._channel.device_type
         if (status := self._channel.status) is not None:
-            attrs["status"] = str(status)[len(status.__class__.__name__) + 1 :]
+            if isinstance(status, enum.IntFlag):
+                attrs["status"] = str(status.name)
+            else:
+                attrs["status"] = str(status)[len(status.__class__.__name__) + 1 :]
         return attrs
 
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -139,16 +139,16 @@ async def async_test_metering(hass, cluster, entity_id):
 
     await send_attributes_report(hass, cluster, {1024: 12346, "status": 64 + 8})
     assert_state(hass, entity_id, "12346.0", None)
-    assert (
-        hass.states.get(entity_id).attributes["status"]
-        == "SERVICE_DISCONNECT|POWER_FAILURE"
+    assert hass.states.get(entity_id).attributes["status"] in (
+        "SERVICE_DISCONNECT|POWER_FAILURE",
+        "POWER_FAILURE|SERVICE_DISCONNECT",
     )
 
     await send_attributes_report(
         hass, cluster, {"status": 32, "metering_device_type": 1}
     )
     # currently only statuses for electric meters are supported
-    assert hass.states.get(entity_id).attributes["status"] == "<bitmap8.32: 32>"
+    assert hass.states.get(entity_id).attributes["status"] in ("<bitmap8.32: 32>", "32")
 
 
 async def async_test_smart_energy_summation(hass, cluster, entity_id):


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There may be additional changes needed, but I could only see what needed to be updated based on the tests


Broken due to a change in behavior in IntFlag enum

This change is by design. see https://github.com/python/cpython/issues/98976
```
(venv) home-assistant % python3.10 intflag_py311.py 
DeviceStatusDefault.NO_ALARMS
(venv) home-assistant % python3.11 intflag_py311.py 
0
(venv) home-assistant % cat intflag_py311.py 
import enum

class DeviceStatusDefault(enum.IntFlag):
    """Metering Device Status."""

    NO_ALARMS = 0

print(str(DeviceStatusDefault(0))
```

```
FAILED tests/components/zha/test_sensor.py::test_sensor[zha_device_joined-1794-instantaneous_demand-async_test_metering-9-read_plug4-unsupported_attrs4] - AssertionError: assert '' == 'NO_ALARMS'
FAILED tests/components/zha/test_sensor.py::test_sensor[zha_device_joined-1794-summation_delivered-async_test_smart_energy_summation-9-read_plug5-unsupported_attrs5] - AssertionError: assert '' == 'NO_ALARMS'
FAILED tests/components/zha/test_sensor.py::test_sensor[zha_device_restored-1794-instantaneous_demand-async_test_metering-9-read_plug4-unsupported_attrs4] - AssertionError: assert '' == 'NO_ALARMS'
FAILED tests/components/zha/test_sensor.py::test_sensor[zha_device_restored-1794-summation_delivered-async_test_smart_energy_summation-9-read_plug5-unsupported_attrs5] - AssertionError: assert '' == 'NO_ALARMS'

Results (30.12s):
     849 passed
       4 failed
         - tests/components/zha/test_sensor.py:273 test_sensor[zha_device_joined-1794-instantaneous_demand-async_test_metering-9-read_plug4-unsupported_attrs4]
         - tests/components/zha/test_sensor.py:273 test_sensor[zha_device_joined-1794-summation_delivered-async_test_smart_energy_summation-9-read_plug5-unsupported_attrs5]
         - tests/components/zha/test_sensor.py:273 test_sensor[zha_device_restored-1794-instantaneous_demand-async_test_metering-9-read_plug4-unsupported_attrs4]
         - tests/components/zha/test_sensor.py:273 test_sensor[zha_device_restored-1794-summation_delivered-async_test_smart_energy_summation-9-read_plug5-unsupported_attrs5]
       4 skipped
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
