### PR TITLE
Add type hints to integration tests (part 17)

### DIFF
--- a/tests/components/picnic/test_config_flow.py
+++ b/tests/components/picnic/test_config_flow.py
@@ -34,7 +34,7 @@ def picnic_api():
         yield picnic_mock
 
 
-async def test_form(hass, picnic_api):
+async def test_form(hass: HomeAssistant, picnic_api) -> None:
     """Test we get the form and a config entry is created."""
 
     result = await hass.config_entries.flow.async_init(
@@ -136,7 +136,7 @@ async def test_form_exception(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_configured(hass, picnic_api):
+async def test_form_already_configured(hass: HomeAssistant, picnic_api) -> None:
     """Test that an entry with unique id can only be added once."""
     # Create a mocked config entry and make sure to use the same user_id as set for the picnic_api mock response.
     MockConfigEntry(
@@ -163,7 +163,7 @@ async def test_form_already_configured(hass, picnic_api):
     assert result_configure["reason"] == "already_configured"
 
 
-async def test_step_reauth(hass, picnic_api):
+async def test_step_reauth(hass: HomeAssistant, picnic_api) -> None:
     """Test the re-auth flow."""
     # Create a mocked config entry
     conf = {CONF_ACCESS_TOKEN: "a3p98fsen.a39p3fap", CONF_COUNTRY_CODE: "NL"}
@@ -242,7 +242,7 @@ async def test_step_reauth_failed(hass: HomeAssistant) -> None:
     assert len(hass.config_entries.async_entries()) == 1
 
 
-async def test_step_reauth_different_account(hass, picnic_api):
+async def test_step_reauth_different_account(hass: HomeAssistant, picnic_api) -> None:
     """Test the re-auth flow when authentication is done with a different account."""
     # Create a mocked config entry, unique_id should be different that the user id in the api response
     conf = {CONF_ACCESS_TOKEN: "a3p98fsen.a39p3fap", CONF_COUNTRY_CODE: "NL"}

--- a/tests/components/picnic/test_services.py
+++ b/tests/components/picnic/test_services.py
@@ -71,7 +71,7 @@ async def test_add_product_using_id(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product by id."""
     await hass.services.async_call(
         DOMAIN,
@@ -92,7 +92,7 @@ async def test_add_product_using_name(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product by name."""
 
     # Set the return value of the search api endpoint
@@ -130,7 +130,7 @@ async def test_add_product_using_name_no_results(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product by name that can't be found."""
 
     # Set the search return value and check that the right exception is raised during the service call
@@ -151,7 +151,7 @@ async def test_add_product_using_name_no_named_results(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product by name for which no named results are returned."""
 
     # Set the search return value and check that the right exception is raised during the service call
@@ -172,7 +172,7 @@ async def test_add_product_multiple_config_entries(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product for a specific Picnic service while multiple are configured."""
     with patch(
         "homeassistant.components.picnic.create_picnic_client"
@@ -197,7 +197,7 @@ async def test_add_product_device_doesnt_exist(
     hass: HomeAssistant,
     picnic_api_client: MagicMock,
     picnic_config_entry: MockConfigEntry,
-):
+) -> None:
     """Test adding a product for a specific Picnic service, which doesn't exist."""
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -63,7 +63,7 @@ class PilightDaemonSim:
 
 
 @patch("homeassistant.components.pilight._LOGGER.error")
-async def test_connection_failed_error(mock_error, hass):
+async def test_connection_failed_error(mock_error, hass: HomeAssistant) -> None:
     """Try to connect at 127.0.0.1:5001 with socket error."""
     with assert_setup_component(4), patch(
         "pilight.pilight.Client", side_effect=socket.error
@@ -78,7 +78,7 @@ async def test_connection_failed_error(mock_error, hass):
 
 
 @patch("homeassistant.components.pilight._LOGGER.error")
-async def test_connection_timeout_error(mock_error, hass):
+async def test_connection_timeout_error(mock_error, hass: HomeAssistant) -> None:
     """Try to connect at 127.0.0.1:5001 with socket timeout."""
     with assert_setup_component(4), patch(
         "pilight.pilight.Client", side_effect=socket.timeout
@@ -114,7 +114,7 @@ async def test_send_code_no_protocol(hass: HomeAssistant) -> None:
 @patch("homeassistant.components.pilight._LOGGER.error")
 @patch("homeassistant.components.pilight._LOGGER", _LOGGER)
 @patch("pilight.pilight.Client", PilightDaemonSim)
-async def test_send_code(mock_pilight_error, hass):
+async def test_send_code(mock_pilight_error, hass: HomeAssistant) -> None:
     """Try to send proper data."""
     with assert_setup_component(4):
         assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
@@ -135,7 +135,7 @@ async def test_send_code(mock_pilight_error, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.components.pilight._LOGGER.error")
-async def test_send_code_fail(mock_pilight_error, hass):
+async def test_send_code_fail(mock_pilight_error, hass: HomeAssistant) -> None:
     """Check IOError exception error message."""
     with assert_setup_component(4), patch(
         "pilight.pilight.Client.send_code", side_effect=IOError
@@ -158,7 +158,7 @@ async def test_send_code_fail(mock_pilight_error, hass):
 @patch("homeassistant.components.pilight._LOGGER.error")
 @patch("homeassistant.components.pilight._LOGGER", _LOGGER)
 @patch("pilight.pilight.Client", PilightDaemonSim)
-async def test_send_code_delay(mock_pilight_error, hass):
+async def test_send_code_delay(mock_pilight_error, hass: HomeAssistant) -> None:
     """Try to send proper data with delay afterwards."""
     with assert_setup_component(4):
         assert await async_setup_component(
@@ -200,7 +200,7 @@ async def test_send_code_delay(mock_pilight_error, hass):
 @patch("homeassistant.components.pilight._LOGGER.error")
 @patch("homeassistant.components.pilight._LOGGER", _LOGGER)
 @patch("pilight.pilight.Client", PilightDaemonSim)
-async def test_start_stop(mock_pilight_error, hass):
+async def test_start_stop(mock_pilight_error, hass: HomeAssistant) -> None:
     """Check correct startup and stop of pilight daemon."""
     with assert_setup_component(4):
         assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
@@ -223,7 +223,7 @@ async def test_start_stop(mock_pilight_error, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.core._LOGGER.debug")
-async def test_receive_code(mock_debug, hass):
+async def test_receive_code(mock_debug, hass: HomeAssistant) -> None:
     """Check if code receiving via pilight daemon works."""
     with assert_setup_component(4):
         assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
@@ -249,7 +249,7 @@ async def test_receive_code(mock_debug, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.core._LOGGER.debug")
-async def test_whitelist_exact_match(mock_debug, hass):
+async def test_whitelist_exact_match(mock_debug, hass: HomeAssistant) -> None:
     """Check whitelist filter with matched data."""
     with assert_setup_component(4):
         whitelist = {
@@ -282,7 +282,7 @@ async def test_whitelist_exact_match(mock_debug, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.core._LOGGER.debug")
-async def test_whitelist_partial_match(mock_debug, hass):
+async def test_whitelist_partial_match(mock_debug, hass: HomeAssistant) -> None:
     """Check whitelist filter with partially matched data, should work."""
     with assert_setup_component(4):
         whitelist = {
@@ -313,7 +313,7 @@ async def test_whitelist_partial_match(mock_debug, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.core._LOGGER.debug")
-async def test_whitelist_or_match(mock_debug, hass):
+async def test_whitelist_or_match(mock_debug, hass: HomeAssistant) -> None:
     """Check whitelist filter with several subsection, should work."""
     with assert_setup_component(4):
         whitelist = {
@@ -347,7 +347,7 @@ async def test_whitelist_or_match(mock_debug, hass):
 
 @patch("pilight.pilight.Client", PilightDaemonSim)
 @patch("homeassistant.core._LOGGER.debug")
-async def test_whitelist_no_match(mock_debug, hass):
+async def test_whitelist_no_match(mock_debug, hass: HomeAssistant) -> None:
     """Check whitelist filter with unmatched data, should not work."""
     with assert_setup_component(4):
         whitelist = {

--- a/tests/components/ping/test_binary_sensor.py
+++ b/tests/components/ping/test_binary_sensor.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config as hass_config, setup
 from homeassistant.components.ping import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
 
 from tests.common import get_fixture_path
 
@@ -17,7 +18,7 @@ def mock_ping():
         yield
 
 
-async def test_reload(hass, mock_ping):
+async def test_reload(hass: HomeAssistant, mock_ping) -> None:
     """Verify we can reload trend sensors."""
 
     await setup.async_setup_component(

--- a/tests/components/plaato/test_config_flow.py
+++ b/tests/components/plaato/test_config_flow.py
@@ -76,7 +76,9 @@ async def test_show_config_form_device_type_keg(hass: HomeAssistant) -> None:
     assert result["data_schema"].schema.get(CONF_USE_WEBHOOK) is None
 
 
-async def test_show_config_form_validate_webhook(hass, webhook_id):
+async def test_show_config_form_validate_webhook(
+    hass: HomeAssistant, webhook_id
+) -> None:
     """Test show configuration form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -120,7 +122,9 @@ async def test_show_config_form_validate_webhook(hass, webhook_id):
     assert result["step_id"] == "webhook"
 
 
-async def test_show_config_form_validate_webhook_not_connected(hass, webhook_id):
+async def test_show_config_form_validate_webhook_not_connected(
+    hass: HomeAssistant, webhook_id
+) -> None:
     """Test validating webhook when not connected aborts."""
 
     result = await hass.config_entries.flow.async_init(
@@ -197,7 +201,9 @@ async def test_show_config_form_validate_token(hass: HomeAssistant) -> None:
     }
 
 
-async def test_show_config_form_no_cloud_webhook(hass, webhook_id):
+async def test_show_config_form_no_cloud_webhook(
+    hass: HomeAssistant, webhook_id
+) -> None:
     """Test show configuration form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -228,7 +234,9 @@ async def test_show_config_form_no_cloud_webhook(hass, webhook_id):
     assert result["errors"] is None
 
 
-async def test_show_config_form_api_method_no_auth_token(hass, webhook_id):
+async def test_show_config_form_api_method_no_auth_token(
+    hass: HomeAssistant, webhook_id
+) -> None:
     """Test show configuration form."""
 
     # Using Keg
@@ -316,7 +324,7 @@ async def test_options(hass: HomeAssistant) -> None:
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_options_webhook(hass, webhook_id):
+async def test_options_webhook(hass: HomeAssistant, webhook_id) -> None:
     """Test updating options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta
 
 import homeassistant.components.plant as plant
+from homeassistant.components.recorder import Recorder
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONDUCTIVITY,
@@ -144,7 +145,7 @@ async def test_state_problem_if_unavailable(hass: HomeAssistant) -> None:
     assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
 
 
-async def test_load_from_db(recorder_mock, hass):
+async def test_load_from_db(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test bootstrapping the brightness history from the database.
 
     This test can should only be executed if the loading of the history

--- a/tests/components/plex/test_browse_media.py
+++ b/tests/components/plex/test_browse_media.py
@@ -2,6 +2,7 @@
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
+import requests_mock
 from yarl import URL
 
 from homeassistant.components.media_player import (
@@ -10,8 +11,11 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.plex.const import CONF_SERVER_IDENTIFIER, PLEX_URI_SCHEME
 from homeassistant.components.websocket_api.const import ERR_UNKNOWN_ERROR, TYPE_RESULT
+from homeassistant.core import HomeAssistant
 
 from .const import DEFAULT_DATA
+
+from tests.typing import WebSocketGenerator
 
 
 class MockPlexShow:
@@ -110,13 +114,13 @@ class MockPlexStation:
 
 
 async def test_browse_media(
-    hass,
-    hass_ws_client,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
     mock_plex_server,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     hubs,
     hubs_music_library,
-):
+) -> None:
     """Test getting Plex clients from plex.tv."""
     websocket_client = await hass_ws_client(hass)
 

--- a/tests/components/plex/test_button.py
+++ b/tests/components/plex/test_button.py
@@ -5,12 +5,15 @@ from unittest.mock import patch
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.plex.const import DEBOUNCE_TIMEOUT
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt
 
 from tests.common import async_fire_time_changed
 
 
-async def test_scan_clients_button_schedule(hass, setup_plex_server):
+async def test_scan_clients_button_schedule(
+    hass: HomeAssistant, setup_plex_server
+) -> None:
     """Test scan_clients button scheduled update."""
     with patch(
         "homeassistant.components.plex.server.PlexServer._async_update_platforms"

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import plexapi.exceptions
 import pytest
 import requests.exceptions
+import requests_mock
 
 from homeassistant.components.plex import config_flow
 from homeassistant.components.plex.const import (
@@ -44,9 +45,12 @@ from .helpers import trigger_plex_update, wait_for_debouncer
 from .mock_classes import MockGDM
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_bad_credentials(hass, current_request_with_host):
+async def test_bad_credentials(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Test when provided credentials are rejected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -74,7 +78,9 @@ async def test_bad_credentials(hass, current_request_with_host):
         assert result["errors"][CONF_TOKEN] == "faulty_credentials"
 
 
-async def test_bad_hostname(hass, mock_plex_calls, current_request_with_host):
+async def test_bad_hostname(
+    hass: HomeAssistant, mock_plex_calls, current_request_with_host: None
+) -> None:
     """Test when an invalid address is provided."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -103,7 +109,9 @@ async def test_bad_hostname(hass, mock_plex_calls, current_request_with_host):
         assert result["errors"][CONF_HOST] == "not_found"
 
 
-async def test_unknown_exception(hass, current_request_with_host):
+async def test_unknown_exception(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Test when an unknown exception is encountered."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -128,8 +136,12 @@ async def test_unknown_exception(hass, current_request_with_host):
 
 
 async def test_no_servers_found(
-    hass, mock_plex_calls, requests_mock, empty_payload, current_request_with_host
-):
+    hass: HomeAssistant,
+    mock_plex_calls,
+    requests_mock: requests_mock.Mocker,
+    empty_payload,
+    current_request_with_host: None,
+) -> None:
     """Test when no servers are on an account."""
     requests_mock.get("https://plex.tv/api/resources", text=empty_payload)
 
@@ -157,8 +169,8 @@ async def test_no_servers_found(
 
 
 async def test_single_available_server(
-    hass, mock_plex_calls, current_request_with_host
-):
+    hass: HomeAssistant, mock_plex_calls, current_request_with_host: None
+) -> None:
     """Test creating an entry with one server available."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -198,12 +210,12 @@ async def test_single_available_server(
 
 
 async def test_multiple_servers_with_selection(
-    hass,
+    hass: HomeAssistant,
     mock_plex_calls,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     plextv_resources_two_servers,
-    current_request_with_host,
-):
+    current_request_with_host: None,
+) -> None:
     """Test creating an entry with multiple servers available."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -256,12 +268,12 @@ async def test_multiple_servers_with_selection(
 
 
 async def test_adding_last_unconfigured_server(
-    hass,
+    hass: HomeAssistant,
     mock_plex_calls,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     plextv_resources_two_servers,
-    current_request_with_host,
-):
+    current_request_with_host: None,
+) -> None:
     """Test automatically adding last unconfigured server when multiple servers on account."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -314,13 +326,13 @@ async def test_adding_last_unconfigured_server(
 
 
 async def test_all_available_servers_configured(
-    hass,
+    hass: HomeAssistant,
     entry,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     plextv_account,
     plextv_resources_two_servers,
-    current_request_with_host,
-):
+    current_request_with_host: None,
+) -> None:
     """Test when all available servers are already configured."""
     entry.add_to_hass(hass)
 
@@ -360,7 +372,7 @@ async def test_all_available_servers_configured(
         assert result["reason"] == "all_configured"
 
 
-async def test_option_flow(hass, entry, mock_plex_server):
+async def test_option_flow(hass: HomeAssistant, entry, mock_plex_server) -> None:
     """Test config options flow selection."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state is ConfigEntryState.LOADED
@@ -392,7 +404,9 @@ async def test_option_flow(hass, entry, mock_plex_server):
     }
 
 
-async def test_missing_option_flow(hass, entry, mock_plex_server):
+async def test_missing_option_flow(
+    hass: HomeAssistant, entry, mock_plex_server
+) -> None:
     """Test config options flow selection when no options stored."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state is ConfigEntryState.LOADED
@@ -424,7 +438,9 @@ async def test_missing_option_flow(hass, entry, mock_plex_server):
     }
 
 
-async def test_option_flow_new_users_available(hass, entry, setup_plex_server):
+async def test_option_flow_new_users_available(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test config options multiselect defaults when new Plex users are seen."""
     OPTIONS_OWNER_ONLY = copy.deepcopy(DEFAULT_OPTIONS)
     OPTIONS_OWNER_ONLY[Platform.MEDIA_PLAYER][CONF_MONITORED_USERS] = {
@@ -454,7 +470,9 @@ async def test_option_flow_new_users_available(hass, entry, setup_plex_server):
         assert "[New]" in multiselect_defaults[user]
 
 
-async def test_external_timed_out(hass, current_request_with_host):
+async def test_external_timed_out(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Test when external flow times out."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -478,7 +496,11 @@ async def test_external_timed_out(hass, current_request_with_host):
         assert result["reason"] == "token_request_timeout"
 
 
-async def test_callback_view(hass, hass_client_no_auth, current_request_with_host):
+async def test_callback_view(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    current_request_with_host: None,
+) -> None:
     """Test callback view."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -501,7 +523,9 @@ async def test_callback_view(hass, hass_client_no_auth, current_request_with_hos
         assert resp.status == HTTPStatus.OK
 
 
-async def test_manual_config(hass, mock_plex_calls, current_request_with_host):
+async def test_manual_config(
+    hass: HomeAssistant, mock_plex_calls, current_request_with_host: None
+) -> None:
     """Test creating via manual configuration."""
 
     class WrongCertValidaitionException(requests.exceptions.SSLError):
@@ -636,8 +660,12 @@ async def test_manual_config(hass, mock_plex_calls, current_request_with_host):
 
 
 async def test_manual_config_with_token(
-    hass, mock_plex_calls, requests_mock, empty_library, empty_payload
-):
+    hass: HomeAssistant,
+    mock_plex_calls,
+    requests_mock: requests_mock.Mocker,
+    empty_library,
+    empty_payload,
+) -> None:
     """Test creating via manual configuration with only token."""
 
     result = await hass.config_entries.flow.async_init(
@@ -680,7 +708,9 @@ async def test_manual_config_with_token(
     await hass.async_block_till_done()
 
 
-async def test_setup_with_limited_credentials(hass, entry, setup_plex_server):
+async def test_setup_with_limited_credentials(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup with a user with limited permissions."""
     with patch(
         "plexapi.server.PlexServer.systemAccounts",
@@ -722,8 +752,12 @@ async def test_integration_discovery(hass: HomeAssistant) -> None:
 
 
 async def test_trigger_reauth(
-    hass, entry, mock_plex_server, mock_websocket, current_request_with_host
-):
+    hass: HomeAssistant,
+    entry,
+    mock_plex_server,
+    mock_websocket,
+    current_request_with_host: None,
+) -> None:
     """Test setup and reauthorization of a Plex token."""
 
     assert entry.state is ConfigEntryState.LOADED
@@ -768,14 +802,14 @@ async def test_trigger_reauth(
 
 
 async def test_trigger_reauth_multiple_servers_available(
-    hass,
+    hass: HomeAssistant,
     entry,
     mock_plex_server,
     mock_websocket,
-    current_request_with_host,
-    requests_mock,
+    current_request_with_host: None,
+    requests_mock: requests_mock.Mocker,
     plextv_resources_two_servers,
-):
+) -> None:
     """Test setup and reauthorization of a Plex token when multiple servers are available."""
     assert entry.state is ConfigEntryState.LOADED
 
@@ -839,7 +873,9 @@ async def test_client_request_missing(hass: HomeAssistant) -> None:
         )
 
 
-async def test_client_header_issues(hass, current_request_with_host):
+async def test_client_header_issues(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Test when client headers are not set properly."""
 
     class MockRequest:

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -1,11 +1,15 @@
 """Tests for handling the device registry."""
+import requests_mock
 
 from homeassistant.components.plex.const import DOMAIN
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 
-async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
+async def test_cleanup_orphaned_devices(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test cleaning up orphaned devices on startup."""
     test_device_id = {(DOMAIN, "temporary_device_123")}
 
@@ -38,8 +42,12 @@ async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
 
 
 async def test_migrate_transient_devices(
-    hass, entry, setup_plex_server, requests_mock, player_plexweb_resources
-):
+    hass: HomeAssistant,
+    entry,
+    setup_plex_server,
+    requests_mock: requests_mock.Mocker,
+    player_plexweb_resources,
+) -> None:
     """Test cleaning up transient devices on startup."""
     plexweb_device_id = {(DOMAIN, "plexweb_id")}
     non_plexweb_device_id = {(DOMAIN, "1234567890123456-com-plexapp-android")}

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import plexapi
 import requests
+import requests_mock
 
 import homeassistant.components.plex.const as const
 from homeassistant.components.plex.models import (
@@ -22,6 +23,7 @@ from homeassistant.const import (
     STATE_IDLE,
     STATE_PLAYING,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, PLEX_DIRECT_URL
@@ -30,7 +32,9 @@ from .helpers import trigger_plex_update, wait_for_debouncer
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_set_config_entry_unique_id(hass, entry, mock_plex_server):
+async def test_set_config_entry_unique_id(
+    hass: HomeAssistant, entry, mock_plex_server
+) -> None:
     """Test updating missing unique_id from config entry."""
     assert len(hass.config_entries.async_entries(const.DOMAIN)) == 1
     assert entry.state is ConfigEntryState.LOADED
@@ -41,7 +45,7 @@ async def test_set_config_entry_unique_id(hass, entry, mock_plex_server):
     )
 
 
-async def test_setup_config_entry_with_error(hass, entry):
+async def test_setup_config_entry_with_error(hass: HomeAssistant, entry) -> None:
     """Test setup component from config entry with errors."""
     with patch(
         "homeassistant.components.plex.PlexServer.connect",
@@ -66,7 +70,9 @@ async def test_setup_config_entry_with_error(hass, entry):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_with_insecure_config_entry(hass, entry, setup_plex_server):
+async def test_setup_with_insecure_config_entry(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup component with config."""
     INSECURE_DATA = copy.deepcopy(DEFAULT_DATA)
     INSECURE_DATA[const.PLEX_SERVER_CONFIG][CONF_VERIFY_SSL] = False
@@ -78,7 +84,9 @@ async def test_setup_with_insecure_config_entry(hass, entry, setup_plex_server):
     assert entry.state is ConfigEntryState.LOADED
 
 
-async def test_unload_config_entry(hass, entry, mock_plex_server):
+async def test_unload_config_entry(
+    hass: HomeAssistant, entry, mock_plex_server
+) -> None:
     """Test unloading a config entry."""
     config_entries = hass.config_entries.async_entries(const.DOMAIN)
     assert len(config_entries) == 1
@@ -95,7 +103,9 @@ async def test_unload_config_entry(hass, entry, mock_plex_server):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_with_photo_session(hass, entry, setup_plex_server):
+async def test_setup_with_photo_session(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup component with config."""
     await setup_plex_server(session_type="photo")
 
@@ -114,7 +124,9 @@ async def test_setup_with_photo_session(hass, entry, setup_plex_server):
     assert sensor.state == "0"
 
 
-async def test_setup_with_live_tv_session(hass, entry, setup_plex_server):
+async def test_setup_with_live_tv_session(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup component with a Live TV session."""
     await setup_plex_server(session_type="live_tv")
 
@@ -134,7 +146,9 @@ async def test_setup_with_live_tv_session(hass, entry, setup_plex_server):
     assert sensor.state == "1"
 
 
-async def test_setup_with_transient_session(hass, entry, setup_plex_server):
+async def test_setup_with_transient_session(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup component with a transient session."""
     await setup_plex_server(session_type="transient")
 
@@ -154,7 +168,9 @@ async def test_setup_with_transient_session(hass, entry, setup_plex_server):
     assert sensor.state == "1"
 
 
-async def test_setup_with_unknown_session(hass, entry, setup_plex_server):
+async def test_setup_with_unknown_session(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setup component with an unknown session."""
     await setup_plex_server(session_type="unknown")
 
@@ -175,8 +191,8 @@ async def test_setup_with_unknown_session(hass, entry, setup_plex_server):
 
 
 async def test_setup_when_certificate_changed(
-    hass,
-    requests_mock,
+    hass: HomeAssistant,
+    requests_mock: requests_mock.Mocker,
     empty_library,
     empty_payload,
     plex_server_accounts,
@@ -185,7 +201,7 @@ async def test_setup_when_certificate_changed(
     plextv_resources,
     plextv_shared_users,
     mock_websocket,
-):
+) -> None:
     """Test setup component when the Plex certificate has changed."""
 
     class WrongCertHostnameException(requests.exceptions.SSLError):
@@ -252,7 +268,7 @@ async def test_setup_when_certificate_changed(
     assert old_entry.data[const.PLEX_SERVER_CONFIG][CONF_URL] == new_url
 
 
-async def test_tokenless_server(entry, setup_plex_server):
+async def test_tokenless_server(entry, setup_plex_server) -> None:
     """Test setup with a server with token auth disabled."""
     TOKENLESS_DATA = copy.deepcopy(DEFAULT_DATA)
     TOKENLESS_DATA[const.PLEX_SERVER_CONFIG].pop(CONF_TOKEN, None)
@@ -263,8 +279,12 @@ async def test_tokenless_server(entry, setup_plex_server):
 
 
 async def test_bad_token_with_tokenless_server(
-    hass, entry, mock_websocket, setup_plex_server, requests_mock
-):
+    hass: HomeAssistant,
+    entry,
+    mock_websocket,
+    setup_plex_server,
+    requests_mock: requests_mock.Mocker,
+) -> None:
     """Test setup with a bad token and a server with token auth disabled."""
     requests_mock.get(
         "https://plex.tv/users/account", status_code=HTTPStatus.UNAUTHORIZED
@@ -279,7 +299,7 @@ async def test_bad_token_with_tokenless_server(
     await hass.async_block_till_done()
 
 
-async def test_scan_clients_schedule(hass, setup_plex_server):
+async def test_scan_clients_schedule(hass: HomeAssistant, setup_plex_server) -> None:
     """Test scan_clients scheduled update."""
     with patch(
         "homeassistant.components.plex.server.PlexServer._async_update_platforms"

--- a/tests/components/plex/test_media_players.py
+++ b/tests/components/plex/test_media_players.py
@@ -2,11 +2,18 @@
 from unittest.mock import patch
 
 from plexapi.exceptions import NotFound
+import requests_mock
+
+from homeassistant.core import HomeAssistant
 
 
 async def test_plex_tv_clients(
-    hass, entry, setup_plex_server, requests_mock, player_plexweb_resources
-):
+    hass: HomeAssistant,
+    entry,
+    setup_plex_server,
+    requests_mock: requests_mock.Mocker,
+    player_plexweb_resources,
+) -> None:
     """Test getting Plex clients from plex.tv."""
     requests_mock.get("/resources", text=player_plexweb_resources)
 

--- a/tests/components/plex/test_media_search.py
+++ b/tests/components/plex/test_media_search.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from plexapi.exceptions import BadRequest, NotFound
 import pytest
+import requests_mock
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
@@ -14,9 +15,15 @@ from homeassistant.components.media_player import (
 from homeassistant.components.plex.const import DOMAIN
 from homeassistant.components.plex.errors import MediaNotFound
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 
 
-async def test_media_lookups(hass, mock_plex_server, requests_mock, playqueue_created):
+async def test_media_lookups(
+    hass: HomeAssistant,
+    mock_plex_server,
+    requests_mock: requests_mock.Mocker,
+    playqueue_created,
+) -> None:
     """Test media lookups to Plex server."""
     # Plex Key searches
     media_player_id = hass.states.async_entity_ids("media_player")[0]

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 import pytest
+import requests_mock
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
@@ -13,6 +14,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.plex.const import CONF_SERVER_IDENTIFIER, PLEX_URI_SCHEME
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DEFAULT_DATA, PLEX_DIRECT_URL
@@ -43,12 +45,12 @@ class MockPlexLibrarySection:
 
 
 async def test_media_player_playback(
-    hass,
+    hass: HomeAssistant,
     setup_plex_server,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     playqueue_created,
     player_plexweb_resources,
-):
+) -> None:
     """Test playing media on a Plex media_player."""
     requests_mock.get("http://1.2.3.5:32400/resources", text=player_plexweb_resources)
 

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -3,11 +3,14 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 import requests.exceptions
+import requests_mock
 
 from homeassistant.components.plex.const import PLEX_UPDATE_LIBRARY_SIGNAL
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import dt
@@ -69,17 +72,17 @@ class MockPlexTVEpisode(MockPlexMedia):
 
 
 async def test_library_sensor_values(
-    hass,
-    caplog,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     setup_plex_server,
     mock_websocket,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     library_movies_size,
     library_music_size,
     library_tvshows_size,
     library_tvshows_size_episodes,
     library_tvshows_size_seasons,
-):
+) -> None:
     """Test the library sensors."""
     requests_mock.get(
         "/library/sections/1/all?includeCollections=0",

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -2,7 +2,9 @@
 import copy
 from unittest.mock import patch
 
+import pytest
 from requests.exceptions import ConnectionError, RequestException
+import requests_mock
 
 from homeassistant.components.plex.const import (
     CONF_IGNORE_NEW_SHARED_USERS,
@@ -13,12 +15,15 @@ from homeassistant.components.plex.const import (
     SERVERS,
 )
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .helpers import trigger_plex_update, wait_for_debouncer
 
 
-async def test_new_users_available(hass, entry, setup_plex_server):
+async def test_new_users_available(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test setting up when new users available on Plex server."""
     MONITORED_USERS = {"User 1": {"enabled": True}}
     OPTIONS_WITH_USERS = copy.deepcopy(DEFAULT_OPTIONS)
@@ -37,14 +42,14 @@ async def test_new_users_available(hass, entry, setup_plex_server):
 
 
 async def test_new_ignored_users_available(
-    hass,
-    caplog,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     entry,
     mock_websocket,
     setup_plex_server,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     session_new_user,
-):
+) -> None:
     """Test setting up when new users available on Plex server but are ignored."""
     MONITORED_USERS = {"User 1": {"enabled": True}}
     OPTIONS_WITH_USERS = copy.deepcopy(DEFAULT_OPTIONS)
@@ -86,7 +91,9 @@ async def test_new_ignored_users_available(
     assert sensor.state == str(len(active_sessions))
 
 
-async def test_network_error_during_refresh(hass, caplog, mock_plex_server):
+async def test_network_error_during_refresh(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_plex_server
+) -> None:
     """Test network failures during refreshes."""
     server_id = mock_plex_server.machine_identifier
     loaded_server = hass.data[DOMAIN][SERVERS][server_id]
@@ -106,7 +113,9 @@ async def test_network_error_during_refresh(hass, caplog, mock_plex_server):
     )
 
 
-async def test_gdm_client_failure(hass, mock_websocket, setup_plex_server):
+async def test_gdm_client_failure(
+    hass: HomeAssistant, mock_websocket, setup_plex_server
+) -> None:
     """Test connection failure to a GDM discovered client."""
     with patch(
         "homeassistant.components.plex.server.PlexClient", side_effect=ConnectionError
@@ -126,8 +135,12 @@ async def test_gdm_client_failure(hass, mock_websocket, setup_plex_server):
 
 
 async def test_mark_sessions_idle(
-    hass, mock_plex_server, mock_websocket, requests_mock, empty_payload
-):
+    hass: HomeAssistant,
+    mock_plex_server,
+    mock_websocket,
+    requests_mock: requests_mock.Mocker,
+    empty_payload,
+) -> None:
     """Test marking media_players as idle when sessions end."""
     await wait_for_debouncer(hass)
 
@@ -148,7 +161,9 @@ async def test_mark_sessions_idle(
     assert sensor.state == "0"
 
 
-async def test_ignore_plex_web_client(hass, entry, setup_plex_server):
+async def test_ignore_plex_web_client(
+    hass: HomeAssistant, entry, setup_plex_server
+) -> None:
     """Test option to ignore Plex Web clients."""
     OPTIONS = copy.deepcopy(DEFAULT_OPTIONS)
     OPTIONS[Platform.MEDIA_PLAYER][CONF_IGNORE_PLEX_WEB_CLIENTS] = True

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -6,6 +6,7 @@ import plexapi.audio
 from plexapi.exceptions import NotFound
 import plexapi.playqueue
 import pytest
+import requests_mock
 
 from homeassistant.components.media_player import MediaType
 from homeassistant.components.plex.const import (
@@ -19,6 +20,7 @@ from homeassistant.components.plex.const import (
 )
 from homeassistant.components.plex.services import process_plex_payload
 from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, SECONDARY_DATA
@@ -27,14 +29,14 @@ from tests.common import MockConfigEntry
 
 
 async def test_refresh_library(
-    hass,
+    hass: HomeAssistant,
     mock_plex_server,
     setup_plex_server,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     empty_payload,
     plex_server_accounts,
     plex_server_base,
-):
+) -> None:
     """Test refresh_library service call."""
     url = mock_plex_server.url_in_use
     refresh = requests_mock.get(
@@ -104,7 +106,7 @@ async def test_refresh_library(
     assert refresh.call_count == 1
 
 
-async def test_scan_clients(hass, mock_plex_server):
+async def test_scan_clients(hass: HomeAssistant, mock_plex_server) -> None:
     """Test scan_for_clients service call."""
     assert await hass.services.async_call(
         DOMAIN,
@@ -114,13 +116,13 @@ async def test_scan_clients(hass, mock_plex_server):
 
 
 async def test_lookup_media_for_other_integrations(
-    hass,
+    hass: HomeAssistant,
     entry,
     setup_plex_server,
-    requests_mock,
+    requests_mock: requests_mock.Mocker,
     playqueue_1234,
     playqueue_created,
-):
+) -> None:
     """Test media lookup for media_player.play_media calls from cast/sonos."""
     CONTENT_ID = PLEX_URI_SCHEME + '{"library_name": "Music", "artist_name": "Artist"}'
     CONTENT_ID_KEY = PLEX_URI_SCHEME + "100"
@@ -212,7 +214,7 @@ async def test_lookup_media_for_other_integrations(
     assert isinstance(result.media, plexapi.playqueue.PlayQueue)
 
 
-async def test_lookup_media_with_urls(hass, mock_plex_server):
+async def test_lookup_media_with_urls(hass: HomeAssistant, mock_plex_server) -> None:
     """Test media lookup for media_player.play_media calls from cast/sonos."""
     CONTENT_ID_URL = f"{PLEX_URI_SCHEME}{DEFAULT_DATA[CONF_SERVER_IDENTIFIER]}/100"
 

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -28,7 +28,7 @@ async def test_adam_climate_switch_entities(
 
 async def test_adam_climate_switch_negative_testing(
     hass: HomeAssistant, mock_smile_adam: MagicMock, init_integration: MockConfigEntry
-):
+) -> None:
     """Test exceptions of climate related switch entities."""
     mock_smile_adam.set_switch_state.side_effect = PlugwiseException
 

--- a/tests/components/plum_lightpad/test_init.py
+++ b/tests/components/plum_lightpad/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
-async def test_async_setup_no_domain_config(hass: HomeAssistant):
+async def test_async_setup_no_domain_config(hass: HomeAssistant) -> None:
     """Test setup without configuration is noop."""
     result = await async_setup_component(hass, DOMAIN, {})
 
@@ -19,7 +19,7 @@ async def test_async_setup_no_domain_config(hass: HomeAssistant):
     assert DOMAIN not in hass.data
 
 
-async def test_async_setup_imports_from_config(hass: HomeAssistant):
+async def test_async_setup_imports_from_config(hass: HomeAssistant) -> None:
     """Test that specifying config will setup an entry."""
     with patch(
         "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"
@@ -44,7 +44,7 @@ async def test_async_setup_imports_from_config(hass: HomeAssistant):
     assert len(mock_async_setup_entry.mock_calls) == 1
 
 
-async def test_async_setup_entry_sets_up_light(hass: HomeAssistant):
+async def test_async_setup_entry_sets_up_light(hass: HomeAssistant) -> None:
     """Test that configuring entry sets up light domain."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -66,7 +66,7 @@ async def test_async_setup_entry_sets_up_light(hass: HomeAssistant):
     assert len(mock_light_async_setup_entry.mock_calls) == 1
 
 
-async def test_async_setup_entry_handles_auth_error(hass: HomeAssistant):
+async def test_async_setup_entry_handles_auth_error(hass: HomeAssistant) -> None:
     """Test that configuring entry handles Plum Cloud authentication error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -86,7 +86,7 @@ async def test_async_setup_entry_handles_auth_error(hass: HomeAssistant):
     assert len(mock_light_async_setup_entry.mock_calls) == 0
 
 
-async def test_async_setup_entry_handles_http_error(hass: HomeAssistant):
+async def test_async_setup_entry_handles_http_error(hass: HomeAssistant) -> None:
     """Test that configuring entry handles HTTP error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/point/test_config_flow.py
+++ b/tests/components/point/test_config_flow.py
@@ -68,7 +68,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow_implementation(hass, mock_pypoint):
+async def test_full_flow_implementation(hass: HomeAssistant, mock_pypoint) -> None:
     """Test registering an implementation and finishing flow works."""
     config_flow.register_flow_implementation(hass, "test-other", None, None)
     flow = init_config_flow(hass)
@@ -94,7 +94,7 @@ async def test_full_flow_implementation(hass, mock_pypoint):
     assert result["data"]["token"] == {"access_token": "boo"}
 
 
-async def test_step_import(hass, mock_pypoint):
+async def test_step_import(hass: HomeAssistant, mock_pypoint) -> None:
     """Test that we trigger import when configuring with client."""
     flow = init_config_flow(hass)
 
@@ -104,7 +104,9 @@ async def test_step_import(hass, mock_pypoint):
 
 
 @pytest.mark.parametrize("is_authorized", [False])
-async def test_wrong_code_flow_implementation(hass, mock_pypoint):
+async def test_wrong_code_flow_implementation(
+    hass: HomeAssistant, mock_pypoint
+) -> None:
     """Test wrong code."""
     flow = init_config_flow(hass)
 

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -16,7 +16,7 @@ from .mocks import _mock_powerwall_with_fixtures
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_update_data_reauthenticate_on_access_denied(hass: HomeAssistant):
+async def test_update_data_reauthenticate_on_access_denied(hass: HomeAssistant) -> None:
     """Test if _update_data of PowerwallDataManager reauthenticates on AccessDeniedError."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -20,7 +20,7 @@ from .mocks import _mock_powerwall_with_fixtures
 from tests.common import MockConfigEntry
 
 
-async def test_sensors(hass, entity_registry_enabled_by_default):
+async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
     """Test creation of the sensors."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)

--- a/tests/components/powerwall/test_switch.py
+++ b/tests/components/powerwall/test_switch.py
@@ -1,5 +1,4 @@
 """Test for Powerwall off-grid switch."""
-
 from unittest.mock import Mock, patch
 
 import pytest
@@ -12,6 +11,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_IP_ADDRESS, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as ent_reg
 
@@ -38,7 +38,7 @@ async def mock_powerwall_fixture(hass):
         yield mock_powerwall
 
 
-async def test_entity_registry(hass, mock_powerwall):
+async def test_entity_registry(hass: HomeAssistant, mock_powerwall) -> None:
     """Test powerwall off-grid switch device."""
 
     mock_powerwall.get_grid_status = Mock(return_value=GridStatus.CONNECTED)
@@ -47,7 +47,7 @@ async def test_entity_registry(hass, mock_powerwall):
     assert ENTITY_ID in entity_registry.entities
 
 
-async def test_initial(hass, mock_powerwall):
+async def test_initial(hass: HomeAssistant, mock_powerwall) -> None:
     """Test initial grid status without off grid switch selected."""
 
     mock_powerwall.get_grid_status = Mock(return_value=GridStatus.CONNECTED)
@@ -56,7 +56,7 @@ async def test_initial(hass, mock_powerwall):
     assert state.state == STATE_OFF
 
 
-async def test_on(hass, mock_powerwall):
+async def test_on(hass: HomeAssistant, mock_powerwall) -> None:
     """Test state once offgrid switch has been turned on."""
 
     mock_powerwall.get_grid_status = Mock(return_value=GridStatus.ISLANDED)
@@ -72,7 +72,7 @@ async def test_on(hass, mock_powerwall):
     assert state.state == STATE_ON
 
 
-async def test_off(hass, mock_powerwall):
+async def test_off(hass: HomeAssistant, mock_powerwall) -> None:
     """Test state once offgrid switch has been turned off."""
 
     mock_powerwall.get_grid_status = Mock(return_value=GridStatus.CONNECTED)
@@ -88,7 +88,9 @@ async def test_off(hass, mock_powerwall):
     assert state.state == STATE_OFF
 
 
-async def test_exception_on_powerwall_error(hass, mock_powerwall):
+async def test_exception_on_powerwall_error(
+    hass: HomeAssistant, mock_powerwall
+) -> None:
     """Ensure that an exception in the tesla_powerwall library causes a HomeAssistantError."""
 
     with pytest.raises(HomeAssistantError, match="Setting off-grid operation to"):

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -23,7 +23,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_basic_usage(hass, tmpdir):
+async def test_basic_usage(hass: HomeAssistant, tmpdir) -> None:
     """Test we can setup and the service is registered."""
     test_dir = tmpdir.mkdir("profiles")
 
@@ -53,7 +53,7 @@ async def test_basic_usage(hass, tmpdir):
     await hass.async_block_till_done()
 
 
-async def test_memory_usage(hass, tmpdir):
+async def test_memory_usage(hass: HomeAssistant, tmpdir) -> None:
     """Test we can setup and the service is registered."""
     test_dir = tmpdir.mkdir("profiles")
 

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -57,7 +57,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfTemperature,
 )
-from homeassistant.core import split_entity_id
+from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -107,7 +107,7 @@ async def generate_latest_metrics(client):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_view_empty_namespace(client, sensor_entities):
+async def test_view_empty_namespace(client, sensor_entities) -> None:
     """Test prometheus metrics view."""
     body = await generate_latest_metrics(client)
 
@@ -131,7 +131,7 @@ async def test_view_empty_namespace(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [None])
-async def test_view_default_namespace(client, sensor_entities):
+async def test_view_default_namespace(client, sensor_entities) -> None:
     """Test prometheus metrics view."""
     body = await generate_latest_metrics(client)
 
@@ -149,7 +149,7 @@ async def test_view_default_namespace(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_sensor_unit(client, sensor_entities):
+async def test_sensor_unit(client, sensor_entities) -> None:
     """Test prometheus metrics for sensors with a unit."""
     body = await generate_latest_metrics(client)
 
@@ -179,7 +179,7 @@ async def test_sensor_unit(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_sensor_without_unit(client, sensor_entities):
+async def test_sensor_without_unit(client, sensor_entities) -> None:
     """Test prometheus metrics for sensors without a unit."""
     body = await generate_latest_metrics(client)
 
@@ -203,7 +203,7 @@ async def test_sensor_without_unit(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_sensor_device_class(client, sensor_entities):
+async def test_sensor_device_class(client, sensor_entities) -> None:
     """Test prometheus metrics for sensor with a device_class."""
     body = await generate_latest_metrics(client)
 
@@ -233,7 +233,7 @@ async def test_sensor_device_class(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_input_number(client, input_number_entities):
+async def test_input_number(client, input_number_entities) -> None:
     """Test prometheus metrics for input_number."""
     body = await generate_latest_metrics(client)
 
@@ -257,7 +257,7 @@ async def test_input_number(client, input_number_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_battery(client, sensor_entities):
+async def test_battery(client, sensor_entities) -> None:
     """Test prometheus metrics for battery."""
     body = await generate_latest_metrics(client)
 
@@ -269,7 +269,7 @@ async def test_battery(client, sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_climate(client, climate_entities):
+async def test_climate(client, climate_entities) -> None:
     """Test prometheus metrics for climate entities."""
     body = await generate_latest_metrics(client)
 
@@ -305,7 +305,7 @@ async def test_climate(client, climate_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_humidifier(client, humidifier_entities):
+async def test_humidifier(client, humidifier_entities) -> None:
     """Test prometheus metrics for humidifier entities."""
     body = await generate_latest_metrics(client)
 
@@ -336,7 +336,7 @@ async def test_humidifier(client, humidifier_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_attributes(client, switch_entities):
+async def test_attributes(client, switch_entities) -> None:
     """Test prometheus metrics for entity attributes."""
     body = await generate_latest_metrics(client)
 
@@ -366,7 +366,7 @@ async def test_attributes(client, switch_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_binary_sensor(client, binary_sensor_entities):
+async def test_binary_sensor(client, binary_sensor_entities) -> None:
     """Test prometheus metrics for binary_sensor."""
     body = await generate_latest_metrics(client)
 
@@ -384,7 +384,7 @@ async def test_binary_sensor(client, binary_sensor_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_input_boolean(client, input_boolean_entities):
+async def test_input_boolean(client, input_boolean_entities) -> None:
     """Test prometheus metrics for input_boolean."""
     body = await generate_latest_metrics(client)
 
@@ -402,7 +402,7 @@ async def test_input_boolean(client, input_boolean_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_light(client, light_entities):
+async def test_light(client, light_entities) -> None:
     """Test prometheus metrics for lights."""
     body = await generate_latest_metrics(client)
 
@@ -432,7 +432,7 @@ async def test_light(client, light_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_lock(client, lock_entities):
+async def test_lock(client, lock_entities) -> None:
     """Test prometheus metrics for lock."""
     body = await generate_latest_metrics(client)
 
@@ -450,7 +450,7 @@ async def test_lock(client, lock_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_cover(client, cover_entities):
+async def test_cover(client, cover_entities) -> None:
     """Test prometheus metrics for cover."""
     data = {**cover_entities}
     body = await generate_latest_metrics(client)
@@ -509,7 +509,7 @@ async def test_cover(client, cover_entities):
 
 
 @pytest.mark.parametrize("namespace", [""])
-async def test_counter(client, counter_entities):
+async def test_counter(client, counter_entities) -> None:
     """Test prometheus metrics for counter."""
     body = await generate_latest_metrics(client)
 
@@ -522,8 +522,8 @@ async def test_counter(client, counter_entities):
 
 @pytest.mark.parametrize("namespace", [""])
 async def test_renaming_entity_name(
-    hass, registry, client, sensor_entities, climate_entities
-):
+    hass: HomeAssistant, registry, client, sensor_entities, climate_entities
+) -> None:
     """Test renaming entity name."""
     data = {**sensor_entities, **climate_entities}
     body = await generate_latest_metrics(client)
@@ -644,8 +644,8 @@ async def test_renaming_entity_name(
 
 @pytest.mark.parametrize("namespace", [""])
 async def test_renaming_entity_id(
-    hass, registry, client, sensor_entities, climate_entities
-):
+    hass: HomeAssistant, registry, client, sensor_entities, climate_entities
+) -> None:
     """Test renaming entity id."""
     data = {**sensor_entities, **climate_entities}
     body = await generate_latest_metrics(client)
@@ -720,8 +720,8 @@ async def test_renaming_entity_id(
 
 @pytest.mark.parametrize("namespace", [""])
 async def test_deleting_entity(
-    hass, registry, client, sensor_entities, climate_entities
-):
+    hass: HomeAssistant, registry, client, sensor_entities, climate_entities
+) -> None:
     """Test deleting a entity."""
     data = {**sensor_entities, **climate_entities}
     body = await generate_latest_metrics(client)
@@ -795,8 +795,8 @@ async def test_deleting_entity(
 
 @pytest.mark.parametrize("namespace", [""])
 async def test_disabling_entity(
-    hass, registry, client, sensor_entities, climate_entities
-):
+    hass: HomeAssistant, registry, client, sensor_entities, climate_entities
+) -> None:
     """Test disabling a entity."""
     data = {**sensor_entities, **climate_entities}
 
@@ -1540,7 +1540,7 @@ def mock_bus(hass):
 
 
 @pytest.mark.usefixtures("mock_bus")
-async def test_minimal_config(hass, mock_client):
+async def test_minimal_config(hass: HomeAssistant, mock_client) -> None:
     """Test the minimal config and defaults of component."""
     config = {prometheus.DOMAIN: {}}
     assert await async_setup_component(hass, prometheus.DOMAIN, config)
@@ -1550,7 +1550,7 @@ async def test_minimal_config(hass, mock_client):
 
 
 @pytest.mark.usefixtures("mock_bus")
-async def test_full_config(hass, mock_client):
+async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     """Test the full config of component."""
     config = {
         prometheus.DOMAIN: {
@@ -1598,7 +1598,7 @@ async def _setup(hass, filter_config):
 
 
 @pytest.mark.usefixtures("mock_bus")
-async def test_allowlist(hass, mock_client):
+async def test_allowlist(hass: HomeAssistant, mock_client) -> None:
     """Test an allowlist only config."""
     handler_method = await _setup(
         hass,
@@ -1628,7 +1628,7 @@ async def test_allowlist(hass, mock_client):
 
 
 @pytest.mark.usefixtures("mock_bus")
-async def test_denylist(hass, mock_client):
+async def test_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist only config."""
     handler_method = await _setup(
         hass,
@@ -1658,7 +1658,7 @@ async def test_denylist(hass, mock_client):
 
 
 @pytest.mark.usefixtures("mock_bus")
-async def test_filtered_denylist(hass, mock_client):
+async def test_filtered_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist config with a filtering allowlist."""
     handler_method = await _setup(
         hass,

--- a/tests/components/prosegur/test_alarm_control_panel.py
+++ b/tests/components/prosegur/test_alarm_control_panel.py
@@ -1,5 +1,4 @@
 """Tests for the Prosegur alarm control panel device."""
-
 from unittest.mock import AsyncMock, patch
 
 from pyprosegur.installation import Status
@@ -18,6 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_component, entity_registry as er
 
 from .common import CONTRACT, setup_platform
@@ -46,7 +46,7 @@ def mock_status(request):
         yield
 
 
-async def test_entity_registry(hass, mock_auth, mock_status):
+async def test_entity_registry(hass: HomeAssistant, mock_auth, mock_status) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass)
     entity_registry = er.async_get(hass)
@@ -63,7 +63,7 @@ async def test_entity_registry(hass, mock_auth, mock_status):
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 3
 
 
-async def test_connection_error(hass, mock_auth):
+async def test_connection_error(hass: HomeAssistant, mock_auth) -> None:
     """Test the alarm control panel when connection can't be made to the cloud service."""
 
     install = AsyncMock()
@@ -94,7 +94,9 @@ async def test_connection_error(hass, mock_auth):
         (Status.DISARMED, SERVICE_ALARM_DISARM, STATE_ALARM_DISARMED),
     ],
 )
-async def test_arm(hass, mock_auth, code, alarm_service, alarm_state):
+async def test_arm(
+    hass: HomeAssistant, mock_auth, code, alarm_service, alarm_state
+) -> None:
     """Test the alarm control panel can be set to away."""
 
     install = AsyncMock()

--- a/tests/components/prosegur/test_config_flow.py
+++ b/tests/components/prosegur/test_config_flow.py
@@ -188,7 +188,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
         (Exception, "unknown"),
     ],
 )
-async def test_reauth_flow_error(hass, exception, base_error):
+async def test_reauth_flow_error(hass: HomeAssistant, exception, base_error) -> None:
     """Test a reauthentication flow with errors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/prosegur/test_init.py
+++ b/tests/components/prosegur/test_init.py
@@ -17,7 +17,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
         ConnectionError,
     ],
 )
-async def test_setup_entry_fail_retrieve(hass, error):
+async def test_setup_entry_fail_retrieve(hass: HomeAssistant, error) -> None:
     """Test loading the Prosegur entry."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -1,5 +1,4 @@
 """Test Prusalink buttons."""
-
 from unittest.mock import patch
 
 from pyprusalink import Conflict
@@ -9,6 +8,8 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +30,7 @@ async def test_button_pause_cancel(
     hass: HomeAssistant,
     mock_config_entry,
     mock_api,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     mock_job_api_printing,
     object_id,
     method,
@@ -71,7 +72,7 @@ async def test_button_resume(
     hass: HomeAssistant,
     mock_config_entry,
     mock_api,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     mock_job_api_paused,
     object_id,
     method,

--- a/tests/components/prusalink/test_camera.py
+++ b/tests/components/prusalink/test_camera.py
@@ -1,5 +1,4 @@
 """Test Prusalink camera."""
-
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +6,8 @@ import pytest
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +21,7 @@ async def test_camera_no_job(
     hass: HomeAssistant,
     mock_config_entry,
     mock_api,
-    hass_client,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test camera while no job active."""
     assert await async_setup_component(hass, "prusalink", {})
@@ -38,8 +39,8 @@ async def test_camera_active_job(
     mock_config_entry,
     mock_api,
     mock_job_api_printing,
-    hass_client,
-):
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test camera while job active."""
     assert await async_setup_component(hass, "prusalink", {})
     state = hass.states.get("camera.mock_title_job_preview")

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -16,7 +16,7 @@ async def test_unloading(
     hass: HomeAssistant,
     mock_config_entry: ConfigEntry,
     mock_api,
-):
+) -> None:
     """Test unloading prusalink."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state == ConfigEntryState.LOADED
@@ -33,7 +33,7 @@ async def test_unloading(
 @pytest.mark.parametrize("exception", [InvalidAuth, PrusaLinkError])
 async def test_failed_update(
     hass: HomeAssistant, mock_config_entry: ConfigEntry, mock_api, exception
-):
+) -> None:
     """Test failed update marks prusalink unavailable."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state == ConfigEntryState.LOADED

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -33,7 +33,7 @@ def setup_sensor_platform_only():
         yield
 
 
-async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api):
+async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) -> None:
     """Test sensors while no job active."""
     assert await async_setup_component(hass, "prusalink", {})
 
@@ -89,7 +89,7 @@ async def test_sensors_active_job(
     mock_api,
     mock_printer_api,
     mock_job_api_printing,
-):
+) -> None:
     """Test sensors while active job."""
     with patch(
         "homeassistant.components.prusalink.sensor.utcnow",

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -262,7 +262,9 @@ async def test_media_attributes_are_fetched(hass: HomeAssistant) -> None:
     assert mock_attrs.get(ATTR_MEDIA_CONTENT_TYPE) == MediaType.APP
 
 
-async def test_media_attributes_are_loaded(hass, patch_load_json):
+async def test_media_attributes_are_loaded(
+    hass: HomeAssistant, patch_load_json
+) -> None:
     """Test that media attributes are loaded."""
     mock_entity_id = await setup_mock_component(hass)
     patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA_LOCKED}
@@ -290,8 +292,8 @@ async def test_media_attributes_are_loaded(hass, patch_load_json):
 
 
 async def test_device_info_is_set_from_status_correctly(
-    hass, patch_get_status, device_registry
-):
+    hass: HomeAssistant, patch_get_status, device_registry: dr.DeviceRegistry
+) -> None:
     """Test that device info is set correctly from status update."""
     patch_get_status.return_value = MOCK_STATUS_STANDBY
     mock_entity_id = await setup_mock_component(hass)
@@ -449,7 +451,7 @@ async def test_media_stop(hass: HomeAssistant) -> None:
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source(hass, patch_load_json):
+async def test_select_source(hass: HomeAssistant, patch_load_json) -> None:
     """Test that select source service calls function with title."""
     patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
@@ -469,7 +471,7 @@ async def test_select_source(hass, patch_load_json):
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_caps(hass, patch_load_json):
+async def test_select_source_caps(hass: HomeAssistant, patch_load_json) -> None:
     """Test that select source service calls function with upper case title."""
     patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
@@ -492,7 +494,7 @@ async def test_select_source_caps(hass, patch_load_json):
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_id(hass, patch_load_json):
+async def test_select_source_id(hass: HomeAssistant, patch_load_json) -> None:
     """Test that select source service calls function with Title ID."""
     patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import data_entry_flow
 from homeassistant.components.purpleair import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import TEST_API_KEY, TEST_SENSOR_INDEX1, TEST_SENSOR_INDEX2
@@ -32,14 +33,14 @@ TEST_LONGITUDE = -0.2416796
     ],
 )
 async def test_create_entry_by_coordinates(
-    hass,
+    hass: HomeAssistant,
     api,
     check_api_key_errors,
     check_api_key_mock,
     get_nearby_sensors_errors,
     get_nearby_sensors_mock,
     mock_aiopurpleair,
-):
+) -> None:
     """Test creating an entry by entering a latitude/longitude (including errors)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -101,7 +102,9 @@ async def test_create_entry_by_coordinates(
     }
 
 
-async def test_duplicate_error(hass, config_entry, setup_config_entry):
+async def test_duplicate_error(
+    hass: HomeAssistant, config_entry, setup_config_entry
+) -> None:
     """Test that the proper error is shown when adding a duplicate config entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={"api_key": TEST_API_KEY}
@@ -119,13 +122,13 @@ async def test_duplicate_error(hass, config_entry, setup_config_entry):
     ],
 )
 async def test_reauth(
-    hass,
+    hass: HomeAssistant,
     api,
     check_api_key_errors,
     check_api_key_mock,
     config_entry,
     setup_config_entry,
-):
+) -> None:
     """Test re-auth (including errors)."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -165,13 +168,13 @@ async def test_reauth(
     ],
 )
 async def test_options_add_sensor(
-    hass,
+    hass: HomeAssistant,
     api,
     config_entry,
     get_nearby_sensors_errors,
     get_nearby_sensors_mock,
     setup_config_entry,
-):
+) -> None:
     """Test adding a sensor via the options flow (including errors)."""
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.MENU
@@ -224,7 +227,9 @@ async def test_options_add_sensor(
     ]
 
 
-async def test_options_add_sensor_duplicate(hass, config_entry, setup_config_entry):
+async def test_options_add_sensor_duplicate(
+    hass: HomeAssistant, config_entry, setup_config_entry
+) -> None:
     """Test adding a duplicate sensor via the options flow."""
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.MENU
@@ -257,7 +262,9 @@ async def test_options_add_sensor_duplicate(hass, config_entry, setup_config_ent
     assert result["reason"] == "already_configured"
 
 
-async def test_options_remove_sensor(hass, config_entry, setup_config_entry):
+async def test_options_remove_sensor(
+    hass: HomeAssistant, config_entry, setup_config_entry
+) -> None:
     """Test removing a sensor via the options flow."""
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.MENU

--- a/tests/components/purpleair/test_diagnostics.py
+++ b/tests/components/purpleair/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test PurpleAir diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/pushbullet/test_notify.py
+++ b/tests/components/pushbullet/test_notify.py
@@ -1,17 +1,20 @@
 """Test pushbullet notification platform."""
 from http import HTTPStatus
 
-from requests_mock import Mocker
+import requests_mock
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.components.pushbullet.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from . import MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 
 
-async def test_pushbullet_push_default(hass, requests_mock: Mocker):
+async def test_pushbullet_push_default(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test pushbullet push to default target."""
     requests_mock.register_uri(
         "POST",
@@ -37,7 +40,9 @@ async def test_pushbullet_push_default(hass, requests_mock: Mocker):
     assert requests_mock.last_request.json() == expected_body
 
 
-async def test_pushbullet_push_device(hass, requests_mock):
+async def test_pushbullet_push_device(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test pushbullet push to default target."""
     requests_mock.register_uri(
         "POST",
@@ -70,7 +75,9 @@ async def test_pushbullet_push_device(hass, requests_mock):
     assert requests_mock.last_request.json() == expected_body
 
 
-async def test_pushbullet_push_devices(hass, requests_mock):
+async def test_pushbullet_push_devices(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test pushbullet push to default target."""
     requests_mock.register_uri(
         "POST",
@@ -110,7 +117,9 @@ async def test_pushbullet_push_devices(hass, requests_mock):
     assert requests_mock.request_history[-1].json() == expected_body
 
 
-async def test_pushbullet_push_email(hass, requests_mock):
+async def test_pushbullet_push_email(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test pushbullet push to default target."""
     requests_mock.register_uri(
         "POST",
@@ -143,7 +152,9 @@ async def test_pushbullet_push_email(hass, requests_mock):
     assert requests_mock.last_request.json() == expected_body
 
 
-async def test_pushbullet_push_mixed(hass, requests_mock):
+async def test_pushbullet_push_mixed(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test pushbullet push to default target."""
     requests_mock.register_uri(
         "POST",

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 from pushover_complete import BadAPIRequestError
 import pytest
-from requests_mock import Mocker
+import requests_mock
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.components.pushover.const import DOMAIN
@@ -112,7 +112,7 @@ async def test_async_setup_entry_failed_conn_error(
 
 
 async def test_async_setup_entry_failed_json_error(
-    hass: HomeAssistant, requests_mock: Mocker
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
     """Test pushover failed setup due to bad json response from library."""
     entry = MockConfigEntry(

--- a/tests/components/pvoutput/test_diagnostics.py
+++ b/tests/components/pvoutput/test_diagnostics.py
@@ -11,7 +11,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.pvpc_hourly_pricing import (
     TARIFFS,
 )
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import check_valid_state
@@ -22,7 +23,9 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 _MOCK_TIME_VALID_RESPONSES = datetime(2023, 1, 6, 12, 0, tzinfo=date_util.UTC)
 
 
-async def test_config_flow(hass, pvpc_aioclient_mock: AiohttpClientMocker):
+async def test_config_flow(
+    hass: HomeAssistant, pvpc_aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test config flow for pvpc_hourly_pricing.
 
     - Create a new entry with tariff "2.0TD (Ceuta/Melilla)"

--- a/tests/components/qnap_qsw/test_config_flow.py
+++ b/tests/components/qnap_qsw/test_config_flow.py
@@ -101,7 +101,7 @@ async def test_form_duplicated_id(hass: HomeAssistant) -> None:
         assert result["reason"] == "already_configured"
 
 
-async def test_form_unique_id_error(hass: HomeAssistant):
+async def test_form_unique_id_error(hass: HomeAssistant) -> None:
     """Test unique ID error."""
 
     system_board = MagicMock()
@@ -119,7 +119,7 @@ async def test_form_unique_id_error(hass: HomeAssistant):
         assert result["reason"] == "invalid_id"
 
 
-async def test_connection_error(hass: HomeAssistant):
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test connection to host error."""
 
     with patch(
@@ -133,7 +133,7 @@ async def test_connection_error(hass: HomeAssistant):
         assert result["errors"] == {CONF_URL: "cannot_connect"}
 
 
-async def test_login_error(hass: HomeAssistant):
+async def test_login_error(hass: HomeAssistant) -> None:
     """Test login error."""
 
     with patch(
@@ -210,7 +210,7 @@ async def test_dhcp_flow_error(hass: HomeAssistant) -> None:
     assert result["reason"] == "cannot_connect"
 
 
-async def test_dhcp_connection_error(hass: HomeAssistant):
+async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
     """Test DHCP connection to host error."""
 
     with patch(
@@ -241,7 +241,7 @@ async def test_dhcp_connection_error(hass: HomeAssistant):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_dhcp_login_error(hass: HomeAssistant):
+async def test_dhcp_login_error(hass: HomeAssistant) -> None:
     """Test DHCP login error."""
 
     with patch(

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -1,5 +1,6 @@
 """Test qwikswitch sensors."""
 import asyncio
+from typing import Any
 from unittest.mock import Mock
 
 from aiohttp.client_exceptions import ClientError
@@ -52,7 +53,9 @@ def qs_devices():
 EMPTY_PACKET = {"cmd": ""}
 
 
-async def test_binary_sensor_device(hass, aioclient_mock, qs_devices):
+async def test_binary_sensor_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test a binary sensor device."""
     config = {
         "qwikswitch": {
@@ -91,7 +94,9 @@ async def test_binary_sensor_device(hass, aioclient_mock, qs_devices):
     listen_mock.stop()
 
 
-async def test_sensor_device(hass, aioclient_mock, qs_devices):
+async def test_sensor_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test a sensor device."""
     config = {
         "qwikswitch": {
@@ -125,7 +130,9 @@ async def test_sensor_device(hass, aioclient_mock, qs_devices):
     listen_mock.stop()
 
 
-async def test_switch_device(hass, aioclient_mock, qs_devices):
+async def test_switch_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test a switch device."""
 
     async def get_devices_json(method, url, data):
@@ -186,7 +193,9 @@ async def test_switch_device(hass, aioclient_mock, qs_devices):
     listen_mock.stop()
 
 
-async def test_light_device(hass, aioclient_mock, qs_devices):
+async def test_light_device(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test a light device."""
 
     async def get_devices_json(method, url, data):
@@ -257,7 +266,9 @@ async def test_light_device(hass, aioclient_mock, qs_devices):
     listen_mock.stop()
 
 
-async def test_button(hass, aioclient_mock, qs_devices):
+async def test_button(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test that buttons fire an event."""
 
     async def get_devices_json(method, url, data):
@@ -298,7 +309,9 @@ async def test_failed_update_devices(
     listen_mock.stop()
 
 
-async def test_single_invalid_sensor(hass, aioclient_mock, qs_devices):
+async def test_single_invalid_sensor(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, qs_devices
+) -> None:
     """Test that a single misconfigured sensor doesn't block the others."""
 
     config = {
@@ -324,8 +337,11 @@ async def test_single_invalid_sensor(hass, aioclient_mock, qs_devices):
 
 
 async def test_non_binary_sensor_with_binary_args(
-    hass, aioclient_mock, qs_devices, caplog
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    qs_devices,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that the system logs a warning when a non-binary device has binary specific args."""
 
     config = {
@@ -354,7 +370,12 @@ async def test_non_binary_sensor_with_binary_args(
     listen_mock.stop()
 
 
-async def test_non_relay_switch(hass, aioclient_mock, qs_devices, caplog):
+async def test_non_relay_switch(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    qs_devices,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that the system logs a warning when a switch is configured for a device that is not a relay."""
 
     config = {"qwikswitch": {"switches": ["@a00003"]}}
@@ -371,7 +392,12 @@ async def test_non_relay_switch(hass, aioclient_mock, qs_devices, caplog):
     listen_mock.stop()
 
 
-async def test_unknown_device(hass, aioclient_mock, qs_devices, caplog):
+async def test_unknown_device(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    qs_devices,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that the system logs a warning when a network device has unknown type."""
 
     config = {"qwikswitch": {}}
@@ -391,7 +417,12 @@ async def test_unknown_device(hass, aioclient_mock, qs_devices, caplog):
     listen_mock.stop()
 
 
-async def test_no_discover_info(hass, hass_storage, aioclient_mock, caplog):
+async def test_no_discover_info(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that discovery with no discovery_info does not result in errors."""
     config = {
         "qwikswitch": {},

--- a/tests/components/radarr/test_binary_sensor.py
+++ b/tests/components/radarr/test_binary_sensor.py
@@ -8,7 +8,9 @@ from . import setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_binary_sensors(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_binary_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test for binary sensor values."""
     await setup_integration(hass, aioclient_mock)
 

--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -11,7 +11,7 @@ from . import create_entry, patch_radarr, setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test unload."""
     entry = await setup_integration(hass, aioclient_mock)
     assert entry.state == ConfigEntryState.LOADED
@@ -25,7 +25,7 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
 
 async def test_async_setup_entry_not_ready(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-):
+) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = await setup_integration(hass, aioclient_mock, connection_error=True)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
@@ -33,7 +33,7 @@ async def test_async_setup_entry_not_ready(
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_auth_failed(hass: HomeAssistant):
+async def test_async_setup_entry_auth_failed(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryAuthFailed when authentication fails."""
     entry = create_entry(hass)
     with patch_radarr() as radarrmock:
@@ -44,7 +44,9 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant):
         assert not hass.data.get(DOMAIN)
 
 
-async def test_device_info(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_device_info(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test device info."""
     entry = await setup_integration(hass, aioclient_mock)
     device_registry = dr.async_get(hass)

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -14,7 +14,7 @@ async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     entity_registry_enabled_by_default: AsyncMock,
-):
+) -> None:
     """Test for successfully setting up the Radarr platform."""
     await setup_integration(hass, aioclient_mock)
 
@@ -29,7 +29,9 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
 
 
-async def test_windows(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
+async def test_windows(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Test for successfully setting up the Radarr platform on Windows."""
     await setup_integration(hass, aioclient_mock, windows=True)
 

--- a/tests/components/rainforest_eagle/test_diagnostics.py
+++ b/tests/components/rainforest_eagle/test_diagnostics.py
@@ -4,15 +4,20 @@ from homeassistant.components.rainforest_eagle.const import (
     CONF_CLOUD_ID,
     CONF_INSTALL_CODE,
 )
+from homeassistant.core import HomeAssistant
 
 from . import MOCK_200_RESPONSE_WITHOUT_PRICE
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 async def test_entry_diagnostics(
-    hass, hass_client, setup_rainforest_200, config_entry_200
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup_rainforest_200,
+    config_entry_200,
+) -> None:
     """Test config entry diagnostics."""
     result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry_200)
 

--- a/tests/components/rainforest_eagle/test_sensor.py
+++ b/tests/components/rainforest_eagle/test_sensor.py
@@ -1,10 +1,11 @@
 """Tests for rainforest eagle sensors."""
 from homeassistant.components.rainforest_eagle.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from . import MOCK_200_RESPONSE_WITH_PRICE
 
 
-async def test_sensors_200(hass, setup_rainforest_200):
+async def test_sensors_200(hass: HomeAssistant, setup_rainforest_200) -> None:
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 
@@ -37,7 +38,7 @@ async def test_sensors_200(hass, setup_rainforest_200):
     assert price.attributes["unit_of_measurement"] == "USD/kWh"
 
 
-async def test_sensors_100(hass, setup_rainforest_100):
+async def test_sensors_100(hass: HomeAssistant, setup_rainforest_100) -> None:
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
-async def test_duplicate_error(hass, config, config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
@@ -25,7 +25,7 @@ async def test_duplicate_error(hass, config, config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_password(hass, config):
+async def test_invalid_password(hass: HomeAssistant, config) -> None:
     """Test that an invalid password throws an error."""
     with patch("regenmaschine.client.Client.load_local", side_effect=RainMachineError):
         result = await hass.config_entries.flow.async_init(
@@ -54,7 +54,7 @@ async def test_invalid_password(hass, config):
     ],
 )
 async def test_migrate_1_2(
-    hass,
+    hass: HomeAssistant,
     client,
     config,
     config_entry,
@@ -63,7 +63,7 @@ async def test_migrate_1_2(
     old_unique_id,
     new_unique_id,
     platform,
-):
+) -> None:
     """Test migration from version 1 to 2 (consistent unique IDs)."""
     ent_reg = er.async_get(hass)
 
@@ -93,7 +93,7 @@ async def test_migrate_1_2(
     assert ent_reg.async_get_entity_id(platform, DOMAIN, old_unique_id) is None
 
 
-async def test_options_flow(hass, config, config_entry):
+async def test_options_flow(hass: HomeAssistant, config, config_entry) -> None:
     """Test config flow options."""
     with patch(
         "homeassistant.components.rainmachine.async_setup_entry", return_value=True
@@ -125,7 +125,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_step_user(hass, config, setup_rainmachine):
+async def test_step_user(hass: HomeAssistant, config, setup_rainmachine) -> None:
     """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -147,8 +147,8 @@ async def test_step_user(hass, config, setup_rainmachine):
     "source", [config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT]
 )
 async def test_step_homekit_zeroconf_ip_already_exists(
-    hass, client, config, config_entry, source
-):
+    hass: HomeAssistant, client, config, config_entry, source
+) -> None:
     """Test homekit and zeroconf with an ip that already exists."""
     with patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client
@@ -174,7 +174,9 @@ async def test_step_homekit_zeroconf_ip_already_exists(
 @pytest.mark.parametrize(
     "source", [config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT]
 )
-async def test_step_homekit_zeroconf_ip_change(hass, client, config_entry, source):
+async def test_step_homekit_zeroconf_ip_change(
+    hass: HomeAssistant, client, config_entry, source
+) -> None:
     """Test zeroconf with an ip change."""
     with patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client
@@ -202,8 +204,8 @@ async def test_step_homekit_zeroconf_ip_change(hass, client, config_entry, sourc
     "source", [config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT]
 )
 async def test_step_homekit_zeroconf_new_controller_when_some_exist(
-    hass, client, config, source
-):
+    hass: HomeAssistant, client, config, source
+) -> None:
     """Test homekit and zeroconf for a new controller when one already exists."""
     with patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client
@@ -251,7 +253,9 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
     }
 
 
-async def test_discovery_by_homekit_and_zeroconf_same_time(hass, client):
+async def test_discovery_by_homekit_and_zeroconf_same_time(
+    hass: HomeAssistant, client
+) -> None:
     """Test the same controller gets discovered by two different methods."""
     with patch(
         "homeassistant.components.rainmachine.config_flow.Client", return_value=client

--- a/tests/components/rainmachine/test_diagnostics.py
+++ b/tests/components/rainmachine/test_diagnostics.py
@@ -2,11 +2,18 @@
 from regenmaschine.errors import RainMachineError
 
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_rainmachine):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_rainmachine,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {
@@ -626,8 +633,12 @@ async def test_entry_diagnostics(hass, config_entry, hass_client, setup_rainmach
 
 
 async def test_entry_diagnostics_failed_controller_diagnostics(
-    hass, config_entry, controller, hass_client, setup_rainmachine
-):
+    hass: HomeAssistant,
+    config_entry,
+    controller,
+    hass_client: ClientSessionGenerator,
+    setup_rainmachine,
+) -> None:
     """Test config entry diagnostics when the controller diagnostics API call fails."""
     controller.diagnostics.current.side_effect = RainMachineError
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {

--- a/tests/components/raspberry_pi/test_hardware.py
+++ b/tests/components/raspberry_pi/test_hardware.py
@@ -7,9 +7,12 @@ from homeassistant.components.raspberry_pi.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.typing import WebSocketGenerator
 
 
-async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_hardware_info(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can get the board info."""
     mock_integration(hass, MockModule("hassio"))
 
@@ -58,7 +61,9 @@ async def test_hardware_info(hass: HomeAssistant, hass_ws_client) -> None:
 
 
 @pytest.mark.parametrize("os_info", [None, {"board": None}, {"board": "other"}])
-async def test_hardware_info_fail(hass: HomeAssistant, hass_ws_client, os_info) -> None:
+async def test_hardware_info_fail(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, os_info
+) -> None:
     """Test async_info raises if os_info is not as expected."""
     mock_integration(hass, MockModule("hassio"))
 

--- a/tests/components/rdw/test_diagnostics.py
+++ b/tests/components/rdw/test_diagnostics.py
@@ -11,7 +11,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
