### PR TITLE
Fix aprs tests with python 3.11

### DIFF
--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -1,5 +1,6 @@
 """Test APRS device tracker."""
-from unittest.mock import Mock, patch
+from collections.abc import Generator
+from unittest.mock import MagicMock, Mock, patch
 
 import aprslib
 from aprslib import IS
@@ -18,7 +19,7 @@ TEST_PASSWORD = "testpass"
 
 
 @pytest.fixture(name="mock_ais")
-def mock_ais():
+def mock_ais() -> Generator[MagicMock, None, None]:
     """Mock aprslib."""
     with patch("aprslib.IS") as mock_ais:
         yield mock_ais
@@ -94,7 +95,7 @@ def test_gps_accuracy_invalid_float() -> None:
         pass
 
 
-def test_aprs_listener(mock_ais) -> None:
+def test_aprs_listener(mock_ais: MagicMock) -> None:
     """Test listener thread."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD
@@ -143,7 +144,7 @@ def test_aprs_listener_start_fail() -> None:
         assert listener.start_message == "Unable to connect."
 
 
-def test_aprs_listener_stop(mock_ais) -> None:
+def test_aprs_listener_stop(mock_ais: MagicMock) -> None:
     """Test listener thread stop."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD
@@ -168,7 +169,7 @@ def test_aprs_listener_stop(mock_ais) -> None:
     listener.ais.close.assert_called_with()
 
 
-def test_aprs_listener_rx_msg(mock_ais) -> None:
+def test_aprs_listener_rx_msg(mock_ais: MagicMock) -> None:
     """Test rx_msg."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD
@@ -204,7 +205,7 @@ def test_aprs_listener_rx_msg(mock_ais) -> None:
     )
 
 
-def test_aprs_listener_rx_msg_ambiguity(mock_ais) -> None:
+def test_aprs_listener_rx_msg_ambiguity(mock_ais: MagicMock) -> None:
     """Test rx_msg with posambiguity."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD
@@ -240,7 +241,7 @@ def test_aprs_listener_rx_msg_ambiguity(mock_ais) -> None:
     )
 
 
-def test_aprs_listener_rx_msg_ambiguity_invalid(mock_ais) -> None:
+def test_aprs_listener_rx_msg_ambiguity_invalid(mock_ais: MagicMock) -> None:
     """Test rx_msg with invalid posambiguity."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD
@@ -274,7 +275,7 @@ def test_aprs_listener_rx_msg_ambiguity_invalid(mock_ais) -> None:
     )
 
 
-def test_aprs_listener_rx_msg_no_position(mock_ais) -> None:
+def test_aprs_listener_rx_msg_no_position(mock_ais: MagicMock) -> None:
     """Test rx_msg with non-position report."""
     callsign = TEST_CALLSIGN
     password = TEST_PASSWORD

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 import aprslib
+from aprslib import IS
 import pytest
 
 import homeassistant.components.aprs.device_tracker as device_tracker
@@ -14,6 +15,13 @@ TEST_COORDS_NULL_ISLAND = (0, 0)
 TEST_FILTER = "testfilter"
 TEST_HOST = "testhost"
 TEST_PASSWORD = "testpass"
+
+
+@pytest.fixture(name="mock_ais")
+def mock_ais():
+    """Mock aprslib."""
+    with patch("aprslib.IS") as mock_ais:
+        yield mock_ais
 
 
 def test_make_filter() -> None:
@@ -86,35 +94,34 @@ def test_gps_accuracy_invalid_float() -> None:
         pass
 
 
-def test_aprs_listener() -> None:
+def test_aprs_listener(mock_ais) -> None:
     """Test listener thread."""
-    with patch("aprslib.IS") as mock_ais:
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        port = DEFAULT_PORT
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    port = DEFAULT_PORT
+    see = Mock()
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.run()
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.run()
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_success
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        mock_ais.assert_called_with(callsign, passwd=password, host=host, port=port)
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_success
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    mock_ais.assert_called_with(callsign, passwd=password, host=host, port=port)
 
 
 def test_aprs_listener_start_fail() -> None:
     """Test listener thread start failure."""
-    with patch(
-        "aprslib.IS.connect", side_effect=aprslib.ConnectionError("Unable to connect.")
+    with patch.object(
+        IS, "connect", side_effect=aprslib.ConnectionError("Unable to connect.")
     ):
         callsign = TEST_CALLSIGN
         password = TEST_PASSWORD
@@ -136,166 +143,161 @@ def test_aprs_listener_start_fail() -> None:
         assert listener.start_message == "Unable to connect."
 
 
-def test_aprs_listener_stop() -> None:
+def test_aprs_listener_stop(mock_ais) -> None:
     """Test listener thread stop."""
-    with patch("aprslib.IS"):
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    see = Mock()
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.ais.close = Mock()
-        listener.run()
-        listener.stop()
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.ais.close = Mock()
+    listener.run()
+    listener.stop()
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        assert listener.start_success
-        listener.ais.close.assert_called_with()
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    assert listener.start_success
+    listener.ais.close.assert_called_with()
 
 
-def test_aprs_listener_rx_msg() -> None:
+def test_aprs_listener_rx_msg(mock_ais) -> None:
     """Test rx_msg."""
-    with patch("aprslib.IS"):
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    see = Mock()
 
-        sample_msg = {
-            device_tracker.ATTR_FORMAT: "uncompressed",
-            device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
-            device_tracker.ATTR_LATITUDE: 0.0,
-            device_tracker.ATTR_LONGITUDE: 0.0,
-            device_tracker.ATTR_ALTITUDE: 0,
-        }
+    sample_msg = {
+        device_tracker.ATTR_FORMAT: "uncompressed",
+        device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
+        device_tracker.ATTR_LATITUDE: 0.0,
+        device_tracker.ATTR_LONGITUDE: 0.0,
+        device_tracker.ATTR_ALTITUDE: 0,
+    }
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.run()
-        listener.rx_msg(sample_msg)
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.run()
+    listener.rx_msg(sample_msg)
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_success
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        see.assert_called_with(
-            dev_id=device_tracker.slugify("ZZ0FOOBAR-1"),
-            gps=(0.0, 0.0),
-            attributes={"altitude": 0},
-        )
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_success
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    see.assert_called_with(
+        dev_id=device_tracker.slugify("ZZ0FOOBAR-1"),
+        gps=(0.0, 0.0),
+        attributes={"altitude": 0},
+    )
 
 
-def test_aprs_listener_rx_msg_ambiguity() -> None:
+def test_aprs_listener_rx_msg_ambiguity(mock_ais) -> None:
     """Test rx_msg with posambiguity."""
-    with patch("aprslib.IS"):
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    see = Mock()
 
-        sample_msg = {
-            device_tracker.ATTR_FORMAT: "uncompressed",
-            device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
-            device_tracker.ATTR_LATITUDE: 0.0,
-            device_tracker.ATTR_LONGITUDE: 0.0,
-            device_tracker.ATTR_POS_AMBIGUITY: 1,
-        }
+    sample_msg = {
+        device_tracker.ATTR_FORMAT: "uncompressed",
+        device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
+        device_tracker.ATTR_LATITUDE: 0.0,
+        device_tracker.ATTR_LONGITUDE: 0.0,
+        device_tracker.ATTR_POS_AMBIGUITY: 1,
+    }
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.run()
-        listener.rx_msg(sample_msg)
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.run()
+    listener.rx_msg(sample_msg)
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_success
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        see.assert_called_with(
-            dev_id=device_tracker.slugify("ZZ0FOOBAR-1"),
-            gps=(0.0, 0.0),
-            attributes={device_tracker.ATTR_GPS_ACCURACY: 186},
-        )
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_success
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    see.assert_called_with(
+        dev_id=device_tracker.slugify("ZZ0FOOBAR-1"),
+        gps=(0.0, 0.0),
+        attributes={device_tracker.ATTR_GPS_ACCURACY: 186},
+    )
 
 
-def test_aprs_listener_rx_msg_ambiguity_invalid() -> None:
+def test_aprs_listener_rx_msg_ambiguity_invalid(mock_ais) -> None:
     """Test rx_msg with invalid posambiguity."""
-    with patch("aprslib.IS"):
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    see = Mock()
 
-        sample_msg = {
-            device_tracker.ATTR_FORMAT: "uncompressed",
-            device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
-            device_tracker.ATTR_LATITUDE: 0.0,
-            device_tracker.ATTR_LONGITUDE: 0.0,
-            device_tracker.ATTR_POS_AMBIGUITY: 5,
-        }
+    sample_msg = {
+        device_tracker.ATTR_FORMAT: "uncompressed",
+        device_tracker.ATTR_FROM: "ZZ0FOOBAR-1",
+        device_tracker.ATTR_LATITUDE: 0.0,
+        device_tracker.ATTR_LONGITUDE: 0.0,
+        device_tracker.ATTR_POS_AMBIGUITY: 5,
+    }
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.run()
-        listener.rx_msg(sample_msg)
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.run()
+    listener.rx_msg(sample_msg)
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_success
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        see.assert_called_with(
-            dev_id=device_tracker.slugify("ZZ0FOOBAR-1"), gps=(0.0, 0.0), attributes={}
-        )
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_success
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    see.assert_called_with(
+        dev_id=device_tracker.slugify("ZZ0FOOBAR-1"), gps=(0.0, 0.0), attributes={}
+    )
 
 
-def test_aprs_listener_rx_msg_no_position() -> None:
+def test_aprs_listener_rx_msg_no_position(mock_ais) -> None:
     """Test rx_msg with non-position report."""
-    with patch("aprslib.IS"):
-        callsign = TEST_CALLSIGN
-        password = TEST_PASSWORD
-        host = TEST_HOST
-        server_filter = TEST_FILTER
-        see = Mock()
+    callsign = TEST_CALLSIGN
+    password = TEST_PASSWORD
+    host = TEST_HOST
+    server_filter = TEST_FILTER
+    see = Mock()
 
-        sample_msg = {device_tracker.ATTR_FORMAT: "invalid"}
+    sample_msg = {device_tracker.ATTR_FORMAT: "invalid"}
 
-        listener = device_tracker.AprsListenerThread(
-            callsign, password, host, server_filter, see
-        )
-        listener.run()
-        listener.rx_msg(sample_msg)
+    listener = device_tracker.AprsListenerThread(
+        callsign, password, host, server_filter, see
+    )
+    listener.run()
+    listener.rx_msg(sample_msg)
 
-        assert listener.callsign == callsign
-        assert listener.host == host
-        assert listener.server_filter == server_filter
-        assert listener.see == see
-        assert listener.start_event.is_set()
-        assert listener.start_success
-        assert listener.start_message == "Connected to testhost with callsign testcall."
-        see.assert_not_called()
+    assert listener.callsign == callsign
+    assert listener.host == host
+    assert listener.server_filter == server_filter
+    assert listener.see == see
+    assert listener.start_event.is_set()
+    assert listener.start_success
+    assert listener.start_message == "Connected to testhost with callsign testcall."
+    see.assert_not_called()
 
 
 async def test_setup_scanner(hass: HomeAssistant) -> None:
@@ -324,7 +326,7 @@ async def test_setup_scanner(hass: HomeAssistant) -> None:
 
 async def test_setup_scanner_timeout(hass: HomeAssistant) -> None:
     """Test setup_scanner failure from timeout."""
-    with patch("aprslib.IS.connect", side_effect=TimeoutError):
+    with patch.object(IS, "connect", side_effect=TimeoutError):
         config = {
             "username": TEST_CALLSIGN,
             "password": TEST_PASSWORD,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix aprs tests with python 3.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
