### PR TITLE
Add ZHA "consumer connected" binary sensor for Xiaomi EU plugs

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -203,3 +203,13 @@ class AqaraPetFeederErrorDetected(BinarySensor, id_suffix="error_detected"):
     SENSOR_ATTR = "error_detected"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PROBLEM
     _attr_name: str = "Error detected"
+
+
+@MULTI_MATCH(
+    channel_names="opple_cluster", models={"lumi.plug.mmeu01", "lumi.plug.maeu01"}
+)
+class XiaomiPlugConsumerConnected(BinarySensor, id_suffix="consumer_connected"):
+    """ZHA Xiaomi plug consumer connected binary sensor."""
+
+    SENSOR_ATTR = "consumer_connected"
+    _attr_name: str = "Consumer connected"

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -125,6 +125,7 @@ class OppleRemote(ZigbeeChannel):
         elif self.cluster.endpoint.model in ("lumi.plug.mmeu01", "lumi.plug.maeu01"):
             self.ZCL_INIT_ATTRS = {
                 "power_outage_memory": True,
+                "consumer_connected": True,
             }
         elif self.cluster.endpoint.model == "aqara.feeder.acn001":
             self.ZCL_INIT_ATTRS = {


### PR DESCRIPTION
### REQUIRES:
- zha-quirks bump with:
- https://github.com/zigpy/zha-device-handlers/pull/2198

## Proposed change
Adds a binary sensor entity for the "consumer connected" attribute of Xiaomi EU plugs.
The sensor turns on when a consumer is plugged in (even if the plug is turned off or the consumer isn't consuming any power).

It looks like attribute reporting is already set up out-of-the-box for the `consumer_connected` attribute.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/zigpy/zha-device-handlers/issues/2181
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
