### PR TITLE
Enable Ruff PT006

### DIFF
--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -34,7 +34,7 @@ from .conftest import (
 
 
 @pytest.mark.parametrize(
-    "integration_type,input_form_step,patched_method,config,entry_title",
+    ("integration_type", "input_form_step", "patched_method", "config", "entry_title"),
     [
         (
             INTEGRATION_TYPE_GEOGRAPHY_COORDS,

--- a/tests/components/airvisual_pro/test_config_flow.py
+++ b/tests/components/airvisual_pro/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize(
-    "connect_mock,connect_errors",
+    ("connect_mock", "connect_errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidAuthenticationError), {"base": "invalid_auth"}),
@@ -84,7 +84,7 @@ async def test_step_import(hass: HomeAssistant, config, setup_airvisual_pro) -> 
 
 
 @pytest.mark.parametrize(
-    "connect_mock,connect_errors",
+    ("connect_mock", "connect_errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidAuthenticationError), {"base": "invalid_auth"}),

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -32,7 +32,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_action_types",
+    ("set_state", "features_reg", "features_state", "expected_action_types"),
     [
         (False, 0, 0, ["disarm"]),
         (
@@ -127,7 +127,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/alarm_control_panel/test_device_condition.py
+++ b/tests/components/alarm_control_panel/test_device_condition.py
@@ -37,7 +37,7 @@ def calls(hass: HomeAssistant) -> list[ServiceCall]:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_condition_types",
+    ("set_state", "features_reg", "features_state", "expected_condition_types"),
     [
         (False, 0, 0, []),
         (False, AlarmControlPanelEntityFeature.ARM_AWAY, 0, ["is_armed_away"]),
@@ -133,7 +133,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -42,7 +42,7 @@ def calls(hass: HomeAssistant) -> list[ServiceCall]:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_trigger_types",
+    ("set_state", "features_reg", "features_state", "expected_trigger_types"),
     [
         (False, 0, 0, ["triggered", "disarmed", "arming"]),
         (
@@ -125,7 +125,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/alarmdecoder/test_config_flow.py
+++ b/tests/components/alarmdecoder/test_config_flow.py
@@ -35,7 +35,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "protocol,connection,title",
+    ("protocol", "connection", "title"),
     [
         (
             PROTOCOL_SOCKET,
@@ -394,7 +394,7 @@ async def test_options_zone_flow_validation(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "protocol,connection",
+    ("protocol", "connection"),
     [
         (
             PROTOCOL_SOCKET,

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -119,7 +119,7 @@ async def test_api_set_color_temperature(hass: HomeAssistant) -> None:
     assert msg["header"]["name"] == "Response"
 
 
-@pytest.mark.parametrize("result,initial", [(383, "333"), (500, "500")])
+@pytest.mark.parametrize(("result", "initial"), [(383, "333"), (500, "500")])
 async def test_api_decrease_color_temp(
     hass: HomeAssistant, result: int, initial: str
 ) -> None:
@@ -149,7 +149,7 @@ async def test_api_decrease_color_temp(
     assert msg["header"]["name"] == "Response"
 
 
-@pytest.mark.parametrize("result,initial", [(283, "333"), (142, "142")])
+@pytest.mark.parametrize(("result", "initial"), [(283, "333"), (142, "142")])
 async def test_api_increase_color_temp(
     hass: HomeAssistant, result: int, initial: str
 ) -> None:
@@ -180,7 +180,7 @@ async def test_api_increase_color_temp(
 
 
 @pytest.mark.parametrize(
-    "domain,payload,source_list,idx",
+    ("domain", "payload", "source_list", "idx"),
     [
         ("media_player", "GAME CONSOLE", ["tv", "game console", 10000], 1),
         ("media_player", "SATELLITE TV", ["satellite-tv", "game console"], 0),

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4120,7 +4120,7 @@ async def test_camera_discovery_without_stream(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "url,result",
+    ("url", "result"),
     [
         ("http://nohttpswrongport.org:8123", 2),
         ("http://nohttpsport443.org:443", 2),

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -357,7 +357,7 @@ async def test_report_state_humidifier(
 
 
 @pytest.mark.parametrize(
-    "domain,value,unit,label",
+    ("domain", "value", "unit", "label"),
     [
         (
             "number",

--- a/tests/components/ambient_station/test_config_flow.py
+++ b/tests/components/ambient_station/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize(
-    "devices_response,errors",
+    ("devices_response", "errors"),
     [
         (AsyncMock(side_effect=AmbientError), {"base": "invalid_key"}),
         (AsyncMock(return_value=[]), {"base": "no_devices"}),

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -83,7 +83,7 @@ class MockConfigDevice:
 
 
 @pytest.mark.parametrize(
-    ["config", "eth_mac", "wifi_mac"],
+    ("config", "eth_mac", "wifi_mac"),
     [
         (CONFIG_PYTHON_ADB, ETH_MAC, None),
         (CONFIG_ADB_SERVER, ETH_MAC, None),
@@ -202,7 +202,7 @@ async def test_error_invalid_key(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ["config", "eth_mac", "wifi_mac"],
+    ("config", "eth_mac", "wifi_mac"),
     [
         (CONFIG_ADB_SERVER, None, None),
         (CONFIG_PYTHON_ADB, None, None),

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -395,7 +395,7 @@ async def test_sources(hass: HomeAssistant, config: dict[str, Any]) -> None:
 
 
 @pytest.mark.parametrize(
-    ["config", "expected_sources"],
+    ("config", "expected_sources"),
     [
         (CONFIG_ANDROIDTV_DEFAULT, ["TEST 1"]),
         (CONFIG_FIRETV_DEFAULT, ["TEST 1"]),
@@ -482,7 +482,7 @@ async def _test_select_source(
 
 
 @pytest.mark.parametrize(
-    ["source", "expected_arg", "method_patch"],
+    ("source", "expected_arg", "method_patch"),
     [
         ("com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
         ("TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
@@ -526,7 +526,7 @@ async def test_androidtv_select_source_overridden_app_name(hass: HomeAssistant) 
 
 
 @pytest.mark.parametrize(
-    ["source", "expected_arg", "method_patch"],
+    ("source", "expected_arg", "method_patch"),
     [
         ("com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
         ("TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP),
@@ -552,7 +552,7 @@ async def test_select_source_firetv(
 
 
 @pytest.mark.parametrize(
-    ["config", "connect"],
+    ("config", "connect"),
     [
         (CONFIG_ANDROIDTV_DEFAULT, False),
         (CONFIG_FIRETV_DEFAULT, False),

--- a/tests/components/anthemav/test_media_player.py
+++ b/tests/components/anthemav/test_media_player.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "entity_id,entity_name",
+    ("entity_id", "entity_name"),
     [
         ("media_player.anthem_av", "Anthem AV"),
         ("media_player.anthem_av_zone_2", "Anthem AV zone 2"),

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -131,7 +131,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "extra_status,expected_title",
+    ("extra_status", "expected_title"),
     [
         ({"UPSNAME": "Friendly Name"}, "Friendly Name"),
         ({"MODEL": "MODEL X"}, "MODEL X"),

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -113,7 +113,7 @@ async def test_update(player, state) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, value",
+    ("source", "value"),
     [("PVR", SourceCodes.PVR), ("BD", SourceCodes.BD), ("INVALID", None)],
 )
 async def test_select_source(
@@ -168,7 +168,7 @@ async def test_volume_down(player, state) -> None:
 
 
 @pytest.mark.parametrize(
-    "mode, mode_enum",
+    ("mode", "mode_enum"),
     [
         ("STEREO", DecodeMode2CH.STEREO),
         ("STEREO_DOWNMIX", DecodeModeMCH.STEREO_DOWNMIX),
@@ -183,7 +183,7 @@ async def test_sound_mode(player, state, mode, mode_enum) -> None:
 
 
 @pytest.mark.parametrize(
-    "modes, modes_enum",
+    ("modes", "modes_enum"),
     [
         (["STEREO", "DOLBY_PL"], [DecodeMode2CH.STEREO, DecodeMode2CH.DOLBY_PL]),
         (["STEREO_DOWNMIX"], [DecodeModeMCH.STEREO_DOWNMIX]),
@@ -219,7 +219,7 @@ async def test_volume_level(player, state) -> None:
     assert player.volume_level is None
 
 
-@pytest.mark.parametrize("volume, call", [(0.0, 0), (0.5, 50), (1.0, 99)])
+@pytest.mark.parametrize(("volume", "call"), [(0.0, 0), (0.5, 50), (1.0, 99)])
 async def test_set_volume_level(player, state, volume, call) -> None:
     """Test setting volume."""
     await player.async_set_volume_level(volume)
@@ -227,7 +227,7 @@ async def test_set_volume_level(player, state, volume, call) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, media_content_type",
+    ("source", "media_content_type"),
     [
         (SourceCodes.DAB, MediaType.MUSIC),
         (SourceCodes.FM, MediaType.MUSIC),
@@ -242,7 +242,7 @@ async def test_media_content_type(player, state, source, media_content_type) -> 
 
 
 @pytest.mark.parametrize(
-    "source, dab, rds, channel",
+    ("source", "dab", "rds", "channel"),
     [
         (SourceCodes.DAB, "dab", "rds", "dab"),
         (SourceCodes.DAB, None, None, None),
@@ -260,7 +260,7 @@ async def test_media_channel(player, state, source, dab, rds, channel) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, dls, artist",
+    ("source", "dls", "artist"),
     [
         (SourceCodes.DAB, "dls", "dls"),
         (SourceCodes.FM, "dls", None),
@@ -275,7 +275,7 @@ async def test_media_artist(player, state, source, dls, artist) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, channel, title",
+    ("source", "channel", "title"),
     [
         (SourceCodes.DAB, "channel", "DAB - channel"),
         (SourceCodes.DAB, None, "DAB"),

--- a/tests/components/aseko_pool_live/test_config_flow.py
+++ b/tests/components/aseko_pool_live/test_config_flow.py
@@ -48,7 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error_web, error_mobile, reason",
+    ("error_web", "error_mobile", "reason"),
     [
         (APIUnavailable, None, "cannot_connect"),
         (InvalidAuthCredentials, None, "invalid_auth"),

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_user(hass: HomeAssistant, mock_unique_id, unique_id) -> None:
 
 
 @pytest.mark.parametrize(
-    ["config", "error"],
+    ("config", "error"),
     [
         ({CONF_PASSWORD: None}, "pwd_or_ssh"),
         ({CONF_SSH_KEY: SSH_KEY}, "pwd_and_ssh"),
@@ -221,7 +221,7 @@ async def test_abort_invalid_unique_id(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ["side_effect", "error"],
+    ("side_effect", "error"),
     [
         (OSError, "cannot_connect"),
         (TypeError, "unknown"),

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -386,7 +386,7 @@ async def test_refresh_token_provider_rejected(
 
 
 @pytest.mark.parametrize(
-    "url,base_data", [("/auth/token", {"action": "revoke"}), ("/auth/revoke", {})]
+    ("url", "base_data"), [("/auth/token", {"action": "revoke"}), ("/auth/revoke", {})]
 )
 async def test_revoking_refresh_token(
     url, base_data, hass: HomeAssistant, aiohttp_client: ClientSessionGenerator

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1354,7 +1354,7 @@ async def test_automation_not_trigger_on_bootstrap(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "broken_config, problem, details",
+    ("broken_config", "problem", "details"),
     (
         (
             {},
@@ -1984,7 +1984,7 @@ async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
 
 
 @pytest.mark.parametrize(
-    "blueprint_inputs, problem, details",
+    ("blueprint_inputs", "problem", "details"),
     (
         (
             # No input
@@ -2193,7 +2193,7 @@ async def test_trigger_condition_explicit_id(hass: HomeAssistant, calls) -> None
 
 
 @pytest.mark.parametrize(
-    "automation_mode,automation_runs",
+    ("automation_mode", "automation_runs"),
     (
         (SCRIPT_MODE_PARALLEL, 2),
         (SCRIPT_MODE_QUEUED, 2),

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -246,7 +246,7 @@ async def test_reauth_flow_update_configuration(
 
 
 @pytest.mark.parametrize(
-    "source,discovery_info",
+    ("source", "discovery_info"),
     [
         (
             SOURCE_DHCP,
@@ -349,7 +349,7 @@ async def test_discovery_flow(
 
 
 @pytest.mark.parametrize(
-    "source,discovery_info",
+    ("source", "discovery_info"),
     [
         (
             SOURCE_DHCP,
@@ -401,7 +401,7 @@ async def test_discovered_device_already_configured(
 
 
 @pytest.mark.parametrize(
-    "source,discovery_info,expected_port",
+    ("source", "discovery_info", "expected_port"),
     [
         (
             SOURCE_DHCP,
@@ -477,7 +477,7 @@ async def test_discovery_flow_updated_configuration(
 
 
 @pytest.mark.parametrize(
-    "source,discovery_info",
+    ("source", "discovery_info"),
     [
         (
             SOURCE_DHCP,
@@ -526,7 +526,7 @@ async def test_discovery_flow_ignore_non_axis_device(
 
 
 @pytest.mark.parametrize(
-    "source,discovery_info",
+    ("source", "discovery_info"),
     [
         (
             SOURCE_DHCP,

--- a/tests/components/azure_event_hub/test_config_flow.py
+++ b/tests/components/azure_event_hub/test_config_flow.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "step1_config, step_id, step2_config, data_config",
+    ("step1_config", "step_id", "step2_config", "data_config"),
     [
         (BASE_CONFIG_CS, STEP_CONN_STRING, CS_CONFIG, CS_CONFIG_FULL),
         (BASE_CONFIG_SAS, STEP_SAS, SAS_CONFIG, SAS_CONFIG_FULL),
@@ -115,7 +115,7 @@ async def test_single_instance(hass: HomeAssistant, source) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_message",
+    ("side_effect", "error_message"),
     [(EventHubError("test"), "cannot_connect"), (Exception, "unknown")],
     ids=["cannot_connect", "unknown"],
 )
@@ -144,7 +144,7 @@ async def test_connection_error_sas(
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_message",
+    ("side_effect", "error_message"),
     [(EventHubError("test"), "cannot_connect"), (Exception, "unknown")],
     ids=["cannot_connect", "unknown"],
 )

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -140,7 +140,7 @@ async def test_full_batch(
 
 
 @pytest.mark.parametrize(
-    "filter_schema, tests",
+    ("filter_schema", "tests"),
     [
         (
             {

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -75,7 +75,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -75,7 +75,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -18,7 +18,7 @@ VEHICLE_NAME_SLUG = "i3_rex"
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {
@@ -75,7 +75,7 @@ async def test_migrate_unique_ids(
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {

--- a/tests/components/bmw_connected_drive/test_sensor.py
+++ b/tests/components/bmw_connected_drive/test_sensor.py
@@ -12,7 +12,7 @@ from . import setup_mocked_integration
 
 
 @pytest.mark.parametrize(
-    "entity_id,unit_system,value,unit_of_measurement",
+    ("entity_id", "unit_system", "value", "unit_of_measurement"),
     [
         ("sensor.i3_rex_remaining_range_total", METRIC, "279", "km"),
         ("sensor.i3_rex_remaining_range_total", IMPERIAL, "173.36", "mi"),

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -192,7 +192,7 @@ async def test_user_invalid_host(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_message",
+    ("side_effect", "error_message"),
     [
         (BraviaAuthError, "invalid_auth"),
         (BraviaNotSupported, "unsupported_model"),
@@ -219,7 +219,7 @@ async def test_pin_form_error(hass: HomeAssistant, side_effect, error_message) -
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_message",
+    ("side_effect", "error_message"),
     [
         (BraviaAuthError, "invalid_auth"),
         (BraviaNotSupported, "unsupported_model"),
@@ -376,7 +376,7 @@ async def test_create_entry_psk(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "use_psk, new_pin",
+    ("use_psk", "new_pin"),
     [
         (True, "7777"),
         (False, "newpsk"),

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_form_duplicate_login(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_message",
+    ("side_effect", "error_message"),
     [
         (ServerDisconnectedError, "cannot_connect"),
         (ClientResponseError(Mock(), None, status=403), "invalid_auth"),
@@ -86,7 +86,7 @@ async def test_form_error(hass: HomeAssistant, side_effect, error_message) -> No
 
 
 @pytest.mark.parametrize(
-    "side_effect, result_type, password, step_id, reason",
+    ("side_effect", "result_type", "password", "step_id", "reason"),
     [
         (None, data_entry_flow.FlowResultType.ABORT, "test", None, "reauth_successful"),
         (

--- a/tests/components/bthome/test_binary_sensor.py
+++ b/tests/components/bthome/test_binary_sensor.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    "mac_address, advertisement, bind_key, result",
+    ("mac_address", "advertisement", "bind_key", "result"),
     [
         (
             "A4:C1:38:8D:18:B2",
@@ -102,7 +102,7 @@ async def test_v1_binary_sensors(
 
 
 @pytest.mark.parametrize(
-    "mac_address, advertisement, bind_key, result",
+    ("mac_address", "advertisement", "bind_key", "result"),
     [
         (
             "A4:C1:38:8D:18:B2",

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Tests for BTHome v1
 @pytest.mark.parametrize(
-    "mac_address, advertisement, bind_key, result",
+    ("mac_address", "advertisement", "bind_key", "result"),
     [
         (
             "A4:C1:38:8D:18:B2",
@@ -372,7 +372,7 @@ async def test_v1_sensors(
 
 # Tests for BTHome V2
 @pytest.mark.parametrize(
-    "mac_address, advertisement, bind_key, result",
+    ("mac_address", "advertisement", "bind_key", "result"),
     [
         (
             "A4:C1:38:8D:18:B2",

--- a/tests/components/button/test_device_action.py
+++ b/tests/components/button/test_device_action.py
@@ -48,7 +48,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -57,7 +57,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -88,7 +88,7 @@ async def test_calendars_http_api(
 
 
 @pytest.mark.parametrize(
-    "payload,code",
+    ("payload", "code"),
     [
         (
             {
@@ -198,7 +198,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "date_fields,expected_error,error_match",
+    ("date_fields", "expected_error", "error_match"),
     [
         (
             {},

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -215,7 +215,7 @@ async def test_event_start_trigger(hass: HomeAssistant, calls, fake_schedule) ->
 
 
 @pytest.mark.parametrize(
-    "offset_str, offset_delta",
+    ("offset_str", "offset_delta"),
     [
         ("-01:00", datetime.timedelta(hours=-1)),
         ("+01:00", datetime.timedelta(hours=1)),
@@ -278,7 +278,7 @@ async def test_event_end_trigger(hass: HomeAssistant, calls, fake_schedule) -> N
 
 
 @pytest.mark.parametrize(
-    "offset_str, offset_delta",
+    ("offset_str", "offset_delta"),
     [
         ("-01:00", datetime.timedelta(hours=-1)),
         ("+01:00", datetime.timedelta(hours=1)),
@@ -566,7 +566,7 @@ async def test_update_missed(hass: HomeAssistant, calls, fake_schedule) -> None:
 
 
 @pytest.mark.parametrize(
-    "create_data,fire_time,payload_data",
+    ("create_data", "fire_time", "payload_data"),
     [
         (
             {

--- a/tests/components/camera/test_img_util.py
+++ b/tests/components/camera/test_img_util.py
@@ -102,7 +102,7 @@ SCALE_TEST_EXPECTED = [
 
 
 @pytest.mark.parametrize(
-    "image_width, image_height, input_width, input_height, scaling_factor",
+    ("image_width", "image_height", "input_width", "input_height", "scaling_factor"),
     SCALE_TEST_EXPECTED,
 )
 def test_find_supported_scaling_factor(

--- a/tests/components/cast/test_helpers.py
+++ b/tests/components/cast/test_helpers.py
@@ -17,7 +17,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.parametrize(
-    "url,fixture,content_type",
+    ("url", "fixture", "content_type"),
     (
         (
             "http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_fourfm.m3u8",
@@ -47,7 +47,7 @@ async def test_hls_playlist_supported(
 
 
 @pytest.mark.parametrize(
-    "url,fixture,content_type,expected_playlist",
+    ("url", "fixture", "content_type", "expected_playlist"),
     (
         (
             "https://sverigesradio.se/topsy/direkt/209-hi-mp3.m3u",
@@ -115,7 +115,7 @@ async def test_parse_playlist(
 
 
 @pytest.mark.parametrize(
-    "url,fixture",
+    ("url", "fixture"),
     (
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_invalid_entries.pls"),
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_invalid_file.pls"),
@@ -139,7 +139,7 @@ async def test_parse_bad_playlist(
 
 
 @pytest.mark.parametrize(
-    "url,exc",
+    ("url", "exc"),
     (
         ("http://sverigesradio.se/164-hi-aac.pls", asyncio.TimeoutError),
         ("http://sverigesradio.se/164-hi-aac.pls", client_exceptions.ClientError),

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -760,7 +760,7 @@ async def test_entity_availability(hass: HomeAssistant) -> None:
     assert state.state == "unavailable"
 
 
-@pytest.mark.parametrize("port,entry_type", ((8009, None), (12345, None)))
+@pytest.mark.parametrize(("port", "entry_type"), ((8009, None), (12345, None)))
 async def test_device_registry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, port, entry_type
 ) -> None:
@@ -890,7 +890,7 @@ async def test_entity_cast_status(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "cast_type,supported_features,supported_features_no_media",
+    ("cast_type", "supported_features", "supported_features_no_media"),
     [
         (
             pychromecast.const.CAST_TYPE_AUDIO,
@@ -1248,7 +1248,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistant, quick_play_mock) 
 
 
 @pytest.mark.parametrize(
-    "url,fixture,playlist_item",
+    ("url", "fixture", "playlist_item"),
     (
         # Test title is extracted from m3u playlist
         (
@@ -1510,7 +1510,7 @@ async def test_entity_control(hass: HomeAssistant, quick_play_mock) -> None:
 
 # Some smart TV's with Google TV report "Netflix", not the Netflix app's ID
 @pytest.mark.parametrize(
-    "app_id, state_no_media",
+    ("app_id", "state_no_media"),
     [(pychromecast.APP_YOUTUBE, "idle"), ("Netflix", "playing")],
 )
 async def test_entity_media_states(hass: HomeAssistant, app_id, state_no_media) -> None:

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -25,7 +25,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_action_types",
+    ("set_state", "features_reg", "features_state", "expected_action_types"),
     [
         (False, 0, 0, ["set_hvac_mode"]),
         (
@@ -91,7 +91,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -200,7 +200,13 @@ async def test_action(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "set_state,capabilities_reg,capabilities_state,action,expected_capabilities",
+    (
+        "set_state",
+        "capabilities_reg",
+        "capabilities_state",
+        "action",
+        "expected_capabilities",
+    ),
     [
         (
             False,
@@ -312,7 +318,7 @@ async def test_capabilities(
 
 
 @pytest.mark.parametrize(
-    "action,capability_name",
+    ("action", "capability_name"),
     [("set_hvac_mode", "hvac_mode"), ("set_preset_mode", "preset_mode")],
 )
 async def test_capabilities_missing_entity(

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -31,7 +31,7 @@ def calls(hass):
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_condition_types",
+    ("set_state", "features_reg", "features_state", "expected_condition_types"),
     [
         (False, 0, 0, ["is_hvac_mode"]),
         (
@@ -95,7 +95,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -249,7 +249,13 @@ async def test_if_state(hass: HomeAssistant, calls) -> None:
 
 
 @pytest.mark.parametrize(
-    "set_state,capabilities_reg,capabilities_state,condition,expected_capabilities",
+    (
+        "set_state",
+        "capabilities_reg",
+        "capabilities_state",
+        "condition",
+        "expected_capabilities",
+    ),
     [
         (
             False,
@@ -362,7 +368,7 @@ async def test_capabilities(
 
 
 @pytest.mark.parametrize(
-    "condition,capability_name",
+    ("condition", "capability_name"),
     [("is_hvac_mode", "hvac_mode"), ("is_preset_mode", "preset_mode")],
 )
 async def test_capabilities_missing_entity(

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -83,7 +83,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/climate/test_reproduce_state.py
+++ b/tests/components/climate/test_reproduce_state.py
@@ -93,7 +93,7 @@ async def test_state_with_context(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service,attribute",
+    ("service", "attribute"),
     [
         (SERVICE_SET_AUX_HEAT, ATTR_AUX_HEAT),
         (SERVICE_SET_PRESET_MODE, ATTR_PRESET_MODE),

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -170,7 +170,7 @@ async def test_alexa_config_invalidate_token(
 
 
 @pytest.mark.parametrize(
-    "reject_reason,expected_exception",
+    ("reject_reason", "expected_exception"),
     [
         ("RefreshTokenNotFound", errors.RequireRelink),
         ("UnknownRegion", errors.RequireRelink),

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -135,7 +135,7 @@ async def test_handler_google_actions(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "intent,response_payload",
+    ("intent", "response_payload"),
     [
         ("action.devices.SYNC", {"agentUserId": "myUserName", "devices": []}),
         ("action.devices.QUERY", {"errorCode": "deviceTurnedOff"}),

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -131,7 +131,7 @@ async def test_form_country(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "err_str,err_code",
+    ("err_str", "err_code"),
     [
         ("Invalid authentication credentials", "invalid_auth"),
         ("API rate limit exceeded.", "api_ratelimit"),

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -317,7 +317,7 @@ async def test_reload_entry_in_setup_retry(
 
 
 @pytest.mark.parametrize(
-    "type_filter,result",
+    ("type_filter", "result"),
     (
         (None, {"hello", "another", "world"}),
         ("integration", {"hello", "another"}),

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -112,7 +112,7 @@ async def test_list_devices(
 
 
 @pytest.mark.parametrize(
-    "payload_key,payload_value",
+    ("payload_key", "payload_value"),
     [
         ["area_id", "12345A"],
         ["area_id", None],

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -21,7 +21,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_action_types",
+    ("set_state", "features_reg", "features_state", "expected_action_types"),
     [
         (False, 0, 0, []),
         (False, CoverEntityFeature.CLOSE_TILT, 0, ["close_tilt"]),
@@ -88,7 +88,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -35,7 +35,7 @@ def calls(hass):
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_condition_types",
+    ("set_state", "features_reg", "features_state", "expected_condition_types"),
     [
         (False, 0, 0, []),
         (
@@ -117,7 +117,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -38,7 +38,7 @@ def calls(hass):
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_trigger_types",
+    ("set_state", "features_reg", "features_state", "expected_trigger_types"),
     [
         (False, CoverEntityFeature.OPEN, 0, ["opened", "closed", "opening", "closing"]),
         (
@@ -118,7 +118,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -78,7 +78,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant, mock_daikin) -> None:
 
 
 @pytest.mark.parametrize(
-    "s_effect,reason",
+    ("s_effect", "reason"),
     [
         (asyncio.TimeoutError, "cannot_connect"),
         (ClientError, "cannot_connect"),
@@ -114,7 +114,7 @@ async def test_api_password_abort(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data, unique_id",
+    ("source", "data", "unique_id"),
     [
         (
             SOURCE_ZEROCONF,

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -477,7 +477,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("sensor_data", "expected"), TEST_DATA)
 async def test_binary_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/deconz/test_button.py
+++ b/tests/components/deconz/test_button.py
@@ -99,7 +99,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("raw_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("raw_data", "expected"), TEST_DATA)
 async def test_button(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
 ) -> None:

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -357,7 +357,7 @@ async def test_manual_configuration_timeout_get_bridge(
 
 
 @pytest.mark.parametrize(
-    "raised_error, error_string",
+    ("raised_error", "error_string"),
     [
         (pydeconz.errors.LinkButtonNotPressed, "linking_not_possible"),
         (asyncio.TimeoutError, "no_key"),

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -293,7 +293,7 @@ async def test_get_deconz_session(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, raised_exception",
+    ("side_effect", "raised_exception"),
     [
         (asyncio.TimeoutError, CannotConnect),
         (pydeconz.RequestError, CannotConnect),

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -55,7 +55,7 @@ async def test_no_lights_or_groups(
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    ("input", "expected"),
     [
         (  # RGB light in color temp color mode
             {
@@ -373,7 +373,7 @@ async def test_light_state_change(
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    ("input", "expected"),
     [
         (  # Turn on light with hue and sat
             {
@@ -706,7 +706,7 @@ async def test_configuration_tool(
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    ("input", "expected"),
     [
         (
             {
@@ -859,7 +859,7 @@ async def test_groups(
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    ("input", "expected"),
     [
         (  # Turn on group with short color loop
             {

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -107,7 +107,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("sensor_data", "expected"), TEST_DATA)
 async def test_number_entities(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -55,7 +55,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("raw_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("raw_data", "expected"), TEST_DATA)
 async def test_scenes(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
 ) -> None:

--- a/tests/components/deconz/test_select.py
+++ b/tests/components/deconz/test_select.py
@@ -166,7 +166,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("raw_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("raw_data", "expected"), TEST_DATA)
 async def test_select(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, raw_data, expected
 ) -> None:

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -619,7 +619,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("sensor_data, expected", TEST_DATA)
+@pytest.mark.parametrize(("sensor_data", "expected"), TEST_DATA)
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
@@ -829,7 +829,7 @@ BAD_SENSOR_DATA = [
 ]
 
 
-@pytest.mark.parametrize("sensor_type, sensor_property", BAD_SENSOR_DATA)
+@pytest.mark.parametrize(("sensor_type", "sensor_property"), BAD_SENSOR_DATA)
 async def test_dont_add_sensor_if_state_is_none(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/demo/test_sensor.py
+++ b/tests/components/demo/test_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import mock_restore_cache_with_extra_data
 
 
-@pytest.mark.parametrize("entity_id, delta", (("sensor.total_energy_kwh", 0.5),))
+@pytest.mark.parametrize(("entity_id", "delta"), (("sensor.total_energy_kwh", 0.5),))
 async def test_energy_sensor(hass: HomeAssistant, entity_id, delta, freezer) -> None:
     """Test energy sensors increase periodically."""
     assert await async_setup_component(
@@ -31,7 +31,7 @@ async def test_energy_sensor(hass: HomeAssistant, entity_id, delta, freezer) -> 
     assert state.state == str(delta)
 
 
-@pytest.mark.parametrize("entity_id, delta", (("sensor.total_energy_kwh", 0.5),))
+@pytest.mark.parametrize(("entity_id", "delta"), (("sensor.total_energy_kwh", 0.5),))
 async def test_restore_state(hass: HomeAssistant, entity_id, delta, freezer) -> None:
     """Test energy sensors restore state."""
     fake_state = ha.State(

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -58,7 +58,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -89,7 +89,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -62,7 +62,7 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]):
 
 
 @pytest.mark.parametrize(
-    "exception_type, expected_error",
+    ("exception_type", "expected_error"),
     [[DeviceNotFound, "cannot_connect"], [Exception, "unknown"]],
 )
 async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -> None:

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -240,7 +240,7 @@ async def test_update_enable_leds(hass: HomeAssistant, mock_device: MockDevice) 
 
 
 @pytest.mark.parametrize(
-    "name, get_method, update_interval",
+    ("name", "get_method", "update_interval"),
     [
         ["enable_guest_wifi", "async_get_wifi_guest_access", SHORT_UPDATE_INTERVAL],
         ["enable_leds", "async_get_led_setting", SHORT_UPDATE_INTERVAL],
@@ -275,7 +275,7 @@ async def test_device_failure(
 
 
 @pytest.mark.parametrize(
-    "name, set_method",
+    ("name", "set_method"),
     [
         ["enable_guest_wifi", "async_set_wifi_guest_access"],
         ["enable_leds", "async_set_led_setting"],

--- a/tests/components/dormakaba_dkey/test_config_flow.py
+++ b/tests/components/dormakaba_dkey/test_config_flow.py
@@ -220,7 +220,7 @@ async def test_bluetooth_step_already_in_progress(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exc, error",
+    ("exc", "error"),
     (
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
@@ -259,7 +259,7 @@ async def test_bluetooth_step_cannot_connect(hass: HomeAssistant, exc, error) ->
 
 
 @pytest.mark.parametrize(
-    "exc, error",
+    ("exc", "error"),
     (
         (dkey_errors.InvalidActivationCode, "invalid_code"),
         (dkey_errors.WrongActivationCode, "wrong_code"),

--- a/tests/components/dsmr/test_init.py
+++ b/tests/components/dsmr/test_init.py
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "dsmr_version,old_unique_id,new_unique_id",
+    ("dsmr_version", "old_unique_id", "new_unique_id"),
     [
         ("5", "1234_Power_Consumption", "1234_current_electricity_usage"),
         ("5", "1234_Power_Production", "1234_current_electricity_delivery"),

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "first_con, second_con,exp_type, exp_result, exp_reason",
+    ("first_con", "second_con", "exp_type", "exp_result", "exp_reason"),
     [
         (True, True, "create_entry", config_entries.ConfigEntryState.LOADED, ""),
         (False, False, "abort", None, "no_connection"),

--- a/tests/components/dynalite/test_switch.py
+++ b/tests/components/dynalite/test_switch.py
@@ -48,7 +48,7 @@ async def test_switch_setup(hass: HomeAssistant, mock_device) -> None:
     )
 
 
-@pytest.mark.parametrize("saved_state, level", [(STATE_ON, 1), (STATE_OFF, 0)])
+@pytest.mark.parametrize(("saved_state", "level"), [(STATE_ON, 1), (STATE_OFF, 0)])
 async def test_switch_restore_state(
     hass: HomeAssistant, mock_device, saved_state, level
 ) -> None:

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -976,7 +976,7 @@ async def test_form_import_existing(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, ELK_DISCOVERY_INFO),
@@ -1006,7 +1006,7 @@ async def test_discovered_by_dhcp_or_discovery_mac_address_mismatch_host_already
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, ELK_DISCOVERY_INFO),

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -439,7 +439,7 @@ async def test_light_without_brightness_can_be_turned_on(hass_hue, hue_client) -
 
 
 @pytest.mark.parametrize(
-    "state,is_reachable",
+    ("state", "is_reachable"),
     [
         (const.STATE_UNAVAILABLE, False),
         (const.STATE_OK, True),

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -134,7 +134,9 @@ async def test_cost_sensor_attributes(
     assert entry.hidden_by == er.RegistryEntryHider.INTEGRATION
 
 
-@pytest.mark.parametrize("initial_energy,initial_cost", [(0, "0.0"), (None, "unknown")])
+@pytest.mark.parametrize(
+    ("initial_energy", "initial_cost"), [(0, "0.0"), (None, "unknown")]
+)
 @pytest.mark.parametrize(
     "price_entity,fixed_price", [("sensor.energy_price", None), (None, 1)]
 )
@@ -336,7 +338,9 @@ async def test_cost_sensor_price_entity_total_increasing(
     assert statistics["stat"]["sum"] == 38.0
 
 
-@pytest.mark.parametrize("initial_energy,initial_cost", [(0, "0.0"), (None, "unknown")])
+@pytest.mark.parametrize(
+    ("initial_energy", "initial_cost"), [(0, "0.0"), (None, "unknown")]
+)
 @pytest.mark.parametrize(
     "price_entity,fixed_price", [("sensor.energy_price", None), (None, 1)]
 )
@@ -542,7 +546,9 @@ async def test_cost_sensor_price_entity_total(
     assert statistics["stat"]["sum"] == 38.0
 
 
-@pytest.mark.parametrize("initial_energy,initial_cost", [(0, "0.0"), (None, "unknown")])
+@pytest.mark.parametrize(
+    ("initial_energy", "initial_cost"), [(0, "0.0"), (None, "unknown")]
+)
 @pytest.mark.parametrize(
     "price_entity,fixed_price", [("sensor.energy_price", None), (None, 1)]
 )
@@ -724,7 +730,7 @@ async def test_cost_sensor_price_entity_total_no_reset(
 
 
 @pytest.mark.parametrize(
-    "energy_unit,factor",
+    ("energy_unit", "factor"),
     [
         (UnitOfEnergy.WATT_HOUR, 1000),
         (UnitOfEnergy.KILO_WATT_HOUR, 1),
@@ -794,7 +800,7 @@ async def test_cost_sensor_handle_energy_units(
 
 
 @pytest.mark.parametrize(
-    "price_unit,factor",
+    ("price_unit", "factor"),
     [
         (f"EUR/{UnitOfEnergy.WATT_HOUR}", 0.001),
         (f"EUR/{UnitOfEnergy.KILO_WATT_HOUR}", 1),
@@ -973,7 +979,7 @@ async def test_cost_sensor_handle_gas_kwh(
 
 
 @pytest.mark.parametrize(
-    "unit_system,usage_unit,growth",
+    ("unit_system", "usage_unit", "growth"),
     (
         # 1 cubic foot = 7.47 gl, 100 ft3 growth @ 0.5/ft3:
         (US_CUSTOMARY_SYSTEM, UnitOfVolume.CUBIC_FEET, 374.025974025974),

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -62,7 +62,7 @@ async def test_validation_empty_config(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "state_class, energy_unit, extra",
+    ("state_class", "energy_unit", "extra"),
     [
         ("total_increasing", UnitOfEnergy.KILO_WATT_HOUR, {}),
         ("total_increasing", UnitOfEnergy.MEGA_WATT_HOUR, {}),
@@ -688,7 +688,7 @@ async def test_validation_grid_auto_cost_entity_errors(
 
 
 @pytest.mark.parametrize(
-    "state, unit, expected",
+    ("state", "unit", "expected"),
     (
         (
             "123,123.12",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -18,7 +18,7 @@ def stub_reconnect():
 
 
 @pytest.mark.parametrize(
-    "devices_payload,expected_state,expected_attributes",
+    ("devices_payload", "expected_state", "expected_attributes"),
     [
         (
             [

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -52,7 +52,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -58,7 +58,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -63,7 +63,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -66,7 +66,7 @@ async def test_async_fanentity(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "attribute_name, attribute_value",
+    ("attribute_name", "attribute_value"),
     [
         ("current_direction", "forward"),
         ("oscillating", True),

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -563,7 +563,7 @@ async def test_discovered_by_dhcp_no_udp_response_or_tcp_response(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, FLUX_DISCOVERY),
@@ -633,7 +633,7 @@ async def test_mac_address_off_by_one_not_updated_from_dhcp(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, FLUX_DISCOVERY),
@@ -700,7 +700,7 @@ async def test_options(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, FLUX_DISCOVERY),

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -182,7 +182,7 @@ async def test_coordinator_retry_right_away_on_discovery_already_setup(
 
 
 @pytest.mark.parametrize(
-    "discovery,title",
+    ("discovery", "title"),
     [
         (FLUX_DISCOVERY, DEFAULT_ENTRY_TITLE),
         (FLUX_DISCOVERY_PARTIAL, DEFAULT_ENTRY_TITLE),

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -154,7 +154,7 @@ async def test_light_mac_address_not_found(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "protocol,sw_version,model_num,model",
+    ("protocol", "sw_version", "model_num", "model"),
     [
         ("LEDENET_ORIGINAL", 1, 0x01, "Original LEDEDNET (0x35)"),
         ("LEDENET", 8, 0x33, "Magic Home Branded RGB Controller (0x33)"),

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -173,7 +173,7 @@ async def test_disabled_by_default(
 
 
 @pytest.mark.parametrize(
-    "key,name,value",
+    ("key", "name", "value"),
     [
         (
             "power_production_next_12hours",

--- a/tests/components/freedompro/test_binary_sensor.py
+++ b/tests/components/freedompro/test_binary_sensor.py
@@ -15,7 +15,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name, model",
+    ("entity_id", "uid", "name", "model"),
     [
         (
             "binary_sensor.doorway_motion_sensor",

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -24,7 +24,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name, model",
+    ("entity_id", "uid", "name", "model"),
     [
         (
             "cover.blind",
@@ -84,7 +84,7 @@ async def test_cover_get_state(
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name, model",
+    ("entity_id", "uid", "name", "model"),
     [
         (
             "cover.blind",
@@ -139,7 +139,7 @@ async def test_cover_set_position(
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name, model",
+    ("entity_id", "uid", "name", "model"),
     [
         (
             "cover.blind",
@@ -202,7 +202,7 @@ async def test_cover_close(
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name, model",
+    ("entity_id", "uid", "name", "model"),
     [
         (
             "cover.blind",

--- a/tests/components/freedompro/test_sensor.py
+++ b/tests/components/freedompro/test_sensor.py
@@ -14,7 +14,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    "entity_id, uid, name",
+    ("entity_id", "uid", "name"),
     [
         (
             "sensor.garden_humidity_sensor",

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -33,7 +33,7 @@ async def test_button_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -
 
 
 @pytest.mark.parametrize(
-    "entity_id, wrapper_method",
+    ("entity_id", "wrapper_method"),
     [
         ("button.mock_title_firmware_update", "async_trigger_firmware_update"),
         ("button.mock_title_reboot", "async_trigger_reboot"),

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -246,7 +246,7 @@ async def test_reauth_successful(
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (FritzAuthorizationError, ERROR_AUTH_INVALID),
         (FritzConnectionException, ERROR_CANNOT_CONNECT),

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -154,7 +154,7 @@ MOCK_WLANCONFIGS_DIFF2_SSID: dict[str, dict] = {
 
 
 @pytest.mark.parametrize(
-    "fc_data, expected_wifi_names",
+    ("fc_data", "expected_wifi_names"),
     [
         (
             {**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_SAME_SSID},

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -201,7 +201,7 @@ async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
 
 
 @pytest.mark.parametrize(
-    "test_data,expected_result",
+    ("test_data", "expected_result"),
     [
         (MOCK_SSDP_DATA["ip4_valid"], FlowResultType.FORM),
         (MOCK_SSDP_DATA["ip6_valid"], FlowResultType.FORM),

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -46,7 +46,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {
@@ -99,7 +99,7 @@ async def test_update_unique_id(
 
 
 @pytest.mark.parametrize(
-    "entitydata,unique_id",
+    ("entitydata", "unique_id"),
     [
         (
             {

--- a/tests/components/fully_kiosk/test_config_flow.py
+++ b/tests/components/fully_kiosk/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_user_flow(
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    ("side_effect", "reason"),
     [
         (FullyKioskError("error", "status"), "cannot_connect"),
         (ClientConnectorError(None, Mock()), "cannot_connect"),

--- a/tests/components/garages_amsterdam/test_config_flow.py
+++ b/tests/components/garages_amsterdam/test_config_flow.py
@@ -37,7 +37,7 @@ async def test_full_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    ("side_effect", "reason"),
     [
         (RuntimeError, "unknown"),
         (

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -304,7 +304,7 @@ async def test_set_target_temp(hass: HomeAssistant, setup_comp_2) -> None:
 
 
 @pytest.mark.parametrize(
-    "preset,temp",
+    ("preset", "temp"),
     [
         (PRESET_NONE, 23),
         (PRESET_AWAY, 16),
@@ -323,7 +323,7 @@ async def test_set_away_mode(hass: HomeAssistant, setup_comp_2, preset, temp) ->
 
 
 @pytest.mark.parametrize(
-    "preset,temp",
+    ("preset", "temp"),
     [
         (PRESET_NONE, 23),
         (PRESET_AWAY, 16),
@@ -350,7 +350,7 @@ async def test_set_away_mode_and_restore_prev_temp(
 
 
 @pytest.mark.parametrize(
-    "preset,temp",
+    ("preset", "temp"),
     [
         (PRESET_NONE, 23),
         (PRESET_AWAY, 16),

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -548,7 +548,7 @@ async def test_http_api_all_day_event(
 
 
 @pytest.mark.parametrize(
-    "calendars_config_ignore_availability,transparency,expect_visible_event",
+    ("calendars_config_ignore_availability", "transparency", "expect_visible_event"),
     [
         # Look at visibility to determine if entity is created
         (False, "opaque", True),
@@ -798,7 +798,7 @@ async def test_invalid_unique_id_cleanup(
 
 
 @pytest.mark.parametrize(
-    "time_zone,event_order,calendar_access_role",
+    ("time_zone", "event_order", "calendar_access_role"),
     # This only tests the reader role to force testing against the local
     # database filtering based on start/end time. (free busy reader would
     # just use the API response which this test is not exercising)
@@ -1075,7 +1075,7 @@ async def test_websocket_delete_recurring_event_instance(
 
 
 @pytest.mark.parametrize(
-    "calendar_access_role,token_scopes,config_entry_options",
+    ("calendar_access_role", "token_scopes", "config_entry_options"),
     [
         (
             "reader",

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -525,7 +525,7 @@ async def test_reauth_flow(
 
 
 @pytest.mark.parametrize(
-    "primary_calendar_error,primary_calendar_status,reason",
+    ("primary_calendar_error", "primary_calendar_status", "reason"),
     [
         (ClientError(), None, "cannot_connect"),
         (None, HTTPStatus.FORBIDDEN, "api_disabled"),

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -297,7 +297,7 @@ async def test_multiple_config_entries(
 
 
 @pytest.mark.parametrize(
-    "date_fields,expected_error,error_match",
+    ("date_fields", "expected_error", "error_match"),
     [
         (
             {},
@@ -436,7 +436,7 @@ async def test_add_event_invalid_params(
 
 
 @pytest.mark.parametrize(
-    "date_fields,start_timedelta,end_timedelta",
+    ("date_fields", "start_timedelta", "end_timedelta"),
     [
         (
             {"in": {"days": 3}},
@@ -682,7 +682,7 @@ async def test_expired_token_requires_reauth(
 
 
 @pytest.mark.parametrize(
-    "calendars_config,expect_write_calls",
+    ("calendars_config", "expect_write_calls"),
     [
         (
             [
@@ -799,7 +799,7 @@ async def test_assign_unique_id(
 
 
 @pytest.mark.parametrize(
-    "config_entry_unique_id,request_status,config_entry_status",
+    ("config_entry_unique_id", "request_status", "config_entry_status"),
     [
         (None, http.HTTPStatus.BAD_REQUEST, ConfigEntryState.SETUP_RETRY),
         (

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -315,7 +315,7 @@ async def test_report_state_all(agents) -> None:
 
 
 @pytest.mark.parametrize(
-    "agents, result",
+    ("agents", "result"),
     [({}, 204), ({"1": 200}, 200), ({"1": 200, "2": 300}, 300)],
 )
 async def test_sync_entities_all(agents, result) -> None:

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -441,7 +441,8 @@ async def test_query_message(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "report_state,on,brightness,value", [(False, True, 20, 0.2), (True, ANY, ANY, ANY)]
+    ("report_state", "on", "brightness", "value"),
+    [(False, True, 20, 0.2), (True, ANY, ANY, ANY)],
 )
 async def test_execute(
     hass: HomeAssistant, report_state, on, brightness, value
@@ -621,7 +622,9 @@ async def test_execute(
     assert service_events[3].context == events[0].context
 
 
-@pytest.mark.parametrize("report_state,on,brightness,value", [(False, False, ANY, ANY)])
+@pytest.mark.parametrize(
+    ("report_state", "on", "brightness", "value"), [(False, False, ANY, ANY)]
+)
 async def test_execute_times_out(
     hass: HomeAssistant, report_state, on, brightness, value
 ) -> None:
@@ -998,7 +1001,7 @@ async def test_unavailable_state_does_sync(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "device_class,google_type",
+    ("device_class", "google_type"),
     [
         ("non_existing_class", "action.devices.types.SWITCH"),
         ("switch", "action.devices.types.SWITCH"),
@@ -1048,7 +1051,7 @@ async def test_device_class_switch(
 
 
 @pytest.mark.parametrize(
-    "device_class,google_type",
+    ("device_class", "google_type"),
     [
         ("door", "action.devices.types.DOOR"),
         ("garage_door", "action.devices.types.GARAGE"),
@@ -1098,7 +1101,7 @@ async def test_device_class_binary_sensor(
 
 
 @pytest.mark.parametrize(
-    "device_class,google_type",
+    ("device_class", "google_type"),
     [
         ("non_existing_class", "action.devices.types.BLINDS"),
         ("door", "action.devices.types.DOOR"),
@@ -1148,7 +1151,7 @@ async def test_device_class_cover(
 
 
 @pytest.mark.parametrize(
-    "device_class,google_type",
+    ("device_class", "google_type"),
     [
         ("non_existing_class", "action.devices.types.SETTOP"),
         ("tv", "action.devices.types.TV"),

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1647,7 +1647,7 @@ async def test_fan_speed_without_percentage_step(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "percentage,percentage_step, speed, speeds, percentage_result",
+    ("percentage", "percentage_step", "speed", "speeds", "percentage_result"),
     [
         (
             33,
@@ -1758,7 +1758,7 @@ async def test_fan_speed_ordered(
 
 
 @pytest.mark.parametrize(
-    "direction_state,direction_call",
+    ("direction_state", "direction_call"),
     [
         (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE),
         (fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD),
@@ -1935,7 +1935,7 @@ async def test_inputselector(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sources,source,source_next,source_prev",
+    ("sources", "source", "source_next", "source_prev"),
     [
         (["a"], "a", "a", "a"),
         (["a", "b"], "a", "b", "b"),
@@ -1990,7 +1990,7 @@ async def test_inputselector_nextprev(
 
 
 @pytest.mark.parametrize(
-    "sources,source", [(None, "a"), (["a", "b"], None), (["a", "b"], "c")]
+    ("sources", "source"), [(None, "a"), (["a", "b"], None), (["a", "b"], "c")]
 )
 async def test_inputselector_nextprev_invalid(
     hass: HomeAssistant, sources, source
@@ -2916,7 +2916,7 @@ async def test_temperature_control_sensor(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "unit_in,unit_out,state,ambient",
+    ("unit_in", "unit_out", "state", "ambient"),
     [
         (UnitOfTemperature.FAHRENHEIT, "F", "70", 21.1),
         (UnitOfTemperature.CELSIUS, "C", "21.1", 21.1),
@@ -2971,7 +2971,7 @@ async def test_humidity_setting_sensor(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "state,ambient", [("70", 70), ("unavailable", None), ("unknown", None)]
+    ("state", "ambient"), [("70", 70), ("unavailable", None), ("unknown", None)]
 )
 async def test_humidity_setting_sensor_data(
     hass: HomeAssistant, state, ambient

--- a/tests/components/google_assistant_sdk/test_init.py
+++ b/tests/components/google_assistant_sdk/test_init.py
@@ -85,7 +85,7 @@ async def test_expired_token_refresh_success(
 
 
 @pytest.mark.parametrize(
-    "expires_at,status,expected_state",
+    ("expires_at", "status", "expected_state"),
     [
         (
             time.time() - 3600,
@@ -122,7 +122,7 @@ async def test_expired_token_refresh_failure(
 
 
 @pytest.mark.parametrize(
-    "configured_language_code,expected_language_code",
+    ("configured_language_code", "expected_language_code"),
     [("", "en-US"), ("en-US", "en-US"), ("es-ES", "es-ES")],
     ids=["default", "english", "spanish"],
 )
@@ -187,7 +187,7 @@ async def test_send_text_commands(
 
 
 @pytest.mark.parametrize(
-    "status,requires_reauth",
+    ("status", "requires_reauth"),
     [
         (
             http.HTTPStatus.UNAUTHORIZED,

--- a/tests/components/google_assistant_sdk/test_notify.py
+++ b/tests/components/google_assistant_sdk/test_notify.py
@@ -13,7 +13,7 @@ from .conftest import ComponentSetup, ExpectedCredentials
 
 
 @pytest.mark.parametrize(
-    "language_code,message,expected_command",
+    ("language_code", "message", "expected_command"),
     [
         ("en-US", "Dinner is served", "broadcast Dinner is served"),
         ("es-ES", "La cena está en la mesa", "Anuncia La cena está en la mesa"),
@@ -51,7 +51,7 @@ async def test_broadcast_no_targets(
 
 
 @pytest.mark.parametrize(
-    "language_code,message,target,expected_command",
+    ("language_code", "message", "target", "expected_command"),
     [
         (
             "en-US",

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -71,7 +71,7 @@ async def test_full_flow(
 
 
 @pytest.mark.parametrize(
-    "fixture,abort_reason,placeholders,calls,access_token",
+    ("fixture", "abort_reason", "placeholders", "calls", "access_token"),
     [
         ("get_profile", "reauth_successful", None, 1, "updated-access-token"),
         (

--- a/tests/components/google_mail/test_init.py
+++ b/tests/components/google_mail/test_init.py
@@ -61,7 +61,7 @@ async def test_expired_token_refresh_success(
 
 
 @pytest.mark.parametrize(
-    "expires_at,status,expected_state",
+    ("expires_at", "status", "expected_state"),
     [
         (
             time.time() - 3600,

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -150,7 +150,7 @@ async def test_expired_token_refresh_success(
 
 
 @pytest.mark.parametrize(
-    "expires_at,status,expected_state",
+    ("expires_at", "status", "expected_state"),
     [
         (
             time.time() - 3600,

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -136,7 +136,7 @@ async def test_malformed_api_key(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,
@@ -197,7 +197,7 @@ async def test_options_flow(hass: HomeAssistant, mock_config) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -80,7 +80,7 @@ def mock_update_empty_fixture(mock_update):
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [(MOCK_CONFIG, {})],
 )
 @pytest.mark.usefixtures("mock_update", "mock_config")
@@ -115,7 +115,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [(MOCK_CONFIG, {})],
 )
 @pytest.mark.usefixtures("mock_update_duration", "mock_config")
@@ -125,7 +125,7 @@ async def test_sensor_duration(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [(MOCK_CONFIG, {})],
 )
 @pytest.mark.usefixtures("mock_update_empty", "mock_config")
@@ -135,7 +135,7 @@ async def test_sensor_empty_response(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,
@@ -152,7 +152,7 @@ async def test_sensor_departure_time(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,
@@ -169,7 +169,7 @@ async def test_sensor_departure_time_custom_timestamp(hass: HomeAssistant) -> No
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,
@@ -186,7 +186,7 @@ async def test_sensor_arrival_time(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,
@@ -203,7 +203,7 @@ async def test_sensor_arrival_time_custom_timestamp(hass: HomeAssistant) -> None
 
 
 @pytest.mark.parametrize(
-    "unit_system, expected_unit_option",
+    ("unit_system", "expected_unit_option"),
     [
         (METRIC_SYSTEM, CONF_UNIT_SYSTEM_METRIC),
         (US_CUSTOMARY_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL),

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -271,7 +271,7 @@ async def test_report_with_binary_state(
 
 
 @pytest.mark.parametrize(
-    "error, log_text",
+    ("error", "log_text"),
     [
         (OSError, "Failed to send data to graphite"),
         (socket.gaierror, "Unable to connect to host"),

--- a/tests/components/gree/test_climate.py
+++ b/tests/components/gree/test_climate.py
@@ -376,7 +376,7 @@ async def test_send_power_off_device_timeout(
 
 
 @pytest.mark.parametrize(
-    "units,temperature",
+    ("units", "temperature"),
     [(UnitOfTemperature.CELSIUS, 26), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
 async def test_send_target_temperature(
@@ -415,7 +415,7 @@ async def test_send_target_temperature(
 
 
 @pytest.mark.parametrize(
-    "units,temperature",
+    ("units", "temperature"),
     [(UnitOfTemperature.CELSIUS, 25), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
 async def test_send_target_temperature_device_timeout(
@@ -445,7 +445,7 @@ async def test_send_target_temperature_device_timeout(
 
 
 @pytest.mark.parametrize(
-    "units,temperature",
+    ("units", "temperature"),
     [(UnitOfTemperature.CELSIUS, 25), (UnitOfTemperature.FAHRENHEIT, 74)],
 )
 async def test_update_target_temperature(

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -161,7 +161,7 @@ async def test_send_switch_toggle(hass: HomeAssistant, entity) -> None:
 
 
 @pytest.mark.parametrize(
-    "entity,name",
+    ("entity", "name"),
     [
         (ENTITY_ID_LIGHT_PANEL, "Panel Light"),
         (ENTITY_ID_QUIET, "Quiet"),

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -13,7 +13,15 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "group_type,group_state,member_state,member_attributes,extra_input,extra_options,extra_attrs",
+    (
+        "group_type",
+        "group_state",
+        "member_state",
+        "member_attributes",
+        "extra_input",
+        "extra_options",
+        "extra_attrs",
+    ),
     (
         ("binary_sensor", "on", "on", {}, {}, {"all": False}, {}),
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
@@ -105,7 +113,7 @@ async def test_config_flow(
 
 
 @pytest.mark.parametrize(
-    "hide_members,hidden_by", ((False, None), (True, "integration"))
+    ("hide_members", "hidden_by"), ((False, None), (True, "integration"))
 )
 @pytest.mark.parametrize(
     "group_type,extra_input",
@@ -180,7 +188,7 @@ def get_suggested(schema, key):
 
 
 @pytest.mark.parametrize(
-    "group_type,member_state,extra_options,options_options",
+    ("group_type", "member_state", "extra_options", "options_options"),
     (
         ("binary_sensor", "on", {"all": False}, {}),
         ("cover", "open", {}, {}),
@@ -285,7 +293,7 @@ async def test_options(
 
 
 @pytest.mark.parametrize(
-    "group_type,extra_options,extra_options_after,advanced",
+    ("group_type", "extra_options", "extra_options_after", "advanced"),
     (
         ("light", {"all": False}, {"all": False}, False),
         ("light", {"all": True}, {"all": True}, False),
@@ -356,7 +364,7 @@ async def test_all_options(
 
 
 @pytest.mark.parametrize(
-    "hide_members,hidden_by_initial,hidden_by",
+    ("hide_members", "hidden_by_initial", "hidden_by"),
     (
         (False, er.RegistryEntryHider.INTEGRATION, None),
         (True, None, er.RegistryEntryHider.INTEGRATION),

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -836,7 +836,7 @@ async def test_group_mixed_domains_off(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "states,group_state",
+    ("states", "group_state"),
     [
         (("locked", "locked", "unlocked"), "unlocked"),
         (("locked", "locked", "locked"), "locked"),
@@ -1433,7 +1433,7 @@ async def test_plant_group(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "group_type,member_state,extra_options",
+    ("group_type", "member_state", "extra_options"),
     (
         ("binary_sensor", "on", {"all": False}),
         ("cover", "open", {}),
@@ -1497,7 +1497,7 @@ async def test_setup_and_remove_config_entry(
 
 
 @pytest.mark.parametrize(
-    "hide_members,hidden_by_initial,hidden_by",
+    ("hide_members", "hidden_by_initial", "hidden_by"),
     (
         (False, er.RegistryEntryHider.INTEGRATION, er.RegistryEntryHider.INTEGRATION),
         (False, None, None),

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -48,7 +48,7 @@ SUM_VALUE = sum(VALUES)
 
 
 @pytest.mark.parametrize(
-    "sensor_type, result, attributes",
+    ("sensor_type", "result", "attributes"),
     [
         ("min", MIN_VALUE, {ATTR_MIN_ENTITY_ID: "sensor.test_3"}),
         ("max", MAX_VALUE, {ATTR_MAX_ENTITY_ID: "sensor.test_2"}),

--- a/tests/components/hassio/test_addon_manager.py
+++ b/tests/components/hassio/test_addon_manager.py
@@ -257,7 +257,7 @@ async def test_get_addon_info_not_installed(
 
 
 @pytest.mark.parametrize(
-    "addon_info_state, addon_state",
+    ("addon_info_state", "addon_state"),
     [("started", AddonState.RUNNING), ("stopped", AddonState.NOT_RUNNING)],
 )
 async def test_get_addon_info(
@@ -279,7 +279,12 @@ async def test_get_addon_info(
 
 
 @pytest.mark.parametrize(
-    "addon_info_error, addon_info_calls, addon_store_info_error, addon_store_info_calls",
+    (
+        "addon_info_error",
+        "addon_info_calls",
+        "addon_store_info_error",
+        "addon_store_info_calls",
+    ),
     [(HassioAPIError("Boom"), 1, None, 1), (None, 0, HassioAPIError("Boom"), 1)],
 )
 async def test_get_addon_info_error(
@@ -746,9 +751,13 @@ async def test_schedule_update_addon(
 
 @pytest.mark.parametrize(
     (
-        "create_backup_error, create_backup_calls, "
-        "update_addon_error, update_addon_calls, "
-        "error_message"
+        (
+            "create_backup_error",
+            "create_backup_calls",
+            "update_addon_error",
+            "update_addon_calls",
+            "error_message",
+        )
     ),
     [
         (
@@ -794,9 +803,13 @@ async def test_schedule_update_addon_error(
 
 @pytest.mark.parametrize(
     (
-        "create_backup_error, create_backup_calls, "
-        "update_addon_error, update_addon_calls, "
-        "error_log"
+        (
+            "create_backup_error",
+            "create_backup_calls",
+            "update_addon_error",
+            "update_addon_calls",
+            "error_log",
+        )
     ),
     [
         (
@@ -918,10 +931,15 @@ async def test_schedule_install_setup_addon(
 
 @pytest.mark.parametrize(
     (
-        "install_addon_error, install_addon_calls, "
-        "set_addon_options_error, set_addon_options_calls, "
-        "start_addon_error, start_addon_calls, "
-        "error_message"
+        (
+            "install_addon_error",
+            "install_addon_calls",
+            "set_addon_options_error",
+            "set_addon_options_calls",
+            "start_addon_error",
+            "start_addon_calls",
+            "error_message",
+        )
     ),
     [
         (
@@ -984,10 +1002,15 @@ async def test_schedule_install_setup_addon_error(
 
 @pytest.mark.parametrize(
     (
-        "install_addon_error, install_addon_calls, "
-        "set_addon_options_error, set_addon_options_calls, "
-        "start_addon_error, start_addon_calls, "
-        "error_log"
+        (
+            "install_addon_error",
+            "install_addon_calls",
+            "set_addon_options_error",
+            "set_addon_options_calls",
+            "start_addon_error",
+            "start_addon_calls",
+            "error_log",
+        )
     ),
     [
         (
@@ -1081,9 +1104,13 @@ async def test_schedule_setup_addon(
 
 @pytest.mark.parametrize(
     (
-        "set_addon_options_error, set_addon_options_calls, "
-        "start_addon_error, start_addon_calls, "
-        "error_message"
+        (
+            "set_addon_options_error",
+            "set_addon_options_calls",
+            "start_addon_error",
+            "start_addon_calls",
+            "error_message",
+        )
     ),
     [
         (
@@ -1128,9 +1155,13 @@ async def test_schedule_setup_addon_error(
 
 @pytest.mark.parametrize(
     (
-        "set_addon_options_error, set_addon_options_calls, "
-        "start_addon_error, start_addon_calls, "
-        "error_log"
+        (
+            "set_addon_options_error",
+            "set_addon_options_calls",
+            "start_addon_error",
+            "start_addon_calls",
+            "error_log",
+        )
     ),
     [
         (

--- a/tests/components/hassio/test_addon_manager.py
+++ b/tests/components/hassio/test_addon_manager.py
@@ -751,13 +751,11 @@ async def test_schedule_update_addon(
 
 @pytest.mark.parametrize(
     (
-        (
-            "create_backup_error",
-            "create_backup_calls",
-            "update_addon_error",
-            "update_addon_calls",
-            "error_message",
-        )
+        "create_backup_error",
+        "create_backup_calls",
+        "update_addon_error",
+        "update_addon_calls",
+        "error_message",
     ),
     [
         (
@@ -803,13 +801,11 @@ async def test_schedule_update_addon_error(
 
 @pytest.mark.parametrize(
     (
-        (
-            "create_backup_error",
-            "create_backup_calls",
-            "update_addon_error",
-            "update_addon_calls",
-            "error_log",
-        )
+        "create_backup_error",
+        "create_backup_calls",
+        "update_addon_error",
+        "update_addon_calls",
+        "error_log",
     ),
     [
         (
@@ -931,15 +927,13 @@ async def test_schedule_install_setup_addon(
 
 @pytest.mark.parametrize(
     (
-        (
-            "install_addon_error",
-            "install_addon_calls",
-            "set_addon_options_error",
-            "set_addon_options_calls",
-            "start_addon_error",
-            "start_addon_calls",
-            "error_message",
-        )
+        "install_addon_error",
+        "install_addon_calls",
+        "set_addon_options_error",
+        "set_addon_options_calls",
+        "start_addon_error",
+        "start_addon_calls",
+        "error_message",
     ),
     [
         (
@@ -1002,15 +996,13 @@ async def test_schedule_install_setup_addon_error(
 
 @pytest.mark.parametrize(
     (
-        (
-            "install_addon_error",
-            "install_addon_calls",
-            "set_addon_options_error",
-            "set_addon_options_calls",
-            "start_addon_error",
-            "start_addon_calls",
-            "error_log",
-        )
+        "install_addon_error",
+        "install_addon_calls",
+        "set_addon_options_error",
+        "set_addon_options_calls",
+        "start_addon_error",
+        "start_addon_calls",
+        "error_log",
     ),
     [
         (
@@ -1104,13 +1096,11 @@ async def test_schedule_setup_addon(
 
 @pytest.mark.parametrize(
     (
-        (
-            "set_addon_options_error",
-            "set_addon_options_calls",
-            "start_addon_error",
-            "start_addon_calls",
-            "error_message",
-        )
+        "set_addon_options_error",
+        "set_addon_options_calls",
+        "start_addon_error",
+        "start_addon_calls",
+        "error_message",
     ),
     [
         (
@@ -1155,13 +1145,11 @@ async def test_schedule_setup_addon_error(
 
 @pytest.mark.parametrize(
     (
-        (
-            "set_addon_options_error",
-            "set_addon_options_calls",
-            "start_addon_error",
-            "start_addon_calls",
-            "error_log",
-        )
+        "set_addon_options_error",
+        "set_addon_options_calls",
+        "start_addon_error",
+        "start_addon_calls",
+        "error_log",
     ),
     [
         (

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -150,7 +150,7 @@ def mock_all(aioclient_mock, request):
 
 
 @pytest.mark.parametrize(
-    "entity_id,expected",
+    ("entity_id", "expected"),
     [
         ("binary_sensor.test_running", "on"),
         ("binary_sensor.test2_running", "off"),

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -795,7 +795,7 @@ async def test_coordinator_updates(
 
 
 @pytest.mark.parametrize(
-    "extra_os_info, integration",
+    ("extra_os_info", "integration"),
     [
         ({"board": "odroid-c2"}, "hardkernel"),
         ({"board": "odroid-c4"}, "hardkernel"),

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -143,7 +143,7 @@ def mock_all(aioclient_mock, request):
 
 
 @pytest.mark.parametrize(
-    "entity_id,expected",
+    ("entity_id", "expected"),
     [
         ("sensor.home_assistant_operating_system_version", "1.0.0"),
         ("sensor.home_assistant_operating_system_newest_version", "1.0.0"),

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -157,7 +157,7 @@ def mock_all(aioclient_mock, request):
 
 
 @pytest.mark.parametrize(
-    "entity_id,expected_state, auto_update",
+    ("entity_id", "expected_state", "auto_update"),
     [
         ("update.home_assistant_operating_system_update", "on", False),
         ("update.home_assistant_supervisor_update", "on", True),

--- a/tests/components/hdmi_cec/test_init.py
+++ b/tests/components/hdmi_cec/test_init.py
@@ -46,7 +46,7 @@ def mock_tcp_adapter_fixture():
 
 
 @pytest.mark.parametrize(
-    "mapping,expected",
+    ("mapping", "expected"),
     [
         ({}, []),
         (
@@ -276,7 +276,7 @@ async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) 
 
 
 @pytest.mark.parametrize(
-    "count,calls",
+    ("count", "calls"),
     [
         (3, 3),
         (1, 1),
@@ -312,7 +312,7 @@ async def test_service_volume_x_times(
         )
 
 
-@pytest.mark.parametrize("direction,key", [("up", 65), ("down", 66)])
+@pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_press(
     hass: HomeAssistant, create_hdmi_network, direction, key
 ) -> None:
@@ -333,7 +333,7 @@ async def test_service_volume_press(
     assert arg.dst == 5
 
 
-@pytest.mark.parametrize("direction,key", [("up", 65), ("down", 66)])
+@pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_release(
     hass: HomeAssistant, create_hdmi_network, direction, key
 ) -> None:
@@ -354,7 +354,7 @@ async def test_service_volume_release(
 
 
 @pytest.mark.parametrize(
-    "attr,key",
+    ("attr", "key"),
     [
         ("toggle", 67),
         ("on", 101),
@@ -387,7 +387,7 @@ async def test_service_volume_mute(
 
 
 @pytest.mark.parametrize(
-    "data,expected",
+    ("data", "expected"),
     [
         ({"raw": "20:0D"}, "20:0d"),
         pytest.param(
@@ -460,7 +460,7 @@ async def test_service_send_command(
 
 
 @pytest.mark.parametrize(
-    "adapter_initialized_value, watchdog_actions", [(False, 1), (True, 0)]
+    ("adapter_initialized_value", "watchdog_actions"), [(False, 1), (True, 0)]
 )
 async def test_watchdog(
     hass: HomeAssistant,

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -174,7 +174,7 @@ async def test_service_off(
 
 
 @pytest.mark.parametrize(
-    "type_id,expected_features",
+    ("type_id", "expected_features"),
     [
         (TYPE_TV, (MPEF.TURN_ON, MPEF.TURN_OFF)),
         (
@@ -268,7 +268,7 @@ async def test_supported_features(
 
 
 @pytest.mark.parametrize(
-    "service,extra_data,key",
+    ("service", "extra_data", "key"),
     [
         (SERVICE_VOLUME_DOWN, None, KEY_VOLUME_DOWN),
         (SERVICE_VOLUME_UP, None, KEY_VOLUME_UP),
@@ -306,7 +306,7 @@ async def test_volume_services(
 
 
 @pytest.mark.parametrize(
-    "service,key",
+    ("service", "key"),
     [
         (SERVICE_MEDIA_NEXT_TRACK, KEY_FORWARD),
         (SERVICE_MEDIA_PREVIOUS_TRACK, KEY_BACKWARD),
@@ -333,7 +333,7 @@ async def test_track_change_services(
 
 
 @pytest.mark.parametrize(
-    "service,key,expected_state",
+    ("service", "key", "expected_state"),
     [
         pytest.param(
             SERVICE_MEDIA_PLAY,
@@ -417,7 +417,7 @@ async def test_play_pause_service(
 
 
 @pytest.mark.parametrize(
-    "type_id,update_data,expected_state",
+    ("type_id", "update_data", "expected_state"),
     [
         (TYPE_TV, {"power_status": POWER_OFF}, STATE_OFF),
         (TYPE_TV, {"power_status": 3}, STATE_OFF),
@@ -461,7 +461,7 @@ async def test_update_state(
 
 
 @pytest.mark.parametrize(
-    "data,expected_state",
+    ("data", "expected_state"),
     [
         ({"power_status": POWER_OFF}, STATE_OFF),
         ({"power_status": 3}, STATE_OFF),

--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -103,7 +103,7 @@ async def test_service_off(
 
 
 @pytest.mark.parametrize(
-    "power_status,expected_state",
+    ("power_status", "expected_state"),
     [(3, STATE_OFF), (POWER_OFF, STATE_OFF), (4, STATE_ON), (POWER_ON, STATE_ON)],
 )
 @pytest.mark.parametrize(
@@ -140,7 +140,7 @@ async def test_device_status_change(
 
 
 @pytest.mark.parametrize(
-    "device_values, expected",
+    ("device_values", "expected"),
     [
         ({"osd_name": "Switch", "vendor": "Nintendo"}, "Nintendo Switch"),
         ({"type_name": "TV"}, "TV 3"),
@@ -165,7 +165,7 @@ async def test_friendly_name(
 
 
 @pytest.mark.parametrize(
-    "device_values,expected_attributes",
+    ("device_values", "expected_attributes"),
     [
         (
             {"physical_address": PhysicalAddress("3.0.0.0")},
@@ -225,7 +225,7 @@ async def test_extra_state_attributes(
 
 
 @pytest.mark.parametrize(
-    "device_type,expected_icon",
+    ("device_type", "expected_icon"),
     [
         (None, "mdi:help"),
         (0, "mdi:television"),

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -84,7 +84,7 @@ from tests.common import (
 
 
 @pytest.mark.parametrize(
-    "mode,icon,arrival_time,departure_time",
+    ("mode", "icon", "arrival_time", "departure_time"),
     [
         (
             TRAVEL_MODE_CAR,
@@ -614,7 +614,7 @@ async def test_restore_state(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception,expected_message",
+    ("exception", "expected_message"),
     [
         (
             HERETransitNoRouteFoundError,

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -510,7 +510,7 @@ async def test_if_not_above_fires_on_entity_change_to_equal(hass, calls, above):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (5, 10),
         (5, "input_number.value_10"),
@@ -545,7 +545,7 @@ async def test_if_fires_on_entity_change_below_range(hass, calls, above, below):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (5, 10),
         (5, "input_number.value_10"),
@@ -577,7 +577,7 @@ async def test_if_fires_on_entity_change_below_above_range(hass, calls, above, b
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (5, 10),
         (5, "input_number.value_10"),
@@ -613,7 +613,7 @@ async def test_if_fires_on_entity_change_over_to_below_range(hass, calls, above,
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (5, 10),
         (5, "input_number.value_10"),
@@ -983,7 +983,7 @@ async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(hass, 
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1031,7 +1031,7 @@ async def test_if_action(hass, calls, above, below):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1087,7 +1087,7 @@ async def test_if_fails_setup_for_without_above_below(hass, calls):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1124,7 +1124,7 @@ async def test_if_not_fires_on_entity_change_with_for(hass, calls, above, below)
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1182,7 +1182,7 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1231,7 +1231,7 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1310,7 +1310,7 @@ async def test_wait_template_with_trigger(hass, calls, above):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1366,7 +1366,7 @@ async def test_if_fires_on_entities_change_no_overlap(hass, calls, above, below)
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1433,7 +1433,7 @@ async def test_if_fires_on_entities_change_overlap(hass, calls, above, below):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1472,7 +1472,7 @@ async def test_if_fires_on_change_with_for_template_1(hass, calls, above, below)
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1511,7 +1511,7 @@ async def test_if_fires_on_change_with_for_template_2(hass, calls, above, below)
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1586,7 +1586,7 @@ async def test_if_not_fires_on_error_with_for_template(hass, calls):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1623,7 +1623,7 @@ async def test_invalid_for_template(hass, calls, above, below):
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     (
         (8, 12),
         (8, "input_number.value_12"),
@@ -1791,7 +1791,7 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
 
 
 @pytest.mark.parametrize(
-    "above, below",
+    ("above", "below"),
     ((8, 12),),
 )
 async def test_variables_priority(hass, calls, above, below):

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -70,7 +70,7 @@ async def test_if_fires_using_at(hass, calls):
 
 
 @pytest.mark.parametrize(
-    "has_date,has_time", [(True, True), (True, False), (False, True)]
+    ("has_date", "has_time"), [(True, True), (True, False), (False, True)]
 )
 async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time):
     """Test for firing at input_datetime."""

--- a/tests/components/homeassistant_alerts/test_init.py
+++ b/tests/components/homeassistant_alerts/test_init.py
@@ -33,7 +33,7 @@ async def setup_repairs(hass):
 
 
 @pytest.mark.parametrize(
-    "ha_version, supervisor_info, expected_alerts",
+    ("ha_version", "supervisor_info", "expected_alerts"),
     (
         (
             "2022.7.0",
@@ -166,7 +166,7 @@ async def test_alerts(
 
 
 @pytest.mark.parametrize(
-    "ha_version, fixture, expected_alerts",
+    ("ha_version", "fixture", "expected_alerts"),
     (
         (
             "2022.7.0",
@@ -270,7 +270,7 @@ async def test_no_alerts(
 
 
 @pytest.mark.parametrize(
-    "ha_version, fixture_1, expected_alerts_1, fixture_2, expected_alerts_2",
+    ("ha_version", "fixture_1", "expected_alerts_1", "fixture_2", "expected_alerts_2"),
     (
         (
             "2022.7.0",

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -45,7 +45,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
 
 
 @pytest.mark.parametrize(
-    "onboarded, num_entries, num_flows", ((False, 1, 0), (True, 0, 1))
+    ("onboarded", "num_entries", "num_flows"), ((False, 1, 0), (True, 0, 1))
 )
 async def test_setup_entry(
     mock_zha_config_flow_setup,

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 
 
 @pytest.mark.parametrize(
-    "onboarded, num_entries, num_flows", ((False, 1, 0), (True, 0, 1))
+    ("onboarded", "num_entries", "num_flows"), ((False, 1, 0), (True, 0, 1))
 )
 async def test_setup_entry(
     hass: HomeAssistant, onboarded, num_entries, num_flows, addon_store_info

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -59,7 +59,7 @@ def test_not_supported_media_player() -> None:
 
 
 @pytest.mark.parametrize(
-    "config, name", [({CONF_NAME: "Customize Name"}, "Customize Name")]
+    ("config", "name"), [({CONF_NAME: "Customize Name"}, "Customize Name")]
 )
 def test_customize_options(config, name) -> None:
     """Test with customized options."""
@@ -73,7 +73,7 @@ def test_customize_options(config, name) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs, config",
+    ("type_name", "entity_id", "state", "attrs", "config"),
     [
         ("Fan", "fan.test", "on", {}, {}),
         ("Light", "light.test", "on", {}, {}),
@@ -110,7 +110,7 @@ def test_types(type_name, entity_id, state, attrs, config) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs",
+    ("type_name", "entity_id", "state", "attrs"),
     [
         (
             "GarageDoorOpener",
@@ -172,7 +172,7 @@ def test_type_covers(type_name, entity_id, state, attrs) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs, config",
+    ("type_name", "entity_id", "state", "attrs", "config"),
     [
         (
             "MediaPlayer",
@@ -206,7 +206,7 @@ def test_type_media_player(type_name, entity_id, state, attrs, config) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs",
+    ("type_name", "entity_id", "state", "attrs"),
     [
         ("BinarySensor", "binary_sensor.opening", "on", {ATTR_DEVICE_CLASS: "opening"}),
         ("BinarySensor", "device_tracker.someone", "not_home", {}),
@@ -288,7 +288,7 @@ def test_type_sensors(type_name, entity_id, state, attrs) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs, config",
+    ("type_name", "entity_id", "state", "attrs", "config"),
     [
         ("Outlet", "switch.test", "on", {}, {CONF_TYPE: TYPE_OUTLET}),
         ("Switch", "automation.test", "on", {}, {}),
@@ -318,7 +318,7 @@ def test_type_switches(type_name, entity_id, state, attrs, config) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs",
+    ("type_name", "entity_id", "state", "attrs"),
     [
         (
             "Vacuum",
@@ -342,7 +342,7 @@ def test_type_vacuum(type_name, entity_id, state, attrs) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_name, entity_id, state, attrs",
+    ("type_name", "entity_id", "state", "attrs"),
     [("Camera", "camera.basic", "on", {})],
 )
 def test_type_camera(type_name, entity_id, state, attrs) -> None:

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -579,7 +579,7 @@ async def test_light_restore(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 @pytest.mark.parametrize(
-    "supported_color_modes, state_props, turn_on_props_with_brightness",
+    ("supported_color_modes", "state_props", "turn_on_props_with_brightness"),
     [
         [
             [ColorMode.COLOR_TEMP, ColorMode.RGBW],
@@ -699,7 +699,7 @@ async def test_light_rgb_with_color_temp(
 
 
 @pytest.mark.parametrize(
-    "supported_color_modes, state_props, turn_on_props_with_brightness",
+    ("supported_color_modes", "state_props", "turn_on_props_with_brightness"),
     [
         [
             [ColorMode.RGBW],
@@ -896,7 +896,7 @@ async def test_light_rgb_or_w_lights(
 
 
 @pytest.mark.parametrize(
-    "supported_color_modes, state_props",
+    ("supported_color_modes", "state_props"),
     [
         [
             [ColorMode.COLOR_TEMP, ColorMode.RGBW],

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -86,7 +86,7 @@ async def test_outlet_set_state(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 @pytest.mark.parametrize(
-    "entity_id, attrs",
+    ("entity_id", "attrs"),
     [
         ("automation.test", {}),
         ("input_boolean.test", {}),

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -555,7 +555,7 @@ async def test_discovery_already_configured_update_csharp(
     assert entry.data["AccessoryPort"] == discovery_info.port
 
 
-@pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)
+@pytest.mark.parametrize(("exception", "expected"), PAIRING_START_ABORT_ERRORS)
 async def test_pair_abort_errors_on_start(
     hass: HomeAssistant, controller, exception, expected
 ) -> None:
@@ -579,7 +579,7 @@ async def test_pair_abort_errors_on_start(
     assert result["reason"] == expected
 
 
-@pytest.mark.parametrize("exception,expected", PAIRING_TRY_LATER_ERRORS)
+@pytest.mark.parametrize(("exception", "expected"), PAIRING_TRY_LATER_ERRORS)
 async def test_pair_try_later_errors_on_start(
     hass: HomeAssistant, controller, exception, expected
 ) -> None:
@@ -618,7 +618,7 @@ async def test_pair_try_later_errors_on_start(
     assert result4["title"] == "Koogeek-LS1-20833F"
 
 
-@pytest.mark.parametrize("exception,expected", PAIRING_START_FORM_ERRORS)
+@pytest.mark.parametrize(("exception", "expected"), PAIRING_START_FORM_ERRORS)
 async def test_pair_form_errors_on_start(
     hass: HomeAssistant, controller, exception, expected
 ) -> None:
@@ -669,7 +669,7 @@ async def test_pair_form_errors_on_start(
     assert result["title"] == "Koogeek-LS1-20833F"
 
 
-@pytest.mark.parametrize("exception,expected", PAIRING_FINISH_ABORT_ERRORS)
+@pytest.mark.parametrize(("exception", "expected"), PAIRING_FINISH_ABORT_ERRORS)
 async def test_pair_abort_errors_on_finish(
     hass: HomeAssistant, controller, exception, expected
 ) -> None:
@@ -711,7 +711,7 @@ async def test_pair_abort_errors_on_finish(
     assert result["reason"] == expected
 
 
-@pytest.mark.parametrize("exception,expected", PAIRING_FINISH_FORM_ERRORS)
+@pytest.mark.parametrize(("exception", "expected"), PAIRING_FINISH_FORM_ERRORS)
 async def test_pair_form_errors_on_finish(
     hass: HomeAssistant, controller, exception, expected
 ) -> None:

--- a/tests/components/honeywell/test_sensor.py
+++ b/tests/components/honeywell/test_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("unit,temp", [("C", "5"), ("F", "-15")])
+@pytest.mark.parametrize(("unit", "temp"), [("C", "5"), ("F", "-15")])
 async def test_outdoor_sensor(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -411,7 +411,7 @@ async def test_auth_access_signed_path_with_query_param_safe_param(
 
 
 @pytest.mark.parametrize(
-    "base_url,test_url",
+    ("base_url", "test_url"),
     [
         ("/?test=test", "/?test=test&foo=bar"),
         ("/", "/?test=test"),

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -179,7 +179,7 @@ async def test_ip_ban_manager_never_started(
 
 
 @pytest.mark.parametrize(
-    "remote_addr, bans, status",
+    ("remote_addr", "bans", "status"),
     list(
         zip(
             BANNED_IPS_WITH_SUPERVISOR,

--- a/tests/components/http/test_forwarded.py
+++ b/tests/components/http/test_forwarded.py
@@ -47,7 +47,7 @@ async def test_x_forwarded_for_without_trusted_proxy(
 
 
 @pytest.mark.parametrize(
-    "trusted_proxies,x_forwarded_for,remote",
+    ("trusted_proxies", "x_forwarded_for", "remote"),
     [
         (
             ["127.0.0.0/24", "1.1.1.1", "10.10.10.0/24"],
@@ -198,7 +198,7 @@ async def test_x_forwarded_for_with_multiple_headers(
 
 
 @pytest.mark.parametrize(
-    "x_forwarded_for,remote,x_forwarded_proto,secure",
+    ("x_forwarded_for", "remote", "x_forwarded_proto", "secure"),
     [
         ("10.10.10.10, 127.0.0.1, 127.0.0.2", "10.10.10.10", "https, http, http", True),
         ("10.10.10.10, 127.0.0.1, 127.0.0.2", "10.10.10.10", "https,http,http", True),
@@ -358,7 +358,7 @@ async def test_x_forwarded_proto_empty_element(
 
 
 @pytest.mark.parametrize(
-    "x_forwarded_for,x_forwarded_proto,expected,got",
+    ("x_forwarded_for", "x_forwarded_proto", "expected", "got"),
     [
         ("1.1.1.1, 2.2.2.2", "https, https, https", 2, 3),
         ("1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4", "https, https, https", 4, 3),

--- a/tests/components/http/test_security_filter.py
+++ b/tests/components/http/test_security_filter.py
@@ -16,7 +16,7 @@ async def mock_handler(request):
 
 
 @pytest.mark.parametrize(
-    "request_path,request_params",
+    ("request_path", "request_params"),
     [
         ("/", {}),
         ("/lovelace/dashboard", {}),
@@ -42,7 +42,7 @@ async def test_ok_requests(
 
 
 @pytest.mark.parametrize(
-    "request_path,request_params,fail_on_query_string",
+    ("request_path", "request_params", "fail_on_query_string"),
     [
         ("/proc/self/environ", {}, False),
         ("/", {"test": "/test/../../api"}, True),

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -25,7 +25,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_action_types",
+    ("set_state", "features_reg", "features_state", "expected_action_types"),
     [
         (False, 0, 0, []),
         (False, const.HumidifierEntityFeature.MODES, 0, ["set_mode"]),
@@ -89,7 +89,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -267,7 +267,13 @@ async def test_action(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "set_state,capabilities_reg,capabilities_state,action,expected_capabilities",
+    (
+        "set_state",
+        "capabilities_reg",
+        "capabilities_state",
+        "action",
+        "expected_capabilities",
+    ),
     [
         (
             False,
@@ -405,7 +411,7 @@ async def test_capabilities(
 
 
 @pytest.mark.parametrize(
-    "action,capability_name,extra",
+    ("action", "capability_name", "extra"),
     [
         ("set_humidity", "humidity", {"type": "integer"}),
         ("set_mode", "mode", {"type": "select", "options": []}),

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -31,7 +31,7 @@ def calls(hass):
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_condition_types",
+    ("set_state", "features_reg", "features_state", "expected_condition_types"),
     [
         (False, 0, 0, []),
         (False, const.HumidifierEntityFeature.MODES, 0, ["is_mode"]),
@@ -97,7 +97,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -247,7 +247,13 @@ async def test_if_state(hass: HomeAssistant, calls) -> None:
 
 
 @pytest.mark.parametrize(
-    "set_state,capabilities_reg,capabilities_state,condition,expected_capabilities",
+    (
+        "set_state",
+        "capabilities_reg",
+        "capabilities_state",
+        "condition",
+        "expected_capabilities",
+    ),
     [
         (
             False,
@@ -411,7 +417,7 @@ async def test_capabilities(
 
 
 @pytest.mark.parametrize(
-    "condition,capability_name,extra",
+    ("condition", "capability_name", "extra"),
     [
         ("is_mode", "mode", {"type": "select", "options": []}),
     ],

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -89,7 +89,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/humidifier/test_reproduce_state.py
+++ b/tests/components/humidifier/test_reproduce_state.py
@@ -223,7 +223,7 @@ async def test_state_with_context(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service,attribute",
+    ("service", "attribute"),
     [(SERVICE_SET_MODE, ATTR_MODE), (SERVICE_SET_HUMIDITY, ATTR_HUMIDITY)],
 )
 async def test_attribute(hass: HomeAssistant, service, attribute) -> None:

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -176,7 +176,7 @@ async def test_user_form_legacy(hass: HomeAssistant) -> None:
     assert result4["type"] == "abort"
 
 
-@pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
+@pytest.mark.parametrize(("source", "discovery_info"), DISCOVERY_DATA)
 async def test_form_homekit_and_dhcp_cannot_connect(
     hass: HomeAssistant, source, discovery_info
 ) -> None:
@@ -204,7 +204,7 @@ async def test_form_homekit_and_dhcp_cannot_connect(
     assert result["reason"] == "cannot_connect"
 
 
-@pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
+@pytest.mark.parametrize(("source", "discovery_info"), DISCOVERY_DATA)
 async def test_form_homekit_and_dhcp(
     hass: HomeAssistant, source, discovery_info
 ) -> None:

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -87,7 +87,7 @@ def _get_write_api_mock_v2(mock_influx_client):
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api",
+    ("mock_client", "config_ext", "get_write_api"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -135,7 +135,7 @@ async def test_setup_config_full(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_base, config_ext, expected_client_args",
+    ("mock_client", "config_base", "config_ext", "expected_client_args"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -269,7 +269,7 @@ async def test_setup_config_ssl(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api",
+    ("mock_client", "config_ext", "get_write_api"),
     [
         (influxdb.DEFAULT_API_VERSION, BASE_V1_CONFIG, _get_write_api_mock_v1),
         (influxdb.API_VERSION_2, BASE_V2_CONFIG, _get_write_api_mock_v2),
@@ -291,7 +291,7 @@ async def test_setup_minimal_config(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api",
+    ("mock_client", "config_ext", "get_write_api"),
     [
         (influxdb.DEFAULT_API_VERSION, {"username": "user"}, _get_write_api_mock_v1),
         (
@@ -351,7 +351,7 @@ async def _setup(hass, mock_influx_client, config_ext, get_write_api):
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -437,7 +437,7 @@ async def test_event_listener(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -491,7 +491,7 @@ async def test_event_listener_no_units(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -540,7 +540,7 @@ async def test_event_listener_inf(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -624,7 +624,7 @@ def execute_filter_test(hass, tests, handler_method, write_api, get_mock_call):
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -658,7 +658,7 @@ async def test_event_listener_denylist(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -692,7 +692,7 @@ async def test_event_listener_denylist_domain(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -726,7 +726,7 @@ async def test_event_listener_denylist_glob(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -760,7 +760,7 @@ async def test_event_listener_allowlist(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -794,7 +794,7 @@ async def test_event_listener_allowlist_domain(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -828,7 +828,7 @@ async def test_event_listener_allowlist_glob(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -878,7 +878,7 @@ async def test_event_listener_filtered_allowlist(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -918,7 +918,7 @@ async def test_event_listener_filtered_denylist(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -992,7 +992,7 @@ async def test_event_listener_invalid_type(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1042,7 +1042,7 @@ async def test_event_listener_default_measurement(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1093,7 +1093,7 @@ async def test_event_listener_unit_of_measurement_field(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1148,7 +1148,7 @@ async def test_event_listener_tags_attributes(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1214,7 +1214,7 @@ async def test_event_listener_component_override_measurement(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1287,7 +1287,7 @@ async def test_event_listener_component_measurement_attr(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1375,7 +1375,7 @@ async def test_event_listener_ignore_attributes(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1429,7 +1429,7 @@ async def test_event_listener_ignore_attributes_overlapping_entities(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1482,7 +1482,7 @@ async def test_event_listener_scheduled_write(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1530,7 +1530,7 @@ async def test_event_listener_backlog_full(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1579,7 +1579,7 @@ async def test_event_listener_attribute_name_conflict(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call, test_exception",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call", "test_exception"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1646,7 +1646,7 @@ async def test_connection_failure_on_startup(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call, test_exception",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call", "test_exception"),
     [
         (
             influxdb.DEFAULT_API_VERSION,
@@ -1712,7 +1712,7 @@ async def test_invalid_inputs_error(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, get_write_api, get_mock_call, precision",
+    ("mock_client", "config_ext", "get_write_api", "get_mock_call", "precision"),
     [
         (
             influxdb.DEFAULT_API_VERSION,

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -210,7 +210,7 @@ async def _setup(hass, config_ext, queries, expected_sensors):
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock",
+    ("mock_client", "config_ext", "queries", "set_query_mock"),
     [
         (DEFAULT_API_VERSION, BASE_V1_CONFIG, BASE_V1_QUERY, _set_query_mock_v1),
         (API_VERSION_2, BASE_V2_CONFIG, BASE_V2_QUERY, _set_query_mock_v2),
@@ -226,7 +226,7 @@ async def test_minimal_config(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock",
+    ("mock_client", "config_ext", "queries", "set_query_mock"),
     [
         (
             DEFAULT_API_VERSION,
@@ -308,7 +308,7 @@ async def test_config_failure(hass: HomeAssistant, config_ext) -> None:
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, make_resultset",
+    ("mock_client", "config_ext", "queries", "set_query_mock", "make_resultset"),
     [
         (
             DEFAULT_API_VERSION,
@@ -344,7 +344,7 @@ async def test_state_matches_query_result(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, make_resultset",
+    ("mock_client", "config_ext", "queries", "set_query_mock", "make_resultset"),
     [
         (
             DEFAULT_API_VERSION,
@@ -383,7 +383,7 @@ async def test_state_matches_first_query_result_for_multiple_return(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock",
+    ("mock_client", "config_ext", "queries", "set_query_mock"),
     [
         (
             DEFAULT_API_VERSION,
@@ -414,7 +414,7 @@ async def test_state_for_no_results(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, query_exception",
+    ("mock_client", "config_ext", "queries", "set_query_mock", "query_exception"),
     [
         (
             DEFAULT_API_VERSION,
@@ -481,7 +481,7 @@ async def test_error_querying_influx(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, make_resultset, key",
+    ("mock_client", "config_ext", "queries", "set_query_mock", "make_resultset", "key"),
     [
         (
             DEFAULT_API_VERSION,
@@ -549,7 +549,14 @@ async def test_error_rendering_template(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, test_exception, make_resultset",
+    (
+        "mock_client",
+        "config_ext",
+        "queries",
+        "set_query_mock",
+        "test_exception",
+        "make_resultset",
+    ),
     [
         (
             DEFAULT_API_VERSION,
@@ -625,7 +632,7 @@ async def test_connection_error_at_startup(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock",
+    ("mock_client", "config_ext", "queries", "set_query_mock"),
     [
         (
             DEFAULT_API_VERSION,

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -765,7 +765,7 @@ async def test_timestamp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "config, error",
+    ("config", "error"),
     [
         (
             {"has_time": True, "has_date": True, "initial": "abc"},

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -154,7 +154,7 @@ MELACHA_TEST_IDS = [
 
 
 @pytest.mark.parametrize(
-    [
+    (
         "now",
         "candle_lighting",
         "havdalah",
@@ -163,7 +163,7 @@ MELACHA_TEST_IDS = [
         "latitude",
         "longitude",
         "result",
-    ],
+    ),
     MELACHA_PARAMS,
     ids=MELACHA_TEST_IDS,
 )
@@ -237,7 +237,7 @@ async def test_issur_melacha_sensor(
 
 
 @pytest.mark.parametrize(
-    [
+    (
         "now",
         "candle_lighting",
         "havdalah",
@@ -246,7 +246,7 @@ async def test_issur_melacha_sensor(
         "latitude",
         "longitude",
         "result",
-    ],
+    ),
     [
         make_nyc_test_params(
             dt(2020, 10, 23, 17, 44, 59, 999999), [STATE_OFF, STATE_ON]

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -138,7 +138,7 @@ TEST_IDS = [
 
 
 @pytest.mark.parametrize(
-    [
+    (
         "now",
         "tzname",
         "latitude",
@@ -147,7 +147,7 @@ TEST_IDS = [
         "sensor",
         "diaspora",
         "result",
-    ],
+    ),
     TEST_PARAMS,
     ids=TEST_IDS,
 )
@@ -591,7 +591,7 @@ OMER_TEST_IDS = [
 ]
 
 
-@pytest.mark.parametrize(["test_time", "result"], OMER_PARAMS, ids=OMER_TEST_IDS)
+@pytest.mark.parametrize(("test_time", "result"), OMER_PARAMS, ids=OMER_TEST_IDS)
 async def test_omer_sensor(hass: HomeAssistant, test_time, result) -> None:
     """Test Omer Count sensor output."""
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))
@@ -625,7 +625,7 @@ DAFYOMI_TEST_IDS = [
 ]
 
 
-@pytest.mark.parametrize(["test_time", "result"], DAFYOMI_PARAMS, ids=DAFYOMI_TEST_IDS)
+@pytest.mark.parametrize(("test_time", "result"), DAFYOMI_PARAMS, ids=DAFYOMI_TEST_IDS)
 async def test_dafyomi_sensor(hass: HomeAssistant, test_time, result) -> None:
     """Test Daf Yomi sensor output."""
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))

--- a/tests/components/justnimbus/test_config_flow.py
+++ b/tests/components/justnimbus/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,errors",
+    ("side_effect", "errors"),
     (
         (
             InvalidClientID(client_id="test_id"),

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -403,7 +403,7 @@ async def test_routing_secure_keyfile(
 
 
 @pytest.mark.parametrize(
-    "user_input,config_entry_data",
+    ("user_input", "config_entry_data"),
     [
         (
             {

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -45,7 +45,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "config_entry_data,connection_config",
+    ("config_entry_data", "connection_config"),
     [
         (
             {

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -11,7 +11,7 @@ from tests.common import async_capture_events
 
 
 @pytest.mark.parametrize(
-    "service_payload,expected_telegrams,expected_apci",
+    ("service_payload", "expected_telegrams", "expected_apci"),
     [
         # send DPT 1 telegram
         (

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -88,7 +88,7 @@ async def test_field_not_supported(
 
 
 @pytest.mark.parametrize(
-    "test_input,expected,entity_id",
+    ("test_input", "expected", "entity_id"),
     [
         (TEST_FLOAT_SENSOR, "2.3", "temperature"),
         (TEST_STRING_SENSOR, "dry", "wet_dry"),

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -356,7 +356,7 @@ async def test_full_ssdp_manual_entry(
 
 
 @pytest.mark.parametrize(
-    "data,reason",
+    ("data", "reason"),
     [
         (
             SsdpServiceInfo(ssdp_usn="mock_usn", ssdp_st="mock_st", upnp={}),
@@ -543,7 +543,7 @@ async def test_cloud_abort_no_devices(
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    ("side_effect", "reason"),
     [
         (LaMetricConnectionTimeoutError, "cannot_connect"),
         (LaMetricConnectionError, "cannot_connect"),
@@ -602,7 +602,7 @@ async def test_manual_errors(
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    ("side_effect", "reason"),
     [
         (LaMetricConnectionTimeoutError, "cannot_connect"),
         (LaMetricConnectionError, "cannot_connect"),

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -73,7 +73,7 @@ async def test_step_import_existing_host(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error,reason",
+    ("error", "reason"),
     [
         (PchkAuthenticationError, "authentication_error"),
         (PchkLicenseError, "license_error"),

--- a/tests/components/life360/test_config_flow.py
+++ b/tests/components/life360/test_config_flow.py
@@ -143,7 +143,8 @@ async def test_user_config_flow_success(hass: HomeAssistant, life360_api) -> Non
 
 
 @pytest.mark.parametrize(
-    "exception,error", [(LoginError, "invalid_auth"), (Life360Error, "cannot_connect")]
+    ("exception", "error"),
+    [(LoginError, "invalid_auth"), (Life360Error, "cannot_connect")],
 )
 async def test_user_config_flow_error(
     hass: HomeAssistant, life360_api, caplog: pytest.LogCaptureFixture, exception, error

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -379,7 +379,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -434,7 +434,7 @@ async def test_discovered_by_dhcp_or_discovery(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -475,7 +475,7 @@ async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -78,7 +78,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -168,7 +168,15 @@ async def test_get_action_capabilities(
 
 
 @pytest.mark.parametrize(
-    "set_state,expected_actions,supported_features_reg,supported_features_state,capabilities_reg,attributes_state,expected_capabilities",
+    (
+        "set_state",
+        "expected_actions",
+        "supported_features_reg",
+        "supported_features_state",
+        "capabilities_reg",
+        "attributes_state",
+        "expected_capabilities",
+    ),
     [
         (
             False,

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -63,7 +63,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -63,7 +63,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -433,7 +433,7 @@ async def test_services(
 
 
 @pytest.mark.parametrize(
-    "profile_name, last_call, expected_data",
+    ("profile_name", "last_call", "expected_data"),
     (
         (
             "test",
@@ -582,7 +582,11 @@ async def test_default_profiles_group(
 
 
 @pytest.mark.parametrize(
-    "extra_call_params, expected_params_state_was_off, expected_params_state_was_on",
+    (
+        "extra_call_params",
+        "expected_params_state_was_off",
+        "expected_params_state_was_on",
+    ),
     (
         (
             # No turn on params, should apply profile

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -42,7 +42,7 @@ async def test_unload_entry(hass: HomeAssistant, mock_account) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,expected_state",
+    ("side_effect", "expected_state"),
     (
         (LitterRobotLoginException, ConfigEntryState.SETUP_ERROR),
         (LitterRobotException, ConfigEntryState.SETUP_RETRY),

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -34,7 +34,7 @@ async def test_switch(hass: HomeAssistant, mock_account: MagicMock) -> None:
 
 
 @pytest.mark.parametrize(
-    "entity_id,robot_command,updated_field",
+    ("entity_id", "robot_command", "updated_field"),
     [
         (NIGHT_LIGHT_MODE_ENTITY_ID, "set_night_light", "nightLightActive"),
         (PANEL_LOCKOUT_ENTITY_ID, "set_panel_lockout", "panelLockActive"),

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -95,7 +95,7 @@ async def test_vacuum_with_error(
 
 
 @pytest.mark.parametrize(
-    "service,command,extra",
+    ("service", "command", "extra"),
     [
         (SERVICE_START, "start_cleaning", None),
         (SERVICE_TURN_OFF, "set_power_status", None),

--- a/tests/components/livisi/test_config_flow.py
+++ b/tests/components/livisi/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception,expected_reason",
+    ("exception", "expected_reason"),
     [
         (livisi_errors.ShcUnreachableException(), "cannot_connect"),
         (livisi_errors.IncorrectIpAddressException(), "wrong_ip_address"),

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -789,7 +789,7 @@ async def test_invalid_rrule(
 
 
 @pytest.mark.parametrize(
-    "time_zone,event_order",
+    ("time_zone", "event_order"),
     [
         ("America/Los_Angeles", ["One", "Two", "All Day Event"]),
         ("America/Regina", ["One", "Two", "All Day Event"]),

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -20,7 +20,7 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 
 @pytest.mark.parametrize(
-    "set_state,features_reg,features_state,expected_action_types",
+    ("set_state", "features_reg", "features_state", "expected_action_types"),
     [
         (False, 0, 0, []),
         (False, LockEntityFeature.OPEN, 0, ["open"]),
@@ -84,7 +84,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -71,7 +71,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -70,7 +70,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -142,7 +142,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (asyncio.TimeoutError, "authorize_url_timeout"),
         (AuthorizationFailed, "invalid_auth"),

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -44,7 +44,7 @@ async def test_setup_demo_platform(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -85,7 +85,7 @@ async def test_no_pending(hass: HomeAssistant, service, expected_state) -> None:
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -129,7 +129,7 @@ async def test_no_pending_when_code_not_req(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -194,7 +194,7 @@ async def test_with_pending(hass: HomeAssistant, service, expected_state) -> Non
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -235,7 +235,7 @@ async def test_with_invalid_code(hass: HomeAssistant, service, expected_state) -
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -277,7 +277,7 @@ async def test_with_template_code(hass: HomeAssistant, service, expected_state) 
 
 
 @pytest.mark.parametrize(
-    "service,expected_state,",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -74,7 +74,7 @@ async def test_fail_setup_without_command_topic(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -122,7 +122,7 @@ async def test_no_pending(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -171,7 +171,7 @@ async def test_no_pending_when_code_not_req(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -243,7 +243,7 @@ async def test_with_pending(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -291,7 +291,7 @@ async def test_with_invalid_code(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -340,7 +340,7 @@ async def test_with_template_code(
 
 
 @pytest.mark.parametrize(
-    "service,expected_state",
+    ("service", "expected_state"),
     [
         (SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (SERVICE_ALARM_ARM_CUSTOM_BYPASS, STATE_ALARM_ARMED_CUSTOM_BYPASS),
@@ -1319,7 +1319,7 @@ async def test_disarm_with_template_code(
 
 
 @pytest.mark.parametrize(
-    "config,expected_state",
+    ("config", "expected_state"),
     [
         ("payload_arm_away", STATE_ALARM_ARMED_AWAY),
         ("payload_arm_custom_bypass", STATE_ALARM_ARMED_CUSTOM_BYPASS),

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -109,7 +109,7 @@ async def test_manual_create_entry(
 
 
 @pytest.mark.parametrize(
-    "error, side_effect",
+    ("error", "side_effect"),
     [
         ("cannot_connect", CannotConnect(Exception("Boom"))),
         ("invalid_server_version", InvalidServerVersion("Invalid version")),
@@ -212,7 +212,7 @@ async def test_supervisor_discovery(
 
 
 @pytest.mark.parametrize(
-    "discovery_info, error",
+    ("discovery_info", "error"),
     [({"config": ADDON_DISCOVERY_INFO}, HassioAPIError())],
 )
 async def test_supervisor_discovery_addon_info_failed(
@@ -566,8 +566,15 @@ async def test_addon_running(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, discovery_info_error, client_connect_error, addon_info_error, "
-        "abort_reason, discovery_info_called, client_connect_called"
+        (
+            "discovery_info",
+            "discovery_info_error",
+            "client_connect_error",
+            "addon_info_error",
+            "abort_reason",
+            "discovery_info_called",
+            "client_connect_called",
+        )
     ),
     [
         (
@@ -724,8 +731,13 @@ async def test_addon_installed(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, start_addon_error, client_connect_error, "
-        "discovery_info_called, client_connect_called"
+        (
+            "discovery_info",
+            "start_addon_error",
+            "client_connect_error",
+            "discovery_info_called",
+            "client_connect_called",
+        )
     ),
     [
         (

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -566,15 +566,13 @@ async def test_addon_running(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "discovery_info_error",
-            "client_connect_error",
-            "addon_info_error",
-            "abort_reason",
-            "discovery_info_called",
-            "client_connect_called",
-        )
+        "discovery_info",
+        "discovery_info_error",
+        "client_connect_error",
+        "addon_info_error",
+        "abort_reason",
+        "discovery_info_called",
+        "client_connect_called",
     ),
     [
         (
@@ -731,13 +729,11 @@ async def test_addon_installed(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "start_addon_error",
-            "client_connect_error",
-            "discovery_info_called",
-            "client_connect_called",
-        )
+        "discovery_info",
+        "start_addon_error",
+        "client_connect_error",
+        "discovery_info_called",
+        "client_connect_called",
     ),
     [
         (

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -349,8 +349,14 @@ async def test_addon_info_failure(
 
 
 @pytest.mark.parametrize(
-    "addon_version, update_available, update_calls, backup_calls, "
-    "update_addon_side_effect, create_backup_side_effect",
+    (
+        "addon_version",
+        "update_available",
+        "update_calls",
+        "backup_calls",
+        "update_addon_side_effect",
+        "create_backup_side_effect",
+    ),
     [
         ("1.0.0", True, 1, 1, None, None),
         ("1.0.0", False, 0, 0, None, None),
@@ -434,7 +440,7 @@ async def test_issue_registry_invalid_version(
 
 
 @pytest.mark.parametrize(
-    "stop_addon_side_effect, entry_state",
+    ("stop_addon_side_effect", "entry_state"),
     [
         (None, ConfigEntryState.NOT_LOADED),
         (HassioAPIError("Boom"), ConfigEntryState.LOADED),

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -15,7 +15,7 @@ from .common import (
 
 
 @pytest.mark.parametrize(
-    "fixture, entity_id",
+    ("fixture", "entity_id"),
     [
         ("extended-color-light", "light.mock_extended_color_light"),
         ("color-temperature-light", "light.mock_color_temperature_light"),
@@ -91,7 +91,7 @@ async def test_on_off_light(
 
 
 @pytest.mark.parametrize(
-    "fixture, entity_id",
+    ("fixture", "entity_id"),
     [
         ("extended-color-light", "light.mock_extended_color_light"),
         ("color-temperature-light", "light.mock_color_temperature_light"),
@@ -145,7 +145,7 @@ async def test_dimmable_light(
 
 
 @pytest.mark.parametrize(
-    "fixture, entity_id",
+    ("fixture", "entity_id"),
     [
         ("extended-color-light", "light.mock_extended_color_light"),
         ("color-temperature-light", "light.mock_color_temperature_light"),
@@ -209,7 +209,7 @@ async def test_color_temperature_light(
 
 
 @pytest.mark.parametrize(
-    "fixture, entity_id",
+    ("fixture", "entity_id"),
     [
         ("extended-color-light", "light.mock_extended_color_light"),
     ],

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -109,7 +109,7 @@ async def test_button_setup_electric_vehicle(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "entity_id_suffix, api_method_name",
+    ("entity_id_suffix", "api_method_name"),
     [
         ("start_engine", "start_engine"),
         ("stop_engine", "stop_engine"),

--- a/tests/components/mazda/test_climate.py
+++ b/tests/components/mazda/test_climate.py
@@ -62,7 +62,19 @@ async def test_climate_setup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "region, hvac_on, target_temperature, temperature_unit, front_defroster, rear_defroster, current_temperature_celsius, expected_hvac_mode, expected_preset_mode, expected_min_temp, expected_max_temp",
+    (
+        "region",
+        "hvac_on",
+        "target_temperature",
+        "temperature_unit",
+        "front_defroster",
+        "rear_defroster",
+        "current_temperature_celsius",
+        "expected_hvac_mode",
+        "expected_preset_mode",
+        "expected_min_temp",
+        "expected_max_temp",
+    ),
     [
         # Test with HVAC off
         (
@@ -262,7 +274,7 @@ async def test_climate_state(
 
 
 @pytest.mark.parametrize(
-    "hvac_mode, api_method",
+    ("hvac_mode", "api_method"),
     [
         (HVACMode.HEAT_COOL, "turn_on_hvac"),
         (HVACMode.OFF, "turn_off_hvac"),
@@ -299,7 +311,7 @@ async def test_set_target_temperature(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "preset_mode, front_defroster, rear_defroster",
+    ("preset_mode", "front_defroster", "rear_defroster"),
     [
         (PRESET_DEFROSTER_OFF, False, False),
         (PRESET_DEFROSTER_FRONT, True, False),

--- a/tests/components/mazda/test_init.py
+++ b/tests/components/mazda/test_init.py
@@ -201,7 +201,7 @@ async def test_device_no_nickname(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service, service_data, expected_args",
+    ("service", "service_data", "expected_args"),
     [
         (
             "send_poi",

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -73,7 +73,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -81,7 +81,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -243,7 +243,7 @@ async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    ("input", "expected"),
     (
         (True, MediaPlayerEnqueue.ADD),
         (False, MediaPlayerEnqueue.PLAY),

--- a/tests/components/media_player/test_reproduce_state.py
+++ b/tests/components/media_player/test_reproduce_state.py
@@ -40,7 +40,7 @@ ENTITY_2 = "media_player.test2"
 
 
 @pytest.mark.parametrize(
-    "service,state,supported_feature",
+    ("service", "state", "supported_feature"),
     [
         (SERVICE_TURN_ON, STATE_ON, MediaPlayerEntityFeature.TURN_ON),
         (SERVICE_TURN_OFF, STATE_OFF, MediaPlayerEntityFeature.TURN_OFF),
@@ -196,7 +196,7 @@ async def test_attribute_no_state(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service,attribute,supported_feature",
+    ("service", "attribute", "supported_feature"),
     [
         (
             SERVICE_VOLUME_SET,

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -75,7 +75,7 @@ async def test_form(hass: HomeAssistant, mock_login, mock_get_devices) -> None:
 
 
 @pytest.mark.parametrize(
-    "error,reason",
+    ("error", "reason"),
     [(ClientError(), "cannot_connect"), (asyncio.TimeoutError(), "cannot_connect")],
 )
 async def test_form_errors(
@@ -96,7 +96,7 @@ async def test_form_errors(
 
 
 @pytest.mark.parametrize(
-    "error,message",
+    ("error", "message"),
     [
         (HTTPStatus.UNAUTHORIZED, "invalid_auth"),
         (HTTPStatus.FORBIDDEN, "invalid_auth"),

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -109,7 +109,9 @@ async def test_onboarding_step(hass: HomeAssistant) -> None:
     assert result["data"] == {"track_home": True}
 
 
-@pytest.mark.parametrize("latitude,longitude", [(52.3731339, 4.8903147), (0.0, 0.0)])
+@pytest.mark.parametrize(
+    ("latitude", "longitude"), [(52.3731339, 4.8903147), (0.0, 0.0)]
+)
 async def test_onboarding_step_abort_no_home(
     hass: HomeAssistant, latitude, longitude
 ) -> None:

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -18,7 +18,7 @@ from tests.common import MockConfigEntry
 
 @freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
 @pytest.mark.parametrize(
-    "old_unique_id,new_unique_id,migration_needed",
+    ("old_unique_id", "new_unique_id", "migration_needed"),
     [
         (
             f"Station Name_{TEST_COORDINATES_WAVERTREE}",

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 
 @pytest.mark.parametrize(
-    "unit_system, state_unit, state1, state2",
+    ("unit_system", "state_unit", "state1", "state2"),
     (
         (METRIC_SYSTEM, UnitOfTemperature.CELSIUS, "100", "123"),
         (US_CUSTOMARY_SYSTEM, UnitOfTemperature.FAHRENHEIT, "212", "253"),
@@ -127,7 +127,7 @@ async def test_sensor(
 
 
 @pytest.mark.parametrize(
-    "unique_id, unit_system, state_unit, state1, state2",
+    ("unique_id", "unit_system", "state_unit", "state1", "state2"),
     (
         ("battery_temperature", METRIC_SYSTEM, UnitOfTemperature.CELSIUS, "100", "123"),
         (
@@ -437,7 +437,7 @@ async def test_update_sensor_no_state(
 
 
 @pytest.mark.parametrize(
-    "device_class,native_value,state_value",
+    ("device_class", "native_value", "state_value"),
     [
         (SensorDeviceClass.DATE, "2021-11-18", "2021-11-18"),
         (

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -339,7 +339,7 @@ async def test_webhook_returns_error_incorrect_json(
 
 
 @pytest.mark.parametrize(
-    "msg,generate_response",
+    ("msg", "generate_response"),
     (
         (RENDER_TEMPLATE, lambda hass: {"one": "Hello world"}),
         (

--- a/tests/components/mochad/test_light.py
+++ b/tests/components/mochad/test_light.py
@@ -37,7 +37,7 @@ async def test_setup_adds_proper_devices(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "brightness,expected", [(32, "on"), (256, "xdim 255"), (64, "xdim 63")]
+    ("brightness", "expected"), [(32, "on"), (256, "xdim 255"), (64, "xdim 63")]
 )
 async def test_turn_on_with_no_brightness(light_mock, expected) -> None:
     """Test turn_on."""
@@ -46,7 +46,7 @@ async def test_turn_on_with_no_brightness(light_mock, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "brightness,expected",
+    ("brightness", "expected"),
     [
         (32, [mock.call("on"), mock.call("dim 25")]),
         (256, [mock.call("xdim 45")]),

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -201,7 +201,7 @@ async def test_temperature_climate(
 
 
 @pytest.mark.parametrize(
-    "do_config,result,register_words",
+    ("do_config", "result", "register_words"),
     [
         (
             {
@@ -291,7 +291,7 @@ async def test_service_climate_update(
 
 
 @pytest.mark.parametrize(
-    "temperature, result, do_config",
+    ("temperature", "result", "do_config"),
     [
         (
             35,
@@ -372,7 +372,7 @@ async def test_service_climate_set_temperature(
 
 
 @pytest.mark.parametrize(
-    "hvac_mode, result, do_config",
+    ("hvac_mode", "result", "do_config"),
     [
         (
             HVACMode.COOL,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -594,7 +594,7 @@ async def mock_modbus_read_pymodbus_fixture(
 
 
 @pytest.mark.parametrize(
-    "do_domain, do_group,do_type,do_scan_interval",
+    ("do_domain", "do_group", "do_type", "do_scan_interval"),
     [
         [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_HOLDING, 10],
         [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_INPUT, 10],

--- a/tests/components/moon/test_sensor.py
+++ b/tests/components/moon/test_sensor.py
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "moon_value,native_value,icon",
+    ("moon_value", "native_value", "icon"),
     [
         (0, STATE_NEW_MOON, MOON_ICONS[STATE_NEW_MOON]),
         (5, STATE_WAXING_CRESCENT, MOON_ICONS[STATE_WAXING_CRESCENT]),

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -130,7 +130,7 @@ def alarm_control_panel_platform_only():
 
 
 @pytest.mark.parametrize(
-    "config,valid",
+    ("config", "valid"),
     [
         (
             {
@@ -235,7 +235,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
 
 
 @pytest.mark.parametrize(
-    "service,payload",
+    ("service", "payload"),
     [
         (SERVICE_ALARM_ARM_HOME, "ARM_HOME"),
         (SERVICE_ALARM_ARM_AWAY, "ARM_AWAY"),
@@ -272,7 +272,7 @@ async def test_publish_mqtt_no_code(
 
 
 @pytest.mark.parametrize(
-    "service,payload",
+    ("service", "payload"),
     [
         (SERVICE_ALARM_ARM_HOME, "ARM_HOME"),
         (SERVICE_ALARM_ARM_AWAY, "ARM_AWAY"),
@@ -328,7 +328,7 @@ async def test_publish_mqtt_with_code(
 
 
 @pytest.mark.parametrize(
-    "service,payload",
+    ("service", "payload"),
     [
         (SERVICE_ALARM_ARM_HOME, "ARM_HOME"),
         (SERVICE_ALARM_ARM_AWAY, "ARM_AWAY"),
@@ -375,7 +375,7 @@ async def test_publish_mqtt_with_remote_code(
 
 
 @pytest.mark.parametrize(
-    "service,payload",
+    ("service", "payload"),
     [
         (SERVICE_ALARM_ARM_HOME, "ARM_HOME"),
         (SERVICE_ALARM_ARM_AWAY, "ARM_AWAY"),
@@ -422,7 +422,7 @@ async def test_publish_mqtt_with_remote_code_text(
 
 
 @pytest.mark.parametrize(
-    "service,payload,disable_code",
+    ("service", "payload", "disable_code"),
     [
         (SERVICE_ALARM_ARM_HOME, "ARM_HOME", "code_arm_required"),
         (SERVICE_ALARM_ARM_AWAY, "ARM_AWAY", "code_arm_required"),
@@ -889,7 +889,7 @@ async def test_discovery_broken(
 
 
 @pytest.mark.parametrize(
-    "topic,value",
+    ("topic", "value"),
     [
         ("state_topic", "armed_home"),
         ("state_topic", "disarmed"),
@@ -1001,7 +1001,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template,tpl_par,tpl_output",
+    ("service", "topic", "parameters", "payload", "template", "tpl_par", "tpl_output"),
     [
         (
             alarm_control_panel.SERVICE_ALARM_ARM_AWAY,

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -907,7 +907,7 @@ async def test_discovery_update_binary_sensor_template(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("json_attributes_topic", '{ "id": 123 }', "id", 123),
         (
@@ -1084,7 +1084,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "payload1, state1, payload2, state2",
+    ("payload1", "state1", "payload2", "state2"),
     [("ON", "on", "OFF", "off"), ("OFF", "off", "ON", "on")],
 )
 async def test_cleanup_triggers_and_restoring_state(

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -490,7 +490,7 @@ async def test_valid_device_class(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (button.SERVICE_PRESS, "command_topic", None, "PRESS", "command_template"),
     ],

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -135,7 +135,7 @@ async def test_preset_none_in_preset_modes(
 
 
 @pytest.mark.parametrize(
-    "parameter,config_value",
+    ("parameter", "config_value"),
     [
         ("away_mode_command_topic", "away-mode-command-topic"),
         ("away_mode_state_topic", "away-mode-state-topic"),
@@ -1544,7 +1544,7 @@ async def test_unique_id(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("action_topic", "heating", ATTR_HVAC_ACTION, "heating"),
         ("action_topic", "cooling", ATTR_HVAC_ACTION, "cooling"),
@@ -1789,7 +1789,7 @@ async def test_precision_whole(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             climate.SERVICE_TURN_ON,
@@ -1903,7 +1903,7 @@ async def test_publishing_with_custom_encoding(
 
 
 @pytest.mark.parametrize(
-    "config,valid",
+    ("config", "valid"),
     [
         (
             {

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -656,7 +656,7 @@ async def test_bad_certificate(
 
 
 @pytest.mark.parametrize(
-    "input_value, error",
+    ("input_value", "error"),
     [
         ("", True),
         ("-10", True),
@@ -1015,7 +1015,7 @@ async def test_option_flow_default_suggested_values(
 
 
 @pytest.mark.parametrize(
-    "advanced_options, step_id", [(False, "options"), (True, "broker")]
+    ("advanced_options", "step_id"), [(False, "options"), (True, "broker")]
 )
 async def test_skipping_advanced_options(
     hass: HomeAssistant,

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -444,7 +444,7 @@ async def test_position_via_template_and_entity_id(
 
 
 @pytest.mark.parametrize(
-    "config, assumed_state",
+    ("config", "assumed_state"),
     [
         ({"command_topic": "abc"}, True),
         ({"command_topic": "abc", "state_topic": "abc"}, False),
@@ -889,7 +889,7 @@ async def test_position_update(
 
 
 @pytest.mark.parametrize(
-    "pos_template,pos_call,pos_message",
+    ("pos_template", "pos_call", "pos_message"),
     [("{{position-1}}", 43, "42"), ("{{100-62}}", 100, "38")],
 )
 async def test_set_position_templated(
@@ -3441,7 +3441,7 @@ async def test_tilt_status_template_without_tilt_status_topic_topic(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             SERVICE_OPEN_COVER,
@@ -3510,7 +3510,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "open", None, None),
         ("state_topic", "closing", None, None),

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -69,7 +69,7 @@ async def test_subscribing_config_topic(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.BINARY_SENSOR])
 @pytest.mark.parametrize(
-    "topic, log",
+    ("topic", "log"),
     [
         ("homeassistant/binary_sensor/bla/not_config", False),
         ("homeassistant/binary_sensor/rörkrökare/config", True),
@@ -239,7 +239,7 @@ async def test_discover_alarm_control_panel(
 
 
 @pytest.mark.parametrize(
-    "topic, config, entity_id, name, domain",
+    ("topic", "config", "entity_id", "name", "domain"),
     [
         (
             "homeassistant/alarm_control_panel/object/bla/config",

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -1357,7 +1357,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "ON", None, "on"),
         (CONF_PRESET_MODE_STATE_TOPIC, "auto", ATTR_PRESET_MODE, "auto"),
@@ -1455,7 +1455,7 @@ async def test_attributes(
 
 
 @pytest.mark.parametrize(
-    "name,config,success,features",
+    ("name", "config", "success", "features"),
     [
         (
             "test1",
@@ -1933,7 +1933,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             fan.SERVICE_TURN_ON,

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -744,7 +744,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "ON", None, "on"),
         (CONF_MODE_STATE_TOPIC, "auto", ATTR_MODE, "auto"),
@@ -829,7 +829,7 @@ async def test_attributes(
 
 
 @pytest.mark.parametrize(
-    "config,valid",
+    ("config", "valid"),
     [
         (
             {
@@ -920,7 +920,7 @@ async def test_validity_configurations(hass: HomeAssistant, config, valid) -> No
 
 
 @pytest.mark.parametrize(
-    "name,config,success,features",
+    ("name", "config", "success", "features"),
     [
         (
             "test1",
@@ -1304,7 +1304,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             humidifier.SERVICE_TURN_ON,

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1746,7 +1746,7 @@ async def test_setup_raises_config_entry_not_ready_if_no_connect_broker(
 
 
 @pytest.mark.parametrize(
-    "config, insecure_param",
+    ("config", "insecure_param"),
     [
         ({"certificate": "auto"}, "not set"),
         ({"certificate": "auto", "tls_insecure": False}, False),
@@ -3148,7 +3148,7 @@ async def test_disabling_and_enabling_entry(
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.LIGHT])
 @pytest.mark.parametrize(
-    "config, unique",
+    ("config", "unique"),
     [
         (
             [

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -922,7 +922,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             vacuum.SERVICE_TURN_ON,
@@ -1011,7 +1011,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         (CONF_BATTERY_LEVEL_TOPIC, '{ "battery_level": 60 }', "battery_level", 60),
         (CONF_CHARGING_TOPIC, '{ "charging": true }', "status", "Stopped"),

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -2892,7 +2892,7 @@ async def test_max_mireds(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template,tpl_par,tpl_output",
+    ("service", "topic", "parameters", "payload", "template", "tpl_par", "tpl_output"),
     [
         (
             light.SERVICE_TURN_ON,
@@ -3028,7 +3028,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value,init_payload",
+    ("topic", "value", "attribute", "attribute_value", "init_payload"),
     [
         ("state_topic", "ON", None, "on", None),
         (
@@ -3095,7 +3095,7 @@ async def test_encoding_subscribable_topics(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value,init_payload",
+    ("topic", "value", "attribute", "attribute_value", "init_payload"),
     [
         ("brightness_state_topic", "60", "brightness", 60, ("state_topic", "ON")),
     ],

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -208,7 +208,7 @@ async def test_fail_setup_if_color_mode_deprecated(
 
 
 @pytest.mark.parametrize(
-    "supported_color_modes,error",
+    ("supported_color_modes", "error"),
     [
         (["onoff", "rgb"], "Unknown error calling mqtt CONFIG_SCHEMA"),
         (["brightness", "rgb"], "Unknown error calling mqtt CONFIG_SCHEMA"),
@@ -2216,7 +2216,7 @@ async def test_max_mireds(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template,tpl_par,tpl_output",
+    ("service", "topic", "parameters", "payload", "template", "tpl_par", "tpl_output"),
     [
         (
             light.SERVICE_TURN_ON,
@@ -2287,7 +2287,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value,init_payload",
+    ("topic", "value", "attribute", "attribute_value", "init_payload"),
     [
         (
             "state_topic",

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -1194,7 +1194,7 @@ async def test_max_mireds(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template,tpl_par,tpl_output",
+    ("service", "topic", "parameters", "payload", "template", "tpl_par", "tpl_output"),
     [
         (
             light.SERVICE_TURN_ON,
@@ -1265,7 +1265,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value,init_payload",
+    ("topic", "value", "attribute", "attribute_value", "init_payload"),
     [
         ("state_topic", "on", None, "on", None),
     ],

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -73,7 +73,7 @@ def lock_platform_only():
 
 
 @pytest.mark.parametrize(
-    "payload,lock_state",
+    ("payload", "lock_state"),
     [
         ("LOCKED", STATE_LOCKED),
         ("LOCKING", STATE_LOCKING),
@@ -122,7 +122,7 @@ async def test_controlling_state_via_topic(
 
 
 @pytest.mark.parametrize(
-    "payload,lock_state",
+    ("payload", "lock_state"),
     [
         ("closed", STATE_LOCKED),
         ("closing", STATE_LOCKING),
@@ -170,7 +170,7 @@ async def test_controlling_non_default_state_via_topic(
 
 
 @pytest.mark.parametrize(
-    "payload,lock_state",
+    ("payload", "lock_state"),
     [
         ('{"val":"LOCKED"}', STATE_LOCKED),
         ('{"val":"LOCKING"}', STATE_LOCKING),
@@ -218,7 +218,7 @@ async def test_controlling_state_via_topic_and_json_message(
 
 
 @pytest.mark.parametrize(
-    "payload,lock_state",
+    ("payload", "lock_state"),
     [
         ('{"val":"closed"}', STATE_LOCKED),
         ('{"val":"closing"}', STATE_LOCKING),
@@ -929,7 +929,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             SERVICE_LOCK,
@@ -983,7 +983,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "LOCKED", None, "locked"),
     ],

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -836,7 +836,7 @@ async def test_mode(
     assert state.attributes.get(ATTR_MODE) == mode
 
 
-@pytest.mark.parametrize("mode,valid", [("bleh", False), ("auto", True)])
+@pytest.mark.parametrize(("mode", "valid"), [("bleh", False), ("auto", True)])
 async def test_invalid_mode(hass: HomeAssistant, mode, valid) -> None:
     """Test invalid mode."""
     topic = "test/number"
@@ -924,7 +924,7 @@ async def test_mqtt_payload_out_of_range_error(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             SERVICE_SET_VALUE,
@@ -978,7 +978,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "10", None, "10"),
         ("state_topic", "60", None, "60"),

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -669,7 +669,7 @@ async def test_mqtt_payload_not_an_option_warning(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             select.SERVICE_SELECT_OPTION,
@@ -724,7 +724,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "milk", None, "milk"),
         ("state_topic", "beer", None, "beer"),

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -112,7 +112,7 @@ async def test_setting_sensor_value_via_mqtt_message(
 
 
 @pytest.mark.parametrize(
-    "device_class,native_value,state_value,log",
+    ("device_class", "native_value", "state_value", "log"),
     [
         (sensor.SensorDeviceClass.DATE, "2021-11-18", "2021-11-18", False),
         (sensor.SensorDeviceClass.DATE, "invalid", STATE_UNKNOWN, True),
@@ -1363,7 +1363,7 @@ async def test_skip_restoring_state_with_over_due_expire_trigger(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "2.21", None, "2.21"),
         ("state_topic", "beer", None, "beer"),

--- a/tests/components/mqtt/test_siren.py
+++ b/tests/components/mqtt/test_siren.py
@@ -956,7 +956,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             siren.SERVICE_TURN_ON,
@@ -1018,7 +1018,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "ON", None, "on"),
     ],

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -637,7 +637,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             vacuum.SERVICE_START,
@@ -731,7 +731,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         (
             "state_topic",

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -633,7 +633,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             switch.SERVICE_TURN_ON,
@@ -694,7 +694,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "ON", None, "on"),
     ],

--- a/tests/components/mqtt/test_text.py
+++ b/tests/components/mqtt/test_text.py
@@ -639,7 +639,7 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "service,topic,parameters,payload,template",
+    ("service", "topic", "parameters", "payload", "template"),
     [
         (
             text.SERVICE_SET_VALUE,
@@ -693,7 +693,7 @@ async def test_reloadable(
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute,attribute_value",
+    ("topic", "value", "attribute", "attribute_value"),
     [
         ("state_topic", "some text", None, "some text"),
     ],

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -21,7 +21,7 @@ def mock_temp_dir():
 
 
 @pytest.mark.parametrize(
-    "option,content,file_created",
+    ("option", "content", "file_created"),
     [
         (mqtt.CONF_CERTIFICATE, "auto", False),
         (mqtt.CONF_CERTIFICATE, "### CA CERTIFICATE ###", True),

--- a/tests/components/mutesync/test_config_flow.py
+++ b/tests/components/mutesync/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (Exception, "unknown"),
         (aiohttp.ClientResponseError(None, None, status=403), "invalid_auth"),

--- a/tests/components/mysensors/test_config_flow.py
+++ b/tests/components/mysensors/test_config_flow.py
@@ -220,7 +220,7 @@ async def test_fail_to_connect(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "gateway_type, expected_step_id, user_input, err_field, err_string",
+    ("gateway_type", "expected_step_id", "user_input", "err_field", "err_string"),
     [
         (
             CONF_GATEWAY_TYPE_TCP,
@@ -380,7 +380,7 @@ async def test_config_invalid(
 
 
 @pytest.mark.parametrize(
-    "first_input, second_input, expected_result",
+    ("first_input", "second_input", "expected_result"),
     [
         (
             {

--- a/tests/components/mysensors/test_gateway.py
+++ b/tests/components/mysensors/test_gateway.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize(
-    "port, expect_valid",
+    ("port", "expect_valid"),
     [
         ("COM5", True),
         ("asdf", False),

--- a/tests/components/mysensors/test_sensor.py
+++ b/tests/components/mysensors/test_sensor.py
@@ -145,7 +145,7 @@ async def test_distance_sensor(
 
 
 @pytest.mark.parametrize(
-    "unit_system, unit",
+    ("unit_system", "unit"),
     [
         (METRIC_SYSTEM, UnitOfTemperature.CELSIUS),
         (US_CUSTOMARY_SYSTEM, UnitOfTemperature.FAHRENHEIT),

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -81,7 +81,7 @@ async def test_user_unavailable_user_step_link_step(hass: HomeAssistant) -> None
 
 
 @pytest.mark.parametrize(
-    "error, reason",
+    ("error", "reason"),
     [
         (Unavailable, "cannot_connect"),
         (InvalidToken, "invalid_token"),
@@ -216,7 +216,7 @@ async def test_user_exception_user_step(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, type_in_discovery_info",
+    ("source", "type_in_discovery_info"),
     [
         (config_entries.SOURCE_HOMEKIT, "_hap._tcp.local"),
         (config_entries.SOURCE_ZEROCONF, "_nanoleafms._tcp.local"),
@@ -303,7 +303,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, type_in_discovery",
+    ("source", "type_in_discovery"),
     [
         (config_entries.SOURCE_HOMEKIT, "_hap._tcp.local"),
         (config_entries.SOURCE_ZEROCONF, "_nanoleafms._tcp.local"),

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -518,7 +518,7 @@ async def test_reauth_multiple_config_entries(
 
 
 @pytest.mark.parametrize(
-    "nest_test_config,auth_implementation", [(TEST_CONFIG_HYBRID, APP_AUTH_DOMAIN)]
+    ("nest_test_config", "auth_implementation"), [(TEST_CONFIG_HYBRID, APP_AUTH_DOMAIN)]
 )
 async def test_app_auth_yaml_reauth(
     hass: HomeAssistant, oauth, setup_platform, config_entry
@@ -583,7 +583,8 @@ async def test_app_auth_yaml_reauth(
 
 
 @pytest.mark.parametrize(
-    "nest_test_config,auth_implementation", [(TEST_CONFIG_YAML_ONLY, WEB_AUTH_DOMAIN)]
+    ("nest_test_config", "auth_implementation"),
+    [(TEST_CONFIG_YAML_ONLY, WEB_AUTH_DOMAIN)],
 )
 async def test_web_auth_yaml_reauth(
     hass: HomeAssistant, oauth, setup_platform, config_entry

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -117,7 +117,7 @@ def create_events(events, device_id=DEVICE_ID, timestamp=None):
 
 
 @pytest.mark.parametrize(
-    "device_type,device_traits,event_trait,expected_model,expected_type",
+    ("device_type", "device_traits", "event_trait", "expected_model", "expected_type"),
     [
         (
             "sdm.devices.types.DOORBELL",

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -209,7 +209,7 @@ async def test_unload_entry(hass: HomeAssistant, setup_platform) -> None:
 
 
 @pytest.mark.parametrize(
-    "nest_test_config,delete_called",
+    ("nest_test_config", "delete_called"),
     [
         (
             TEST_CONFIG_YAML_ONLY,

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -226,7 +226,7 @@ def create_battery_event_data(
 
 
 @pytest.mark.parametrize(
-    "device_type,device_traits",
+    ("device_type", "device_traits"),
     [
         (
             "sdm.devices.types.THERMOSTAT",
@@ -1310,7 +1310,7 @@ async def test_media_store_load_filesystem_error(
         )
 
 
-@pytest.mark.parametrize("device_traits,cache_size", [(BATTERY_CAMERA_TRAITS, 5)])
+@pytest.mark.parametrize(("device_traits", "cache_size"), [(BATTERY_CAMERA_TRAITS, 5)])
 async def test_camera_event_media_eviction(
     hass: HomeAssistant,
     auth,

--- a/tests/components/netatmo/test_device_trigger.py
+++ b/tests/components/netatmo/test_device_trigger.py
@@ -32,7 +32,7 @@ def calls(hass):
 
 
 @pytest.mark.parametrize(
-    "platform,device_type,event_types",
+    ("platform", "device_type", "event_types"),
     [
         ("camera", "Smart Outdoor Camera", OUTDOOR_CAMERA_TRIGGERS),
         ("camera", "Smart Indoor Camera", INDOOR_CAMERA_TRIGGERS),
@@ -96,7 +96,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "platform,camera_type,event_type",
+    ("platform", "camera_type", "event_type"),
     [("camera", "Smart Outdoor Camera", trigger) for trigger in OUTDOOR_CAMERA_TRIGGERS]
     + [("camera", "Smart Indoor Camera", trigger) for trigger in INDOOR_CAMERA_TRIGGERS]
     + [
@@ -179,7 +179,7 @@ async def test_if_fires_on_event(
 
 
 @pytest.mark.parametrize(
-    "platform,camera_type,event_type,sub_type",
+    ("platform", "camera_type", "event_type", "sub_type"),
     [
         ("climate", "Smart Valve", trigger, subtype)
         for trigger in SUBTYPES
@@ -266,7 +266,7 @@ async def test_if_fires_on_event_with_subtype(
 
 
 @pytest.mark.parametrize(
-    "platform,device_type,event_type",
+    ("platform", "device_type", "event_type"),
     [("climate", "NAPlug", trigger) for trigger in CLIMATE_TRIGGERS],
 )
 async def test_if_invalid_device(

--- a/tests/components/netatmo/test_sensor.py
+++ b/tests/components/netatmo/test_sensor.py
@@ -78,7 +78,7 @@ async def test_public_weather_sensor(
 
 
 @pytest.mark.parametrize(
-    "strength, expected",
+    ("strength", "expected"),
     [(50, "Full"), (60, "High"), (80, "Medium"), (90, "Low")],
 )
 async def test_process_wifi(strength, expected) -> None:
@@ -87,7 +87,7 @@ async def test_process_wifi(strength, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "strength, expected",
+    ("strength", "expected"),
     [(50, "Full"), (70, "High"), (80, "Medium"), (90, "Low")],
 )
 async def test_process_rf(strength, expected) -> None:
@@ -96,7 +96,7 @@ async def test_process_rf(strength, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "health, expected",
+    ("health", "expected"),
     [(4, "Unhealthy"), (3, "Poor"), (2, "Fair"), (1, "Fine"), (0, "Healthy")],
 )
 async def test_process_health(health, expected) -> None:
@@ -105,7 +105,7 @@ async def test_process_health(health, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "uid, name, expected",
+    ("uid", "name", "expected"),
     [
         ("12:34:56:03:1b:e4-reachable", "villa_garden_reachable", "True"),
         ("12:34:56:03:1b:e4-rf_status", "villa_garden_radio", "Full"),

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exc,base_error",
+    ("exc", "base_error"),
     [
         (ApiError("API Error"), "cannot_connect"),
         (InvalidApiKeyError, "invalid_api_key"),

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -157,7 +157,7 @@ async def test_nibegw_address_inuse(hass: HomeAssistant, mock_connection: Mock) 
 
 
 @pytest.mark.parametrize(
-    "connection_type,data",
+    ("connection_type", "data"),
     (
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
@@ -178,7 +178,7 @@ async def test_read_timeout(
 
 
 @pytest.mark.parametrize(
-    "connection_type,data",
+    ("connection_type", "data"),
     (
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
@@ -199,7 +199,7 @@ async def test_write_timeout(
 
 
 @pytest.mark.parametrize(
-    "connection_type,data",
+    ("connection_type", "data"),
     (
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
@@ -220,7 +220,7 @@ async def test_unexpected_exception(
 
 
 @pytest.mark.parametrize(
-    "connection_type,data",
+    ("connection_type", "data"),
     (
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
@@ -244,7 +244,7 @@ async def test_nibegw_invalid_host(
 
 
 @pytest.mark.parametrize(
-    "connection_type,data",
+    ("connection_type", "data"),
     (
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),

--- a/tests/components/notion/test_config_flow.py
+++ b/tests/components/notion/test_config_flow.py
@@ -14,7 +14,7 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
 
 
 @pytest.mark.parametrize(
-    "get_client_with_exception,errors",
+    ("get_client_with_exception", "errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),
@@ -68,7 +68,7 @@ async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry) 
 
 
 @pytest.mark.parametrize(
-    "get_client_with_exception,errors",
+    ("get_client_with_exception", "errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),

--- a/tests/components/number/test_device_action.py
+++ b/tests/components/number/test_device_action.py
@@ -56,7 +56,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -439,9 +439,21 @@ async def test_deprecated_methods(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, state_unit, initial_native_value, initial_state_value, "
-    "updated_native_value, updated_state_value, native_max_value, state_max_value, "
-    "native_min_value, state_min_value, native_step, state_step",
+    (
+        "unit_system",
+        "native_unit",
+        "state_unit",
+        "initial_native_value",
+        "initial_state_value",
+        "updated_native_value",
+        "updated_state_value",
+        "native_max_value",
+        "state_max_value",
+        "native_min_value",
+        "state_min_value",
+        "native_step",
+        "state_step",
+    ),
     [
         (
             US_CUSTOMARY_SYSTEM,
@@ -634,7 +646,16 @@ async def test_restore_number_save_state(
 
 
 @pytest.mark.parametrize(
-    "native_max_value, native_min_value, native_step, native_value, native_value_type, extra_data, device_class, uom",
+    (
+        "native_max_value",
+        "native_min_value",
+        "native_step",
+        "native_value",
+        "native_value_type",
+        "extra_data",
+        "device_class",
+        "uom",
+    ),
     [
         (
             200.0,
@@ -702,7 +723,14 @@ async def test_restore_number_restore_state(
 
 
 @pytest.mark.parametrize(
-    "device_class,native_unit,custom_unit,state_unit,native_value,custom_value",
+    (
+        "device_class",
+        "native_unit",
+        "custom_unit",
+        "state_unit",
+        "native_value",
+        "custom_value",
+    ),
     [
         # Not a supported temperature unit
         (
@@ -772,7 +800,15 @@ async def test_custom_unit(
 
 
 @pytest.mark.parametrize(
-    "native_unit, custom_unit, used_custom_unit, default_unit, native_value, custom_value, default_value",
+    (
+        "native_unit",
+        "custom_unit",
+        "used_custom_unit",
+        "default_unit",
+        "native_value",
+        "custom_value",
+        "default_value",
+    ),
     [
         (
             UnitOfTemperature.CELSIUS,

--- a/tests/components/nws/test_sensor.py
+++ b/tests/components/nws/test_sensor.py
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "units,result_observation,result_forecast",
+    ("units", "result_observation", "result_forecast"),
     [
         (
             US_CUSTOMARY_SYSTEM,

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -32,7 +32,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.parametrize(
-    "units,result_observation,result_forecast",
+    ("units", "result_observation", "result_forecast"),
     [
         (
             US_CUSTOMARY_SYSTEM,

--- a/tests/components/oncue/test_sensor.py
+++ b/tests/components/oncue/test_sensor.py
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "patcher, connections",
+    ("patcher", "connections"),
     [
         [_patch_login_and_data, {("mac", "c9:24:22:6f:14:00")}],
         [_patch_login_and_data_offline_device, set()],
@@ -149,7 +149,7 @@ async def test_sensors(hass: HomeAssistant, patcher, connections) -> None:
 
 
 @pytest.mark.parametrize(
-    "patcher, connections",
+    ("patcher", "connections"),
     [
         [_patch_login_and_data_unavailable_device, set()],
         [_patch_login_and_data_unavailable, {("mac", "c9:24:22:6f:14:00")}],

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_options(
 
 
 @pytest.mark.parametrize(
-    "side_effect, error",
+    ("side_effect", "error"),
     [
         (APIConnectionError(""), "cannot_connect"),
         (AuthenticationError, "invalid_auth"),

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -82,7 +82,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, error",
+    ("side_effect", "error"),
     [
         (BadCredentialsException, "invalid_auth"),
         (TooManyRequestsException, "too_many_requests"),
@@ -114,7 +114,7 @@ async def test_form_invalid_auth(
 
 
 @pytest.mark.parametrize(
-    "side_effect, error",
+    ("side_effect", "error"),
     [
         (BadCredentialsException, "unsupported_hardware"),
     ],

--- a/tests/components/peco/test_sensor.py
+++ b/tests/components/peco/test_sensor.py
@@ -16,7 +16,7 @@ INVALID_COUNTY_DATA = {"county": "INVALID"}
 
 
 @pytest.mark.parametrize(
-    "sensor,expected",
+    ("sensor", "expected"),
     [
         ("customers_out", "123"),
         ("percent_customers_out", "15"),

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_form(
 
 
 @pytest.mark.parametrize(
-    "discovery,username",
+    ("discovery", "username"),
     [
         (TEST_DISCOVERY, TEST_USERNAME),
         (TEST_DISCOVERY2, TEST_USERNAME2),
@@ -268,7 +268,7 @@ async def test_zercoconf_discovery_update_configuration(
 
 
 @pytest.mark.parametrize(
-    "side_effect, reason",
+    ("side_effect", "reason"),
     [
         (ConnectionFailedError, "cannot_connect"),
         (InvalidAuthentication, "invalid_auth"),

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -44,7 +44,7 @@ async def test_load_unload_config_entry(
 
 
 @pytest.mark.parametrize(
-    "side_effect, entry_state",
+    ("side_effect", "entry_state"),
     [
         (ConnectionFailedError, ConfigEntryState.SETUP_RETRY),
         (InvalidAuthentication, ConfigEntryState.SETUP_ERROR),
@@ -72,7 +72,7 @@ async def test_gateway_config_entry_not_ready(
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {
@@ -113,7 +113,7 @@ async def test_migrate_unique_id_temperature(
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {

--- a/tests/components/prosegur/test_alarm_control_panel.py
+++ b/tests/components/prosegur/test_alarm_control_panel.py
@@ -87,7 +87,7 @@ async def test_connection_error(hass: HomeAssistant, mock_auth) -> None:
 
 
 @pytest.mark.parametrize(
-    "code, alarm_service, alarm_state",
+    ("code", "alarm_service", "alarm_state"),
     [
         (Status.ARMED, SERVICE_ALARM_ARM_AWAY, STATE_ALARM_ARMED_AWAY),
         (Status.PARTIALLY, SERVICE_ALARM_ARM_HOME, STATE_ALARM_ARMED_HOME),

--- a/tests/components/prosegur/test_config_flow.py
+++ b/tests/components/prosegur/test_config_flow.py
@@ -181,7 +181,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception, base_error",
+    ("exception", "base_error"),
     [
         (CannotConnect, "cannot_connect"),
         (InvalidAuth, "invalid_auth"),

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -20,7 +20,7 @@ def setup_button_platform_only():
 
 
 @pytest.mark.parametrize(
-    "object_id, method",
+    ("object_id", "method"),
     (
         ("mock_title_cancel_job", "cancel_job"),
         ("mock_title_pause_job", "pause_job"),
@@ -65,7 +65,7 @@ async def test_button_pause_cancel(
 
 
 @pytest.mark.parametrize(
-    "object_id, method",
+    ("object_id", "method"),
     (("mock_title_resume_job", "resume_job"),),
 )
 async def test_button_resume(

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -17,7 +17,7 @@ TEST_LONGITUDE = -0.2416796
 
 
 @pytest.mark.parametrize(
-    "check_api_key_mock,check_api_key_errors",
+    ("check_api_key_mock", "check_api_key_errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidApiKeyError), {"base": "invalid_api_key"}),
@@ -114,7 +114,7 @@ async def test_duplicate_error(
 
 
 @pytest.mark.parametrize(
-    "check_api_key_mock,check_api_key_errors",
+    ("check_api_key_mock", "check_api_key_errors"),
     [
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),
         (AsyncMock(side_effect=InvalidApiKeyError), {"base": "invalid_api_key"}),
@@ -160,7 +160,7 @@ async def test_reauth(
 
 
 @pytest.mark.parametrize(
-    "get_nearby_sensors_mock,get_nearby_sensors_errors",
+    ("get_nearby_sensors_mock", "get_nearby_sensors_errors"),
     [
         (AsyncMock(return_value=[]), {"base": "no_sensors_near_coordinates"}),
         (AsyncMock(side_effect=Exception), {"base": "unknown"}),

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -18,7 +18,7 @@ def platforms() -> list[Platform]:
 
 
 @pytest.mark.parametrize(
-    "rain_response,expected_state",
+    ("rain_response", "expected_state"),
     [(RAIN_SENSOR_OFF, "off"), (RAIN_SENSOR_ON, "on")],
 )
 async def test_rainsensor(

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -27,7 +27,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockRespon
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_data,initial_response",
+    ("yaml_config", "config_entry_data", "initial_response"),
     [
         ({}, CONFIG_ENTRY_DATA, None),
         (
@@ -65,7 +65,7 @@ async def test_init_success(
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_data,responses,config_entry_states",
+    ("yaml_config", "config_entry_data", "responses", "config_entry_states"),
     [
         ({}, CONFIG_ENTRY_DATA, [UNAVAILABLE_RESPONSE], [ConfigEntryState.SETUP_RETRY]),
         (

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -29,7 +29,7 @@ def platforms() -> list[str]:
 
 
 @pytest.mark.parametrize(
-    "rain_delay_response,expected_state",
+    ("rain_delay_response", "expected_state"),
     [(RAIN_DELAY, "16"), (RAIN_DELAY_OFF, "0")],
 )
 async def test_number_values(

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -16,7 +16,7 @@ def platforms() -> list[str]:
 
 
 @pytest.mark.parametrize(
-    "rain_delay_response,expected_state",
+    ("rain_delay_response", "expected_state"),
     [(RAIN_DELAY, "16"), (RAIN_DELAY_OFF, "0")],
 )
 async def test_sensors(

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -211,7 +211,7 @@ async def test_irrigation_service(
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_data",
+    ("yaml_config", "config_entry_data"),
     [
         (
             {

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -35,7 +35,7 @@ async def test_invalid_password(hass: HomeAssistant, config) -> None:
 
 
 @pytest.mark.parametrize(
-    "platform,entity_name,entity_id,old_unique_id,new_unique_id",
+    ("platform", "entity_name", "entity_id", "old_unique_id", "new_unique_id"),
     [
         (
             "binary_sensor",

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -17,7 +17,7 @@ from .conftest import TEST_PLACE_ID, TEST_SERVICE_ID
 
 
 @pytest.mark.parametrize(
-    "get_pickup_events_mock,get_pickup_events_errors",
+    ("get_pickup_events_mock", "get_pickup_events_errors"),
     [
         (
             AsyncMock(side_effect=RecollectError),

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -205,7 +205,7 @@ def test_significant_states_with_session_entity_minimal_response_no_matches(
 
 
 @pytest.mark.parametrize(
-    "attributes, no_attributes, limit",
+    ("attributes", "no_attributes", "limit"),
     [
         ({"attr": True}, False, 5000),
         ({}, True, 5000),

--- a/tests/components/recorder/test_history_db_schema_30.py
+++ b/tests/components/recorder/test_history_db_schema_30.py
@@ -132,7 +132,7 @@ def test_significant_states_with_session_entity_minimal_response_no_matches(
 
 
 @pytest.mark.parametrize(
-    "attributes, no_attributes, limit",
+    ("attributes", "no_attributes", "limit"),
     [
         ({"attr": True}, False, 5000),
         ({}, True, 5000),

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -240,7 +240,7 @@ async def test_saving_state(recorder_mock, hass: HomeAssistant):
 
 
 @pytest.mark.parametrize(
-    "dialect_name, expected_attributes",
+    ("dialect_name", "expected_attributes"),
     (
         (SupportedDialect.MYSQL, {"test_attr": 5, "test_attr_10": "silly\0stuff"}),
         (SupportedDialect.POSTGRESQL, {"test_attr": 5, "test_attr_10": "silly"}),
@@ -1798,7 +1798,7 @@ async def test_async_block_till_done(async_setup_recorder_instance, hass):
 
 
 @pytest.mark.parametrize(
-    "db_url, echo",
+    ("db_url", "echo"),
     (
         ("sqlite://blabla", None),
         ("mariadb://blabla", False),
@@ -1828,7 +1828,7 @@ async def test_disable_echo(hass, db_url, echo, caplog):
 
 
 @pytest.mark.parametrize(
-    "config_url, expected_connect_args",
+    ("config_url", "expected_connect_args"),
     (
         (
             "mariadb://user:password@SERVER_IP/DB_NAME",

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -286,7 +286,7 @@ async def test_events_during_migration_queue_exhausted(
 
 
 @pytest.mark.parametrize(
-    "start_version,live",
+    ("start_version", "live"),
     [(0, True), (16, True), (18, True), (22, True), (25, True)],
 )
 async def test_schema_migrate(
@@ -401,7 +401,7 @@ def test_invalid_update(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ["engine_type", "substr"],
+    ("engine_type", "substr"),
     [
         ("postgresql", "ALTER event_type TYPE VARCHAR(64)"),
         ("mssql", "ALTER COLUMN event_type VARCHAR(64)"),

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -318,7 +318,7 @@ def test_setup_connection_for_dialect_sqlite_zero_commit_interval(
 
 
 @pytest.mark.parametrize(
-    "mysql_version,message",
+    ("mysql_version", "message"),
     [
         (
             "10.2.0-MariaDB",
@@ -397,7 +397,7 @@ def test_supported_mysql(caplog, mysql_version):
 
 
 @pytest.mark.parametrize(
-    "pgsql_version,message",
+    ("pgsql_version", "message"),
     [
         (
             "11.12 (Debian 11.12-1.pgdg100+1)",
@@ -477,7 +477,7 @@ def test_supported_pgsql(caplog, pgsql_version):
 
 
 @pytest.mark.parametrize(
-    "sqlite_version,message",
+    ("sqlite_version", "message"),
     [
         (
             "3.30.0",
@@ -560,7 +560,7 @@ def test_supported_sqlite(caplog, sqlite_version):
 
 
 @pytest.mark.parametrize(
-    "dialect,message",
+    ("dialect", "message"),
     [
         ("mssql", "Database mssql is not supported"),
         ("oracle", "Database oracle is not supported"),
@@ -581,7 +581,7 @@ def test_warn_unsupported_dialect(caplog, dialect, message):
 
 
 @pytest.mark.parametrize(
-    "mysql_version,min_version",
+    ("mysql_version", "min_version"),
     [
         (
             "10.5.16-MariaDB",

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -787,7 +787,7 @@ async def test_statistic_during_period_hole(recorder_mock, hass, hass_ws_client)
 
 @freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc))
 @pytest.mark.parametrize(
-    "calendar_period, start_time, end_time",
+    ("calendar_period", "start_time", "end_time"),
     (
         (
             {"period": "hour"},
@@ -870,7 +870,7 @@ async def test_statistic_during_period_calendar(
 
 
 @pytest.mark.parametrize(
-    "attributes, state, value, custom_units, converted_value",
+    ("attributes", "state", "value", "custom_units", "converted_value"),
     [
         (DISTANCE_SENSOR_M_ATTRIBUTES, 10, 10, {"distance": "cm"}, 1000),
         (DISTANCE_SENSOR_M_ATTRIBUTES, 10, 10, {"distance": "m"}, 10),
@@ -970,7 +970,7 @@ async def test_statistics_during_period_unit_conversion(
 
 
 @pytest.mark.parametrize(
-    "attributes, state, value, custom_units, converted_value",
+    ("attributes", "state", "value", "custom_units", "converted_value"),
     [
         (ENERGY_SENSOR_KWH_ATTRIBUTES, 10, 10, {"energy": "kWh"}, 10),
         (ENERGY_SENSOR_KWH_ATTRIBUTES, 10, 10, {"energy": "MWh"}, 0.010),
@@ -1319,7 +1319,7 @@ async def test_statistics_during_period_empty_statistic_ids(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, display_unit, statistics_unit, unit_class",
+    ("units", "attributes", "display_unit", "statistics_unit", "unit_class"),
     [
         (US_CUSTOMARY_SYSTEM, DISTANCE_SENSOR_M_ATTRIBUTES, "m", "m", "distance"),
         (METRIC_SYSTEM, DISTANCE_SENSOR_M_ATTRIBUTES, "m", "m", "distance"),
@@ -1491,7 +1491,7 @@ async def test_list_statistic_ids(
 
 
 @pytest.mark.parametrize(
-    "attributes, attributes2, display_unit, statistics_unit, unit_class",
+    ("attributes", "attributes2", "display_unit", "statistics_unit", "unit_class"),
     [
         (
             DISTANCE_SENSOR_M_ATTRIBUTES,
@@ -1751,7 +1751,7 @@ async def test_clear_statistics(recorder_mock, hass, hass_ws_client):
 
 
 @pytest.mark.parametrize(
-    "new_unit, new_unit_class, new_display_unit",
+    ("new_unit", "new_unit_class", "new_display_unit"),
     [("dogs", None, "dogs"), (None, "unitless", None), ("W", "power", "kW")],
 )
 async def test_update_statistics_metadata(
@@ -2278,7 +2278,7 @@ async def test_backup_end_without_start(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit, unit_class",
+    ("units", "attributes", "unit", "unit_class"),
     [
         (METRIC_SYSTEM, ENERGY_SENSOR_KWH_ATTRIBUTES, "kWh", "energy"),
         (METRIC_SYSTEM, ENERGY_SENSOR_WH_ATTRIBUTES, "kWh", "energy"),
@@ -2438,7 +2438,7 @@ async def test_get_statistics_metadata(
 
 
 @pytest.mark.parametrize(
-    "source, statistic_id",
+    ("source", "statistic_id"),
     (
         ("test", "test:total_energy_import"),
         ("recorder", "sensor.total_energy_import"),
@@ -2665,7 +2665,7 @@ async def test_import_statistics(
 
 
 @pytest.mark.parametrize(
-    "source, statistic_id",
+    ("source", "statistic_id"),
     (
         ("test", "test:total_energy_import"),
         ("recorder", "sensor.total_energy_import"),
@@ -2856,7 +2856,7 @@ async def test_adjust_sum_statistics_energy(
 
 
 @pytest.mark.parametrize(
-    "source, statistic_id",
+    ("source", "statistic_id"),
     (
         ("test", "test:total_gas"),
         ("recorder", "sensor.total_gas"),
@@ -3047,7 +3047,14 @@ async def test_adjust_sum_statistics_gas(
 
 
 @pytest.mark.parametrize(
-    "state_unit, statistic_unit, unit_class, factor, valid_units, invalid_units",
+    (
+        "state_unit",
+        "statistic_unit",
+        "unit_class",
+        "factor",
+        "valid_units",
+        "invalid_units",
+    ),
     (
         ("kWh", "kWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),
         ("MWh", "MWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -52,7 +52,7 @@ async def test_get_actions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -58,7 +58,7 @@ async def test_get_conditions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -58,7 +58,7 @@ async def test_get_triggers(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -266,7 +266,7 @@ async def test_fix_non_existing_issue(
 
 
 @pytest.mark.parametrize(
-    "domain, step, description_placeholders",
+    ("domain", "step", "description_placeholders"),
     (
         ("fake_integration", "custom_step", None),
         ("fake_integration_default_handler", "confirm", {"abc": "123"}),

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -96,7 +96,7 @@ async def test_pt2262_unconfigured(hass, rfxtrx):
 
 
 @pytest.mark.parametrize(
-    "state,event",
+    ("state", "event"),
     [["on", "0b1100cd0213c7f230010f71"], ["off", "0b1100cd0213c7f230000f71"]],
 )
 async def test_state_restore(hass, rfxtrx, state, event):

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -66,7 +66,7 @@ def _get_expected_actions(data):
 
 
 @pytest.mark.parametrize(
-    "device,expected",
+    ("device", "expected"),
     [
         [
             DEVICE_LIGHTING_1,
@@ -100,7 +100,7 @@ async def test_get_actions(hass, device_registry: dr.DeviceRegistry, device, exp
 
 
 @pytest.mark.parametrize(
-    "device,config,expected",
+    ("device", "config", "expected"),
     [
         [
             DEVICE_LIGHTING_1,

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -57,7 +57,7 @@ async def setup_entry(hass, devices):
 
 
 @pytest.mark.parametrize(
-    "event,expected",
+    ("event", "expected"),
     [
         [
             EVENT_LIGHTING_1,

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -89,7 +89,9 @@ async def test_one_light(hass, rfxtrx):
     ]
 
 
-@pytest.mark.parametrize("state,brightness", [["on", 100], ["on", 50], ["off", None]])
+@pytest.mark.parametrize(
+    ("state", "brightness"), [["on", 100], ["on", 50], ["off", None]]
+)
 async def test_state_restore(hass, rfxtrx, state, brightness):
     """State restoration."""
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -50,7 +50,7 @@ async def test_one_sensor(hass, rfxtrx):
 
 
 @pytest.mark.parametrize(
-    "state,event",
+    ("state", "event"),
     [["18.4", "0a520801070100b81b0279"], ["17.9", "0a52085e070100b31b0279"]],
 )
 async def test_state_restore(hass, rfxtrx, state, event):

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -13,7 +13,7 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
 
 
 @pytest.mark.parametrize(
-    "get_client_response,errors",
+    ("get_client_response", "errors"),
     [
         (AsyncMock(side_effect=InvalidCredentialsError), {"base": "invalid_auth"}),
         (AsyncMock(side_effect=RidwellError), {"base": "unknown"}),

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -90,7 +90,7 @@ async def test_cloud_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception, error",
+    ("exception", "error"),
     [
         (UnauthorizedError, "invalid_auth"),
         (CannotConnectError, "cannot_connect"),
@@ -253,7 +253,7 @@ async def test_local_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception, error",
+    ("exception", "error"),
     [
         (UnauthorizedError, "invalid_auth"),
         (CannotConnectError, "cannot_connect"),

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -509,7 +509,7 @@ async def test_services_play_media(
 
 
 @pytest.mark.parametrize(
-    "content_type, content_id, resolved_name, resolved_format",
+    ("content_type", "content_id", "resolved_name", "resolved_format"),
     [
         (MediaType.URL, "http://localhost/media.m4a", "media.m4a", "m4a"),
         (MediaType.MUSIC, "http://localhost/media.m4a", "media.m4a", "m4a"),
@@ -554,7 +554,7 @@ async def test_services_play_media_audio(
 
 
 @pytest.mark.parametrize(
-    "content_type, content_id, resolved_name, resolved_format",
+    ("content_type", "content_id", "resolved_name", "resolved_format"),
     [
         (MediaType.URL, "http://localhost/media.mp4", "media.mp4", "mp4"),
         (MediaType.VIDEO, "http://localhost/media.m4v", "media.m4v", "mp4"),

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -113,7 +113,7 @@ async def test_application_state(
 
 
 @pytest.mark.parametrize(
-    "error, error_string",
+    ("error", "error_string"),
     [
         (RokuConnectionError, "Error communicating with Roku API"),
         (RokuConnectionTimeoutError, "Timeout communicating with Roku API"),

--- a/tests/components/ruuvi_gateway/test_config_flow.py
+++ b/tests/components/ruuvi_gateway/test_config_flow.py
@@ -23,7 +23,7 @@ DHCP_DATA = {**BASE_DATA, "host": DHCP_IP}
 
 
 @pytest.mark.parametrize(
-    "init_data, init_context, entry",
+    ("init_data", "init_context", "entry"),
     [
         (
             None,

--- a/tests/components/rympro/test_config_flow.py
+++ b/tests/components/rympro/test_config_flow.py
@@ -68,7 +68,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception, error",
+    ("exception", "error"),
     [
         (UnauthorizedError, "invalid_auth"),
         (CannotConnectError, "cannot_connect"),

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -116,7 +116,7 @@ async def test_invalid_config(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "schedule,error",
+    ("schedule", "error"),
     (
         (
             [
@@ -593,7 +593,7 @@ async def test_ws_delete(
 
 @pytest.mark.freeze_time("2022-08-10 20:10:00-07:00")
 @pytest.mark.parametrize(
-    "to, next_event, saved_to",
+    ("to", "next_event", "saved_to"),
     (
         ("23:59:59", "2022-08-10T23:59:59-07:00", "23:59:59"),
         ("24:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
@@ -663,7 +663,7 @@ async def test_update(
 
 @pytest.mark.freeze_time("2022-08-11 8:52:00-07:00")
 @pytest.mark.parametrize(
-    "to, next_event, saved_to",
+    ("to", "next_event", "saved_to"),
     (
         ("14:00:00", "2022-08-15T14:00:00-07:00", "14:00:00"),
         ("24:00", "2022-08-16T00:00:00-07:00", "24:00:00"),

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -168,7 +168,7 @@ async def test_setup_with_invalid_configs(hass, value):
 
 
 @pytest.mark.parametrize(
-    "object_id, broken_config, problem, details",
+    ("object_id", "broken_config", "problem", "details"),
     (
         (
             "Bad Script",
@@ -1000,7 +1000,7 @@ async def test_script_restore_last_triggered(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "script_mode,warning_msg",
+    ("script_mode", "warning_msg"),
     (
         (SCRIPT_MODE_PARALLEL, "Maximum number of runs exceeded"),
         (SCRIPT_MODE_QUEUED, "Disallowed recursion detected"),
@@ -1048,7 +1048,7 @@ async def test_recursive_script(hass, script_mode, warning_msg, caplog):
 
 
 @pytest.mark.parametrize(
-    "script_mode,warning_msg",
+    ("script_mode", "warning_msg"),
     (
         (SCRIPT_MODE_PARALLEL, "Maximum number of runs exceeded"),
         (SCRIPT_MODE_QUEUED, "Disallowed recursion detected"),
@@ -1321,7 +1321,7 @@ async def test_script_service_changed_entity_id(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "blueprint_inputs, problem, details",
+    ("blueprint_inputs", "problem", "details"),
     (
         (
             # No input

--- a/tests/components/season/test_sensor.py
+++ b/tests/components/season/test_sensor.py
@@ -71,7 +71,7 @@ def idfn(val):
         return val.strftime("%Y%m%d")
 
 
-@pytest.mark.parametrize("type,day,expected", NORTHERN_PARAMETERS, ids=idfn)
+@pytest.mark.parametrize(("type", "day", "expected"), NORTHERN_PARAMETERS, ids=idfn)
 async def test_season_northern_hemisphere(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -103,7 +103,7 @@ async def test_season_northern_hemisphere(
     assert entry.translation_key == "season"
 
 
-@pytest.mark.parametrize("type,day,expected", SOUTHERN_PARAMETERS, ids=idfn)
+@pytest.mark.parametrize(("type", "day", "expected"), SOUTHERN_PARAMETERS, ids=idfn)
 async def test_season_southern_hemisphere(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -61,7 +61,7 @@ async def test_get_actions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -65,7 +65,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -62,7 +62,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/sensibo/test_config_flow.py
+++ b/tests/components/sensibo/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error_message, p_error",
+    ("error_message", "p_error"),
     [
         (aiohttp.ClientConnectionError, "cannot_connect"),
         (asyncio.TimeoutError, "cannot_connect"),
@@ -216,7 +216,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sideeffect,p_error",
+    ("sideeffect", "p_error"),
     [
         (aiohttp.ClientConnectionError, "cannot_connect"),
         (asyncio.TimeoutError, "cannot_connect"),
@@ -282,7 +282,7 @@ async def test_reauth_flow_error(
 
 
 @pytest.mark.parametrize(
-    "get_devices,get_me,p_error",
+    ("get_devices", "get_me", "p_error"),
     [
         (
             {"result": [{"id": "xyzxyz"}, {"id": "abcabc"}]},

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -77,7 +77,7 @@ async def test_get_conditions(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -167,7 +167,7 @@ async def test_get_conditions_no_state(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "state_class,unit,condition_types",
+    ("state_class", "unit", "condition_types"),
     (
         (SensorStateClass.MEASUREMENT, None, ["is_value"]),
         (SensorStateClass.TOTAL, None, ["is_value"]),
@@ -217,7 +217,7 @@ async def test_get_conditions_no_unit_or_stateclass(
 
 
 @pytest.mark.parametrize(
-    "set_state,device_class_reg,device_class_state,unit_reg,unit_state",
+    ("set_state", "device_class_reg", "device_class_state", "unit_reg", "unit_state"),
     [
         (False, SensorDeviceClass.BATTERY, None, PERCENTAGE, None),
         (True, None, SensorDeviceClass.BATTERY, None, PERCENTAGE),

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -81,7 +81,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
@@ -130,7 +130,7 @@ async def test_get_triggers_hidden_auxiliary(
 
 
 @pytest.mark.parametrize(
-    "state_class,unit,trigger_types",
+    ("state_class", "unit", "trigger_types"),
     (
         (SensorStateClass.MEASUREMENT, None, ["value"]),
         (SensorStateClass.TOTAL, None, ["value"]),
@@ -180,7 +180,7 @@ async def test_get_triggers_no_unit_or_stateclass(
 
 
 @pytest.mark.parametrize(
-    "set_state,device_class_reg,device_class_state,unit_reg,unit_state",
+    ("set_state", "device_class_reg", "device_class_state", "unit_reg", "unit_state"),
     [
         (False, SensorDeviceClass.BATTERY, None, PERCENTAGE, None),
         (True, None, SensorDeviceClass.BATTERY, None, PERCENTAGE),

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -39,7 +39,7 @@ from tests.common import mock_restore_cache_with_extra_data
 
 
 @pytest.mark.parametrize(
-    "unit_system,native_unit,state_unit,native_value,state_value",
+    ("unit_system", "native_unit", "state_unit", "native_value", "state_value"),
     [
         (
             US_CUSTOMARY_SYSTEM,
@@ -199,7 +199,7 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
 
 
 @pytest.mark.parametrize(
-    "device_class,state_value,provides",
+    ("device_class", "state_value", "provides"),
     [
         (SensorDeviceClass.DATE, "2021-01-09", "date"),
         (SensorDeviceClass.TIMESTAMP, "2021-01-09T12:00:00+00:00", "datetime"),
@@ -283,7 +283,7 @@ RESTORE_DATA = {
 
 # None | str | int | float | date | datetime | Decimal:
 @pytest.mark.parametrize(
-    "native_value, native_value_type, expected_extra_data, device_class, uom",
+    ("native_value", "native_value_type", "expected_extra_data", "device_class", "uom"),
     [
         ("abc123", str, RESTORE_DATA["str"], None, None),
         (
@@ -353,7 +353,7 @@ async def test_restore_sensor_save_state(
 
 
 @pytest.mark.parametrize(
-    "native_value, native_value_type, extra_data, device_class, uom",
+    ("native_value", "native_value_type", "extra_data", "device_class", "uom"),
     [
         ("abc123", str, RESTORE_DATA["str"], None, None),
         (123, int, RESTORE_DATA["int"], SensorDeviceClass.TEMPERATURE, "°F"),
@@ -418,7 +418,14 @@ async def test_restore_sensor_restore_state(
 
 
 @pytest.mark.parametrize(
-    "device_class, native_unit, custom_unit, state_unit, native_value, custom_state",
+    (
+        "device_class",
+        "native_unit",
+        "custom_unit",
+        "state_unit",
+        "native_value",
+        "custom_state",
+    ),
     [
         # Smaller to larger unit, InHg is ~33x larger than hPa -> 1 more decimal
         (
@@ -519,7 +526,15 @@ async def test_custom_unit(
 
 
 @pytest.mark.parametrize(
-    "native_unit, custom_unit, state_unit, native_value, native_state, custom_state, device_class",
+    (
+        "native_unit",
+        "custom_unit",
+        "state_unit",
+        "native_value",
+        "native_state",
+        "custom_state",
+        "device_class",
+    ),
     [
         # Distance
         (
@@ -788,9 +803,19 @@ async def test_custom_unit_change(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, automatic_unit, suggested_unit, custom_unit,"
-    "native_value, native_state, automatic_state, suggested_state, custom_state,"
-    "device_class",
+    (
+        "unit_system",
+        "native_unit",
+        "automatic_unit",
+        "suggested_unit",
+        "custom_unit",
+        "native_value",
+        "native_state",
+        "automatic_state",
+        "suggested_state",
+        "custom_state",
+        "device_class",
+    ),
     [
         # Distance
         (
@@ -921,9 +946,20 @@ async def test_unit_conversion_priority(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, automatic_unit, suggested_unit, custom_unit,"
-    "suggested_precision, native_value, native_state, automatic_state, suggested_state,"
-    "custom_state, device_class",
+    (
+        "unit_system",
+        "native_unit",
+        "automatic_unit",
+        "suggested_unit",
+        "custom_unit",
+        "suggested_precision",
+        "native_value",
+        "native_state",
+        "automatic_state",
+        "suggested_state",
+        "custom_state",
+        "device_class",
+    ),
     [
         # Distance
         (
@@ -1062,7 +1098,15 @@ async def test_unit_conversion_priority_precision(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, original_unit, suggested_unit, native_value, original_value, device_class",
+    (
+        "unit_system",
+        "native_unit",
+        "original_unit",
+        "suggested_unit",
+        "native_value",
+        "original_value",
+        "device_class",
+    ),
     [
         # Distance
         (
@@ -1143,8 +1187,15 @@ async def test_unit_conversion_priority_suggested_unit_change(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, integration_suggested_precision,"
-    "options_suggested_precision, native_value, device_class, extra_options",
+    (
+        "unit_system",
+        "native_unit",
+        "integration_suggested_precision",
+        "options_suggested_precision",
+        "native_value",
+        "device_class",
+        "extra_options",
+    ),
     [
         # Distance
         (
@@ -1208,8 +1259,17 @@ async def test_suggested_precision_option(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, suggested_unit, old_precision, new_precision,"
-    "opt_precision, native_value, device_class, extra_options",
+    (
+        "unit_system",
+        "native_unit",
+        "suggested_unit",
+        "old_precision",
+        "new_precision",
+        "opt_precision",
+        "native_value",
+        "device_class",
+        "extra_options",
+    ),
     [
         # Distance
         (
@@ -1301,7 +1361,14 @@ async def test_suggested_precision_option_update(
 
 
 @pytest.mark.parametrize(
-    "unit_system, native_unit, original_unit, native_value, original_value, device_class",
+    (
+        "unit_system",
+        "native_unit",
+        "original_unit",
+        "native_value",
+        "original_value",
+        "device_class",
+    ),
     [
         # Distance
         (
@@ -1552,7 +1619,7 @@ async def test_device_classes_with_invalid_unit_of_measurement(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_class,unit",
+    ("device_class", "state_class", "unit"),
     [
         (SensorDeviceClass.AQI, None, None),
         (None, SensorStateClass.MEASUREMENT, None),
@@ -1603,7 +1670,7 @@ async def test_non_numeric_validation_warn(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_class,unit,precision", ((None, None, None, 1),)
+    ("device_class", "state_class", "unit", "precision"), ((None, None, None, 1),)
 )
 @pytest.mark.parametrize(
     "native_value,expected",
@@ -1648,7 +1715,7 @@ async def test_non_numeric_validation_raise(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_class,unit",
+    ("device_class", "state_class", "unit"),
     [
         (SensorDeviceClass.AQI, None, None),
         (None, SensorStateClass.MEASUREMENT, None),
@@ -1762,7 +1829,13 @@ async def test_device_classes_with_invalid_state_class(
 
 
 @pytest.mark.parametrize(
-    "device_class,state_class,native_unit_of_measurement,suggested_precision,is_numeric",
+    (
+        "device_class",
+        "state_class",
+        "native_unit_of_measurement",
+        "suggested_precision",
+        "is_numeric",
+    ),
     [
         (SensorDeviceClass.ENUM, None, None, None, False),
         (SensorDeviceClass.DATE, None, None, None, False),
@@ -1807,7 +1880,21 @@ async def test_numeric_state_expected_helper(
 
 
 @pytest.mark.parametrize(
-    "unit_system_1, unit_system_2, native_unit, automatic_unit_1, automatic_unit_2, suggested_unit, custom_unit, native_value, automatic_state_1, automatic_state_2, suggested_state, custom_state, device_class",
+    (
+        "unit_system_1",
+        "unit_system_2",
+        "native_unit",
+        "automatic_unit_1",
+        "automatic_unit_2",
+        "suggested_unit",
+        "custom_unit",
+        "native_value",
+        "automatic_state_1",
+        "automatic_state_2",
+        "suggested_state",
+        "custom_state",
+        "device_class",
+    ),
     [
         # Distance
         (

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -93,7 +93,16 @@ def set_time_zone():
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "mean",
+        "min",
+        "max",
+    ),
     [
         (None, "%", "%", "%", "unitless", 13.050847, -10, 30),
         ("battery", "%", "%", "%", "unitless", 13.050847, -10, 30),
@@ -177,7 +186,7 @@ def test_compile_hourly_statistics(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class",
+    ("device_class", "state_unit", "display_unit", "statistics_unit", "unit_class"),
     [
         (None, "%", "%", "%", "unitless"),
     ],
@@ -897,7 +906,17 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
 
 
 @pytest.mark.parametrize(
-    "entity_id, device_class, state_unit, display_unit, statistics_unit, unit_class, offset, warning_1, warning_2",
+    (
+        "entity_id",
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "offset",
+        "warning_1",
+        "warning_2",
+    ),
     [
         (
             "sensor.test1",
@@ -1030,7 +1049,14 @@ def test_compile_hourly_sum_statistics_negative_state(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "factor",
+    ),
     [
         ("energy", "kWh", "kWh", "kWh", "energy", 1),
         ("energy", "Wh", "Wh", "Wh", "energy", 1),
@@ -1134,7 +1160,14 @@ def test_compile_hourly_sum_statistics_total_no_reset(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "factor",
+    ),
     [
         ("energy", "kWh", "kWh", "kWh", "energy", 1),
         ("energy", "Wh", "Wh", "Wh", "energy", 1),
@@ -1239,7 +1272,14 @@ def test_compile_hourly_sum_statistics_total_increasing(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, factor",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "factor",
+    ),
     [("energy", "kWh", "kWh", "kWh", "energy", 1)],
 )
 def test_compile_hourly_sum_statistics_total_increasing_small_dip(
@@ -1619,7 +1659,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,value",
+    ("device_class", "state_unit", "value"),
     [
         ("battery", "%", 30),
         ("battery", None, 30),
@@ -1712,7 +1752,7 @@ def test_compile_hourly_statistics_partially_unavailable(hass_recorder, caplog):
 
 
 @pytest.mark.parametrize(
-    "device_class,state_unit,value",
+    ("device_class", "state_unit", "value"),
     [
         ("battery", "%", 30),
         ("battery", None, 30),
@@ -1796,7 +1836,15 @@ def test_compile_hourly_statistics_fails(hass_recorder, caplog):
 
 
 @pytest.mark.parametrize(
-    "state_class, device_class, state_unit, display_unit, statistics_unit, unit_class, statistic_type",
+    (
+        "state_class",
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "statistic_type",
+    ),
     [
         ("measurement", "battery", "%", "%", "%", "unitless", "mean"),
         ("measurement", "battery", None, None, None, "unitless", "mean"),
@@ -1919,7 +1967,7 @@ def test_list_statistic_ids_unsupported(hass_recorder, caplog, _attributes):
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, state_unit2, unit_class, mean, min, max",
+    ("device_class", "state_unit", "state_unit2", "unit_class", "mean", "min", "max"),
     [
         (None, None, "cats", "unitless", 13.050847, -10, 30),
         (None, "%", "cats", "unitless", 13.050847, -10, 30),
@@ -2038,7 +2086,16 @@ def test_compile_hourly_statistics_changing_units_1(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "mean",
+        "min",
+        "max",
+    ),
     [
         (None, "dogs", "dogs", "dogs", None, 13.050847, -10, 30),
     ],
@@ -2102,7 +2159,16 @@ def test_compile_hourly_statistics_changing_units_2(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "mean",
+        "min",
+        "max",
+    ),
     [
         (None, "dogs", "dogs", "dogs", None, 13.050847, -10, 30),
     ],
@@ -2216,7 +2282,7 @@ def test_compile_hourly_statistics_changing_units_3(
 
 
 @pytest.mark.parametrize(
-    "state_unit_1, state_unit_2, unit_class, mean, min, max, factor",
+    ("state_unit_1", "state_unit_2", "unit_class", "mean", "min", "max", "factor"),
     [
         (None, "%", "unitless", 13.050847, -10, 30, 100),
         ("%", None, "unitless", 13.050847, -10, 30, 0.01),
@@ -2342,7 +2408,17 @@ def test_compile_hourly_statistics_convert_units_1(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, state_unit2, unit_class, unit_class2, mean, mean2, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "state_unit2",
+        "unit_class",
+        "unit_class2",
+        "mean",
+        "mean2",
+        "min",
+        "max",
+    ),
     [
         (None, "RPM", "rpm", None, None, 13.050847, 13.333333, -10, 30),
         (None, "rpm", "RPM", None, None, 13.050847, 13.333333, -10, 30),
@@ -2462,7 +2538,7 @@ def test_compile_hourly_statistics_equivalent_units_1(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, state_unit2, unit_class, mean, min, max",
+    ("device_class", "state_unit", "state_unit2", "unit_class", "mean", "min", "max"),
     [
         (None, "RPM", "rpm", None, 13.333333, -10, 30),
         (None, "rpm", "RPM", None, 13.333333, -10, 30),
@@ -2539,7 +2615,16 @@ def test_compile_hourly_statistics_equivalent_units_2(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, statistic_unit, unit_class, mean1, mean2, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "statistic_unit",
+        "unit_class",
+        "mean1",
+        "mean2",
+        "min",
+        "max",
+    ),
     [
         ("power", "kW", "kW", "power", 13.050847, 13.333333, -10, 30),
     ],
@@ -2727,7 +2812,17 @@ def test_compile_hourly_statistics_changing_device_class_1(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistic_unit, unit_class, mean, mean2, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistic_unit",
+        "unit_class",
+        "mean",
+        "mean2",
+        "min",
+        "max",
+    ),
     [
         ("power", "kW", "kW", "kW", "power", 13.050847, 13.333333, -10, 30),
     ],
@@ -2852,7 +2947,16 @@ def test_compile_hourly_statistics_changing_device_class_2(
 
 
 @pytest.mark.parametrize(
-    "device_class, state_unit, display_unit, statistics_unit, unit_class, mean, min, max",
+    (
+        "device_class",
+        "state_unit",
+        "display_unit",
+        "statistics_unit",
+        "unit_class",
+        "mean",
+        "min",
+        "max",
+    ),
     [
         (None, None, None, None, "unitless", 13.050847, -10, 30),
     ],
@@ -3440,7 +3544,7 @@ def record_states(hass, zero, entity_id, attributes, seq=None):
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit, unit2, supported_unit",
+    ("units", "attributes", "unit", "unit2", "supported_unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
         (METRIC_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
@@ -3578,7 +3682,7 @@ async def test_validate_unit_change_convertible(
 
 
 @pytest.mark.parametrize(
-    "units, attributes",
+    ("units", "attributes"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES),
     ],
@@ -3632,7 +3736,7 @@ async def test_validate_statistics_unit_ignore_device_class(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit, unit2, supported_unit",
+    ("units", "attributes", "unit", "unit2", "supported_unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
         (METRIC_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W", "kW", "W, kW"),
@@ -3777,7 +3881,7 @@ async def test_validate_statistics_unit_change_no_device_class(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit",
+    ("units", "attributes", "unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
@@ -3841,7 +3945,7 @@ async def test_validate_statistics_unsupported_state_class(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit",
+    ("units", "attributes", "unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
@@ -3904,7 +4008,7 @@ async def test_validate_statistics_sensor_no_longer_recorded(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit",
+    ("units", "attributes", "unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
@@ -3964,7 +4068,7 @@ async def test_validate_statistics_sensor_not_recorded(
 
 
 @pytest.mark.parametrize(
-    "units, attributes, unit",
+    ("units", "attributes", "unit"),
     [
         (US_CUSTOMARY_SYSTEM, POWER_SENSOR_ATTRIBUTES, "W"),
     ],
@@ -4022,7 +4126,7 @@ async def test_validate_statistics_sensor_removed(
 
 
 @pytest.mark.parametrize(
-    "attributes, unit1, unit2",
+    ("attributes", "unit1", "unit2"),
     [
         (BATTERY_SENSOR_ATTRIBUTES, "cats", "dogs"),
         (NONE_SENSOR_ATTRIBUTES, "cats", "dogs"),
@@ -4147,7 +4251,7 @@ async def test_validate_statistics_unit_change_no_conversion(
 
 
 @pytest.mark.parametrize(
-    "attributes, unit1, unit2",
+    ("attributes", "unit1", "unit2"),
     [
         (NONE_SENSOR_ATTRIBUTES, "m3", "m³"),
         (NONE_SENSOR_ATTRIBUTES, "rpm", "RPM"),
@@ -4228,7 +4332,7 @@ async def test_validate_statistics_unit_change_equivalent_units(
 
 
 @pytest.mark.parametrize(
-    "attributes, unit1, unit2, supported_unit",
+    ("attributes", "unit1", "unit2", "supported_unit"),
     [
         (NONE_SENSOR_ATTRIBUTES, "m³", "m3", "CCF, L, fl. oz., ft³, gal, mL, m³"),
     ],

--- a/tests/components/sensor/test_significant_change.py
+++ b/tests/components/sensor/test_significant_change.py
@@ -32,7 +32,7 @@ TEMP_FREEDOM_ATTRS = {
 
 
 @pytest.mark.parametrize(
-    "old_state,new_state,attrs,result",
+    ("old_state", "new_state", "attrs", "result"),
     [
         ("0", "1", AQI_ATTRS, True),
         ("1", "0", AQI_ATTRS, True),

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -104,7 +104,7 @@ async def test_setup_entry_with_tracing(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "version,channel",
+    ("version", "channel"),
     [
         ("0.115.0.dev20200815", "nightly"),
         ("0.115.0", "stable"),
@@ -208,7 +208,7 @@ async def test_event_with_platform_context(hass: HomeAssistant):
 
 
 @pytest.mark.parametrize(
-    "logger,tags",
+    ("logger", "tags"),
     [
         ("adguard", {"package": "adguard"}),
         (
@@ -262,7 +262,7 @@ async def test_logger_event_extraction(hass: HomeAssistant, logger, tags):
 
 
 @pytest.mark.parametrize(
-    "logger,options,event",
+    ("logger", "options", "event"),
     [
         ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: True}, True),
         ("adguard", {CONF_EVENT_THIRD_PARTY_PACKAGES: False}, False),
@@ -298,7 +298,7 @@ async def test_filter_log_events(hass: HomeAssistant, logger, options, event):
 
 
 @pytest.mark.parametrize(
-    "handled,options,event",
+    ("handled", "options", "event"),
     [
         ("yes", {CONF_EVENT_HANDLED: True}, True),
         ("yes", {CONF_EVENT_HANDLED: False}, False),

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exc,base_error",
+    ("exc", "base_error"),
     [
         (SharkIqAuthError, "invalid_auth"),
         (aiohttp.ClientError, "cannot_connect"),
@@ -83,7 +83,7 @@ async def test_reauth_success(hass: HomeAssistant):
 
 
 @pytest.mark.parametrize(
-    "side_effect,result_type,msg_field,msg",
+    ("side_effect", "result_type", "msg_field", "msg"),
     [
         (SharkIqAuthError, "form", "errors", "invalid_auth"),
         (aiohttp.ClientError, "abort", "reason", "cannot_connect"),

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -134,7 +134,7 @@ async def test_simple_properties(hass: HomeAssistant):
 
 
 @pytest.mark.parametrize(
-    "attribute,target_value",
+    ("attribute", "target_value"),
     [
         (ATTR_SUPPORTED_FEATURES, EXPECTED_FEATURES),
         (ATTR_BATTERY_LEVEL, 50),
@@ -155,7 +155,7 @@ async def test_initial_attributes(
 
 
 @pytest.mark.parametrize(
-    "service,target_state",
+    ("service", "target_state"),
     [
         (SERVICE_STOP, STATE_IDLE),
         (SERVICE_PAUSE, STATE_PAUSED),
@@ -183,7 +183,7 @@ async def test_fan_speed(hass: HomeAssistant, fan_speed: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "device_property,target_value",
+    ("device_property", "target_value"),
     [
         ("manufacturer", "Shark"),
         ("model", "RV1001AE"),
@@ -209,7 +209,7 @@ async def test_locate(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,success",
+    ("side_effect", "success"),
     [
         (None, True),
         (SharkIqAuthError, False),

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -48,7 +48,7 @@ DISCOVERY_INFO_WITH_MAC = zeroconf.ZeroconfServiceInfo(
 
 
 @pytest.mark.parametrize(
-    "gen, model",
+    ("gen", "model"),
     [
         (1, "SHSW-1"),
         (2, "SNSW-002P16EU"),
@@ -90,7 +90,7 @@ async def test_form(hass, gen, model, mock_block_device, mock_rpc_device):
 
 
 @pytest.mark.parametrize(
-    "gen, model, user_input, username",
+    ("gen", "model", "user_input", "username"),
     [
         (
             1,
@@ -154,7 +154,7 @@ async def test_form_auth(
 
 
 @pytest.mark.parametrize(
-    "exc, base_error",
+    ("exc", "base_error"),
     [
         (DeviceConnectionError, "cannot_connect"),
         (ValueError, "unknown"),
@@ -249,7 +249,7 @@ async def test_form_missing_model_key_zeroconf(
 
 
 @pytest.mark.parametrize(
-    "exc, base_error",
+    ("exc", "base_error"),
     [
         (DeviceConnectionError, "cannot_connect"),
         (ValueError, "unknown"),
@@ -361,7 +361,7 @@ async def test_form_firmware_unsupported(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exc, base_error",
+    ("exc", "base_error"),
     [
         (InvalidAuthError, "invalid_auth"),
         (DeviceConnectionError, "cannot_connect"),
@@ -396,7 +396,7 @@ async def test_form_auth_errors_test_connection_gen1(hass, exc, base_error):
 
 
 @pytest.mark.parametrize(
-    "exc, base_error",
+    ("exc", "base_error"),
     [
         (DeviceConnectionError, "cannot_connect"),
         (InvalidAuthError, "invalid_auth"),
@@ -430,7 +430,7 @@ async def test_form_auth_errors_test_connection_gen2(hass, exc, base_error):
 
 
 @pytest.mark.parametrize(
-    "gen, model, get_info",
+    ("gen", "model", "get_info"),
     [
         (
             1,
@@ -709,7 +709,7 @@ async def test_zeroconf_require_auth(hass, mock_block_device):
 
 
 @pytest.mark.parametrize(
-    "gen, user_input",
+    ("gen", "user_input"),
     [
         (1, {"username": "test user", "password": "test1 password"}),
         (2, {"password": "test2 password"}),
@@ -747,7 +747,7 @@ async def test_reauth_successful(
 
 
 @pytest.mark.parametrize(
-    "gen, user_input",
+    ("gen", "user_input"),
     [
         (1, {"username": "test user", "password": "test1 password"}),
         (2, {"password": "test2 password"}),

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -31,7 +31,7 @@ from tests.common import (
 
 
 @pytest.mark.parametrize(
-    "button_type, is_valid",
+    ("button_type", "is_valid"),
     [
         ("momentary", True),
         ("momentary_on_release", True),

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -106,7 +106,7 @@ async def test_device_auth_error(
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-@pytest.mark.parametrize("entry_sleep, device_sleep", [(None, 0), (1000, 1000)])
+@pytest.mark.parametrize(("entry_sleep", "device_sleep"), [(None, 0), (1000, 1000)])
 async def test_sleeping_block_device_online(
     hass, entry_sleep, device_sleep, mock_block_device, device_reg, caplog
 ):
@@ -126,7 +126,7 @@ async def test_sleeping_block_device_online(
     assert entry.data["sleep_period"] == device_sleep
 
 
-@pytest.mark.parametrize("entry_sleep, device_sleep", [(None, 0), (1000, 1000)])
+@pytest.mark.parametrize(("entry_sleep", "device_sleep"), [(None, 0), (1000, 1000)])
 async def test_sleeping_rpc_device_online(
     hass, entry_sleep, device_sleep, mock_rpc_device, caplog
 ):
@@ -140,7 +140,7 @@ async def test_sleeping_rpc_device_online(
 
 
 @pytest.mark.parametrize(
-    "gen, entity_id",
+    ("gen", "entity_id"),
     [
         (1, "switch.test_name_channel_1"),
         (2, "switch.test_switch_0"),
@@ -161,7 +161,7 @@ async def test_entry_unload(hass, gen, entity_id, mock_block_device, mock_rpc_de
 
 
 @pytest.mark.parametrize(
-    "gen, entity_id",
+    ("gen", "entity_id"),
     [
         (1, "switch.test_name_channel_1"),
         (2, "switch.test_switch_0"),

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -446,7 +446,7 @@ async def test_rpc_beta_update(hass: HomeAssistant, mock_rpc_device, monkeypatch
 
 
 @pytest.mark.parametrize(
-    "exc, error",
+    ("exc", "error"),
     [
         (DeviceConnectionError, "Error starting OTA update"),
         (RpcCallError(-1, "error"), "OTA update request error"),

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -138,7 +138,7 @@ async def test_is_block_momentary_input(mock_block_device, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "settings, sleep_period",
+    ("settings", "sleep_period"),
     [
         ({}, 0),
         ({"sleep_mode": {"period": 1000, "unit": "m"}}, 1000 * 60),

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -216,7 +216,7 @@ def mock_sia():
 
 
 @pytest.mark.parametrize(
-    "field, value, error",
+    ("field", "value", "error"),
     [
         ("encryption_key", "AAAAAAAAAAAAAZZZ", "invalid_key_format"),
         ("encryption_key", "AAAAAAAAAAAAA", "invalid_key_length"),
@@ -243,7 +243,7 @@ async def test_validation_errors_user(
 
 
 @pytest.mark.parametrize(
-    "field, value, error",
+    ("field", "value", "error"),
     [
         ("encryption_key", "AAAAAAAAAAAAAZZZ", "invalid_key_format"),
         ("encryption_key", "AAAAAAAAAAAAA", "invalid_key_length"),

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -131,7 +131,7 @@ async def test_step_reauth_wrong_account(config_entry, hass, setup_simplisafe):
 
 
 @pytest.mark.parametrize(
-    "auth_code,log_statement",
+    ("auth_code", "log_statement"),
     [
         (
             VALID_AUTH_CODE,

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (SleepIQLoginException, "invalid_auth"),
         (SleepIQTimeoutException, "cannot_connect"),

--- a/tests/components/smarttub/test_light.py
+++ b/tests/components/smarttub/test_light.py
@@ -8,7 +8,7 @@ from smarttub import SpaLight
 # service_name with service_params, and expect the resultant call to
 # SpaLight.set_mode to have set_mode_args parameters
 @pytest.mark.parametrize(
-    "light_zone,light_state,service_name,service_params,set_mode_args",
+    ("light_zone", "light_state", "service_name", "service_params", "set_mode_args"),
     [
         (1, "off", "turn_on", {}, (SpaLight.LightMode.PURPLE, 50)),
         (1, "off", "turn_on", {"brightness": 255}, (SpaLight.LightMode.PURPLE, 100)),

--- a/tests/components/smarttub/test_sensor.py
+++ b/tests/components/smarttub/test_sensor.py
@@ -5,7 +5,7 @@ import smarttub
 
 
 @pytest.mark.parametrize(
-    "entity_suffix,expected_state",
+    ("entity_suffix", "expected_state"),
     [
         ("state", "normal"),
         ("flow_switch", "open"),

--- a/tests/components/smarttub/test_switch.py
+++ b/tests/components/smarttub/test_switch.py
@@ -6,7 +6,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 
 
 @pytest.mark.parametrize(
-    "pump_id,entity_suffix,pump_state",
+    ("pump_id", "entity_suffix", "pump_state"),
     [
         ("CP", "circulation_pump", "off"),
         ("P1", "jet_p1", "off"),

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -122,7 +122,7 @@ EMAIL_DATA = [
 
 
 @pytest.mark.parametrize(
-    "message_data, data, content_type",
+    ("message_data", "data", "content_type"),
     EMAIL_DATA,
     ids=[
         "Tests when sending text message and images.",

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -127,7 +127,7 @@ async def test_query_mssql_no_result(
 
 
 @pytest.mark.parametrize(
-    "url,expected_patterns,not_expected_patterns",
+    ("url", "expected_patterns", "not_expected_patterns"),
     [
         (
             "sqlite://homeassistant:hunter2@homeassistant.local",
@@ -256,7 +256,7 @@ async def test_config_from_old_yaml(
 
 
 @pytest.mark.parametrize(
-    "url,expected_patterns,not_expected_patterns",
+    ("url", "expected_patterns", "not_expected_patterns"),
     [
         (
             "sqlite://homeassistant:hunter2@homeassistant.local",

--- a/tests/components/steamist/test_config_flow.py
+++ b/tests/components/steamist/test_config_flow.py
@@ -332,7 +332,7 @@ async def test_discovered_by_dhcp_discovery_finds_non_steamist_device(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, DISCOVERY_30303),
@@ -364,7 +364,7 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, DISCOVERY_30303),

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -184,7 +184,7 @@ def h264_mov_video():
 
 
 @pytest.mark.parametrize(
-    "audio_codec,expected_audio_streams",
+    ("audio_codec", "expected_audio_streams"),
     [
         ("aac", 1),  # aac is a valid mp4 codec
         ("pcm_mulaw", 0),  # G.711 is not a valid mp4 codec

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -749,7 +749,7 @@ test_worker_log_cases = (
 )
 
 
-@pytest.mark.parametrize("stream_url, redacted_url", test_worker_log_cases)
+@pytest.mark.parametrize(("stream_url", "redacted_url"), test_worker_log_cases)
 async def test_worker_log(hass, caplog, stream_url, redacted_url):
     """Test that the worker logs the url without username and password."""
     stream = Stream(

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -134,7 +134,7 @@ async def test_stream_audio(
 
 
 @pytest.mark.parametrize(
-    "header,status,error",
+    ("header", "status", "error"),
     (
         (None, 400, "Missing X-Speech-Content header"),
         (

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -58,7 +58,7 @@ async def test_sensors_missing_vin_data(hass, ev_entry):
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {
@@ -90,7 +90,7 @@ async def test_sensor_migrate_unique_ids(
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id",
+    ("entitydata", "old_unique_id", "new_unique_id"),
     [
         (
             {

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -53,7 +53,7 @@ async def test_get_actions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -58,7 +58,7 @@ async def test_get_conditions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -58,7 +58,7 @@ async def test_get_triggers(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_config_flow(
 
 
 @pytest.mark.parametrize(
-    "hidden_by_before,hidden_by_after",
+    ("hidden_by_before", "hidden_by_after"),
     (
         (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
         (None, er.RegistryEntryHider.INTEGRATION),

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -57,7 +57,7 @@ async def test_config_entry_unregistered_uuid(
 
 
 @pytest.mark.parametrize(
-    "target_domain,state_on,state_off",
+    ("target_domain", "state_on", "state_off"),
     (
         (Platform.COVER, STATE_OPEN, STATE_CLOSED),
         (Platform.FAN, STATE_ON, STATE_OFF),
@@ -364,7 +364,7 @@ async def test_setup_and_remove_config_entry(
 
 
 @pytest.mark.parametrize(
-    "hidden_by_before,hidden_by_after",
+    ("hidden_by_before", "hidden_by_after"),
     (
         (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
         (er.RegistryEntryHider.INTEGRATION, None),

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -21,7 +21,7 @@ SWING_OFF_EID = BASE_ENTITY_ID + "_vertical_swing_off"
 
 
 @pytest.mark.parametrize(
-    "entity, state",
+    ("entity", "state"),
     [
         (ASSUME_ON_EID, DeviceState.ON),
         (ASSUME_OFF_EID, DeviceState.OFF),
@@ -52,7 +52,7 @@ async def test_assume_button(hass: HomeAssistant, entity, state, mock_bridge, mo
 
 
 @pytest.mark.parametrize(
-    "entity, swing",
+    ("entity", "swing"),
     [
         (SWING_ON_EID, ThermostatSwing.ON),
         (SWING_OFF_EID, ThermostatSwing.OFF),

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -49,7 +49,7 @@ async def test_missing_relay(hass, mqtt_mock, setup_tasmota):
 
 
 @pytest.mark.parametrize(
-    "relay_config, num_covers",
+    ("relay_config", "num_covers"),
     [
         ([3, 3, 3, 3, 3, 3, 1, 1, 3, 3], 4),
         ([3, 3, 3, 3, 0, 0, 0, 0], 2),

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -87,7 +87,7 @@ TEMPLATE_ALARM_CONFIG = {
 }
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -124,7 +124,7 @@ async def test_template_state_text(hass, start_ha):
     assert state.state == "unknown"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -159,7 +159,7 @@ async def test_optimistic_states(hass, start_ha):
         assert hass.states.get(TEMPLATE_NAME).state == set_state
 
 
-@pytest.mark.parametrize("count,domain", [(0, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(0, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config,msg",
     [
@@ -229,7 +229,7 @@ async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
     assert (msg) in caplog_setup_text
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -254,7 +254,7 @@ async def test_name(hass, start_ha):
     assert state.attributes.get("friendly_name") == "Template Alarm Panel"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -289,7 +289,7 @@ async def test_actions(hass, service, start_ha, service_calls):
     assert service_calls[0].data["service_data"]["code"] == TEMPLATE_NAME
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -315,7 +315,7 @@ async def test_unique_id(hass, start_ha):
     assert len(hass.states.async_all()) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config,code_format,code_arm_required",
     [

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -346,7 +346,7 @@ async def setup_mock():
         yield _update_state
 
 
-@pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, binary_sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -377,7 +377,7 @@ async def test_match_all(hass, setup_mock, start_ha):
     assert len(setup_mock.mock_calls) == init_calls
 
 
-@pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, binary_sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -408,7 +408,7 @@ async def test_event(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "config,count,domain",
+    ("config", "count", "domain"),
     [
         (
             {
@@ -646,7 +646,7 @@ async def test_availability_template(hass, start_ha, entity_id):
     assert state.attributes[ATTR_DEVICE_CLASS] == "motion"
 
 
-@pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, binary_sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -673,7 +673,7 @@ async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
     assert ("TemplateError") in caplog_setup_text
 
 
-@pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, binary_sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -767,7 +767,7 @@ async def test_no_update_template_match_all(
     assert hass.states.get("binary_sensor.all_attribute").state == OFF
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -815,7 +815,7 @@ async def test_unique_id(hass, start_ha):
     )
 
 
-@pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, binary_sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -919,7 +919,7 @@ async def test_availability_icon_picture(hass, start_ha, entity_id):
     }
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -983,7 +983,7 @@ async def test_restore_state(
     assert state.state == initial_state
 
 
-@pytest.mark.parametrize("count,domain", [(2, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(2, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1085,7 +1085,7 @@ async def test_trigger_entity(hass, start_ha):
     assert state.attributes.get("another") == "si"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1133,7 +1133,7 @@ async def test_template_with_trigger_templated_delay_on(hass, start_ha):
     assert state.state == OFF
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1215,7 +1215,7 @@ async def test_trigger_entity_restore_state(
     assert state.attributes["another"] == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1276,7 +1276,7 @@ async def test_trigger_entity_restore_state_auto_off(
     assert state.state == OFF
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -46,7 +46,7 @@ OPEN_CLOSE_COVER_CONFIG = {
 }
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config, states",
     [
@@ -145,7 +145,7 @@ async def test_template_state_text(hass, states, start_ha, caplog):
         assert text in caplog.text
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -168,7 +168,7 @@ async def test_template_state_boolean(hass, start_ha):
     assert state.state == STATE_OPEN
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -204,7 +204,7 @@ async def test_template_position(hass, start_ha):
         assert state.state == test_state
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -228,7 +228,7 @@ async def test_template_tilt(hass, start_ha):
     assert state.attributes.get("current_tilt_position") == 42.0
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -271,7 +271,7 @@ async def test_template_out_of_bounds(hass, start_ha):
     assert state.attributes.get("current_position") is None
 
 
-@pytest.mark.parametrize("count,domain", [(0, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -306,7 +306,7 @@ async def test_template_open_or_position(hass, start_ha, caplog_setup_text):
     assert "Invalid config for [cover.template]" in caplog_setup_text
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -338,7 +338,7 @@ async def test_open_action(hass, start_ha, calls):
     assert calls[0].data["caller"] == "cover.test_template_cover"
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -384,7 +384,7 @@ async def test_close_stop_action(hass, start_ha, calls):
     assert calls[1].data["caller"] == "cover.test_template_cover"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "input_number")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "input_number")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -484,7 +484,7 @@ async def test_set_position(hass, start_ha, calls):
     assert calls[-1].data["position"] == 25
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -536,7 +536,7 @@ async def test_set_tilt_position(hass, service, attr, start_ha, calls, tilt_posi
     assert calls[-1].data["tilt_position"] == tilt_position
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -581,7 +581,7 @@ async def test_set_position_optimistic(hass, start_ha, calls):
         assert state.state == test_state
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -628,7 +628,7 @@ async def test_set_tilt_position_optimistic(hass, start_ha, calls):
         assert state.attributes.get("current_tilt_position") == pos
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -661,7 +661,7 @@ async def test_icon_template(hass, start_ha):
     assert state.attributes["icon"] == "mdi:check"
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -696,7 +696,7 @@ async def test_entity_picture_template(hass, start_ha):
     assert state.attributes["entity_picture"] == "/local/cover.png"
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -729,7 +729,7 @@ async def test_availability_template(hass, start_ha):
     assert hass.states.get("cover.test_template_cover").state != STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -752,7 +752,7 @@ async def test_availability_without_availability_template(hass, start_ha):
     assert state.state != STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -778,7 +778,7 @@ async def test_invalid_availability_template_keeps_component_available(
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -802,7 +802,7 @@ async def test_device_class(hass, start_ha):
     assert state.attributes.get("device_class") == "door"
 
 
-@pytest.mark.parametrize("count,domain", [(0, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -826,7 +826,7 @@ async def test_invalid_device_class(hass, start_ha):
     assert not state
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -854,7 +854,7 @@ async def test_unique_id(hass, start_ha):
     assert len(hass.states.async_all()) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -888,7 +888,7 @@ async def test_state_gets_lowercased(hass, start_ha):
     assert hass.states.get("cover.garage_door").state == STATE_CLOSED
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -33,7 +33,7 @@ _OSC_INPUT = "input_select.osc"
 _DIRECTION_INPUT_SELECT = "input_select.direction"
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -56,7 +56,7 @@ async def test_missing_optional_config(hass, start_ha):
     _verify(hass, STATE_ON, None, None, None, None)
 
 
-@pytest.mark.parametrize("count,domain", [(0, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -123,7 +123,7 @@ async def test_wrong_template_config(hass, start_ha):
     assert hass.states.async_all("fan") == []
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -184,7 +184,7 @@ async def test_templates_with_entities(hass, start_ha):
     _verify(hass, STATE_OFF, 0, True, DIRECTION_FORWARD, None)
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config,entity,tests",
     [
@@ -248,7 +248,7 @@ async def test_templates_with_entities2(hass, entity, tests, start_ha):
         _verify(hass, STATE_ON, test_percentage, None, None, test_type)
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -279,7 +279,7 @@ async def test_availability_template_with_entities(hass, start_ha):
         assert (hass.states.get(_TEST_FAN).state != STATE_UNAVAILABLE) == test_assert
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config, states",
     [
@@ -359,7 +359,7 @@ async def test_template_with_unavailable_entities(hass, states, start_ha):
     _verify(hass, states[0], states[1], states[2], states[3], None)
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -889,7 +889,7 @@ async def _register_components(
     await hass.async_block_till_done()
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -932,7 +932,7 @@ async def test_unique_id(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "speed_count, percentage_step", [(0, 1), (100, 1), (3, 100 / 3)]
+    ("speed_count", "percentage_step"), [(0, 1), (100, 1), (3, 100 / 3)]
 )
 async def test_implemented_percentage(hass, speed_count, percentage_step):
     """Test a fan that implements percentage."""
@@ -1008,7 +1008,7 @@ async def test_implemented_percentage(hass, speed_count, percentage_step):
     assert attributes.get("supported_features") & FanEntityFeature.SET_SPEED
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.util import dt as dt_util
 from tests.common import async_fire_time_changed, get_fixture_path
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -76,7 +76,7 @@ async def test_reloadable(hass, start_ha):
     assert hass.states.get("sensor.top_level_2").state == "reload"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -113,7 +113,7 @@ async def test_reloadable_can_remove(hass, start_ha):
     assert len(hass.states.async_all()) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -141,7 +141,7 @@ async def test_reloadable_stops_on_invalid_config(hass, start_ha):
     assert len(hass.states.async_all()) == 2
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -172,7 +172,7 @@ async def test_reloadable_handles_partial_valid_config(hass, start_ha):
     assert float(hass.states.get("sensor.combined_sensor_energy_usage").state) == 0
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -218,7 +218,7 @@ async def test_reloadable_multiple_platforms(hass, start_ha):
     assert hass.states.get("sensor.top_level_2") is not None
 
 
-@pytest.mark.parametrize("count,domain", [(1, "sensor")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -231,7 +231,7 @@ async def test_template_syntax_error(hass, setup_light):
 
 
 @pytest.mark.parametrize(
-    "light_config, count",
+    ("light_config", "count"),
     [
         (
             {

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -24,7 +24,7 @@ OPTIMISTIC_LOCK_CONFIG = {
 }
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -52,7 +52,7 @@ async def test_template_state(hass, start_ha):
     assert state.state == lock.STATE_UNLOCKED
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -70,7 +70,7 @@ async def test_template_state_boolean_on(hass, start_ha):
     assert state.state == lock.STATE_LOCKED
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -88,7 +88,7 @@ async def test_template_state_boolean_off(hass, start_ha):
     assert state.state == lock.STATE_UNLOCKED
 
 
-@pytest.mark.parametrize("count,domain", [(0, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -143,7 +143,7 @@ async def test_template_syntax_error(hass, start_ha):
     assert hass.states.async_all("lock") == []
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -166,7 +166,7 @@ async def test_template_static(hass, start_ha):
     assert state.state == lock.STATE_LOCKED
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -197,7 +197,7 @@ async def test_lock_action(hass, start_ha, calls):
     assert calls[0].data["caller"] == "lock.template_lock"
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -228,7 +228,7 @@ async def test_unlock_action(hass, start_ha, calls):
     assert calls[0].data["caller"] == "lock.template_lock"
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -252,7 +252,7 @@ async def test_lock_state(hass, test_state, start_ha):
     assert state.state == test_state
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -282,7 +282,7 @@ async def test_available_template_with_entities(hass, start_ha):
     assert hass.states.get("lock.template_lock").state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -303,7 +303,7 @@ async def test_invalid_availability_template_keeps_component_available(
     assert ("UndefinedError: 'x' is undefined") in caplog_setup_text
 
 
-@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, lock.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -33,7 +33,7 @@ from tests.common import (
 TEST_NAME = "sensor.test_template_sensor"
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -58,7 +58,7 @@ async def test_template_legacy(hass, start_ha):
     assert hass.states.get(TEST_NAME).state == "It Works."
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -87,7 +87,7 @@ async def test_icon_template(hass, start_ha):
     assert hass.states.get(TEST_NAME).attributes["icon"] == "mdi:check"
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -118,7 +118,7 @@ async def test_entity_picture_template(hass, start_ha):
     )
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "attribute,config,expected",
     [
@@ -195,7 +195,7 @@ async def test_friendly_name_template(hass, attribute, expected, start_ha):
     assert hass.states.get(TEST_NAME).attributes[attribute] == expected[1]
 
 
-@pytest.mark.parametrize("count,domain", [(0, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -260,7 +260,7 @@ async def test_template_syntax_error(hass, start_ha):
     assert hass.states.async_all("sensor") == []
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -282,7 +282,7 @@ async def test_template_attribute_missing(hass, start_ha):
     assert hass.states.get(TEST_NAME).state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -352,7 +352,7 @@ async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
     assert order == ["group", "sensor.template"]
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -388,7 +388,7 @@ async def test_available_template_with_entities(hass, start_ha):
     assert hass.states.get(TEST_NAME).state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -420,7 +420,7 @@ async def test_invalid_attribute_template(hass, caplog, start_ha, caplog_setup_t
     assert "test_attribute" in caplog.text
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -529,7 +529,7 @@ async def test_no_template_match_all(
     assert hass.states.get("sensor.invalid_attribute").state == "hello"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -570,7 +570,7 @@ async def test_unique_id(hass, start_ha):
     )
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -629,7 +629,7 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
     }
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -670,7 +670,7 @@ async def test_this_variable(hass, start_ha):
     assert hass.states.get(TEST_NAME).state == "It Works: " + TEST_NAME
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -732,7 +732,7 @@ async def test_this_variable_early_hass_not_running(hass, config, count, domain)
     }
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -784,7 +784,7 @@ async def test_this_variable_early_hass_running(hass, config, count, domain):
     }
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -811,7 +811,7 @@ async def test_self_referencing_sensor_loop(hass, start_ha, caplog_setup_text):
     assert int(hass.states.get("sensor.test").state) == 2
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -845,7 +845,7 @@ async def test_self_referencing_sensor_with_icon_loop(
     assert int(state.state) == 3
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -881,7 +881,7 @@ async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
     assert int(state.state) == 4
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -996,7 +996,7 @@ async def test_self_referencing_icon_with_no_loop(
     assert "Template loop detected" not in caplog.text
 
 
-@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1028,7 +1028,7 @@ async def test_duplicate_templates(hass, start_ha):
     assert state.state == "Def"
 
 
-@pytest.mark.parametrize("count,domain", [(2, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(2, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1127,7 +1127,7 @@ async def test_trigger_entity(hass, start_ha):
     assert state.context is context
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1163,7 +1163,7 @@ async def test_trigger_entity_render_error(hass, start_ha):
     assert ent_reg.entities["sensor.hello"].unique_id == "no-base-id"
 
 
-@pytest.mark.parametrize("count,domain", [(0, sensor.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1191,7 +1191,7 @@ async def test_trigger_not_allowed_platform_config(hass, start_ha, caplog_setup_
     )
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -1427,7 +1427,7 @@ async def test_entity_device_class_errors_works(hass: HomeAssistant) -> None:
     assert ts_state.state == STATE_UNKNOWN
 
 
-@pytest.mark.parametrize("count,domain", [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -22,7 +22,7 @@ def setup_comp(hass, calls):
     hass.states.async_set("test.entity", "hello")
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -62,7 +62,7 @@ async def test_if_fires_on_change_bool(hass, start_ha, calls):
     assert calls[0].data["id"] == 0
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config, call_setup",
     [
@@ -273,7 +273,7 @@ async def test_general(hass, call_setup, start_ha, calls):
         assert len(calls) == call_len
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config, call_setup",
     [
@@ -308,7 +308,7 @@ async def test_if_not_fires_because_fail(hass, call_setup, start_ha, calls):
         assert len(calls) == call_len
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -349,7 +349,7 @@ async def test_if_fires_on_change_with_template_advanced(hass, start_ha, calls):
     assert calls[0].data["some"] == "template - test.entity - hello - world - None"
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -385,7 +385,7 @@ async def test_if_action(hass, start_ha, calls):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(0, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(0, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -401,7 +401,7 @@ async def test_if_fires_on_change_with_bad_template(hass, start_ha, calls):
     """Test for firing on change with bad template."""
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -475,7 +475,7 @@ async def test_if_fires_on_change_with_for(hass, calls):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -520,7 +520,7 @@ async def test_if_fires_on_change_with_for_advanced(hass, start_ha, calls):
     assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:05"
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -562,7 +562,7 @@ async def test_if_fires_on_change_with_for_0_advanced(hass, start_ha, calls):
     assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:00"
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -605,7 +605,7 @@ async def test_if_fires_on_change_with_for_2(hass, start_ha, calls):
     assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:05"
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -637,7 +637,7 @@ async def test_if_not_fires_on_change_with_for(hass, start_ha, calls):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -673,7 +673,7 @@ async def test_if_not_fires_when_turned_off_with_for(hass, start_ha, calls):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -699,7 +699,7 @@ async def test_if_fires_on_change_with_for_template_1(hass, start_ha, calls):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -725,7 +725,7 @@ async def test_if_fires_on_change_with_for_template_2(hass, start_ha, calls):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [
@@ -751,7 +751,7 @@ async def test_if_fires_on_change_with_for_template_3(hass, start_ha, calls):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("count,domain", [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -25,7 +25,7 @@ _FAN_SPEED_INPUT_SELECT = "input_select.fan_speed"
 _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
 
 
-@pytest.mark.parametrize("count,domain", [(1, "vacuum")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "vacuum")])
 @pytest.mark.parametrize(
     "parm1,parm2,config",
     [
@@ -98,7 +98,7 @@ async def test_valid_configs(hass, count, parm1, parm2, start_ha):
     _verify(hass, parm1, parm2)
 
 
-@pytest.mark.parametrize("count,domain", [(0, "vacuum")])
+@pytest.mark.parametrize(("count", "domain"), [(0, "vacuum")])
 @pytest.mark.parametrize(
     "config",
     [
@@ -120,7 +120,7 @@ async def test_invalid_configs(hass, count, start_ha):
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,
@@ -151,7 +151,7 @@ async def test_templates_with_entities(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,
@@ -189,7 +189,7 @@ async def test_available_template_with_entities(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,
@@ -217,7 +217,7 @@ async def test_invalid_availability_template_keeps_component_available(
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,
@@ -252,7 +252,7 @@ async def test_attribute_templates(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,
@@ -282,7 +282,7 @@ async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
 
 
 @pytest.mark.parametrize(
-    "count,domain,config",
+    ("count", "domain", "config"),
     [
         (
             1,

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -14,7 +14,7 @@ from homeassistant.components.weather import (
 from homeassistant.const import ATTR_ATTRIBUTION
 
 
-@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/components/text/test_device_action.py
+++ b/tests/components/text/test_device_action.py
@@ -48,7 +48,7 @@ async def test_get_actions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -150,7 +150,7 @@ async def test_restore_number_save_state(
 
 
 @pytest.mark.parametrize(
-    "native_max, native_min, native_value, native_value_type, extra_data",
+    ("native_max", "native_min", "native_value", "native_value_type", "extra_data"),
     [
         (5, 1, "Hello", str, RESTORE_DATA),
         (255, 1, None, type(None), None),

--- a/tests/components/threshold/test_config_flow.py
+++ b/tests/components/threshold/test_config_flow.py
@@ -60,7 +60,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     assert config_entry.title == "My threshold sensor"
 
 
-@pytest.mark.parametrize("extra_input_data,error", (({}, "need_lower_upper"),))
+@pytest.mark.parametrize(("extra_input_data", "error"), (({}, "need_lower_upper"),))
 async def test_fail(hass: HomeAssistant, extra_input_data, error) -> None:
     """Test not providing lower or upper limit fails."""
     input_sensor = "sensor.input"

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -13,7 +13,7 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
 
 
 @pytest.mark.parametrize(
-    "mock_login_response,errors",
+    ("mock_login_response", "errors"),
     [
         (AsyncMock(side_effect=InvalidAuthError), {"base": "invalid_auth"}),
         (AsyncMock(side_effect=TileError), {"base": "unknown"}),

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -297,7 +297,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -338,7 +338,7 @@ async def test_discovered_by_dhcp_or_discovery(hass, source, data):
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,

--- a/tests/components/tplink/test_diagnostics.py
+++ b/tests/components/tplink/test_diagnostics.py
@@ -14,7 +14,7 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.parametrize(
-    "mocked_dev,fixture_file,sysinfo_vars",
+    ("mocked_dev", "fixture_file", "sysinfo_vars"),
     [
         (
             _mocked_bulb(),

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -58,7 +58,7 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "bulb, transition", [(_mocked_bulb(), 2.0), (_mocked_smart_light_strip(), None)]
+    ("bulb", "transition"), [(_mocked_bulb(), 2.0), (_mocked_smart_light_strip(), None)]
 )
 async def test_color_light(
     hass: HomeAssistant, bulb: MagicMock, transition: float | None
@@ -198,7 +198,7 @@ async def test_color_light_no_temp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "bulb, is_color", [(_mocked_bulb(), True), (_mocked_smart_light_strip(), False)]
+    ("bulb", "is_color"), [(_mocked_bulb(), True), (_mocked_smart_light_strip(), False)]
 )
 async def test_color_temp_light(
     hass: HomeAssistant, bulb: MagicMock, is_color: bool

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -56,7 +56,7 @@ async def test_plug(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "dev, domain",
+    ("dev", "domain"),
     [
         (_mocked_plug(), "switch"),
         (_mocked_strip(), "switch"),

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -87,7 +87,14 @@ async def _assert_contexts(client, next_id, contexts, domain=None, item_id=None)
 
 
 @pytest.mark.parametrize(
-    "domain, prefix, extra_trace_keys, trigger, context_key, condition_results",
+    (
+        "domain",
+        "prefix",
+        "extra_trace_keys",
+        "trigger",
+        "context_key",
+        "condition_results",
+    ),
     [
         (
             "automation",
@@ -500,7 +507,7 @@ async def test_get_invalid_trace(hass, hass_ws_client, domain):
 
 
 @pytest.mark.parametrize(
-    "domain,stored_traces",
+    ("domain", "stored_traces"),
     [("automation", None), ("automation", 10), ("script", None), ("script", 10)],
 )
 async def test_trace_overflow(hass, hass_ws_client, domain, stored_traces):
@@ -573,7 +580,7 @@ async def test_trace_overflow(hass, hass_ws_client, domain, stored_traces):
 
 
 @pytest.mark.parametrize(
-    "domain,num_restored_moon_traces", [("automation", 3), ("script", 1)]
+    ("domain", "num_restored_moon_traces"), [("automation", 3), ("script", 1)]
 )
 async def test_restore_traces_overflow(
     hass, hass_storage, hass_ws_client, domain, num_restored_moon_traces
@@ -648,7 +655,7 @@ async def test_restore_traces_overflow(
 
 
 @pytest.mark.parametrize(
-    "domain,num_restored_moon_traces,restored_run_id",
+    ("domain", "num_restored_moon_traces", "restored_run_id"),
     [("automation", 3, "e2c97432afe9b8a42d7983588ed5e6ef"), ("script", 1, "")],
 )
 async def test_restore_traces_late_overflow(
@@ -753,7 +760,7 @@ async def test_trace_no_traces(hass, hass_ws_client, domain):
 
 
 @pytest.mark.parametrize(
-    "domain, prefix, trigger, last_step, script_execution",
+    ("domain", "prefix", "trigger", "last_step", "script_execution"),
     [
         (
             "automation",
@@ -902,7 +909,7 @@ async def test_list_traces(
 
 
 @pytest.mark.parametrize(
-    "domain, prefix, extra_trace_keys",
+    ("domain", "prefix", "extra_trace_keys"),
     [("automation", "action", {"trigger/0"}), ("script", "sequence", set())],
 )
 async def test_nested_traces(hass, hass_ws_client, domain, prefix, extra_trace_keys):
@@ -961,7 +968,7 @@ async def test_nested_traces(hass, hass_ws_client, domain, prefix, extra_trace_k
 
 
 @pytest.mark.parametrize(
-    "domain, prefix", [("automation", "action"), ("script", "sequence")]
+    ("domain", "prefix"), [("automation", "action"), ("script", "sequence")]
 )
 async def test_breakpoints(hass, hass_ws_client, domain, prefix):
     """Test script and automation breakpoints."""
@@ -1130,7 +1137,7 @@ async def test_breakpoints(hass, hass_ws_client, domain, prefix):
 
 
 @pytest.mark.parametrize(
-    "domain, prefix", [("automation", "action"), ("script", "sequence")]
+    ("domain", "prefix"), [("automation", "action"), ("script", "sequence")]
 )
 async def test_breakpoints_2(hass, hass_ws_client, domain, prefix):
     """Test execution resumes and breakpoints are removed after subscription removed."""
@@ -1233,7 +1240,7 @@ async def test_breakpoints_2(hass, hass_ws_client, domain, prefix):
 
 
 @pytest.mark.parametrize(
-    "domain, prefix", [("automation", "action"), ("script", "sequence")]
+    ("domain", "prefix"), [("automation", "action"), ("script", "sequence")]
 )
 async def test_breakpoints_3(hass, hass_ws_client, domain, prefix):
     """Test breakpoints can be cleared."""
@@ -1379,7 +1386,7 @@ async def test_breakpoints_3(hass, hass_ws_client, domain, prefix):
 
 
 @pytest.mark.parametrize(
-    "script_mode,max_runs,script_execution",
+    ("script_mode", "max_runs", "script_execution"),
     [
         ({"mode": "single"}, 1, "failed_single"),
         ({"mode": "parallel", "max": 2}, 2, "failed_max_runs"),
@@ -1447,7 +1454,7 @@ async def test_script_mode(
 
 
 @pytest.mark.parametrize(
-    "script_mode,script_execution",
+    ("script_mode", "script_execution"),
     [("restart", "cancelled"), ("parallel", "finished")],
 )
 async def test_script_mode_2(hass, hass_ws_client, script_mode, script_execution):

--- a/tests/components/tradfri/test_cover.py
+++ b/tests/components/tradfri/test_cover.py
@@ -43,7 +43,7 @@ async def test_cover_available(
 
 
 @pytest.mark.parametrize(
-    "service, service_data, expected_state, expected_position",
+    ("service", "service_data", "expected_state", "expected_position"),
     [
         ("set_cover_position", {"position": 100}, STATE_OPEN, 100),
         ("set_cover_position", {"position": 0}, STATE_CLOSED, 0),

--- a/tests/components/tradfri/test_fan.py
+++ b/tests/components/tradfri/test_fan.py
@@ -67,14 +67,12 @@ async def test_fan_available(
 
 @pytest.mark.parametrize(
     (
-        (
-            "service",
-            "service_data",
-            "device_state",
-            "expected_state",
-            "expected_percentage",
-            "expected_preset_mode",
-        )
+        "service",
+        "service_data",
+        "device_state",
+        "expected_state",
+        "expected_percentage",
+        "expected_preset_mode",
     ),
     [
         (

--- a/tests/components/tradfri/test_fan.py
+++ b/tests/components/tradfri/test_fan.py
@@ -67,8 +67,14 @@ async def test_fan_available(
 
 @pytest.mark.parametrize(
     (
-        "service, service_data, device_state, expected_state, "
-        "expected_percentage, expected_preset_mode"
+        (
+            "service",
+            "service_data",
+            "device_state",
+            "expected_state",
+            "expected_percentage",
+            "expected_preset_mode",
+        )
     ),
     [
         (

--- a/tests/components/tradfri/test_switch.py
+++ b/tests/components/tradfri/test_switch.py
@@ -61,7 +61,7 @@ async def test_switch_available(
 
 
 @pytest.mark.parametrize(
-    "service, expected_state",
+    ("service", "expected_state"),
     [
         ("turn_on", STATE_ON),
         ("turn_off", STATE_OFF),

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -5,7 +5,7 @@ from homeassistant.components.tradfri.fan import _from_fan_percentage, _from_fan
 
 
 @pytest.mark.parametrize(
-    "fan_speed, expected_result",
+    ("fan_speed", "expected_result"),
     [
         (0, 0),
         (2, 2),
@@ -19,7 +19,7 @@ def test_from_fan_speed(fan_speed, expected_result):
 
 
 @pytest.mark.parametrize(
-    "percentage, expected_result",
+    ("percentage", "expected_result"),
     [
         (1, 2),
         (100, 50),

--- a/tests/components/trafikverket_ferry/test_config_flow.py
+++ b/tests/components/trafikverket_ferry/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error_message,base_error",
+    ("error_message", "base_error"),
     [
         (
             "Source: Security, message: Invalid authentication",
@@ -161,7 +161,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sideeffect,p_error",
+    ("sideeffect", "p_error"),
     [
         (
             ValueError("Source: Security, message: Invalid authentication"),

--- a/tests/components/trafikverket_train/test_config_flow.py
+++ b/tests/components/trafikverket_train/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_form_entry_already_exist(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error_message,base_error",
+    ("error_message", "base_error"),
     [
         (
             "Source: Security, message: Invalid authentication",
@@ -234,7 +234,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sideeffect,p_error",
+    ("sideeffect", "p_error"),
     [
         (
             ValueError("Source: Security, message: Invalid authentication"),

--- a/tests/components/trafikverket_weatherstation/test_config_flow.py
+++ b/tests/components/trafikverket_weatherstation/test_config_flow.py
@@ -48,7 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error_message,base_error",
+    ("error_message", "base_error"),
     [
         (
             "Source: Security, message: Invalid authentication",

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -766,7 +766,7 @@ def test_invalid_base_url(value):
 
 
 @pytest.mark.parametrize(
-    "engine,language,options,cache,result_engine,result_query",
+    ("engine", "language", "options", "cache", "result_engine", "result_query"),
     (
         (None, None, None, None, "demo", ""),
         (None, "de", None, None, "demo", "language=de"),
@@ -791,7 +791,7 @@ async def test_generate_media_source_id(
 
 
 @pytest.mark.parametrize(
-    "engine,language,options",
+    ("engine", "language", "options"),
     (
         ("not-loaded-engine", None, None),
         (None, "unsupported-language", None),

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -65,7 +65,7 @@ def tuya_setup_fixture() -> None:
 
 
 @pytest.mark.parametrize(
-    "app_type,side_effects, project_type",
+    ("app_type", "side_effects", "project_type"),
     [
         ("", [RESPONSE_SUCCESS], 1),
         (TUYA_SMART_APP, [RESPONSE_ERROR, RESPONSE_SUCCESS], 0),

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -489,7 +489,7 @@ async def test_get_unifi_controller_verify_ssl_false(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.parametrize(
-    "side_effect,raised_exception",
+    ("side_effect", "raised_exception"),
     [
         (asyncio.TimeoutError, CannotConnect),
         (aiounifi.BadGateway, CannotConnect),

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -183,7 +183,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
 
 @pytest.mark.parametrize(
-    "initial_uptime,event_uptime,new_uptime",
+    ("initial_uptime", "event_uptime", "new_uptime"),
     [
         # Uptime listed in epoch time should never change
         (1609462800, 1609462800, 1612141200),

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -280,7 +280,7 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_SSDP, SSDP_DISCOVERY),

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -462,7 +462,7 @@ TWO_MONTH_SIMPLE = (
 
 
 @pytest.mark.parametrize(
-    "start,months",
+    ("start", "months"),
     [ONE_MONTH_SIMPLE, TWO_MONTH_SIMPLE],
 )
 @freeze_time("2022-09-15 03:00:00-07:00")
@@ -534,7 +534,7 @@ TWO_MONTH_TIMEZONE = (
 
 
 @pytest.mark.parametrize(
-    "start,months",
+    ("start", "months"),
     [ONE_MONTH_TIMEZONE, TWO_MONTH_TIMEZONE],
 )
 @freeze_time("2022-08-31 21:00:00-07:00")

--- a/tests/components/unifiprotect/test_views.py
+++ b/tests/components/unifiprotect/test_views.py
@@ -40,7 +40,7 @@ async def test_thumbnail_bad_nvr_id(
     ufp.api.get_event_thumbnail.assert_not_called
 
 
-@pytest.mark.parametrize("width,height", [("test", None), (None, "test")])
+@pytest.mark.parametrize(("width", "height"), [("test", None), (None, "test")])
 async def test_thumbnail_bad_params(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -332,7 +332,7 @@ async def test_video_bad_camera_perms(
     ufp.api.request.assert_not_called
 
 
-@pytest.mark.parametrize("start,end", [("test", None), (None, "test")])
+@pytest.mark.parametrize(("start", "end"), [("test", None), (None, "test")])
 async def test_video_bad_params(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -64,7 +64,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form_read_only(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception,error_key",
+    ("exception", "error_key"),
     [
         (Exception, "unknown"),
         (UptimeRobotException, "cannot_connect"),

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -380,7 +380,7 @@ async def test_setup_missing_discovery(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "tariffs,expected_entities",
+    ("tariffs", "expected_entities"),
     (
         (
             [],

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -56,7 +56,7 @@ def set_utc(hass):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {
@@ -251,7 +251,7 @@ async def test_not_unique_tariffs(hass, yaml_config):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {
@@ -349,7 +349,7 @@ async def test_unique_id(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "yaml_config,entity_id, name",
+    ("yaml_config", "entity_id", "name"),
     (
         (
             {
@@ -404,7 +404,7 @@ async def test_entity_name(hass, yaml_config, entity_id, name):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_configs",
+    ("yaml_config", "config_entry_configs"),
     (
         (
             {
@@ -492,7 +492,7 @@ async def test_device_class(hass, yaml_config, config_entry_configs):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {
@@ -649,7 +649,7 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {
@@ -717,7 +717,7 @@ async def test_net_consumption(hass, yaml_config, config_entry_config):
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {
@@ -796,7 +796,7 @@ async def test_non_net_consumption(hass, yaml_config, config_entry_config, caplo
 
 
 @pytest.mark.parametrize(
-    "yaml_config,config_entry_config",
+    ("yaml_config", "config_entry_config"),
     (
         (
             {

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -249,7 +249,7 @@ async def test_setup_incomplete_config(hass, mock_remote, config):
 
 
 @pytest.mark.parametrize(
-    "error, ready_states",
+    ("error", "ready_states"),
     [
         (nvr.NotAuthorized, 0),
         (nvr.NvrError, 2),
@@ -280,7 +280,7 @@ async def test_setup_nvr_errors_during_indexing(hass, mock_remote, error, ready_
 
 
 @pytest.mark.parametrize(
-    "error, ready_states",
+    ("error", "ready_states"),
     [
         (nvr.NotAuthorized, 0),
         (nvr.NvrError, 2),
@@ -506,7 +506,7 @@ async def test_login_fails_both_properly(hass, mock_remote, camera_v320):
 
 
 @pytest.mark.parametrize(
-    "source_error, raised_error, snapshot_calls",
+    ("source_error", "raised_error", "snapshot_calls"),
     [
         (camera.CameraConnectError, HomeAssistantError, 1),
         (camera.CameraAuthError, camera.CameraAuthError, 2),

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -48,7 +48,7 @@ async def test_get_actions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -58,7 +58,7 @@ async def test_get_conditions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -58,7 +58,7 @@ async def test_get_triggers(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/vallox/test_binary_sensor.py
+++ b/tests/components/vallox/test_binary_sensor.py
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "metrics,expected_state",
+    ("metrics", "expected_state"),
     [
         ({"A_CYC_IO_HEATER": 1}, "on"),
         ({"A_CYC_IO_HEATER": 0}, "off"),

--- a/tests/components/vallox/test_fan.py
+++ b/tests/components/vallox/test_fan.py
@@ -21,7 +21,8 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "metrics, expected_state", [({"A_CYC_MODE": 0}, "on"), ({"A_CYC_MODE": 5}, "off")]
+    ("metrics", "expected_state"),
+    [({"A_CYC_MODE": 0}, "on"), ({"A_CYC_MODE": 5}, "off")],
 )
 async def test_fan_state(
     metrics: dict[str, int],
@@ -43,7 +44,7 @@ async def test_fan_state(
 
 
 @pytest.mark.parametrize(
-    "profile, expected_preset",
+    ("profile", "expected_preset"),
     [
         (PROFILE.HOME, "Home"),
         (PROFILE.AWAY, "Away"),
@@ -71,7 +72,7 @@ async def test_fan_profile(
 
 
 @pytest.mark.parametrize(
-    "service, initial_metrics, expected_called_with",
+    ("service", "initial_metrics", "expected_called_with"),
     [
         (SERVICE_TURN_ON, {"A_CYC_MODE": 5}, {"A_CYC_MODE": 0}),
         (SERVICE_TURN_OFF, {"A_CYC_MODE": 0}, {"A_CYC_MODE": 5}),
@@ -98,7 +99,7 @@ async def test_turn_on_off(
 
 
 @pytest.mark.parametrize(
-    "initial_metrics, expected_call_args_list",
+    ("initial_metrics", "expected_call_args_list"),
     [
         (
             {"A_CYC_MODE": 5},
@@ -142,7 +143,7 @@ async def test_turn_on_with_parameters(
 
 
 @pytest.mark.parametrize(
-    "preset, initial_profile, expected_call_args_list",
+    ("preset", "initial_profile", "expected_call_args_list"),
     [
         ("Home", PROFILE.AWAY, [call(PROFILE.HOME)]),
         ("Away", PROFILE.HOME, [call(PROFILE.AWAY)]),
@@ -209,7 +210,7 @@ async def test_set_preset_mode_exception(
 
 
 @pytest.mark.parametrize(
-    "profile, percentage, expected_call_args_list",
+    ("profile", "percentage", "expected_call_args_list"),
     [
         (PROFILE.HOME, 40, [call({"A_CYC_HOME_SPEED_SETTING": 40})]),
         (PROFILE.AWAY, 30, [call({"A_CYC_AWAY_SPEED_SETTING": 30})]),

--- a/tests/components/vallox/test_number.py
+++ b/tests/components/vallox/test_number.py
@@ -32,7 +32,9 @@ TEST_TEMPERATURE_ENTITIES_DATA = [
 ]
 
 
-@pytest.mark.parametrize("entity_id, metric_key, value", TEST_TEMPERATURE_ENTITIES_DATA)
+@pytest.mark.parametrize(
+    ("entity_id", "metric_key", "value"), TEST_TEMPERATURE_ENTITIES_DATA
+)
 async def test_temperature_number_entities(
     entity_id: str,
     metric_key: str,
@@ -55,7 +57,9 @@ async def test_temperature_number_entities(
     assert sensor.attributes["unit_of_measurement"] == "°C"
 
 
-@pytest.mark.parametrize("entity_id, metric_key, value", TEST_TEMPERATURE_ENTITIES_DATA)
+@pytest.mark.parametrize(
+    ("entity_id", "metric_key", "value"), TEST_TEMPERATURE_ENTITIES_DATA
+)
 async def test_temperature_number_entity_set(
     entity_id: str,
     metric_key: str,

--- a/tests/components/vallox/test_switch.py
+++ b/tests/components/vallox/test_switch.py
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "entity_id, metric_key, value, expected_state",
+    ("entity_id", "metric_key", "value", "expected_state"),
     [
         ("switch.vallox_bypass_locked", "A_CYC_BYPASS_LOCKED", 1, "on"),
         ("switch.vallox_bypass_locked", "A_CYC_BYPASS_LOCKED", 0, "off"),
@@ -41,7 +41,7 @@ async def test_switch_entities(
 
 
 @pytest.mark.parametrize(
-    "service, metric_key, value",
+    ("service", "metric_key", "value"),
     [
         (SERVICE_TURN_ON, "A_CYC_BYPASS_LOCKED", 1),
         (SERVICE_TURN_OFF, "A_CYC_BYPASS_LOCKED", 0),

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -178,7 +178,7 @@ async def test_async_setup_entry_error(
 
 
 @pytest.mark.parametrize(
-    ["options"],
+    "options",
     [
         [{CONF_LIGHTS: [4, 10, 12, "AAA"], CONF_EXCLUDE: [1, "BBB"]}],
         [{CONF_LIGHTS: ["4", "10", "12", "AAA"], CONF_EXCLUDE: ["1", "BBB"]}],

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -180,8 +180,8 @@ async def test_async_setup_entry_error(
 @pytest.mark.parametrize(
     "options",
     [
-        [{CONF_LIGHTS: [4, 10, 12, "AAA"], CONF_EXCLUDE: [1, "BBB"]}],
-        [{CONF_LIGHTS: ["4", "10", "12", "AAA"], CONF_EXCLUDE: ["1", "BBB"]}],
+        {CONF_LIGHTS: [4, 10, 12, "AAA"], CONF_EXCLUDE: [1, "BBB"]},
+        {CONF_LIGHTS: ["4", "10", "12", "AAA"], CONF_EXCLUDE: ["1", "BBB"]},
     ],
 )
 async def test_exclude_and_light_ids(

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -222,7 +222,7 @@ async def test_full_user_flow_multiple_installations_with_mfa(
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (VerisureLoginError, "invalid_auth"),
         (VerisureError, "unknown"),
@@ -447,7 +447,7 @@ async def test_reauth_flow_with_mfa(
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (VerisureLoginError, "invalid_auth"),
         (VerisureError, "unknown"),
@@ -559,7 +559,7 @@ async def test_reauth_flow_errors(
 
 
 @pytest.mark.parametrize(
-    "input,output",
+    ("input", "output"),
     [
         (
             {

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "input_data, entry_data",
+    ("input_data", "entry_data"),
     [
         (
             {
@@ -178,7 +178,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error, connect_side_effect, login_side_effect",
+    ("error", "connect_side_effect", "login_side_effect"),
     [
         ("invalid_auth", None, AuthError),
         ("cannot_connect", ConnectError, None),
@@ -294,7 +294,7 @@ async def test_hassio_already_configured(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "error, connect_side_effect, login_side_effect",
+    ("error", "connect_side_effect", "login_side_effect"),
     [
         ("invalid_auth", None, AuthError),
         ("cannot_connect", ConnectError, None),

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -48,7 +48,7 @@ async def test_get_actions(hass, device_registry, entity_registry):
 
 
 @pytest.mark.parametrize(
-    "hidden_by,entity_category",
+    ("hidden_by", "entity_category"),
     (
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -26,7 +26,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 
 @pytest.mark.parametrize(
-    "exc,error", [(InvalidCredentialsError, "invalid_auth"), (Exception, "unknown")]
+    ("exc", "error"),
+    [(InvalidCredentialsError, "invalid_auth"), (Exception, "unknown")],
 )
 async def test_auth_errors(
     hass: HomeAssistant, config_auth, config_location_type, exc, error
@@ -44,7 +45,7 @@ async def test_auth_errors(
 
 
 @pytest.mark.parametrize(
-    "get_grid_region,errors",
+    ("get_grid_region", "errors"),
     [
         (
             AsyncMock(side_effect=CoordinatesNotFoundError),

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -49,7 +49,7 @@ def mock_update_keyerror_fixture(mock_wrc):
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
 @pytest.mark.usefixtures("mock_update", "mock_config")
@@ -78,7 +78,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data,options",
+    ("data", "options"),
     [
         (
             MOCK_CONFIG,

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form(hass, client):
 
 
 @pytest.mark.parametrize(
-    "apps, inputs",
+    ("apps", "inputs"),
     [
         # Live TV in apps (default)
         (MOCK_APPS, MOCK_INPUTS),
@@ -320,7 +320,7 @@ async def test_reauth_successful(hass, client, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "side_effect,reason",
+    ("side_effect", "reason"),
     [
         (WebOsTvPairError, "error_pairing"),
         (ConnectionRefusedError, "reauth_unsuccessful"),

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -72,7 +72,7 @@ from tests.common import async_fire_time_changed, mock_restore_cache
 
 
 @pytest.mark.parametrize(
-    "service, attr_data, client_call",
+    ("service", "attr_data", "client_call"),
     [
         (SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: True}, ("set_mute", True)),
         (SERVICE_VOLUME_MUTE, {ATTR_MEDIA_VOLUME_MUTED: False}, ("set_mute", False)),
@@ -92,7 +92,7 @@ async def test_services_with_parameters(hass, client, service, attr_data, client
 
 
 @pytest.mark.parametrize(
-    "service, client_call",
+    ("service", "client_call"),
     [
         (SERVICE_TURN_OFF, "power_off"),
         (SERVICE_VOLUME_UP, "volume_up"),
@@ -136,7 +136,7 @@ async def test_media_play_pause(hass, client):
 
 
 @pytest.mark.parametrize(
-    "service, client_call",
+    ("service", "client_call"),
     [
         (SERVICE_MEDIA_NEXT_TRACK, ("fast_forward", "channel_up")),
         (SERVICE_MEDIA_PREVIOUS_TRACK, ("rewind", "channel_down")),
@@ -359,7 +359,7 @@ async def test_service_entity_id_none(hass, client):
 
 
 @pytest.mark.parametrize(
-    "media_id, ch_id",
+    ("media_id", "ch_id"),
     [
         ("Channel 1", "ch1id"),  # Perfect Match by channel name
         ("Name 2", "ch2id"),  # Partial Match by channel name

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -117,7 +117,7 @@ async def test_icon_not_found(hass, caplog, client, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "side_effect,error",
+    ("side_effect", "error"),
     [
         (WebOsTvPairError, "Pairing with TV failed"),
         (ConnectionRefusedError, "TV unreachable"),

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1733,7 +1733,7 @@ async def test_integration_setup_info(hass, websocket_client, hass_admin_user):
 
 
 @pytest.mark.parametrize(
-    "key,config",
+    ("key", "config"),
     (
         ("trigger", {"platform": "event", "event_type": "hello"}),
         (
@@ -1755,7 +1755,7 @@ async def test_validate_config_works(websocket_client, key, config):
 
 
 @pytest.mark.parametrize(
-    "key,config,error",
+    ("key", "config", "error"),
     (
         (
             "trigger",

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -15,7 +15,7 @@ from tests.common import MockUser
 
 
 @pytest.mark.parametrize(
-    "exc,code,err,log",
+    ("exc", "code", "err", "log"),
     [
         (
             exceptions.Unauthorized(),

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -112,7 +112,7 @@ async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):
 
 
 @pytest.mark.parametrize(
-    "test_input,expected",
+    ("test_input", "expected"),
     [
         (0, DesiredHumidity.FortyFivePercent),
         (45, DesiredHumidity.FortyFivePercent),
@@ -139,7 +139,7 @@ async def test_fan_set_humidity_service(
 
 
 @pytest.mark.parametrize(
-    "percentage,expected_fan_mode",
+    ("percentage", "expected_fan_mode"),
     [
         (0, FanMode.Off),
         (10, FanMode.Minimum),

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -200,7 +200,7 @@ class TestInsight:
         return pywemo_device
 
     @pytest.mark.parametrize(
-        "subscribed,state,expected_calls",
+        ("subscribed", "state", "expected_calls"),
         [
             (False, 0, [call(), call(True), call(), call()]),
             (False, 1, [call(), call(True), call(), call()]),

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_full_user_flow(
 
 
 @pytest.mark.parametrize(
-    "throw,reason",
+    ("throw", "reason"),
     [
         (UnknownTld, "unknown_tld"),
         (FailedParsingWhoisOutput, "unexpected_response"),

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -53,7 +53,7 @@ async def test_config_entry_withings_api(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ["user_id", "arg_user_id", "arg_appli", "expected_code"],
+    ("user_id", "arg_user_id", "arg_appli", "expected_code"),
     [
         [0, 0, NotifyAppli.WEIGHT.value, 0],  # Success
         [0, None, 1, 0],  # Success, we ignore the user_id.

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -109,9 +109,9 @@ async def test_async_setup_no_config(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "exception",
     [
-        [UnauthorizedException("401")],
-        [UnauthorizedException("401")],
-        [Exception("401, this is the message")],
+        UnauthorizedException("401"),
+        UnauthorizedException("401"),
+        Exception("401, this is the message"),
     ],
 )
 @patch("homeassistant.components.withings.common._RETRY_COEFFICIENT", 0)

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -107,7 +107,7 @@ async def test_async_setup_no_config(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ["exception"],
+    "exception",
     [
         [UnauthorizedException("401")],
         [UnauthorizedException("401")],

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -111,7 +111,7 @@ async def test_user_flow_enters_dns_name(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect, error_base",
+    ("side_effect", "error_base"),
     [
         (WizLightTimeOutError, "bulb_time_out"),
         (WizLightConnectionError, "no_wiz_light"),
@@ -163,7 +163,7 @@ async def test_form_updates_unique_id(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),
@@ -185,7 +185,7 @@ async def test_discovered_by_dhcp_connection_fails(hass, source, data):
 
 
 @pytest.mark.parametrize(
-    "source, data, bulb_type, extended_white_range, name",
+    ("source", "data", "bulb_type", "extended_white_range", "name"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -284,7 +284,7 @@ async def test_discovered_by_dhcp_or_integration_discovery(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),
@@ -313,7 +313,7 @@ async def test_discovered_by_dhcp_or_integration_discovery_updates_host(
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),
@@ -510,7 +510,7 @@ async def test_discovery_with_firmware_update(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (config_entries.SOURCE_DHCP, DHCP_DISCOVERY),
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -347,7 +347,7 @@ async def test_xiaomi_vacuum_services(hass, mock_mirobo_is_got_error):
 
 
 @pytest.mark.parametrize(
-    "error, status_calls",
+    ("error", "status_calls"),
     [(None, STATUS_CALLS), (DeviceException("dummy exception"), [])],
 )
 @pytest.mark.parametrize(

--- a/tests/components/yale_smart_alarm/test_config_flow.py
+++ b/tests/components/yale_smart_alarm/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sideeffect,p_error",
+    ("sideeffect", "p_error"),
     [
         (AuthenticationError, "invalid_auth"),
         (ConnectionError, "cannot_connect"),
@@ -166,7 +166,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sideeffect,p_error",
+    ("sideeffect", "p_error"),
     [
         (AuthenticationError, "invalid_auth"),
         (ConnectionError, "cannot_connect"),

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -131,7 +131,7 @@ async def test_enable_output(hass, device, main_zone):
 
 
 @pytest.mark.parametrize(
-    "cursor,method",
+    ("cursor", "method"),
     [
         (yamaha.CURSOR_TYPE_DOWN, "menu_down"),
         (yamaha.CURSOR_TYPE_LEFT, "menu_left"),

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -524,7 +524,7 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -592,7 +592,7 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,
@@ -812,7 +812,7 @@ async def test_discovery_adds_missing_ip_id_only(hass: HomeAssistant):
 
 
 @pytest.mark.parametrize(
-    "source, data",
+    ("source", "data"),
     [
         (
             config_entries.SOURCE_DHCP,

--- a/tests/components/zamg/test_init.py
+++ b/tests/components/zamg/test_init.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id,station_id",
+    ("entitydata", "old_unique_id", "new_unique_id", "station_id"),
     [
         (
             {
@@ -91,7 +91,7 @@ async def test_migrate_unique_ids(
 
 
 @pytest.mark.parametrize(
-    "entitydata,old_unique_id,new_unique_id,station_id",
+    ("entitydata", "old_unique_id", "new_unique_id", "station_id"),
     [
         (
             {
@@ -153,7 +153,7 @@ async def test_dont_migrate_unique_ids(
 
 
 @pytest.mark.parametrize(
-    "entitydata,unique_id",
+    ("entitydata", "unique_id"),
     [
         (
             {

--- a/tests/components/zeversolar/test_config_flow.py
+++ b/tests/components/zeversolar/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "side_effect,errors",
+    ("side_effect", "errors"),
     (
         (
             ZeverSolarHTTPNotFound,

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -470,7 +470,7 @@ async def app_controller(hass, setup_zha):
 
 
 @pytest.mark.parametrize(
-    "params, duration, node",
+    ("params", "duration", "node"),
     (
         ({}, 60, None),
         ({ATTR_DURATION: 30}, 30, None),
@@ -520,7 +520,7 @@ IC_TEST_PARAMS = (
 )
 
 
-@pytest.mark.parametrize("params, src_ieee, code", IC_TEST_PARAMS)
+@pytest.mark.parametrize(("params", "src_ieee", "code"), IC_TEST_PARAMS)
 async def test_permit_with_install_code(
     hass, app_controller, hass_admin_user, params, src_ieee, code
 ):
@@ -609,7 +609,7 @@ IC_QR_CODE_TEST_PARAMS = (
 )
 
 
-@pytest.mark.parametrize("params, src_ieee, code", IC_QR_CODE_TEST_PARAMS)
+@pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_permit_with_qr_code(
     hass, app_controller, hass_admin_user, params, src_ieee, code
 ):
@@ -625,7 +625,7 @@ async def test_permit_with_qr_code(
     assert app_controller.permit_with_key.await_args[1]["code"] == code
 
 
-@pytest.mark.parametrize("params, src_ieee, code", IC_QR_CODE_TEST_PARAMS)
+@pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_ws_permit_with_qr_code(
     app_controller, zha_client, params, src_ieee, code
 ):
@@ -665,7 +665,7 @@ async def test_ws_permit_with_install_code_fail(app_controller, zha_client, para
 
 
 @pytest.mark.parametrize(
-    "params, duration, node",
+    ("params", "duration", "node"),
     (
         ({}, 60, None),
         ({ATTR_DURATION: 30}, 30, None),

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -76,7 +76,7 @@ async def async_test_iaszone_on_off(hass, cluster, entity_id):
 
 
 @pytest.mark.parametrize(
-    "device, on_off_test, cluster_name, reporting",
+    ("device", "on_off_test", "cluster_name", "reporting"),
     [
         (DEVICE_IAS, async_test_iaszone_on_off, "ias_zone", (0,)),
         # (DEVICE_OCCUPANCY, async_test_binary_sensor_on_off, "occupancy", (1,)),

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -104,7 +104,7 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
 
 
 @pytest.mark.parametrize(
-    "cluster_id, bind_count, attrs",
+    ("cluster_id", "bind_count", "attrs"),
     [
         (zigpy.zcl.clusters.general.Basic.cluster_id, 0, {}),
         (
@@ -264,7 +264,7 @@ async def test_in_channel_config(
 
 
 @pytest.mark.parametrize(
-    "cluster_id, bind_count",
+    ("cluster_id", "bind_count"),
     [
         (0x0000, 0),
         (0x0001, 1),

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -475,7 +475,7 @@ async def test_climate_hvac_action_pi_demand(hass, device_climate):
 
 
 @pytest.mark.parametrize(
-    "sys_mode, hvac_mode",
+    ("sys_mode", "hvac_mode"),
     (
         (Thermostat.SystemMode.Auto, HVACMode.HEAT_COOL),
         (Thermostat.SystemMode.Cool, HVACMode.COOL),
@@ -510,7 +510,7 @@ async def test_hvac_mode(hass, device_climate, sys_mode, hvac_mode):
 
 
 @pytest.mark.parametrize(
-    "seq_of_op, modes",
+    ("seq_of_op", "modes"),
     (
         (0xFF, {HVACMode.OFF}),
         (0x00, {HVACMode.OFF, HVACMode.COOL}),
@@ -533,7 +533,7 @@ async def test_hvac_modes(hass, device_climate_mock, seq_of_op, modes):
 
 
 @pytest.mark.parametrize(
-    "sys_mode, preset, target_temp",
+    ("sys_mode", "preset", "target_temp"),
     (
         (Thermostat.SystemMode.Heat, None, 22),
         (Thermostat.SystemMode.Heat, PRESET_AWAY, 16),
@@ -572,7 +572,7 @@ async def test_target_temperature(
 
 
 @pytest.mark.parametrize(
-    "preset, unoccupied, target_temp",
+    ("preset", "unoccupied", "target_temp"),
     (
         (None, 1800, 17),
         (PRESET_AWAY, 1800, 18),
@@ -608,7 +608,7 @@ async def test_target_temperature_high(
 
 
 @pytest.mark.parametrize(
-    "preset, unoccupied, target_temp",
+    ("preset", "unoccupied", "target_temp"),
     (
         (None, 1600, 21),
         (PRESET_AWAY, 1600, 16),
@@ -644,7 +644,7 @@ async def test_target_temperature_low(
 
 
 @pytest.mark.parametrize(
-    "hvac_mode, sys_mode",
+    ("hvac_mode", "sys_mode"),
     (
         (HVACMode.AUTO, None),
         (HVACMode.COOL, Thermostat.SystemMode.Cool),

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -912,7 +912,7 @@ async def test_user_port_config(probe_mock, hass):
 
 
 @pytest.mark.parametrize(
-    "old_type,new_type",
+    ("old_type", "new_type"),
     [
         ("ezsp", "ezsp"),
         ("ti_cc", "znp"),  # only one that should change

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -261,7 +261,7 @@ async def test_ota_sw_version(hass, ota_zha_device):
 
 
 @pytest.mark.parametrize(
-    "device, last_seen_delta, is_available",
+    ("device", "last_seen_delta", "is_available"),
     (
         ("zigpy_device", 0, True),
         (

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -230,7 +230,7 @@ def test_discover_entities(m1, m2):
 
 
 @pytest.mark.parametrize(
-    "device_type, component, hit",
+    ("device_type", "component", "hit"),
     [
         (zigpy.profiles.zha.DeviceType.ON_OFF_LIGHT, Platform.LIGHT, True),
         (zigpy.profiles.zha.DeviceType.ON_OFF_BALLAST, Platform.SWITCH, True),
@@ -441,7 +441,7 @@ def test_single_input_cluster_device_class_by_cluster_class() -> None:
 
 
 @pytest.mark.parametrize(
-    "override, entity_id",
+    ("override", "entity_id"),
     [
         (None, "light.manufacturer_model_light"),
         ("switch", "switch.manufacturer_model_switch"),

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -443,7 +443,7 @@ async def test_zha_group_fan_entity_failure_state(
 
 
 @pytest.mark.parametrize(
-    "plug_read, expected_state, expected_percentage",
+    ("plug_read", "expected_state", "expected_percentage"),
     (
         (None, STATE_OFF, None),
         ({"fan_mode": 0}, STATE_OFF, 0),
@@ -610,7 +610,12 @@ async def test_fan_ikea(hass, zha_device_joined_restored, zigpy_device_ikea):
 
 
 @pytest.mark.parametrize(
-    "ikea_plug_read, ikea_expected_state, ikea_expected_percentage, ikea_preset_mode",
+    (
+        "ikea_plug_read",
+        "ikea_expected_state",
+        "ikea_expected_percentage",
+        "ikea_preset_mode",
+    ),
     (
         (None, STATE_OFF, None, None),
         ({"fan_mode": 0}, STATE_OFF, 0, None),

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -308,7 +308,7 @@ async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 @pytest.mark.parametrize(
-    "device, reporting",
+    ("device", "reporting"),
     [(LIGHT_ON_OFF, (1, 0, 0)), (LIGHT_LEVEL, (1, 1, 0)), (LIGHT_COLOR, (1, 1, 6))],
 )
 async def test_light(
@@ -373,7 +373,7 @@ async def test_light(
 
 
 @pytest.mark.parametrize(
-    "plugged_attr_reads, config_override, expected_state",
+    ("plugged_attr_reads", "config_override", "expected_state"),
     [
         # HS light without cached hue or saturation
         (

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -186,7 +186,7 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
 
 
 @pytest.mark.parametrize(
-    "attr, initial_value, new_value",
+    ("attr", "initial_value", "new_value"),
     (
         ("on_off_transition_time", 20, 5),
         ("on_level", 255, 50),
@@ -326,7 +326,7 @@ async def test_level_control_number(
 
 
 @pytest.mark.parametrize(
-    "attr, initial_value, new_value",
+    ("attr", "initial_value", "new_value"),
     (("start_up_color_temperature", 500, 350),),
 )
 async def test_color_number(

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -26,7 +26,7 @@ def channels(channel):
 
 
 @pytest.mark.parametrize(
-    "rule, matched",
+    ("rule", "matched"),
     [
         (registries.MatchRule(), False),
         (registries.MatchRule(channel_names={"level"}), True),
@@ -131,7 +131,7 @@ def test_registry_matching(rule, matched, channels):
 
 
 @pytest.mark.parametrize(
-    "rule, matched",
+    ("rule", "matched"),
     [
         (registries.MatchRule(), False),
         (registries.MatchRule(channel_names={"level"}), True),
@@ -225,7 +225,7 @@ def test_match_rule_claim_channels_color(channel):
 
 
 @pytest.mark.parametrize(
-    "rule, match",
+    ("rule", "match"),
     [
         (registries.MatchRule(channel_names={"level"}), {"level"}),
         (registries.MatchRule(channel_names={"level", "no match"}), {"level"}),
@@ -263,7 +263,7 @@ def entity_registry():
 
 
 @pytest.mark.parametrize(
-    "manufacturer, model, match_name",
+    ("manufacturer", "model", "match_name"),
     (
         ("random manufacturer", "random model", "OnOff"),
         ("random manufacturer", MODEL, "OnOffModel"),

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -271,7 +271,14 @@ async def async_test_device_temperature(hass, cluster, entity_id):
 
 
 @pytest.mark.parametrize(
-    "cluster_id, entity_suffix, test_func, report_count, read_plug, unsupported_attrs",
+    (
+        "cluster_id",
+        "entity_suffix",
+        "test_func",
+        "report_count",
+        "read_plug",
+        "unsupported_attrs",
+    ),
     (
         (
             measurement.RelativeHumidity.cluster_id,
@@ -513,7 +520,7 @@ def core_rs(hass_storage):
 
 
 @pytest.mark.parametrize(
-    "uom, raw_temp, expected, restore",
+    ("uom", "raw_temp", "expected", "restore"),
     [
         (UnitOfTemperature.CELSIUS, 2900, 29, False),
         (UnitOfTemperature.CELSIUS, 2900, 29, True),
@@ -636,7 +643,7 @@ async def test_electrical_measurement_init(
 
 
 @pytest.mark.parametrize(
-    "cluster_id, unsupported_attributes, entity_ids, missing_entity_ids",
+    ("cluster_id", "unsupported_attributes", "entity_ids", "missing_entity_ids"),
     (
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -747,7 +754,7 @@ async def test_unsupported_attributes_sensor(
 
 
 @pytest.mark.parametrize(
-    "raw_uom, raw_value, expected_state, expected_uom",
+    ("raw_uom", "raw_value", "expected_state", "expected_uom"),
     (
         (
             1,
@@ -868,7 +875,7 @@ async def test_se_summation_uom(
 
 
 @pytest.mark.parametrize(
-    "raw_measurement_type, expected_type",
+    ("raw_measurement_type", "expected_type"),
     (
         (1, "ACTIVE_MEASUREMENT"),
         (8, "PHASE_A_MEASUREMENT"),

--- a/tests/components/zodiac/test_sensor.py
+++ b/tests/components/zodiac/test_sensor.py
@@ -29,7 +29,7 @@ DAY3 = datetime(2020, 4, 21, tzinfo=dt_util.UTC)
 
 
 @pytest.mark.parametrize(
-    "now,sign,element,modality",
+    ("now", "sign", "element", "modality"),
     [
         (DAY1, SIGN_SCORPIO, ELEMENT_WATER, MODALITY_FIXED),
         (DAY2, SIGN_ARIES, ELEMENT_FIRE, MODALITY_CARDINAL),

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2887,7 +2887,7 @@ async def test_firmware_upload_view_invalid_payload(
 
 
 @pytest.mark.parametrize(
-    "method, url",
+    ("method", "url"),
     [("post", "/api/zwave_js/firmware/upload/{}")],
 )
 async def test_node_view_non_admin_user(
@@ -2903,7 +2903,7 @@ async def test_node_view_non_admin_user(
 
 
 @pytest.mark.parametrize(
-    "method, url",
+    ("method", "url"),
     [
         ("post", "/api/zwave_js/firmware/upload/{}"),
     ],
@@ -2920,7 +2920,7 @@ async def test_view_unloaded_config_entry(
 
 
 @pytest.mark.parametrize(
-    "method, url",
+    ("method", "url"),
     [("post", "/api/zwave_js/firmware/upload/INVALID")],
 )
 async def test_view_invalid_device_id(integration, hass_client, method, url):

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -227,7 +227,7 @@ async def slow_server_version(*args):
 
 
 @pytest.mark.parametrize(
-    "flow, flow_params",
+    ("flow", "flow_params"),
     [
         (
             "flow",
@@ -365,7 +365,7 @@ async def test_supervisor_discovery(
 
 
 @pytest.mark.parametrize(
-    "discovery_info, server_version_side_effect",
+    ("discovery_info", "server_version_side_effect"),
     [({"config": ADDON_DISCOVERY_INFO}, asyncio.TimeoutError())],
 )
 async def test_supervisor_discovery_cannot_connect(
@@ -1066,8 +1066,13 @@ async def test_addon_running(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, discovery_info_side_effect, server_version_side_effect, "
-        "addon_info_side_effect, abort_reason"
+        (
+            "discovery_info",
+            "discovery_info_side_effect",
+            "server_version_side_effect",
+            "addon_info_side_effect",
+            "abort_reason",
+        )
     ),
     [
         (
@@ -1258,7 +1263,7 @@ async def test_addon_installed(
 
 
 @pytest.mark.parametrize(
-    "discovery_info, start_addon_side_effect",
+    ("discovery_info", "start_addon_side_effect"),
     [({"config": ADDON_DISCOVERY_INFO}, HassioAPIError())],
 )
 async def test_addon_installed_start_failure(
@@ -1324,7 +1329,7 @@ async def test_addon_installed_start_failure(
 
 
 @pytest.mark.parametrize(
-    "discovery_info, server_version_side_effect",
+    ("discovery_info", "server_version_side_effect"),
     [
         (
             {"config": ADDON_DISCOVERY_INFO},
@@ -1399,7 +1404,7 @@ async def test_addon_installed_failures(
 
 
 @pytest.mark.parametrize(
-    "set_addon_options_side_effect, discovery_info",
+    ("set_addon_options_side_effect", "discovery_info"),
     [(HassioAPIError(), {"config": ADDON_DISCOVERY_INFO})],
 )
 async def test_addon_installed_set_options_failure(
@@ -1747,8 +1752,13 @@ async def test_options_not_addon(hass, client, supervisor, integration):
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, entry_data, old_addon_options, new_addon_options,"
-        " disconnect_calls"
+        (
+            "discovery_info",
+            "entry_data",
+            "old_addon_options",
+            "new_addon_options",
+            "disconnect_calls",
+        )
     ),
     [
         (
@@ -1881,7 +1891,7 @@ async def test_options_addon_running(
 
 
 @pytest.mark.parametrize(
-    "discovery_info, entry_data, old_addon_options, new_addon_options",
+    ("discovery_info", "entry_data", "old_addon_options", "new_addon_options"),
     [
         (
             {"config": ADDON_DISCOVERY_INFO},
@@ -1991,8 +2001,14 @@ async def different_device_server_version(*args):
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, entry_data, old_addon_options, new_addon_options,"
-        " disconnect_calls, server_version_side_effect"
+        (
+            "discovery_info",
+            "entry_data",
+            "old_addon_options",
+            "new_addon_options",
+            "disconnect_calls",
+            "server_version_side_effect",
+        )
     ),
     [
         (
@@ -2142,8 +2158,14 @@ async def test_options_different_device(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, entry_data, old_addon_options, new_addon_options,"
-        " disconnect_calls, restart_addon_side_effect"
+        (
+            "discovery_info",
+            "entry_data",
+            "old_addon_options",
+            "new_addon_options",
+            "disconnect_calls",
+            "restart_addon_side_effect",
+        )
     ),
     [
         (
@@ -2294,8 +2316,14 @@ async def test_options_addon_restart_failed(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, entry_data, old_addon_options, new_addon_options,"
-        " disconnect_calls, server_version_side_effect"
+        (
+            "discovery_info",
+            "entry_data",
+            "old_addon_options",
+            "new_addon_options",
+            "disconnect_calls",
+            "server_version_side_effect",
+        )
     ),
     [
         (
@@ -2381,8 +2409,13 @@ async def test_options_addon_running_server_info_failure(
 
 @pytest.mark.parametrize(
     (
-        "discovery_info, entry_data, old_addon_options, new_addon_options,"
-        " disconnect_calls"
+        (
+            "discovery_info",
+            "entry_data",
+            "old_addon_options",
+            "new_addon_options",
+            "disconnect_calls",
+        )
     ),
     [
         (

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1066,13 +1066,11 @@ async def test_addon_running(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "discovery_info_side_effect",
-            "server_version_side_effect",
-            "addon_info_side_effect",
-            "abort_reason",
-        )
+        "discovery_info",
+        "discovery_info_side_effect",
+        "server_version_side_effect",
+        "addon_info_side_effect",
+        "abort_reason",
     ),
     [
         (
@@ -1752,13 +1750,11 @@ async def test_options_not_addon(hass, client, supervisor, integration):
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "entry_data",
-            "old_addon_options",
-            "new_addon_options",
-            "disconnect_calls",
-        )
+        "discovery_info",
+        "entry_data",
+        "old_addon_options",
+        "new_addon_options",
+        "disconnect_calls",
     ),
     [
         (
@@ -2001,14 +1997,12 @@ async def different_device_server_version(*args):
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "entry_data",
-            "old_addon_options",
-            "new_addon_options",
-            "disconnect_calls",
-            "server_version_side_effect",
-        )
+        "discovery_info",
+        "entry_data",
+        "old_addon_options",
+        "new_addon_options",
+        "disconnect_calls",
+        "server_version_side_effect",
     ),
     [
         (
@@ -2158,14 +2152,12 @@ async def test_options_different_device(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "entry_data",
-            "old_addon_options",
-            "new_addon_options",
-            "disconnect_calls",
-            "restart_addon_side_effect",
-        )
+        "discovery_info",
+        "entry_data",
+        "old_addon_options",
+        "new_addon_options",
+        "disconnect_calls",
+        "restart_addon_side_effect",
     ),
     [
         (
@@ -2316,14 +2308,12 @@ async def test_options_addon_restart_failed(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "entry_data",
-            "old_addon_options",
-            "new_addon_options",
-            "disconnect_calls",
-            "server_version_side_effect",
-        )
+        "discovery_info",
+        "entry_data",
+        "old_addon_options",
+        "new_addon_options",
+        "disconnect_calls",
+        "server_version_side_effect",
     ),
     [
         (
@@ -2409,13 +2399,11 @@ async def test_options_addon_running_server_info_failure(
 
 @pytest.mark.parametrize(
     (
-        (
-            "discovery_info",
-            "entry_data",
-            "old_addon_options",
-            "new_addon_options",
-            "disconnect_calls",
-        )
+        "discovery_info",
+        "entry_data",
+        "old_addon_options",
+        "new_addon_options",
+        "disconnect_calls",
     ),
     [
         (

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -569,11 +569,18 @@ async def test_addon_info_failure(
 
 @pytest.mark.parametrize(
     (
-        "old_device, new_device, "
-        "old_s0_legacy_key, new_s0_legacy_key, "
-        "old_s2_access_control_key, new_s2_access_control_key, "
-        "old_s2_authenticated_key, new_s2_authenticated_key, "
-        "old_s2_unauthenticated_key, new_s2_unauthenticated_key"
+        (
+            "old_device",
+            "new_device",
+            "old_s0_legacy_key",
+            "new_s0_legacy_key",
+            "old_s2_access_control_key",
+            "new_s2_access_control_key",
+            "old_s2_authenticated_key",
+            "new_s2_authenticated_key",
+            "old_s2_unauthenticated_key",
+            "new_s2_unauthenticated_key",
+        )
     ),
     [
         (
@@ -644,8 +651,14 @@ async def test_addon_options_changed(
 
 
 @pytest.mark.parametrize(
-    "addon_version, update_available, update_calls, backup_calls, "
-    "update_addon_side_effect, create_backup_side_effect",
+    (
+        "addon_version",
+        "update_available",
+        "update_calls",
+        "backup_calls",
+        "update_addon_side_effect",
+        "create_backup_side_effect",
+    ),
     [
         ("1.0.0", True, 1, 1, None, None),
         ("1.0.0", False, 0, 0, None, None),
@@ -744,7 +757,7 @@ async def test_issue_registry(hass, client, version_state):
 
 
 @pytest.mark.parametrize(
-    "stop_addon_side_effect, entry_state",
+    ("stop_addon_side_effect", "entry_state"),
     [
         (None, ConfigEntryState.NOT_LOADED),
         (HassioAPIError("Boom"), ConfigEntryState.LOADED),

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -569,18 +569,16 @@ async def test_addon_info_failure(
 
 @pytest.mark.parametrize(
     (
-        (
-            "old_device",
-            "new_device",
-            "old_s0_legacy_key",
-            "new_s0_legacy_key",
-            "old_s2_access_control_key",
-            "new_s2_access_control_key",
-            "old_s2_authenticated_key",
-            "new_s2_authenticated_key",
-            "old_s2_unauthenticated_key",
-            "new_s2_unauthenticated_key",
-        )
+        "old_device",
+        "new_device",
+        "old_s0_legacy_key",
+        "new_s0_legacy_key",
+        "old_s2_access_control_key",
+        "new_s2_access_control_key",
+        "old_s2_authenticated_key",
+        "new_s2_authenticated_key",
+        "old_s2_unauthenticated_key",
+        "new_s2_unauthenticated_key",
     ),
     [
         (

--- a/tests/components/zwave_me/test_remove_stale_devices.py
+++ b/tests/components/zwave_me/test_remove_stale_devices.py
@@ -27,7 +27,7 @@ async def mock_connection(controller):
 
 
 @pytest.mark.parametrize(
-    "identifier,should_exist",
+    ("identifier", "should_exist"),
     [
         (DEFAULT_DEVICE_INFO.id, False),
         (DEFAULT_DEVICE_INFO.deviceIdentifier, True),

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -855,7 +855,7 @@ async def test_entity_category_property(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "value,expected",
+    ("value", "expected"),
     (
         ("config", entity.EntityCategory.CONFIG),
         ("diagnostic", entity.EntityCategory.DIAGNOSTIC),
@@ -894,7 +894,7 @@ async def test_entity_description_fallback() -> None:
 
 
 @pytest.mark.parametrize(
-    "has_entity_name, entity_name, expected_friendly_name",
+    ("has_entity_name", "entity_name", "expected_friendly_name"),
     (
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1456,7 +1456,7 @@ class SlowEntity(MockEntity):
 
 
 @pytest.mark.parametrize(
-    "has_entity_name, entity_name, expected_entity_id",
+    ("has_entity_name", "entity_name", "expected_entity_id"),
     (
         (False, "Entity Blu", "test_domain.entity_blu"),
         (False, None, "test_domain.test_qwer"),  # Set to <platform>_<unique_id>

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1109,7 +1109,7 @@ async def test_wait_timeout(hass, caplog, timeout_param, action_type):
 
 
 @pytest.mark.parametrize(
-    "continue_on_timeout,n_events", [(False, 0), (True, 1), (None, 1)]
+    ("continue_on_timeout", "n_events"), [(False, 0), (True, 1), (None, 1)]
 )
 @pytest.mark.parametrize("action_type", ["template", "trigger"])
 async def test_wait_continue_on_timeout(
@@ -2433,7 +2433,7 @@ async def test_repeat_var_in_condition(hass, condition):
 
 
 @pytest.mark.parametrize(
-    "variables,first_last,inside_x",
+    ("variables", "first_last", "inside_x"),
     [
         (None, {"repeat": None, "x": None}, None),
         (MappingProxyType({"x": 1}), {"repeat": None, "x": 1}, 1),
@@ -2625,7 +2625,9 @@ async def test_choose_warning(hass, caplog):
     assert events[0].data["choice"] == "default"
 
 
-@pytest.mark.parametrize("var,result", [(1, "first"), (2, "second"), (3, "default")])
+@pytest.mark.parametrize(
+    ("var", "result"), [(1, "first"), (2, "second"), (3, "default")]
+)
 async def test_choose(hass, caplog, var, result):
     """Test choose action."""
     event = "test_event"
@@ -2859,7 +2861,7 @@ async def test_if_warning(
 
 
 @pytest.mark.parametrize(
-    "var,if_result,choice", [(1, True, "then"), (2, False, "else")]
+    ("var", "if_result", "choice"), [(1, True, "then"), (2, False, "else")]
 )
 async def test_if(
     hass: HomeAssistant,
@@ -3880,7 +3882,7 @@ async def test_max_exceeded(hass, caplog, max_exceeded, script_mode, max_runs):
 
 
 @pytest.mark.parametrize(
-    "script_mode,messages,last_events",
+    ("script_mode", "messages", "last_events"),
     [("restart", ["Restarting"], [2]), ("parallel", [], [2, 2])],
 )
 async def test_script_mode_2(hass, caplog, script_mode, messages, last_events):
@@ -4717,7 +4719,7 @@ async def test_stop_action(hass, caplog):
 
 
 @pytest.mark.parametrize(
-    "error,error_type,logmsg,script_execution",
+    ("error", "error_type", "logmsg", "script_execution"),
     (
         (True, script._AbortScript, "Error", "aborted"),
         (False, None, "Stop", "finished"),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -78,7 +78,7 @@ def _test_selector(
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (None, ("abc123",), (None,)),
         ({}, ("abc123",), (None,)),
@@ -115,7 +115,7 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         ({}, ("sensor.abc123", FAKE_UUID), (None, "abc123")),
         ({"integration": "zha"}, ("sensor.abc123", FAKE_UUID), (None, "abc123")),
@@ -175,7 +175,7 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         ({}, ("abc123",), (None,)),
         ({"entity": {}}, ("abc123",), (None,)),
@@ -222,7 +222,7 @@ def test_area_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {"min": 10, "max": 50},
@@ -269,7 +269,7 @@ def test_number_selector_schema_error(schema):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, ("abc123",), (None,)),),
 )
 def test_addon_selector_schema(schema, valid_selections, invalid_selections):
@@ -278,7 +278,7 @@ def test_addon_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, (1, "one", None), ()),),  # Everything can be coarced to bool
 )
 def test_boolean_selector_schema(schema, valid_selections, invalid_selections):
@@ -293,7 +293,7 @@ def test_boolean_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -313,7 +313,7 @@ def test_config_entry_selector_schema(schema, valid_selections, invalid_selectio
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, ("00:00:00",), ("blah", None)),),
 )
 def test_time_selector_schema(schema, valid_selections, invalid_selections):
@@ -322,7 +322,7 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {"entity_id": "sensor.abc"},
@@ -337,7 +337,7 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         ({}, ({"entity_id": ["sensor.abc123"]},), ("abc123", None)),
         ({"entity": {}}, (), ()),
@@ -371,7 +371,7 @@ def test_target_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, ("abc123",), ()),),
 )
 def test_action_selector_schema(schema, valid_selections, invalid_selections):
@@ -380,7 +380,7 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, ("abc123",), ()),),
 )
 def test_object_selector_schema(schema, valid_selections, invalid_selections):
@@ -389,7 +389,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         ({}, ("abc123",), (None,)),
         ({"multiline": True}, (), ()),
@@ -402,7 +402,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {"options": ["red", "green", "blue"]},
@@ -492,7 +492,7 @@ def test_select_selector_schema_error(schema):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {"entity_id": "sensor.abc"},
@@ -512,7 +512,7 @@ def test_attribute_selector_schema(schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -535,7 +535,7 @@ def test_duration_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -550,7 +550,7 @@ def test_icon_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -565,7 +565,7 @@ def test_theme_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -604,7 +604,7 @@ def test_media_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -637,7 +637,7 @@ def test_location_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -653,7 +653,7 @@ def test_rgb_color_selector_schema(schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -674,7 +674,7 @@ def test_color_tempselector_schema(schema, valid_selections, invalid_selections)
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -690,7 +690,7 @@ def test_date_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {},
@@ -706,7 +706,7 @@ def test_datetime_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (({}, ("abc123", "{{ now() }}"), (None, "{{ incomplete }", "{% if True %}Hi!")),),
 )
 def test_template_selector_schema(schema, valid_selections, invalid_selections):
@@ -715,7 +715,7 @@ def test_template_selector_schema(schema, valid_selections, invalid_selections):
 
 
 @pytest.mark.parametrize(
-    "schema,valid_selections,invalid_selections",
+    ("schema", "valid_selections", "invalid_selections"),
     (
         (
             {"accept": "image/*"},

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -351,7 +351,7 @@ def test_bool_filter(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (0, True),
         (0.0, True),
@@ -1537,7 +1537,7 @@ def test_utcnow(mock_is_safe, hass):
 
 
 @pytest.mark.parametrize(
-    "now, expected, expected_midnight, timezone_str",
+    ("now", "expected", "expected_midnight", "timezone_str"),
     [
         # Host clock in UTC
         (
@@ -4272,7 +4272,7 @@ async def test_template_states_can_serialize(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "seq, value, expected",
+    ("seq", "value", "expected"),
     [
         ([0], 0, True),
         ([1], 0, False),

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -148,7 +148,7 @@ def test_bad_import(
 
 
 @pytest.mark.parametrize(
-    "import_node,module_name",
+    ("import_node", "module_name"),
     [
         (
             "from homeassistant.components import climate",
@@ -194,7 +194,7 @@ def test_good_root_import(
 
 
 @pytest.mark.parametrize(
-    "import_node,module_name",
+    ("import_node", "module_name"),
     [
         (
             "import homeassistant.components.climate.const as climate",

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -5,6 +5,7 @@ extend-select = [
     "PT001", # Use @pytest.fixture without parentheses
     "PT002", # Configuration for fixture specified via positional args, use kwargs
     "PT003", # The scope='function' is implied in @pytest.fixture()
+    "PT006", # Single parameter in parameterize is a string, multiple a tuple
     "PT013", # Found incorrect pytest import, use simple import pytest instead
     "PT015", # Assertion always fails, replace with pytest.fail()
     "PT021", # use yield instead of request.addfinalizer

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -568,7 +568,7 @@ async def test_loading_configuration(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "minor_version, users, user_data, default_language",
+    ("minor_version", "users", "user_data", "default_language"),
     (
         (2, (), {}, "en"),
         (2, ({"is_owner": True},), {}, "en"),
@@ -692,7 +692,7 @@ async def test_loading_configuration_from_packages(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "unit_system_name, expected_unit_system",
+    ("unit_system_name", "expected_unit_system"),
     [
         (CONF_UNIT_SYSTEM_METRIC, METRIC_SYSTEM),
         (CONF_UNIT_SYSTEM_IMPERIAL, US_CUSTOMARY_SYSTEM),
@@ -1262,7 +1262,7 @@ async def test_component_config_exceptions(hass, caplog):
 
 
 @pytest.mark.parametrize(
-    "domain, schema, expected",
+    ("domain", "schema", "expected"),
     [
         ("zone", vol.Schema({vol.Optional("zone", default=list): [int]}), "list"),
         ("zone", vol.Schema({vol.Optional("zone", default=[]): [int]}), "list"),

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3135,7 +3135,7 @@ async def test_setup_retrying_during_shutdown(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "matchers, reason",
+    ("matchers", "reason"),
     [
         ({}, "already_configured"),
         ({"host": "3.3.3.3"}, "no_match"),

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -51,7 +51,7 @@ In 'box' (item 2 of 2):
 
 
 @pytest.mark.parametrize(
-    "arg, expected",
+    ("arg", "expected"),
     [
         ("message", "message"),
         (Exception("message"), "Exception: message"),

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -53,7 +53,7 @@ def test_convert_nonnumeric_value() -> None:
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 8.04672),
         (LENGTH_METERS, 8046.72),
@@ -71,7 +71,7 @@ def test_convert_from_miles(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 0.0045720000000000005),
         (LENGTH_METERS, 4.572),
@@ -89,7 +89,7 @@ def test_convert_from_yards(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 1.524),
         (LENGTH_METERS, 1524),
@@ -107,7 +107,7 @@ def test_convert_from_feet(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 0.127),
         (LENGTH_METERS, 127.0),
@@ -125,7 +125,7 @@ def test_convert_from_inches(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_METERS, 5000),
         (LENGTH_CENTIMETERS, 500000),
@@ -143,7 +143,7 @@ def test_convert_from_kilometers(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 5),
         (LENGTH_CENTIMETERS, 500000),
@@ -161,7 +161,7 @@ def test_convert_from_meters(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 5),
         (LENGTH_METERS, 5000),
@@ -181,7 +181,7 @@ def test_convert_from_centimeters(unit, expected):
 
 
 @pytest.mark.parametrize(
-    "unit,expected",
+    ("unit", "expected"),
     [
         (LENGTH_KILOMETERS, 5),
         (LENGTH_METERS, 5000),

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -146,7 +146,7 @@ def test_parse_datetime_returns_none_for_incorrect_format() -> None:
 
 
 @pytest.mark.parametrize(
-    "duration_string,expected_result",
+    ("duration_string", "expected_result"),
     [
         ("PT10M", timedelta(minutes=10)),
         ("PT0S", timedelta(0)),
@@ -316,7 +316,7 @@ def test_find_next_time_expression_time_dst() -> None:
 
 # DST begins on 2021.03.28 2:00, clocks were turned forward 1h; 2:00-3:00 time does not exist
 @pytest.mark.parametrize(
-    "now_dt, expected_dt",
+    ("now_dt", "expected_dt"),
     [
         # 00:00 -> 2:30
         (
@@ -345,7 +345,7 @@ def test_find_next_time_expression_entering_dst(now_dt, expected_dt):
 
 # DST ends on 2021.10.31 2:00, clocks were turned backward 1h; 2:00-3:00 time is ambiguous
 @pytest.mark.parametrize(
-    "now_dt, expected_dt",
+    ("now_dt", "expected_dt"),
     [
         # 00:00 -> 2:30
         (

--- a/tests/util/test_enum.py
+++ b/tests/util/test_enum.py
@@ -22,7 +22,7 @@ class _AnIntFlag(IntFlag):
 
 
 @pytest.mark.parametrize(
-    "enum_type,value,expected",
+    ("enum_type", "value", "expected"),
     [
         # StrEnum valid checks
         (_AStrEnum, _AStrEnum.VALUE, _AStrEnum.VALUE),

--- a/tests/util/test_speed.py
+++ b/tests/util/test_speed.py
@@ -63,7 +63,7 @@ def test_convert_nonnumeric_value() -> None:
 
 
 @pytest.mark.parametrize(
-    "from_value, from_unit, expected, to_unit",
+    ("from_value", "from_unit", "expected", "to_unit"),
     [
         # 5 km/h / 1.609 km/mi = 3.10686 mi/h
         (5, UnitOfSpeed.KILOMETERS_PER_HOUR, 3.10686, UnitOfSpeed.MILES_PER_HOUR),

--- a/tests/util/test_temperature.py
+++ b/tests/util/test_temperature.py
@@ -16,7 +16,7 @@ def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "function_name, value, expected",
+    ("function_name", "value", "expected"),
     [
         ("fahrenheit_to_celsius", 75.2, 24),
         ("kelvin_to_celsius", 297.65, 24.5),

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -444,7 +444,7 @@ def test_all_converters(converter: type[BaseUnitConverter]) -> None:
 
 
 @pytest.mark.parametrize(
-    "converter,valid_unit",
+    ("converter", "valid_unit"),
     [
         # Ensure all units are tested
         (converter, valid_unit)
@@ -458,7 +458,7 @@ def test_convert_same_unit(converter: type[BaseUnitConverter], valid_unit: str) 
 
 
 @pytest.mark.parametrize(
-    "converter,valid_unit",
+    ("converter", "valid_unit"),
     [
         # Ensure all units are tested
         (converter, valid_unit)
@@ -478,7 +478,7 @@ def test_convert_invalid_unit(
 
 
 @pytest.mark.parametrize(
-    "converter,from_unit,to_unit",
+    ("converter", "from_unit", "to_unit"),
     [
         # Pick any two units
         (converter, valid_units[0], valid_units[1])
@@ -494,7 +494,7 @@ def test_convert_nonnumeric_value(
 
 
 @pytest.mark.parametrize(
-    "converter,from_unit,to_unit,expected",
+    ("converter", "from_unit", "to_unit", "expected"),
     [
         # Process all items in _GET_UNIT_RATIO
         (converter, item[0], item[1], item[2])
@@ -511,7 +511,7 @@ def test_get_unit_ratio(
 
 
 @pytest.mark.parametrize(
-    "converter,value,from_unit,expected,to_unit",
+    ("converter", "value", "from_unit", "expected", "to_unit"),
     [
         # Process all items in _CONVERTED_VALUE
         (converter, list_item[0], list_item[1], list_item[2], list_item[3])
@@ -531,7 +531,7 @@ def test_unit_conversion(
 
 
 @pytest.mark.parametrize(
-    "value,from_unit,expected,to_unit",
+    ("value", "from_unit", "expected", "to_unit"),
     [
         (100, UnitOfTemperature.CELSIUS, 180, UnitOfTemperature.FAHRENHEIT),
         (100, UnitOfTemperature.CELSIUS, 100, UnitOfTemperature.KELVIN),

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -314,7 +314,7 @@ def test_properties() -> None:
 
 
 @pytest.mark.parametrize(
-    "key, expected_system",
+    ("key", "expected_system"),
     [
         (_CONF_UNIT_SYSTEM_METRIC, METRIC_SYSTEM),
         (_CONF_UNIT_SYSTEM_US_CUSTOMARY, US_CUSTOMARY_SYSTEM),
@@ -335,7 +335,7 @@ def test_get_unit_system_invalid(key: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "device_class, original_unit, state_unit",
+    ("device_class", "original_unit", "state_unit"),
     (
         # Test atmospheric pressure
         (
@@ -543,7 +543,7 @@ def test_metric_converted_units(device_class: SensorDeviceClass) -> None:
 
 
 @pytest.mark.parametrize(
-    "device_class, original_unit, state_unit",
+    ("device_class", "original_unit", "state_unit"),
     (
         # Test atmospheric pressure
         (

--- a/tests/util/test_variance.py
+++ b/tests/util/test_variance.py
@@ -7,7 +7,7 @@ from homeassistant.util.variance import ignore_variance
 
 
 @pytest.mark.parametrize(
-    "value_1, value_2, variance, expected",
+    ("value_1", "value_2", "variance", "expected"),
     [
         (1, 1, 1, 1),
         (1, 2, 2, 1),

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -24,7 +24,7 @@ def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "function_name, value, expected",
+    ("function_name", "value", "expected"),
     [
         ("liter_to_gallon", 2, pytest.approx(0.528344)),
         ("gallon_to_liter", 2, 7.570823568),
@@ -96,7 +96,7 @@ def test_convert_from_cubic_feet() -> None:
 
 
 @pytest.mark.parametrize(
-    "source_unit,target_unit,expected",
+    ("source_unit", "target_unit", "expected"),
     [
         (VOLUME_CUBIC_FEET, VOLUME_CUBIC_METERS, 14.1584233),
         (VOLUME_CUBIC_FEET, VOLUME_FLUID_OUNCE, 478753.2467),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enables rules PT006 in Ruff, which applies to the parameters of `@pytest.mark.parametrize`.

This PR is large and best reviewed by looking at the first commit (enabling the rule). The second commit is an auto-fixed result by Ruff, that has adjusted all cases automatically.

Full context: <https://github.com/m-burst/flake8-pytest-style/blob/master/docs/rules/PT006.md>

When a parameterize only has a single parameter, a string value will be expected, otherwise a tuple.

### Examples

Unwanted examples:

```python
import pytest

# single parameter, always expecting string
@pytest.mark.parametrize(("param", ), [1, 2, 3])
def test_foo(param):
    ...

# multiple parameters, expecting tuple
@pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
def test_bar(param1, param2):
    ...

# multiple parameters, expecting tuple
@pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
def test_baz(param1, param2):
    ...
```

Good examples:

```python
import pytest

@pytest.mark.parametrize("param", [1, 2, 3])
def test_foo(param):
    ...

@pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
def test_bar(param1, param2):
    ...
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
