### PR TITLE
Revert "Remove uamqp version constrain"

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -135,6 +135,9 @@ iso4217!=1.10.20220401
 # Pandas 1.4.4 has issues with wheels om armhf + Py3.10
 pandas==1.4.3
 
+# uamqp 1.6.1, has 1 failing test during built on armv7/armhf
+uamqp==1.6.0
+
 # Matplotlib 3.6.2 has issues building wheels on armhf/armv7
 # We need at least >=2.1.0 (tensorflow integration -> pycocotools)
 matplotlib==3.6.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -143,6 +143,9 @@ iso4217!=1.10.20220401
 # Pandas 1.4.4 has issues with wheels om armhf + Py3.10
 pandas==1.4.3
 
+# uamqp 1.6.1, has 1 failing test during built on armv7/armhf
+uamqp==1.6.0
+
 # Matplotlib 3.6.2 has issues building wheels on armhf/armv7
 # We need at least >=2.1.0 (tensorflow integration -> pycocotools)
 matplotlib==3.6.1


### PR DESCRIPTION
Reverts home-assistant/core#88176

Still causes issues in wheel building. I have no good idea of how to solve this.

At this point, it will break our build process, so for now this has to be reverted until a solution is found.

This will cause problems for the 3.11 upgrade in #88038

```
Collecting uamqp<2.0.0,>=1.5.1
  Downloading uamqp-1.6.4.tar.gz (4.4 MB)
  Installing build dependencies ... 25l- \ | / - \ | / - \ | / - \ | error
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> [70 lines of output]
      Looking in links: https://wheels.home-assistant.io/musllinux/
      Collecting setuptools>=42
        Downloading setuptools-67.3.1-py3-none-any.whl (1.1 MB)
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 8.1 MB/s eta 0:00:00
      Collecting wheel
        Downloading wheel-0.38.4-py3-none-any.whl (36 kB)
      Collecting Cython
        Downloading Cython-0.29.33-py2.py3-none-any.whl (987 kB)
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 987.3/987.3 kB 9.5 MB/s eta 0:00:00
      Collecting cmake
        Downloading cmake-3.25.2.tar.gz (33 kB)
        Installing build dependencies: started
        Installing build dependencies: finished with status 'done'
        Getting requirements to build wheel: started
        Getting requirements to build wheel: finished with status 'done'
        Preparing metadata (pyproject.toml): started
        Preparing metadata (pyproject.toml): finished with status 'done'
      Building wheels for collected packages: cmake
        Building wheel for cmake (pyproject.toml): started
        Building wheel for cmake (pyproject.toml): finished with status 'error'
        error: subprocess-exited-with-error
      
        × Building wheel for cmake (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [36 lines of output]
            Traceback (most recent call last):
              File "/usr/local/bin/cmake", line 5, in <module>
                from cmake import cmake
            ModuleNotFoundError: No module named 'cmake'
            Traceback (most recent call last):
              File "/tmp/pip-build-env-20hcrl2r/overlay/lib/python3.10/site-packages/skbuild/setuptools_wrap.py", line 621, in setup
                cmkr = cmaker.CMaker(cmake_executable)
              File "/tmp/pip-build-env-20hcrl2r/overlay/lib/python3.10/site-packages/skbuild/cmaker.py", line 151, in __init__
                self.cmake_version = get_cmake_version(self.cmake_executable)
              File "/tmp/pip-build-env-20hcrl2r/overlay/lib/python3.10/site-packages/skbuild/cmaker.py", line 106, in get_cmake_version
                raise SKBuildError(
      
      
                =============================DEBUG ASSISTANCE=============================
                If you are seeing a compilation error please try the following steps to
                successfully install cmake:
                1) Upgrade to the latest pip and try again. This will fix errors for most
                   users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
                2) If on Linux, with glibc < 2.12, you can set PIP_ONLY_BINARY=cmake in
                   order to retrieve the last manylinux1 compatible wheel.
                3) If on Linux, with glibc < 2.12, you can cap "cmake<3.23" in your
                   requirements in order to retrieve the last manylinux1 compatible wheel.
                4) Open an issue with the debug information that follows at
                   https://github.com/scikit-build/cmake-python-distributions/issues
      
                Python: 3.10.7
                platform: Linux-5.15.0-1031-azure-armv6l-with
                machine: armv6l
                bits: 32
                pip: n/a
                setuptools: 67.3.1
                scikit-build: 0.16.6
                PEP517_BUILD_BACKEND=setuptools.build_meta
                =============================DEBUG ASSISTANCE=============================
      
            Problem with the CMake installation, aborting build. CMake executable is /usr/local/bin/cmake
            [end of output]
      
        note: This error originates from a subprocess, and is likely not a problem with pip.
        ERROR: Failed building wheel for cmake
      Failed to build cmake
      ERROR: Could not build wheels for cmake, which is required to install pyproject.toml-based projects
```


https://github.com/home-assistant/core/actions/runs/4185379915
