### PR TITLE
Adjust imports in rflink test_init

### DIFF
--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -25,6 +25,8 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     SERVICE_TURN_OFF,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 
@@ -76,7 +78,7 @@ async def mock_rflink(
     return event_callback, mock_create, protocol, disconnect_callback
 
 
-async def test_version_banner(hass, monkeypatch):
+async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
     """Test sending unknown commands doesn't cause issues."""
     # use sensor domain during testing main platform
     domain = "sensor"
@@ -101,7 +103,7 @@ async def test_version_banner(hass, monkeypatch):
     )
 
 
-async def test_send_no_wait(hass, monkeypatch):
+async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     """Test command sending without ack."""
     domain = "switch"
     config = {
@@ -125,7 +127,7 @@ async def test_send_no_wait(hass, monkeypatch):
     assert protocol.send_command.call_args_list[0][0][1] == "off"
 
 
-async def test_cover_send_no_wait(hass, monkeypatch):
+async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     """Test command sending to a cover device without ack."""
     domain = "cover"
     config = {
@@ -149,7 +151,7 @@ async def test_cover_send_no_wait(hass, monkeypatch):
     assert protocol.send_command.call_args_list[0][0][1] == "STOP"
 
 
-async def test_send_command(hass, monkeypatch):
+async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -167,7 +169,7 @@ async def test_send_command(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
 
 
-async def test_send_command_invalid_arguments(hass, monkeypatch):
+async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -200,7 +202,7 @@ async def test_send_command_invalid_arguments(hass, monkeypatch):
     assert not success, "send command should not succeed for unknown command"
 
 
-async def test_send_command_event_propagation(hass, monkeypatch):
+async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) -> None:
     """Test event propagation for send_command service."""
     domain = "light"
     config = {
@@ -242,7 +244,7 @@ async def test_send_command_event_propagation(hass, monkeypatch):
     assert hass.states.get(f"{domain}.test1").state == "off"
 
 
-async def test_reconnecting_after_disconnect(hass, monkeypatch):
+async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -> None:
     """An unexpected disconnect should cause a reconnect."""
     domain = "sensor"
     config = {
@@ -266,7 +268,7 @@ async def test_reconnecting_after_disconnect(hass, monkeypatch):
     assert mock_create.call_count == 2
 
 
-async def test_reconnecting_after_failure(hass, monkeypatch):
+async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> None:
     """A failure to reconnect should be retried."""
     domain = "sensor"
     config = {
@@ -293,7 +295,7 @@ async def test_reconnecting_after_failure(hass, monkeypatch):
     assert mock_create.call_count == 3
 
 
-async def test_error_when_not_connected(hass, monkeypatch):
+async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> None:
     """Sending command should error when not connected."""
     domain = "switch"
     config = {
@@ -323,7 +325,7 @@ async def test_error_when_not_connected(hass, monkeypatch):
     assert not success, "changing state should not succeed when disconnected"
 
 
-async def test_async_send_command_error(hass, monkeypatch):
+async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> None:
     """Sending command should error when protocol fails."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -344,7 +346,7 @@ async def test_async_send_command_error(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[0][0][1] == SERVICE_TURN_OFF
 
 
-async def test_race_condition(hass, monkeypatch):
+async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     """Test race condition for unknown components."""
     domain = "light"
     config = {"rflink": {"port": "/dev/ttyABC0"}, domain: {"platform": "rflink"}}
@@ -380,19 +382,17 @@ async def test_race_condition(hass, monkeypatch):
     assert new_sensor.state == "on"
 
 
-async def test_not_connected(hass, monkeypatch):
+async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
     """Test Error when sending commands to a disconnected device."""
-    import pytest
-
-    from homeassistant.core import HomeAssistantError
-
     test_device = RflinkCommand("DUMMY_DEVICE")
     RflinkCommand.set_rflink_protocol(None)
     with pytest.raises(HomeAssistantError):
         await test_device._async_handle_command("turn_on")
 
 
-async def test_keepalive(hass, monkeypatch, caplog):
+async def test_keepalive(
+    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Validate negative keepalive values."""
     keepalive_value = -3
     domain = RFLINK_DOMAIN
@@ -462,7 +462,9 @@ async def test3_keepalive(hass, monkeypatch, caplog):
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_default_keepalive(hass, monkeypatch, caplog):
+async def test_default_keepalive(
+    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Validate keepalive=0 value."""
     domain = RFLINK_DOMAIN
     config = {RFLINK_DOMAIN: {CONF_HOST: "10.10.0.1", CONF_PORT: 1234}}
@@ -479,7 +481,7 @@ async def test_default_keepalive(hass, monkeypatch, caplog):
     assert "TCP Keepalive IDLE timer was provided" not in caplog.text
 
 
-async def test_unique_id(hass, monkeypatch):
+async def test_unique_id(hass: HomeAssistant, monkeypatch) -> None:
     """Validate the device unique_id."""
 
     DOMAIN = "sensor"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I spotted this weird import whilst working on #88174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
