### PR TITLE
Add type hints to integration tests (part 18)

### DIFF
--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.recollect_waste import (
 )
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
 
 from .conftest import TEST_PLACE_ID, TEST_SERVICE_ID
 
@@ -26,13 +27,13 @@ from .conftest import TEST_PLACE_ID, TEST_SERVICE_ID
     ],
 )
 async def test_create_entry(
-    hass,
+    hass: HomeAssistant,
     client,
     config,
     get_pickup_events_errors,
     get_pickup_events_mock,
     mock_aiorecollect,
-):
+) -> None:
     """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -59,7 +60,7 @@ async def test_create_entry(
     }
 
 
-async def test_duplicate_error(hass, config, setup_config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -68,7 +69,9 @@ async def test_duplicate_error(hass, config, setup_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow(hass, config, config_entry, setup_config_entry):
+async def test_options_flow(
+    hass: HomeAssistant, config, config_entry, setup_config_entry
+) -> None:
     """Test config flow options."""
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == data_entry_flow.FlowResultType.FORM

--- a/tests/components/recollect_waste/test_diagnostics.py
+++ b/tests/components/recollect_waste/test_diagnostics.py
@@ -1,12 +1,19 @@
 """Test ReCollect Waste diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from .conftest import TEST_SERVICE_ID
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -5,7 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +25,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a remote."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -61,12 +66,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -99,7 +104,9 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass, calls, enable_custom_integrations):
+async def test_action(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -8,7 +8,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a remote."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_get_condition_capabilities(hass, device_registry, entity_registry):
+async def test_get_condition_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a remote condition."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_condition_capabilities(hass, device_registry, entity_registry
         assert capabilities == expected_capabilities
 
 
-async def test_if_state(hass, calls, enable_custom_integrations):
+async def test_if_state(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -205,7 +216,9 @@ async def test_if_state(hass, calls, enable_custom_integrations):
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
-async def test_if_fires_on_for_condition(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_for_condition(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a remote."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a remote trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -243,8 +254,8 @@ async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations)
 
 
 async def test_if_fires_on_state_change_with_for(
-    hass, calls, enable_custom_integrations
-):
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -33,7 +33,7 @@ def override_async_setup_entry() -> AsyncMock:
 
 async def test_config_flow_single_account(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
-):
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -92,7 +92,9 @@ async def test_config_flow_single_account(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_config_flow_no_account(hass: HomeAssistant, mock_setup_entry: AsyncMock):
+async def test_config_flow_no_account(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -122,7 +124,7 @@ async def test_config_flow_no_account(hass: HomeAssistant, mock_setup_entry: Asy
 
 async def test_config_flow_multiple_accounts(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
-):
+) -> None:
     """Test what happens if multiple Kamereon accounts are available."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -172,7 +174,9 @@ async def test_config_flow_multiple_accounts(
 
 
 @pytest.mark.usefixtures("config_entry")
-async def test_config_flow_duplicate(hass: HomeAssistant, mock_setup_entry: AsyncMock):
+async def test_config_flow_duplicate(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test abort if unique_id configured."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -206,7 +210,7 @@ async def test_config_flow_duplicate(hass: HomeAssistant, mock_setup_entry: Asyn
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_reauth(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_reauth(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Test the start of the config flow."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -11,6 +11,7 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicles")
 
@@ -164,8 +165,8 @@ VEHICLE_DATA = {
 @pytest.mark.usefixtures("fixtures_with_data")
 @pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
 async def test_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry, hass_client
-):
+    hass: HomeAssistant, config_entry: ConfigEntry, hass_client: ClientSessionGenerator
+) -> None:
     """Test config entry diagnostics."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -190,8 +191,8 @@ async def test_device_diagnostics(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     device_registry: dr.DeviceRegistry,
-    hass_client,
-):
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test config entry diagnostics."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -25,10 +25,13 @@ from homeassistant.helpers.issue_registry import (
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_platform
+from tests.typing import WebSocketGenerator
 
 
 @freeze_time("2022-07-19 07:53:05")
-async def test_create_update_issue(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_create_update_issue(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test creating and updating issues."""
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -125,7 +128,7 @@ async def test_create_update_issue(hass: HomeAssistant, hass_ws_client) -> None:
 
 @pytest.mark.parametrize("ha_version", ("2022.9.cat", "In the future: 2023.1.1"))
 async def test_create_issue_invalid_version(
-    hass: HomeAssistant, hass_ws_client, ha_version
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, ha_version
 ) -> None:
     """Test creating an issue with invalid breaks in version."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -165,7 +168,9 @@ async def test_create_issue_invalid_version(
 
 
 @freeze_time("2022-07-19 07:53:05")
-async def test_ignore_issue(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_ignore_issue(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test ignoring issues."""
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -331,7 +336,9 @@ async def test_ignore_issue(hass: HomeAssistant, hass_ws_client) -> None:
     }
 
 
-async def test_delete_issue(hass: HomeAssistant, hass_ws_client, freezer) -> None:
+async def test_delete_issue(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, freezer
+) -> None:
     """Test we can delete an issue."""
     freezer.move_to("2022-07-19 07:53:05")
     assert await async_setup_component(hass, DOMAIN, {})
@@ -455,7 +462,9 @@ async def test_delete_issue(hass: HomeAssistant, hass_ws_client, freezer) -> Non
     }
 
 
-async def test_non_compliant_platform(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_non_compliant_platform(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test non-compliant platforms are not registered."""
 
     hass.config.components.add("fake_integration")

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
 from aiohttp import ClientWebSocketResponse
@@ -18,8 +19,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_platform
-from tests.typing import ClientSessionGenerator
+from tests.common import MockUser, mock_platform
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 DEFAULT_ISSUES = [
     {
@@ -140,7 +141,9 @@ async def mock_repairs_integration(hass):
     )
 
 
-async def test_dismiss_issue(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_dismiss_issue(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can dismiss an issue."""
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -222,7 +225,9 @@ async def test_dismiss_issue(hass: HomeAssistant, hass_ws_client) -> None:
 
 
 async def test_fix_non_existing_issue(
-    hass: HomeAssistant, hass_client, hass_ws_client
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test trying to fix an issue that doesn't exist."""
     assert await async_setup_component(hass, "http", {})
@@ -274,8 +279,8 @@ async def test_fix_non_existing_issue(
 )
 async def test_fix_issue(
     hass: HomeAssistant,
-    hass_client,
-    hass_ws_client,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
     domain,
     step,
     description_placeholders,
@@ -347,7 +352,7 @@ async def test_fix_issue(
 
 
 async def test_fix_issue_unauth(
-    hass: HomeAssistant, hass_client, hass_admin_user
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_admin_user: MockUser
 ) -> None:
     """Test we can't query the result if not authorized."""
     assert await async_setup_component(hass, "http", {})
@@ -366,7 +371,10 @@ async def test_fix_issue_unauth(
 
 
 async def test_get_progress_unauth(
-    hass: HomeAssistant, hass_client, hass_ws_client, hass_admin_user
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
 ) -> None:
     """Test we can't fix an issue if not authorized."""
     assert await async_setup_component(hass, "http", {})
@@ -394,7 +402,10 @@ async def test_get_progress_unauth(
 
 
 async def test_step_unauth(
-    hass: HomeAssistant, hass_client, hass_ws_client, hass_admin_user
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
 ) -> None:
     """Test we can't fix an issue if not authorized."""
     assert await async_setup_component(hass, "http", {})
@@ -422,7 +433,9 @@ async def test_step_unauth(
 
 
 @freeze_time("2022-07-19 07:53:05")
-async def test_list_issues(hass: HomeAssistant, hass_storage, hass_ws_client) -> None:
+async def test_list_issues(
+    hass: HomeAssistant, hass_storage: dict[str, Any], hass_ws_client
+) -> None:
     """Test we can list issues."""
 
     # Add an inactive issue, this should not be exposed in the list

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState, State, callback
+from homeassistant.core import CoreState, HomeAssistant, State, callback
 import homeassistant.util.dt as dt_util
 
 from .test_init import mock_rflink
@@ -44,7 +44,7 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -83,7 +83,7 @@ async def test_default_setup(hass, monkeypatch):
     assert hass.states.get("binary_sensor.test").state == STATE_OFF
 
 
-async def test_entity_availability(hass, monkeypatch):
+async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
     """If Rflink device is disconnected, entities should become unavailable."""
     # Make sure Rflink mock does not 'recover' to quickly from the
     # disconnect or else the unavailability cannot be measured
@@ -124,7 +124,7 @@ async def test_entity_availability(hass, monkeypatch):
     assert hass.states.get("binary_sensor.test").state == STATE_ON
 
 
-async def test_off_delay(hass, monkeypatch):
+async def test_off_delay(hass: HomeAssistant, monkeypatch) -> None:
     """Test off_delay option."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -187,7 +187,7 @@ async def test_off_delay(hass, monkeypatch):
     assert len(events) == 3
 
 
-async def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State(f"{DOMAIN}.test", STATE_ON), State(f"{DOMAIN}.test2", STATE_ON))

--- a/tests/components/rflink/test_cover.py
+++ b/tests/components/rflink/test_cover.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_CLOSED,
     STATE_OPEN,
 )
-from homeassistant.core import CoreState, State, callback
+from homeassistant.core import CoreState, HomeAssistant, State, callback
 
 from .test_init import mock_rflink
 
@@ -36,7 +36,7 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     """Test all basic functionality of the RFLink cover component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -106,7 +106,7 @@ async def test_default_setup(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[1][0][1] == "UP"
 
 
-async def test_firing_bus_event(hass, monkeypatch):
+async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
     """Incoming RFLink command events should be put on the HA event bus."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -141,7 +141,7 @@ async def test_firing_bus_event(hass, monkeypatch):
     assert calls[0].data == {"state": "down", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_signal_repetitions(hass, monkeypatch):
+async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
     """Command should be sent amount of configured repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -179,7 +179,7 @@ async def test_signal_repetitions(hass, monkeypatch):
     assert protocol.send_command_ack.call_count == 5
 
 
-async def test_signal_repetitions_alternation(hass, monkeypatch):
+async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) -> None:
     """Simultaneously switching entities must alternate repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -210,7 +210,7 @@ async def test_signal_repetitions_alternation(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[3][0][0] == "protocol_0_1"
 
 
-async def test_signal_repetitions_cancelling(hass, monkeypatch):
+async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -> None:
     """Cancel outstanding repetitions when state changed."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -239,7 +239,7 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[3][0][1] == "UP"
 
 
-async def test_group_alias(hass, monkeypatch):
+async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -269,7 +269,7 @@ async def test_group_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_nogroup_alias(hass, monkeypatch):
+async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -302,7 +302,7 @@ async def test_nogroup_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_nogroup_device_id(hass, monkeypatch):
+async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -330,7 +330,7 @@ async def test_nogroup_device_id(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -376,7 +376,7 @@ async def test_restore_state(hass, monkeypatch):
 # The code checks the ID, it will use the
 # 'inverted' class when the name starts with
 # 'newkaku'
-async def test_inverted_cover(hass, monkeypatch):
+async def test_inverted_cover(hass: HomeAssistant, monkeypatch) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     SERVICE_TURN_OFF,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
@@ -76,7 +77,7 @@ async def mock_rflink(
     return event_callback, mock_create, protocol, disconnect_callback
 
 
-async def test_version_banner(hass, monkeypatch):
+async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
     """Test sending unknown commands doesn't cause issues."""
     # use sensor domain during testing main platform
     domain = "sensor"
@@ -101,7 +102,7 @@ async def test_version_banner(hass, monkeypatch):
     )
 
 
-async def test_send_no_wait(hass, monkeypatch):
+async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     """Test command sending without ack."""
     domain = "switch"
     config = {
@@ -125,7 +126,7 @@ async def test_send_no_wait(hass, monkeypatch):
     assert protocol.send_command.call_args_list[0][0][1] == "off"
 
 
-async def test_cover_send_no_wait(hass, monkeypatch):
+async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     """Test command sending to a cover device without ack."""
     domain = "cover"
     config = {
@@ -149,7 +150,7 @@ async def test_cover_send_no_wait(hass, monkeypatch):
     assert protocol.send_command.call_args_list[0][0][1] == "STOP"
 
 
-async def test_send_command(hass, monkeypatch):
+async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -167,7 +168,7 @@ async def test_send_command(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
 
 
-async def test_send_command_invalid_arguments(hass, monkeypatch):
+async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -200,7 +201,7 @@ async def test_send_command_invalid_arguments(hass, monkeypatch):
     assert not success, "send command should not succeed for unknown command"
 
 
-async def test_send_command_event_propagation(hass, monkeypatch):
+async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) -> None:
     """Test event propagation for send_command service."""
     domain = "light"
     config = {
@@ -242,7 +243,7 @@ async def test_send_command_event_propagation(hass, monkeypatch):
     assert hass.states.get(f"{domain}.test1").state == "off"
 
 
-async def test_reconnecting_after_disconnect(hass, monkeypatch):
+async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -> None:
     """An unexpected disconnect should cause a reconnect."""
     domain = "sensor"
     config = {
@@ -266,7 +267,7 @@ async def test_reconnecting_after_disconnect(hass, monkeypatch):
     assert mock_create.call_count == 2
 
 
-async def test_reconnecting_after_failure(hass, monkeypatch):
+async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> None:
     """A failure to reconnect should be retried."""
     domain = "sensor"
     config = {
@@ -293,7 +294,7 @@ async def test_reconnecting_after_failure(hass, monkeypatch):
     assert mock_create.call_count == 3
 
 
-async def test_error_when_not_connected(hass, monkeypatch):
+async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> None:
     """Sending command should error when not connected."""
     domain = "switch"
     config = {
@@ -323,7 +324,7 @@ async def test_error_when_not_connected(hass, monkeypatch):
     assert not success, "changing state should not succeed when disconnected"
 
 
-async def test_async_send_command_error(hass, monkeypatch):
+async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> None:
     """Sending command should error when protocol fails."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -344,7 +345,7 @@ async def test_async_send_command_error(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[0][0][1] == SERVICE_TURN_OFF
 
 
-async def test_race_condition(hass, monkeypatch):
+async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     """Test race condition for unknown components."""
     domain = "light"
     config = {"rflink": {"port": "/dev/ttyABC0"}, domain: {"platform": "rflink"}}
@@ -380,7 +381,7 @@ async def test_race_condition(hass, monkeypatch):
     assert new_sensor.state == "on"
 
 
-async def test_not_connected(hass, monkeypatch):
+async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
     """Test Error when sending commands to a disconnected device."""
     import pytest
 
@@ -392,7 +393,9 @@ async def test_not_connected(hass, monkeypatch):
         await test_device._async_handle_command("turn_on")
 
 
-async def test_keepalive(hass, monkeypatch, caplog):
+async def test_keepalive(
+    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Validate negative keepalive values."""
     keepalive_value = -3
     domain = RFLINK_DOMAIN
@@ -462,7 +465,9 @@ async def test3_keepalive(hass, monkeypatch, caplog):
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_default_keepalive(hass, monkeypatch, caplog):
+async def test_default_keepalive(
+    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Validate keepalive=0 value."""
     domain = RFLINK_DOMAIN
     config = {RFLINK_DOMAIN: {CONF_HOST: "10.10.0.1", CONF_PORT: 1234}}
@@ -479,7 +484,7 @@ async def test_default_keepalive(hass, monkeypatch, caplog):
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_unique_id(hass, monkeypatch):
+async def test_unique_id(hass: HomeAssistant, monkeypatch) -> None:
     """Validate the device unique_id."""
 
     DOMAIN = "sensor"

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     SERVICE_TURN_OFF,
 )
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 
@@ -77,7 +76,7 @@ async def mock_rflink(
     return event_callback, mock_create, protocol, disconnect_callback
 
 
-async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
+async def test_version_banner(hass, monkeypatch):
     """Test sending unknown commands doesn't cause issues."""
     # use sensor domain during testing main platform
     domain = "sensor"
@@ -102,7 +101,7 @@ async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
     )
 
 
-async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_no_wait(hass, monkeypatch):
     """Test command sending without ack."""
     domain = "switch"
     config = {
@@ -126,7 +125,7 @@ async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command.call_args_list[0][0][1] == "off"
 
 
-async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
+async def test_cover_send_no_wait(hass, monkeypatch):
     """Test command sending to a cover device without ack."""
     domain = "cover"
     config = {
@@ -150,7 +149,7 @@ async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command.call_args_list[0][0][1] == "STOP"
 
 
-async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command(hass, monkeypatch):
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -168,7 +167,7 @@ async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
 
 
-async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command_invalid_arguments(hass, monkeypatch):
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -201,7 +200,7 @@ async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) 
     assert not success, "send command should not succeed for unknown command"
 
 
-async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command_event_propagation(hass, monkeypatch):
     """Test event propagation for send_command service."""
     domain = "light"
     config = {
@@ -243,7 +242,7 @@ async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) 
     assert hass.states.get(f"{domain}.test1").state == "off"
 
 
-async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -> None:
+async def test_reconnecting_after_disconnect(hass, monkeypatch):
     """An unexpected disconnect should cause a reconnect."""
     domain = "sensor"
     config = {
@@ -267,7 +266,7 @@ async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -
     assert mock_create.call_count == 2
 
 
-async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> None:
+async def test_reconnecting_after_failure(hass, monkeypatch):
     """A failure to reconnect should be retried."""
     domain = "sensor"
     config = {
@@ -294,7 +293,7 @@ async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> N
     assert mock_create.call_count == 3
 
 
-async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> None:
+async def test_error_when_not_connected(hass, monkeypatch):
     """Sending command should error when not connected."""
     domain = "switch"
     config = {
@@ -324,7 +323,7 @@ async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> Non
     assert not success, "changing state should not succeed when disconnected"
 
 
-async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> None:
+async def test_async_send_command_error(hass, monkeypatch):
     """Sending command should error when protocol fails."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -345,7 +344,7 @@ async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> Non
     assert protocol.send_command_ack.call_args_list[0][0][1] == SERVICE_TURN_OFF
 
 
-async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
+async def test_race_condition(hass, monkeypatch):
     """Test race condition for unknown components."""
     domain = "light"
     config = {"rflink": {"port": "/dev/ttyABC0"}, domain: {"platform": "rflink"}}
@@ -381,7 +380,7 @@ async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     assert new_sensor.state == "on"
 
 
-async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
+async def test_not_connected(hass, monkeypatch):
     """Test Error when sending commands to a disconnected device."""
     import pytest
 
@@ -393,9 +392,7 @@ async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
         await test_device._async_handle_command("turn_on")
 
 
-async def test_keepalive(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_keepalive(hass, monkeypatch, caplog):
     """Validate negative keepalive values."""
     keepalive_value = -3
     domain = RFLINK_DOMAIN
@@ -465,9 +462,7 @@ async def test3_keepalive(hass, monkeypatch, caplog):
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_default_keepalive(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_default_keepalive(hass, monkeypatch, caplog):
     """Validate keepalive=0 value."""
     domain = RFLINK_DOMAIN
     config = {RFLINK_DOMAIN: {CONF_HOST: "10.10.0.1", CONF_PORT: 1234}}
@@ -484,7 +479,7 @@ async def test_default_keepalive(
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_unique_id(hass: HomeAssistant, monkeypatch) -> None:
+async def test_unique_id(hass, monkeypatch):
     """Validate the device unique_id."""
 
     DOMAIN = "sensor"

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import CoreState, State, callback
+from homeassistant.core import CoreState, HomeAssistant, State, callback
 
 from .test_init import mock_rflink
 
@@ -37,7 +37,7 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     """Test all basic functionality of the RFLink switch component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -145,7 +145,7 @@ async def test_default_setup(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[5][0][1] == "7"
 
 
-async def test_firing_bus_event(hass, monkeypatch):
+async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
     """Incoming RFLink command events should be put on the HA event bus."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -180,7 +180,7 @@ async def test_firing_bus_event(hass, monkeypatch):
     assert calls[0].data == {"state": "off", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_signal_repetitions(hass, monkeypatch):
+async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
     """Command should be sent amount of configured repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -236,7 +236,7 @@ async def test_signal_repetitions(hass, monkeypatch):
     assert protocol.send_command_ack.call_count == 8
 
 
-async def test_signal_repetitions_alternation(hass, monkeypatch):
+async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) -> None:
     """Simultaneously switching entities must alternate repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -267,7 +267,7 @@ async def test_signal_repetitions_alternation(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[3][0][0] == "protocol_0_1"
 
 
-async def test_signal_repetitions_cancelling(hass, monkeypatch):
+async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -> None:
     """Cancel outstanding repetitions when state changed."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -296,7 +296,7 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
     ]
 
 
-async def test_type_toggle(hass, monkeypatch):
+async def test_type_toggle(hass: HomeAssistant, monkeypatch) -> None:
     """Test toggle type lights (on/on)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -341,7 +341,7 @@ async def test_type_toggle(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.toggle_test").state == "off"
 
 
-async def test_set_level_command(hass, monkeypatch):
+async def test_set_level_command(hass: HomeAssistant, monkeypatch) -> None:
     """Test 'set_level=XX' events."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -428,7 +428,7 @@ async def test_set_level_command(hass, monkeypatch):
     assert state.attributes[ATTR_BRIGHTNESS] == 0
 
 
-async def test_group_alias(hass, monkeypatch):
+async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -465,7 +465,7 @@ async def test_group_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test2").state == "on"
 
 
-async def test_nogroup_alias(hass, monkeypatch):
+async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -498,7 +498,7 @@ async def test_nogroup_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_device_id(hass, monkeypatch):
+async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -526,7 +526,7 @@ async def test_nogroup_device_id(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_disable_automatic_add(hass, monkeypatch):
+async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
     """If disabled new devices should not be automatically added."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -544,7 +544,7 @@ async def test_disable_automatic_add(hass, monkeypatch):
     assert not hass.states.get(f"{DOMAIN}.protocol_0_0")
 
 
-async def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -4,7 +4,6 @@ Test setup of rflink sensor component/platform. Verify manual and
 automatic sensor creation.
 
 """
-
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL,
     DATA_ENTITY_LOOKUP,
@@ -21,6 +20,7 @@ from homeassistant.const import (
     UnitOfPrecipitationDepth,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_init import mock_rflink
 
@@ -38,7 +38,7 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -99,7 +99,7 @@ async def test_default_setup(hass, monkeypatch):
     assert bat_sensor.attributes[ATTR_ICON] == "mdi:battery"
 
 
-async def test_disable_automatic_add(hass, monkeypatch):
+async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
     """If disabled new devices should not be automatically added."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -124,7 +124,7 @@ async def test_disable_automatic_add(hass, monkeypatch):
     assert not hass.states.get("sensor.test2")
 
 
-async def test_entity_availability(hass, monkeypatch):
+async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
     """If Rflink device is disconnected, entities should become unavailable."""
     # Make sure Rflink mock does not 'recover' to quickly from the
     # disconnect or else the unavailability cannot be measured
@@ -159,7 +159,7 @@ async def test_entity_availability(hass, monkeypatch):
     assert hass.states.get("sensor.test").state == STATE_UNKNOWN
 
 
-async def test_aliases(hass, monkeypatch):
+async def test_aliases(hass: HomeAssistant, monkeypatch) -> None:
     """Validate the response to sensor's alias (with aliases)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -201,7 +201,7 @@ async def test_aliases(hass, monkeypatch):
     assert updated_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
-async def test_race_condition(hass, monkeypatch):
+async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     """Test race condition for unknown components."""
     config = {"rflink": {"port": "/dev/ttyABC0"}, DOMAIN: {"platform": "rflink"}}
     tmp_entity = TMP_ENTITY.format("test3")
@@ -240,7 +240,7 @@ async def test_race_condition(hass, monkeypatch):
     assert new_sensor.state == "ko"
 
 
-async def test_sensor_attributes(hass, monkeypatch):
+async def test_sensor_attributes(hass: HomeAssistant, monkeypatch) -> None:
     """Validate the sensor attributes."""
 
     config = {

--- a/tests/components/rflink/test_switch.py
+++ b/tests/components/rflink/test_switch.py
@@ -4,7 +4,6 @@ Test setup of rflink switch component/platform. State tracking and
 control of Rflink switch devices.
 
 """
-
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -13,7 +12,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import CoreState, State, callback
+from homeassistant.core import CoreState, HomeAssistant, State, callback
 
 from .test_init import mock_rflink
 
@@ -33,7 +32,7 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     """Test all basic functionality of the rflink switch component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -93,7 +92,7 @@ async def test_default_setup(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[1][0][1] == "on"
 
 
-async def test_group_alias(hass, monkeypatch):
+async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -123,7 +122,7 @@ async def test_group_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_alias(hass, monkeypatch):
+async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -156,7 +155,7 @@ async def test_nogroup_alias(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_device_id(hass, monkeypatch):
+async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -184,7 +183,7 @@ async def test_nogroup_device_id(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_device_defaults(hass, monkeypatch):
+async def test_device_defaults(hass: HomeAssistant, monkeypatch) -> None:
     """Event should fire if device_defaults config says so."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -216,7 +215,7 @@ async def test_device_defaults(hass, monkeypatch):
     assert calls[0].data == {"state": "off", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_not_firing_default(hass, monkeypatch):
+async def test_not_firing_default(hass: HomeAssistant, monkeypatch) -> None:
     """By default no bus events should be fired."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -246,7 +245,7 @@ async def test_not_firing_default(hass, monkeypatch):
     assert not calls, "an event has been fired"
 
 
-async def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_utils.py
+++ b/tests/components/rflink/test_utils.py
@@ -3,9 +3,10 @@ from homeassistant.components.rflink.utils import (
     brightness_to_rflink,
     rflink_to_brightness,
 )
+from homeassistant.core import HomeAssistant
 
 
-async def test_utils(hass, monkeypatch):
+async def test_utils(hass: HomeAssistant, monkeypatch) -> None:
     """Test all utils methods."""
     # test brightness_to_rflink
     assert brightness_to_rflink(0) == 0

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import create_rfx_test_cfg
 
@@ -22,7 +22,7 @@ EVENT_LIGHT_DETECTOR_DARK = "08200100a109001470"
 EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
 
 
-async def test_one(hass, rfxtrx):
+async def test_one(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
     entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -38,7 +38,7 @@ async def test_one(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
 
-async def test_one_pt2262(hass, rfxtrx):
+async def test_one_pt2262(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 sensor."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -71,7 +71,7 @@ async def test_one_pt2262(hass, rfxtrx):
     assert state.state == "off"
 
 
-async def test_pt2262_unconfigured(hass, rfxtrx):
+async def test_pt2262_unconfigured(hass: HomeAssistant, rfxtrx) -> None:
     """Test with discovery for PT2262."""
     entry_data = create_rfx_test_cfg(
         devices={"0913000022670e013970": {}, "09130000226707013970": {}}
@@ -99,7 +99,7 @@ async def test_pt2262_unconfigured(hass, rfxtrx):
     ("state", "event"),
     [["on", "0b1100cd0213c7f230010f71"], ["off", "0b1100cd0213c7f230000f71"]],
 )
-async def test_state_restore(hass, rfxtrx, state, event):
+async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
     """State restoration."""
 
     entity_id = "binary_sensor.ac_213c7f2_48"
@@ -117,7 +117,7 @@ async def test_state_restore(hass, rfxtrx, state, event):
     assert hass.states.get(entity_id).state == state
 
 
-async def test_several(hass, rfxtrx):
+async def test_several(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -159,7 +159,7 @@ async def test_several(hass, rfxtrx):
     assert hass.states.get("binary_sensor.ac_118cdea_3").state == "off"
 
 
-async def test_discover(hass, rfxtrx_automatic):
+async def test_discover(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery."""
     rfxtrx = rfxtrx_automatic
 
@@ -174,7 +174,7 @@ async def test_discover(hass, rfxtrx_automatic):
     assert state.state == "on"
 
 
-async def test_off_delay_restore(hass, rfxtrx):
+async def test_off_delay_restore(hass: HomeAssistant, rfxtrx) -> None:
     """Make sure binary sensor restore as off, if off delay is active."""
     mock_restore_cache(
         hass,
@@ -201,7 +201,7 @@ async def test_off_delay_restore(hass, rfxtrx):
     assert state.state == "off"
 
 
-async def test_off_delay(hass, rfxtrx, timestep):
+async def test_off_delay(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with discovery."""
     entry_data = create_rfx_test_cfg(
         devices={"0b1100100118cdea02010f70": {"off_delay": 5}}
@@ -252,7 +252,7 @@ async def test_off_delay(hass, rfxtrx, timestep):
     assert state.state == "off"
 
 
-async def test_panic(hass, rfxtrx_automatic):
+async def test_panic(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test panic entities."""
     rfxtrx = rfxtrx_automatic
 
@@ -266,7 +266,7 @@ async def test_panic(hass, rfxtrx_automatic):
     assert hass.states.get(entity_id).state == "off"
 
 
-async def test_motion(hass, rfxtrx_automatic):
+async def test_motion(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test motion entities."""
     rfxtrx = rfxtrx_automatic
 
@@ -280,7 +280,7 @@ async def test_motion(hass, rfxtrx_automatic):
     assert hass.states.get(entity_id).state == "off"
 
 
-async def test_light(hass, rfxtrx_automatic):
+async def test_light(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test light entities."""
     rfxtrx = rfxtrx_automatic
 
@@ -293,7 +293,7 @@ async def test_light(hass, rfxtrx_automatic):
     assert hass.states.get(entity_id).state == "off"
 
 
-async def test_pt2262_duplicate_id(hass, rfxtrx):
+async def test_pt2262_duplicate_id(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
     entry_data = create_rfx_test_cfg(
         devices={

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -47,7 +47,7 @@ async def start_options_flow(hass, entry):
 
 
 @patch("homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport", autospec=True)
-async def test_setup_network(transport_mock, hass):
+async def test_setup_network(transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -91,7 +91,7 @@ async def test_setup_network(transport_mock, hass):
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
     return_value=None,
 )
-async def test_setup_serial(com_mock, connect_mock, hass):
+async def test_setup_serial(com_mock, connect_mock, hass: HomeAssistant) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -137,7 +137,7 @@ async def test_setup_serial(com_mock, connect_mock, hass):
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
     return_value=None,
 )
-async def test_setup_serial_manual(com_mock, connect_mock, hass):
+async def test_setup_serial_manual(com_mock, connect_mock, hass: HomeAssistant) -> None:
     """Test we can setup serial with manual entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -185,7 +185,7 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
     autospec=True,
     side_effect=OSError,
 )
-async def test_setup_network_fail(transport_mock, hass):
+async def test_setup_network_fail(transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -218,7 +218,7 @@ async def test_setup_network_fail(transport_mock, hass):
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     side_effect=serial.serialutil.SerialException,
 )
-async def test_setup_serial_fail(com_mock, connect_mock, hass):
+async def test_setup_serial_fail(com_mock, connect_mock, hass: HomeAssistant) -> None:
     """Test setup serial failed connection."""
     port = com_port()
 
@@ -253,7 +253,7 @@ async def test_setup_serial_fail(com_mock, connect_mock, hass):
     "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
     serial_connect_fail,
 )
-async def test_setup_serial_manual_fail(com_mock, hass):
+async def test_setup_serial_manual_fail(com_mock, hass: HomeAssistant) -> None:
     """Test setup serial failed connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -4,7 +4,7 @@ from unittest.mock import call
 import pytest
 
 from homeassistant.components.rfxtrx import DOMAIN
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import create_rfx_test_cfg
@@ -12,7 +12,7 @@ from .conftest import create_rfx_test_cfg
 from tests.common import MockConfigEntry, mock_restore_cache
 
 
-async def test_one_cover(hass, rfxtrx):
+async def test_one_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 cover."""
     entry_data = create_rfx_test_cfg(devices={"0b1400cd0213c7f20d010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -54,7 +54,7 @@ async def test_one_cover(hass, rfxtrx):
 
 
 @pytest.mark.parametrize("state", ["open", "closed"])
-async def test_state_restore(hass, rfxtrx, state):
+async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
     """State restoration."""
 
     entity_id = "cover.lightwaverf_siemens_0213c7_242"
@@ -72,7 +72,7 @@ async def test_state_restore(hass, rfxtrx, state):
     assert hass.states.get(entity_id).state == state
 
 
-async def test_several_covers(hass, rfxtrx):
+async def test_several_covers(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 covers."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -104,7 +104,7 @@ async def test_several_covers(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "RollerTrol 009ba8:1"
 
 
-async def test_discover_covers(hass, rfxtrx_automatic):
+async def test_discover_covers(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery of covers."""
     rfxtrx = rfxtrx_automatic
 
@@ -119,7 +119,7 @@ async def test_discover_covers(hass, rfxtrx_automatic):
     assert state.state == "open"
 
 
-async def test_duplicate_cover(hass, rfxtrx):
+async def test_duplicate_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 2 duplicate covers."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -140,7 +140,7 @@ async def test_duplicate_cover(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "LightwaveRF, Siemens 0213c7:242"
 
 
-async def test_rfy_cover(hass, rfxtrx):
+async def test_rfy_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test Rfy venetian blind covers."""
     entry_data = create_rfx_test_cfg(
         devices={

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -9,6 +9,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -40,7 +41,7 @@ DEVICE_TEMPHUM_1 = DeviceTestData(
 
 
 @pytest.mark.parametrize("device", [DEVICE_LIGHTING_1, DEVICE_TEMPHUM_1])
-async def test_device_test_data(rfxtrx, device: DeviceTestData):
+async def test_device_test_data(rfxtrx, device: DeviceTestData) -> None:
     """Verify that our testing data remains correct."""
     pkt: RFXtrx.lowlevel.Packet = RFXtrx.lowlevel.parse(bytearray.fromhex(device.code))
     assert device.device_identifiers == {
@@ -79,7 +80,9 @@ def _get_expected_actions(data):
         [DEVICE_TEMPHUM_1, []],
     ],
 )
-async def test_get_actions(hass, device_registry: dr.DeviceRegistry, device, expected):
+async def test_get_actions(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, device, expected
+) -> None:
     """Test we get the expected actions from a rfxtrx."""
     await setup_entry(hass, {device.code: {}})
 
@@ -120,13 +123,13 @@ async def test_get_actions(hass, device_registry: dr.DeviceRegistry, device, exp
     ],
 )
 async def test_action(
-    hass,
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     rfxtrx: RFXtrx.Connect,
     device,
     config,
     expected,
-):
+) -> None:
     """Test for actions."""
 
     await setup_entry(hass, {device.code: {}})
@@ -160,7 +163,11 @@ async def test_action(
     rfxtrx.transport.send.assert_called_once_with(bytearray.fromhex(expected))
 
 
-async def test_invalid_action(hass, device_registry: dr.DeviceRegistry, caplog):
+async def test_invalid_action(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test for invalid actions."""
     device = DEVICE_LIGHTING_1
 

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -8,6 +8,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -77,7 +78,12 @@ async def setup_entry(hass, devices):
         ]
     ],
 )
-async def test_get_triggers(hass, device_registry, event: EventTestData, expected):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    event: EventTestData,
+    expected,
+) -> None:
     """Test we get the expected triggers from a rfxtrx."""
     await setup_entry(hass, {event.code: {}})
 
@@ -109,7 +115,9 @@ async def test_get_triggers(hass, device_registry, event: EventTestData, expecte
         EVENT_FIREALARM_1,
     ],
 )
-async def test_firing_event(hass, device_registry: dr.DeviceRegistry, rfxtrx, event):
+async def test_firing_event(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, rfxtrx, event
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
 
     await setup_entry(hass, {event.code: {"fire_event": True}})
@@ -148,7 +156,11 @@ async def test_firing_event(hass, device_registry: dr.DeviceRegistry, rfxtrx, ev
     assert calls[0].data["some"] == "device"
 
 
-async def test_invalid_trigger(hass, device_registry: dr.DeviceRegistry, caplog):
+async def test_invalid_trigger(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test for invalid actions."""
     event = EVENT_LIGHTING_1
 

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -19,7 +19,7 @@ from tests.typing import WebSocketGenerator
 SOME_PROTOCOLS = ["ac", "arc"]
 
 
-async def test_fire_event(hass, rfxtrx):
+async def test_fire_event(hass: HomeAssistant, rfxtrx) -> None:
     """Test fire event."""
     await setup_rfx_test_cfg(
         hass,
@@ -78,7 +78,7 @@ async def test_fire_event(hass, rfxtrx):
     ]
 
 
-async def test_send(hass, rfxtrx):
+async def test_send(hass: HomeAssistant, rfxtrx) -> None:
     """Test configuration."""
     await setup_rfx_test_cfg(hass, device="/dev/null", devices={})
 

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -6,14 +6,14 @@ import pytest
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import create_rfx_test_cfg
 
 from tests.common import MockConfigEntry, mock_restore_cache
 
 
-async def test_one_light(hass, rfxtrx):
+async def test_one_light(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 light."""
     entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210020f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -92,7 +92,7 @@ async def test_one_light(hass, rfxtrx):
 @pytest.mark.parametrize(
     ("state", "brightness"), [["on", 100], ["on", 50], ["off", None]]
 )
-async def test_state_restore(hass, rfxtrx, state, brightness):
+async def test_state_restore(hass: HomeAssistant, rfxtrx, state, brightness) -> None:
     """State restoration."""
 
     entity_id = "light.ac_213c7f2_16"
@@ -113,7 +113,7 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
     assert hass.states.get(entity_id).attributes.get(ATTR_BRIGHTNESS) == brightness
 
 
-async def test_several_lights(hass, rfxtrx):
+async def test_several_lights(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 lights."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -162,7 +162,7 @@ async def test_several_lights(hass, rfxtrx):
     assert state.attributes.get("brightness") == 255
 
 
-async def test_discover_light(hass, rfxtrx_automatic):
+async def test_discover_light(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery of lights."""
     rfxtrx = rfxtrx_automatic
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -9,14 +9,14 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import create_rfx_test_cfg
 
 from tests.common import MockConfigEntry, mock_restore_cache
 
 
-async def test_default_config(hass, rfxtrx):
+async def test_default_config(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 0 sensor."""
     entry_data = create_rfx_test_cfg(devices={})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -29,7 +29,7 @@ async def test_default_config(hass, rfxtrx):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_one_sensor(hass, rfxtrx):
+async def test_one_sensor(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
     entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -53,7 +53,7 @@ async def test_one_sensor(hass, rfxtrx):
     ("state", "event"),
     [["18.4", "0a520801070100b81b0279"], ["17.9", "0a52085e070100b31b0279"]],
 )
-async def test_state_restore(hass, rfxtrx, state, event):
+async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
     """State restoration."""
 
     entity_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_07_01_temperature"
@@ -71,7 +71,7 @@ async def test_state_restore(hass, rfxtrx, state, event):
     assert hass.states.get(entity_id).state == state
 
 
-async def test_one_sensor_no_datatype(hass, rfxtrx):
+async def test_one_sensor_no_datatype(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
     entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -118,7 +118,7 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
 
-async def test_several_sensors(hass, rfxtrx):
+async def test_several_sensors(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 sensors."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -162,7 +162,7 @@ async def test_several_sensors(hass, rfxtrx):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
 
-async def test_discover_sensor(hass, rfxtrx_automatic):
+async def test_discover_sensor(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery of sensor."""
     rfxtrx = rfxtrx_automatic
 
@@ -265,7 +265,7 @@ async def test_discover_sensor(hass, rfxtrx_automatic):
     assert len(hass.states.async_all()) == 10
 
 
-async def test_update_of_sensors(hass, rfxtrx):
+async def test_update_of_sensors(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 sensors."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -309,7 +309,7 @@ async def test_update_of_sensors(hass, rfxtrx):
     assert state.state == "15"
 
 
-async def test_rssi_sensor(hass, rfxtrx):
+async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
     entry_data = create_rfx_test_cfg(
         devices={

--- a/tests/components/rfxtrx/test_siren.py
+++ b/tests/components/rfxtrx/test_siren.py
@@ -2,13 +2,14 @@
 from unittest.mock import call
 
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from .conftest import create_rfx_test_cfg
 
 from tests.common import MockConfigEntry
 
 
-async def test_one_chime(hass, rfxtrx, timestep):
+async def test_one_chime(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with 1 entity."""
     entry_data = create_rfx_test_cfg(
         devices={"0a16000000000000000000": {"off_delay": 2.0}}
@@ -64,7 +65,7 @@ async def test_one_chime(hass, rfxtrx, timestep):
     ]
 
 
-async def test_one_security1(hass, rfxtrx, timestep):
+async def test_one_security1(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with 1 entity."""
     entry_data = create_rfx_test_cfg(devices={"08200300a109000670": {"off_delay": 2.0}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -119,7 +120,7 @@ async def test_one_security1(hass, rfxtrx, timestep):
     ]
 
 
-async def test_discover_siren(hass, rfxtrx_automatic):
+async def test_discover_siren(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery."""
     rfxtrx = rfxtrx_automatic
 

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import create_rfx_test_cfg
 
@@ -16,7 +16,7 @@ EVENT_RFY_ENABLE_SUN_AUTO = "0C1a0000030101011300000003"
 EVENT_RFY_DISABLE_SUN_AUTO = "0C1a0000030101011400000003"
 
 
-async def test_one_switch(hass, rfxtrx):
+async def test_one_switch(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 switch."""
     entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -51,7 +51,7 @@ async def test_one_switch(hass, rfxtrx):
     ]
 
 
-async def test_one_pt2262_switch(hass, rfxtrx):
+async def test_one_pt2262_switch(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 switch."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -95,7 +95,7 @@ async def test_one_pt2262_switch(hass, rfxtrx):
 
 
 @pytest.mark.parametrize("state", ["on", "off"])
-async def test_state_restore(hass, rfxtrx, state):
+async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
     """State restoration."""
 
     entity_id = "switch.ac_213c7f2_16"
@@ -113,7 +113,7 @@ async def test_state_restore(hass, rfxtrx, state):
     assert hass.states.get(entity_id).state == state
 
 
-async def test_several_switches(hass, rfxtrx):
+async def test_several_switches(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 switches."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -145,7 +145,7 @@ async def test_several_switches(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
 
-async def test_switch_events(hass, rfxtrx):
+async def test_switch_events(hass: HomeAssistant, rfxtrx) -> None:
     """Event test with 2 switches."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -201,7 +201,7 @@ async def test_switch_events(hass, rfxtrx):
     assert hass.states.get("switch.ac_213c7f2_16").state == "off"
 
 
-async def test_pt2262_switch_events(hass, rfxtrx):
+async def test_pt2262_switch_events(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 switch."""
     entry_data = create_rfx_test_cfg(
         devices={
@@ -241,7 +241,7 @@ async def test_pt2262_switch_events(hass, rfxtrx):
     assert hass.states.get("switch.pt2262_22670e").state == "off"
 
 
-async def test_discover_switch(hass, rfxtrx_automatic):
+async def test_discover_switch(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery of switches."""
     rfxtrx = rfxtrx_automatic
 
@@ -256,7 +256,7 @@ async def test_discover_switch(hass, rfxtrx_automatic):
     assert state.state == "on"
 
 
-async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
+async def test_discover_rfy_sun_switch(hass: HomeAssistant, rfxtrx_automatic) -> None:
     """Test with discovery of switches."""
     rfxtrx = rfxtrx_automatic
 
@@ -271,7 +271,7 @@ async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
     assert state.state == "on"
 
 
-async def test_unknown_event_code(hass, rfxtrx):
+async def test_unknown_event_code(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 switches."""
     entry_data = create_rfx_test_cfg(devices={"1234567890": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.ridwell.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import TEST_PASSWORD, TEST_USERNAME
@@ -19,7 +20,9 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
         (AsyncMock(side_effect=RidwellError), {"base": "unknown"}),
     ],
 )
-async def test_create_entry(hass, config, errors, get_client_response, mock_aioridwell):
+async def test_create_entry(
+    hass: HomeAssistant, config, errors, get_client_response, mock_aioridwell
+) -> None:
     """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -51,7 +54,7 @@ async def test_create_entry(hass, config, errors, get_client_response, mock_aior
     }
 
 
-async def test_duplicate_error(hass, config, setup_config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry) -> None:
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config
@@ -60,7 +63,9 @@ async def test_duplicate_error(hass, config, setup_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_step_reauth(hass, config, config_entry, setup_config_entry) -> None:
+async def test_step_reauth(
+    hass: HomeAssistant, config, config_entry, setup_config_entry
+) -> None:
     """Test a full reauth flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=config

--- a/tests/components/ridwell/test_diagnostics.py
+++ b/tests/components/ridwell/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test Ridwell diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/ring/test_binary_sensor.py
+++ b/tests/components/ring/test_binary_sensor.py
@@ -2,10 +2,16 @@
 from time import time
 from unittest.mock import patch
 
+import requests_mock
+
+from homeassistant.core import HomeAssistant
+
 from .common import setup_platform
 
 
-async def test_binary_sensor(hass, requests_mock):
+async def test_binary_sensor(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test the Ring binary sensors."""
     with patch(
         "ring_doorbell.Ring.active_alerts",

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -1,7 +1,10 @@
 """The tests for the Ring component."""
 from datetime import timedelta
 
+import requests_mock
+
 import homeassistant.components.ring as ring
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
@@ -13,7 +16,7 @@ VALID_CONFIG = {
 }
 
 
-async def test_setup(hass, requests_mock):
+async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test the setup."""
     await async_setup_component(hass, ring.DOMAIN, {})
 

--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -1,5 +1,8 @@
 """The tests for the Ring light platform."""
+import requests_mock
+
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
@@ -7,7 +10,9 @@ from .common import setup_platform
 from tests.common import load_fixture
 
 
-async def test_entity_registry(hass, requests_mock):
+async def test_entity_registry(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, Platform.LIGHT)
     entity_registry = er.async_get(hass)
@@ -19,7 +24,9 @@ async def test_entity_registry(hass, requests_mock):
     assert entry.unique_id == 345678
 
 
-async def test_light_off_reports_correctly(hass, requests_mock):
+async def test_light_off_reports_correctly(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the initial state of a device that should be off is correct."""
     await setup_platform(hass, Platform.LIGHT)
 
@@ -28,7 +35,9 @@ async def test_light_off_reports_correctly(hass, requests_mock):
     assert state.attributes.get("friendly_name") == "Front light"
 
 
-async def test_light_on_reports_correctly(hass, requests_mock):
+async def test_light_on_reports_correctly(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the initial state of a device that should be on is correct."""
     await setup_platform(hass, Platform.LIGHT)
 
@@ -37,7 +46,9 @@ async def test_light_on_reports_correctly(hass, requests_mock):
     assert state.attributes.get("friendly_name") == "Internal light"
 
 
-async def test_light_can_be_turned_on(hass, requests_mock):
+async def test_light_can_be_turned_on(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the light turns on correctly."""
     await setup_platform(hass, Platform.LIGHT)
 
@@ -59,7 +70,9 @@ async def test_light_can_be_turned_on(hass, requests_mock):
     assert state.state == "on"
 
 
-async def test_updates_work(hass, requests_mock):
+async def test_updates_work(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the update service works correctly."""
     await setup_platform(hass, Platform.LIGHT)
     state = hass.states.get("light.front_light")

--- a/tests/components/ring/test_sensor.py
+++ b/tests/components/ring/test_sensor.py
@@ -1,10 +1,14 @@
 """The tests for the Ring sensor platform."""
+import requests_mock
+
+from homeassistant.core import HomeAssistant
+
 from .common import setup_platform
 
 WIFI_ENABLED = False
 
 
-async def test_sensor(hass, requests_mock):
+async def test_sensor(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test the Ring sensors."""
     await setup_platform(hass, "sensor")
 

--- a/tests/components/ring/test_siren.py
+++ b/tests/components/ring/test_siren.py
@@ -1,12 +1,16 @@
 """The tests for the Ring button platform."""
+import requests_mock
 
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
 
-async def test_entity_registry(hass, requests_mock):
+async def test_entity_registry(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, Platform.SIREN)
     entity_registry = er.async_get(hass)
@@ -15,7 +19,9 @@ async def test_entity_registry(hass, requests_mock):
     assert entry.unique_id == "123456-siren"
 
 
-async def test_sirens_report_correctly(hass, requests_mock):
+async def test_sirens_report_correctly(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the initial state of a device that should be on is correct."""
     await setup_platform(hass, Platform.SIREN)
 
@@ -24,7 +30,9 @@ async def test_sirens_report_correctly(hass, requests_mock):
     assert state.state == "unknown"
 
 
-async def test_default_ding_chime_can_be_played(hass, requests_mock):
+async def test_default_ding_chime_can_be_played(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the play chime request is sent correctly."""
     await setup_platform(hass, Platform.SIREN)
 
@@ -51,7 +59,9 @@ async def test_default_ding_chime_can_be_played(hass, requests_mock):
     assert state.state == "unknown"
 
 
-async def test_toggle_plays_default_chime(hass, requests_mock):
+async def test_toggle_plays_default_chime(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the play chime request is sent correctly when toggled."""
     await setup_platform(hass, Platform.SIREN)
 
@@ -78,7 +88,9 @@ async def test_toggle_plays_default_chime(hass, requests_mock):
     assert state.state == "unknown"
 
 
-async def test_explicit_ding_chime_can_be_played(hass, requests_mock):
+async def test_explicit_ding_chime_can_be_played(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the play chime request is sent correctly."""
     await setup_platform(hass, Platform.SIREN)
 
@@ -105,7 +117,9 @@ async def test_explicit_ding_chime_can_be_played(hass, requests_mock):
     assert state.state == "unknown"
 
 
-async def test_motion_chime_can_be_played(hass, requests_mock):
+async def test_motion_chime_can_be_played(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the play chime request is sent correctly."""
     await setup_platform(hass, Platform.SIREN)
 

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,5 +1,8 @@
 """The tests for the Ring switch platform."""
+import requests_mock
+
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
@@ -7,7 +10,9 @@ from .common import setup_platform
 from tests.common import load_fixture
 
 
-async def test_entity_registry(hass, requests_mock):
+async def test_entity_registry(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, Platform.SWITCH)
     entity_registry = er.async_get(hass)
@@ -19,7 +24,9 @@ async def test_entity_registry(hass, requests_mock):
     assert entry.unique_id == "345678-siren"
 
 
-async def test_siren_off_reports_correctly(hass, requests_mock):
+async def test_siren_off_reports_correctly(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the initial state of a device that should be off is correct."""
     await setup_platform(hass, Platform.SWITCH)
 
@@ -28,7 +35,9 @@ async def test_siren_off_reports_correctly(hass, requests_mock):
     assert state.attributes.get("friendly_name") == "Front siren"
 
 
-async def test_siren_on_reports_correctly(hass, requests_mock):
+async def test_siren_on_reports_correctly(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the initial state of a device that should be on is correct."""
     await setup_platform(hass, Platform.SWITCH)
 
@@ -38,7 +47,9 @@ async def test_siren_on_reports_correctly(hass, requests_mock):
     assert state.attributes.get("icon") == "mdi:alarm-bell"
 
 
-async def test_siren_can_be_turned_on(hass, requests_mock):
+async def test_siren_can_be_turned_on(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the siren turns on correctly."""
     await setup_platform(hass, Platform.SWITCH)
 
@@ -60,7 +71,9 @@ async def test_siren_can_be_turned_on(hass, requests_mock):
     assert state.state == "on"
 
 
-async def test_updates_work(hass, requests_mock):
+async def test_updates_work(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the update service works correctly."""
     await setup_platform(hass, Platform.SWITCH)
     state = hass.states.get("switch.front_siren")

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
@@ -128,7 +129,9 @@ def two_part_local_alarm():
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_login(hass, login_with_error, cloud_config_entry):
+async def test_error_on_login(
+    hass: HomeAssistant, login_with_error, cloud_config_entry
+) -> None:
     """Test error on login."""
     await hass.config_entries.async_setup(cloud_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -137,7 +140,9 @@ async def test_error_on_login(hass, login_with_error, cloud_config_entry):
     assert not registry.async_is_registered(SECOND_CLOUD_ENTITY_ID)
 
 
-async def test_cloud_setup(hass, two_part_cloud_alarm, setup_risco_cloud):
+async def test_cloud_setup(
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_CLOUD_ENTITY_ID)
@@ -164,7 +169,9 @@ async def _check_cloud_state(
 
 
 @pytest.mark.parametrize("options", [CUSTOM_MAPPING_OPTIONS])
-async def test_cloud_states(hass, two_part_cloud_alarm, setup_risco_cloud):
+async def test_cloud_states(
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test the various alarm states."""
     assert hass.states.get(FIRST_CLOUD_ENTITY_ID).state == STATE_UNKNOWN
     for partition_id, entity_id in {
@@ -253,7 +260,9 @@ async def _test_cloud_no_service_call(
 
 
 @pytest.mark.parametrize("options", [CUSTOM_MAPPING_OPTIONS])
-async def test_cloud_sets_custom_mapping(hass, two_part_cloud_alarm, setup_risco_cloud):
+async def test_cloud_sets_custom_mapping(
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test settings the various modes when mapping some states."""
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_CLOUD_ENTITY_ID)
@@ -287,8 +296,8 @@ async def test_cloud_sets_custom_mapping(hass, two_part_cloud_alarm, setup_risco
 
 @pytest.mark.parametrize("options", [FULL_CUSTOM_MAPPING])
 async def test_cloud_sets_full_custom_mapping(
-    hass, two_part_cloud_alarm, setup_risco_cloud
-):
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test settings the various modes when mapping all states."""
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_CLOUD_ENTITY_ID)
@@ -343,8 +352,8 @@ async def test_cloud_sets_full_custom_mapping(
     "options", [{**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS}]
 )
 async def test_cloud_sets_with_correct_code(
-    hass, two_part_cloud_alarm, setup_risco_cloud
-):
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test settings the various modes when code is required."""
     code = {"code": 1234}
     await _test_cloud_service_call(
@@ -407,8 +416,8 @@ async def test_cloud_sets_with_correct_code(
     "options", [{**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS}]
 )
 async def test_cloud_sets_with_incorrect_code(
-    hass, two_part_cloud_alarm, setup_risco_cloud
-):
+    hass: HomeAssistant, two_part_cloud_alarm, setup_risco_cloud
+) -> None:
     """Test settings the various modes when code is required and incorrect."""
     code = {"code": 4321}
     await _test_cloud_no_service_call(
@@ -456,7 +465,9 @@ async def test_cloud_sets_with_incorrect_code(
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_connect(hass, connect_with_error, local_config_entry):
+async def test_error_on_connect(
+    hass: HomeAssistant, connect_with_error, local_config_entry
+) -> None:
     """Test error on connect."""
     await hass.config_entries.async_setup(local_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -465,7 +476,9 @@ async def test_error_on_connect(hass, connect_with_error, local_config_entry):
     assert not registry.async_is_registered(SECOND_LOCAL_ENTITY_ID)
 
 
-async def test_local_setup(hass, two_part_local_alarm, setup_risco_local):
+async def test_local_setup(
+    hass: HomeAssistant, two_part_local_alarm, setup_risco_local
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_LOCAL_ENTITY_ID)
@@ -503,8 +516,11 @@ def _mock_partition_handler():
 
 @pytest.mark.parametrize("options", [CUSTOM_MAPPING_OPTIONS])
 async def test_local_states(
-    hass, two_part_local_alarm, _mock_partition_handler, setup_risco_local
-):
+    hass: HomeAssistant,
+    two_part_local_alarm,
+    _mock_partition_handler,
+    setup_risco_local,
+) -> None:
     """Test the various alarm states."""
     callback = _mock_partition_handler.call_args.args[0]
 
@@ -595,7 +611,9 @@ async def _test_local_no_service_call(
 
 
 @pytest.mark.parametrize("options", [CUSTOM_MAPPING_OPTIONS])
-async def test_local_sets_custom_mapping(hass, two_part_local_alarm, setup_risco_local):
+async def test_local_sets_custom_mapping(
+    hass: HomeAssistant, two_part_local_alarm, setup_risco_local
+) -> None:
     """Test settings the various modes when mapping some states."""
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_LOCAL_ENTITY_ID)
@@ -663,8 +681,8 @@ async def test_local_sets_custom_mapping(hass, two_part_local_alarm, setup_risco
 
 @pytest.mark.parametrize("options", [FULL_CUSTOM_MAPPING])
 async def test_local_sets_full_custom_mapping(
-    hass, two_part_local_alarm, setup_risco_local
-):
+    hass: HomeAssistant, two_part_local_alarm, setup_risco_local
+) -> None:
     """Test settings the various modes when mapping all states."""
     registry = er.async_get(hass)
     entity = registry.async_get(FIRST_LOCAL_ENTITY_ID)
@@ -753,8 +771,8 @@ async def test_local_sets_full_custom_mapping(
     "options", [{**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS}]
 )
 async def test_local_sets_with_correct_code(
-    hass, two_part_local_alarm, setup_risco_local
-):
+    hass: HomeAssistant, two_part_local_alarm, setup_risco_local
+) -> None:
     """Test settings the various modes when code is required."""
     code = {"code": 1234}
     await _test_local_service_call(
@@ -847,8 +865,8 @@ async def test_local_sets_with_correct_code(
     "options", [{**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS}]
 )
 async def test_local_sets_with_incorrect_code(
-    hass, two_part_local_alarm, setup_risco_local
-):
+    hass: HomeAssistant, two_part_local_alarm, setup_risco_local
+) -> None:
     """Test settings the various modes when code is required and incorrect."""
     code = {"code": 4321}
     await _test_local_no_service_call(

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.risco import CannotConnectError, UnauthorizedError
 from homeassistant.components.risco.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -20,7 +21,9 @@ SECOND_ARMED_ENTITY_ID = SECOND_ENTITY_ID + "_armed"
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_login(hass, login_with_error, cloud_config_entry):
+async def test_error_on_login(
+    hass: HomeAssistant, login_with_error, cloud_config_entry
+) -> None:
     """Test error on login."""
     await hass.config_entries.async_setup(cloud_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -29,7 +32,9 @@ async def test_error_on_login(hass, login_with_error, cloud_config_entry):
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
-async def test_cloud_setup(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_setup(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_ENTITY_ID)
@@ -59,7 +64,9 @@ async def _check_cloud_state(hass, zones, triggered, entity_id, zone_id):
         assert hass.states.get(entity_id).attributes["zone_id"] == zone_id
 
 
-async def test_cloud_states(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_states(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test the various alarm states."""
     await _check_cloud_state(hass, two_zone_cloud, True, FIRST_ENTITY_ID, 0)
     await _check_cloud_state(hass, two_zone_cloud, False, FIRST_ENTITY_ID, 0)
@@ -68,7 +75,9 @@ async def test_cloud_states(hass, two_zone_cloud, setup_risco_cloud):
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_connect(hass, connect_with_error, local_config_entry):
+async def test_error_on_connect(
+    hass: HomeAssistant, connect_with_error, local_config_entry
+) -> None:
     """Test error on connect."""
     await hass.config_entries.async_setup(local_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -79,7 +88,9 @@ async def test_error_on_connect(hass, connect_with_error, local_config_entry):
     assert not registry.async_is_registered(SECOND_ALARMED_ENTITY_ID)
 
 
-async def test_local_setup(hass, two_zone_local, setup_risco_local):
+async def test_local_setup(
+    hass: HomeAssistant, two_zone_local, setup_risco_local
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_ENTITY_ID)
@@ -120,8 +131,8 @@ def _mock_zone_handler():
 
 
 async def test_local_states(
-    hass, two_zone_local, _mock_zone_handler, setup_risco_local
-):
+    hass: HomeAssistant, two_zone_local, _mock_zone_handler, setup_risco_local
+) -> None:
     """Test the various zone states."""
     callback = _mock_zone_handler.call_args.args[0]
 
@@ -142,8 +153,8 @@ async def test_local_states(
 
 
 async def test_alarmed_local_states(
-    hass, two_zone_local, _mock_zone_handler, setup_risco_local
-):
+    hass: HomeAssistant, two_zone_local, _mock_zone_handler, setup_risco_local
+) -> None:
     """Test the various zone alarmed states."""
     callback = _mock_zone_handler.call_args.args[0]
 
@@ -164,8 +175,8 @@ async def test_alarmed_local_states(
 
 
 async def test_armed_local_states(
-    hass, two_zone_local, _mock_zone_handler, setup_risco_local
-):
+    hass: HomeAssistant, two_zone_local, _mock_zone_handler, setup_risco_local
+) -> None:
     """Test the various zone armed states."""
     callback = _mock_zone_handler.call_args.args[0]
 

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_cloud_form(hass: HomeAssistant) -> None:
         (Exception, "unknown"),
     ],
 )
-async def test_cloud_error(hass, login_with_error, error):
+async def test_cloud_error(hass: HomeAssistant, login_with_error, error) -> None:
     """Test we handle config flow errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -144,7 +144,7 @@ async def test_form_cloud_already_exists(hass: HomeAssistant) -> None:
     assert result3["reason"] == "already_configured"
 
 
-async def test_form_reauth(hass, cloud_config_entry):
+async def test_form_reauth(hass: HomeAssistant, cloud_config_entry) -> None:
     """Test reauthenticate."""
 
     result = await hass.config_entries.flow.async_init(
@@ -178,7 +178,9 @@ async def test_form_reauth(hass, cloud_config_entry):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_reauth_with_new_username(hass, cloud_config_entry):
+async def test_form_reauth_with_new_username(
+    hass: HomeAssistant, cloud_config_entry
+) -> None:
     """Test reauthenticate with new username."""
 
     result = await hass.config_entries.flow.async_init(
@@ -260,7 +262,7 @@ async def test_local_form(hass: HomeAssistant) -> None:
         (Exception, "unknown"),
     ],
 )
-async def test_local_error(hass, connect_with_error, error):
+async def test_local_error(hass: HomeAssistant, connect_with_error, error) -> None:
     """Test we handle config flow errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.risco import (
     CannotConnectError,
     UnauthorizedError,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -120,7 +121,9 @@ def _no_zones_and_partitions():
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_login(hass, login_with_error, cloud_config_entry):
+async def test_error_on_login(
+    hass: HomeAssistant, login_with_error, cloud_config_entry
+) -> None:
     """Test error on login."""
     await hass.config_entries.async_setup(cloud_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -168,8 +171,12 @@ def _save_mock():
 
 @pytest.mark.parametrize("events", [TEST_EVENTS])
 async def test_cloud_setup(
-    hass, two_zone_cloud, _set_utc_time_zone, _save_mock, setup_risco_cloud
-):
+    hass: HomeAssistant,
+    two_zone_cloud,
+    _set_utc_time_zone,
+    _save_mock,
+    setup_risco_cloud,
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     for id in ENTITY_IDS.values():
@@ -193,7 +200,9 @@ async def test_cloud_setup(
         _check_state(hass, category, entity_id)
 
 
-async def test_local_setup(hass, setup_risco_local, _no_zones_and_partitions):
+async def test_local_setup(
+    hass: HomeAssistant, setup_risco_local, _no_zones_and_partitions
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     for id in ENTITY_IDS.values():

--- a/tests/components/risco/test_switch.py
+++ b/tests/components/risco/test_switch.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.risco import CannotConnectError, UnauthorizedError
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -14,7 +15,9 @@ SECOND_ENTITY_ID = "switch.zone_1_bypassed"
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_login(hass, login_with_error, cloud_config_entry):
+async def test_error_on_login(
+    hass: HomeAssistant, login_with_error, cloud_config_entry
+) -> None:
     """Test error on login."""
     await hass.config_entries.async_setup(cloud_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -23,7 +26,9 @@ async def test_error_on_login(hass, login_with_error, cloud_config_entry):
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
-async def test_cloud_setup(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_setup(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_ENTITY_ID)
@@ -44,7 +49,9 @@ async def _check_cloud_state(hass, zones, bypassed, entity_id, zone_id):
         assert hass.states.get(entity_id).attributes["zone_id"] == zone_id
 
 
-async def test_cloud_states(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_states(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test the various alarm states."""
     await _check_cloud_state(hass, two_zone_cloud, True, FIRST_ENTITY_ID, 0)
     await _check_cloud_state(hass, two_zone_cloud, False, FIRST_ENTITY_ID, 0)
@@ -52,7 +59,9 @@ async def test_cloud_states(hass, two_zone_cloud, setup_risco_cloud):
     await _check_cloud_state(hass, two_zone_cloud, False, SECOND_ENTITY_ID, 1)
 
 
-async def test_cloud_bypass(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_bypass(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test bypassing a zone."""
     with patch("homeassistant.components.risco.RiscoCloud.bypass_zone") as mock:
         data = {"entity_id": FIRST_ENTITY_ID}
@@ -64,7 +73,9 @@ async def test_cloud_bypass(hass, two_zone_cloud, setup_risco_cloud):
         mock.assert_awaited_once_with(0, True)
 
 
-async def test_cloud_unbypass(hass, two_zone_cloud, setup_risco_cloud):
+async def test_cloud_unbypass(
+    hass: HomeAssistant, two_zone_cloud, setup_risco_cloud
+) -> None:
     """Test unbypassing a zone."""
     with patch("homeassistant.components.risco.RiscoCloud.bypass_zone") as mock:
         data = {"entity_id": FIRST_ENTITY_ID}
@@ -77,7 +88,9 @@ async def test_cloud_unbypass(hass, two_zone_cloud, setup_risco_cloud):
 
 
 @pytest.mark.parametrize("exception", [CannotConnectError, UnauthorizedError])
-async def test_error_on_connect(hass, connect_with_error, local_config_entry):
+async def test_error_on_connect(
+    hass: HomeAssistant, connect_with_error, local_config_entry
+) -> None:
     """Test error on connect."""
     await hass.config_entries.async_setup(local_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -86,7 +99,9 @@ async def test_error_on_connect(hass, connect_with_error, local_config_entry):
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
-async def test_local_setup(hass, two_zone_local, setup_risco_local):
+async def test_local_setup(
+    hass: HomeAssistant, two_zone_local, setup_risco_local
+) -> None:
     """Test entity setup."""
     registry = er.async_get(hass)
     assert registry.async_is_registered(FIRST_ENTITY_ID)
@@ -114,8 +129,8 @@ def _mock_zone_handler():
 
 
 async def test_local_states(
-    hass, two_zone_local, _mock_zone_handler, setup_risco_local
-):
+    hass: HomeAssistant, two_zone_local, _mock_zone_handler, setup_risco_local
+) -> None:
     """Test the various alarm states."""
     callback = _mock_zone_handler.call_args.args[0]
 
@@ -127,7 +142,9 @@ async def test_local_states(
     await _check_local_state(hass, two_zone_local, False, SECOND_ENTITY_ID, 1, callback)
 
 
-async def test_local_bypass(hass, two_zone_local, setup_risco_local):
+async def test_local_bypass(
+    hass: HomeAssistant, two_zone_local, setup_risco_local
+) -> None:
     """Test bypassing a zone."""
     with patch.object(two_zone_local[0], "bypass") as mock:
         data = {"entity_id": FIRST_ENTITY_ID}
@@ -139,7 +156,9 @@ async def test_local_bypass(hass, two_zone_local, setup_risco_local):
         mock.assert_awaited_once_with(True)
 
 
-async def test_local_unbypass(hass, two_zone_local, setup_risco_local):
+async def test_local_unbypass(
+    hass: HomeAssistant, two_zone_local, setup_risco_local
+) -> None:
     """Test unbypassing a zone."""
     with patch.object(two_zone_local[0], "bypass") as mock:
         data = {"entity_id": FIRST_ENTITY_ID}

--- a/tests/components/rituals_perfume_genie/test_init.py
+++ b/tests/components/rituals_perfume_genie/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from .common import init_integration, mock_config_entry
 
 
-async def test_config_entry_not_ready(hass: HomeAssistant):
+async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Test the Rituals configuration entry setup if connection to Rituals is missing."""
     config_entry = mock_config_entry(unique_id="id_123_not_ready")
     config_entry.add_to_hass(hass)

--- a/tests/components/rituals_perfume_genie/test_number.py
+++ b/tests/components/rituals_perfume_genie/test_number.py
@@ -80,7 +80,7 @@ async def test_set_number_value(hass: HomeAssistant) -> None:
     assert state.state == "1"
 
 
-async def test_set_number_value_out_of_range(hass: HomeAssistant):
+async def test_set_number_value_out_of_range(hass: HomeAssistant) -> None:
     """Test setting the diffuser number entity value out of range."""
     config_entry = mock_config_entry(unique_id="number_set_value_out_of_range_test")
     diffuser = mock_diffuser(hublot="lot123", perfume_amount=2)
@@ -130,7 +130,7 @@ async def test_set_number_value_out_of_range(hass: HomeAssistant):
     assert state.state == "2"
 
 
-async def test_set_number_value_to_float(hass: HomeAssistant):
+async def test_set_number_value_to_float(hass: HomeAssistant) -> None:
     """Test setting the diffuser number entity value to a float."""
     config_entry = mock_config_entry(unique_id="number_set_value_to_float_test")
     diffuser = mock_diffuser(hublot="lot123", perfume_amount=3)

--- a/tests/components/roku/test_diagnostics.py
+++ b/tests/components/roku/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics for config entry."""
     diagnostics_data = json.loads(load_fixture("roku/roku3-diagnostics-data.json"))
 

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -62,6 +62,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 MAIN_ENTITY_ID = f"{MP_DOMAIN}.my_roku_3"
 TV_ENTITY_ID = f"{MP_DOMAIN}.58_onn_roku_tv"
@@ -709,11 +710,11 @@ async def test_tv_services(
 
 
 async def test_media_browse(
-    hass,
+    hass: HomeAssistant,
     init_integration,
     mock_roku,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test browsing media."""
     client = await hass_ws_client(hass)
 
@@ -769,11 +770,11 @@ async def test_media_browse(
 
 
 async def test_media_browse_internal(
-    hass,
+    hass: HomeAssistant,
     init_integration,
     mock_roku,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test browsing media with internal url."""
     await async_process_ha_core_config(
         hass,
@@ -821,11 +822,11 @@ async def test_media_browse_internal(
 
 
 async def test_media_browse_local_source(
-    hass,
+    hass: HomeAssistant,
     init_integration,
     mock_roku,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test browsing local media source."""
     local_media = hass.config.path("media")
     await async_process_ha_core_config(
@@ -943,11 +944,11 @@ async def test_media_browse_local_source(
 
 @pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_media_browse(
-    hass,
+    hass: HomeAssistant,
     init_integration,
     mock_roku,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test browsing media."""
     client = await hass_ws_client(hass)
 

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -323,8 +323,8 @@ async def test_form_user_discover_fails_aborts_already_configured(
 
 
 async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_connect(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test discovery skipped and we can auto fetch the password then we fail to connect."""
 
     with patch(
@@ -496,8 +496,8 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(
 
 
 async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_and_cannot_connect(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test discovery finds no devices and password fetch fails then we cannot connect."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -626,7 +626,9 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
 
 
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES)
-async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
+async def test_dhcp_discovery_and_roomba_discovery_finds(
+    hass: HomeAssistant, discovery_data
+) -> None:
     """Test we can process the discovery from dhcp and roomba discovery matches the device."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -679,7 +681,9 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
 
 
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
-async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
+async def test_dhcp_discovery_falls_back_to_manual(
+    hass: HomeAssistant, discovery_data
+) -> None:
     """Test we can process the discovery from dhcp but roomba discovery cannot find the specific device."""
 
     mocked_roomba = _create_mocked_roomba(
@@ -751,7 +755,9 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
 
 
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
-async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_data):
+async def test_dhcp_discovery_no_devices_falls_back_to_manual(
+    hass: HomeAssistant, discovery_data
+) -> None:
     """Test we can process the discovery from dhcp but roomba discovery cannot find any devices."""
 
     mocked_roomba = _create_mocked_roomba(

--- a/tests/components/rss_feed_template/test_init.py
+++ b/tests/components/rss_feed_template/test_init.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from defusedxml import ElementTree
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -29,13 +30,13 @@ def mock_http_client(event_loop, hass, hass_client):
     return loop.run_until_complete(hass_client())
 
 
-async def test_get_nonexistant_feed(mock_http_client):
+async def test_get_nonexistant_feed(mock_http_client) -> None:
     """Test if we can retrieve the correct rss feed."""
     resp = await mock_http_client.get("/api/rss_template/otherfeed")
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_get_rss_feed(mock_http_client, hass):
+async def test_get_rss_feed(mock_http_client, hass: HomeAssistant) -> None:
     """Test if we can retrieve the correct rss feed."""
     hass.states.async_set("test.test1", "a_state_1")
     hass.states.async_set("test.test2", "a_state_2")

--- a/tests/components/rtsp_to_webrtc/test_diagnostics.py
+++ b/tests/components/rtsp_to_webrtc/test_diagnostics.py
@@ -1,22 +1,24 @@
 """Test nest diagnostics."""
-
 from typing import Any
+
+from homeassistant.core import HomeAssistant
 
 from .conftest import ComponentSetup
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 THERMOSTAT_TYPE = "sdm.devices.types.THERMOSTAT"
 
 
 async def test_entry_diagnostics(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     config_entry: MockConfigEntry,
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
-):
+) -> None:
     """Test config entry diagnostics."""
     await setup_integration()
 

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(enable_bluetooth, hass: HomeAssistant):
+async def test_sensors(enable_bluetooth: None, hass: HomeAssistant) -> None:
     """Test the RuuviTag BLE sensors."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=RUUVITAG_SERVICE_INFO.address)
     entry.add_to_hass(hass)

--- a/tests/components/rympro/test_config_flow.py
+++ b/tests/components/rympro/test_config_flow.py
@@ -75,7 +75,7 @@ async def test_form(hass: HomeAssistant) -> None:
         (Exception, "unknown"),
     ],
 )
-async def test_login_error(hass, exception, error):
+async def test_login_error(hass: HomeAssistant, exception, error) -> None:
     """Test we handle config flow errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -121,7 +121,7 @@ async def test_login_error(hass, exception, error):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_already_exists(hass, _config_entry):
+async def test_form_already_exists(hass: HomeAssistant, _config_entry) -> None:
     """Test that a flow with an existing account aborts."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -147,7 +147,7 @@ async def test_form_already_exists(hass, _config_entry):
     assert result2["reason"] == "already_configured"
 
 
-async def test_form_reauth(hass, _config_entry):
+async def test_form_reauth(hass: HomeAssistant, _config_entry) -> None:
     """Test reauthentication."""
 
     result = await hass.config_entries.flow.async_init(
@@ -186,7 +186,7 @@ async def test_form_reauth(hass, _config_entry):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_reauth_with_new_account(hass, _config_entry):
+async def test_form_reauth_with_new_account(hass: HomeAssistant, _config_entry) -> None:
     """Test reauthentication with new account."""
 
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
