### PR TITLE
Name the Yellow-internal radio and multi-PAN addon as ZHA serial ports

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.components import onboarding, usb, zeroconf
 from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.components.hassio import AddonError, AddonState
 from homeassistant.components.homeassistant_hardware import silabs_multiprotocol_addon
-from homeassistant.components.homeassistant_yellow import hardware
+from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
@@ -83,7 +83,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
 
     # Add useful info to the Yellow's serial port selection screen
     try:
-        hardware.async_info(hass)
+        yellow_hardware.async_info(hass)
     except HomeAssistantError:
         pass
     else:
@@ -96,7 +96,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
 
     try:
         addon_info = await addon_manager.async_get_addon_info()
-    except AddonError:
+    except (AddonError, KeyError):
         addon_info = None
 
     if addon_info is not None and addon_info.state != AddonState.NOT_INSTALLED:

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -88,7 +88,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
         pass
     else:
         yellow_radio = next(p for p in ports if p.device == "/dev/ttyAMA1")
-        yellow_radio.description = "Yellow Radio"
+        yellow_radio.description = "Yellow Zigbee module"
         yellow_radio.manufacturer = "Nabu Casa"
 
     # Present the multi-PAN addon as a setup option, if it's available
@@ -105,7 +105,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
             skip_link_detection=True,
         )
 
-        addon_port.description = "Multi-PAN Addon"
+        addon_port.description = "Multiprotocol add-on"
         addon_port.manufacturer = "Nabu Casa"
         ports.append(addon_port)
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 import serial.tools.list_ports
+from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 import zigpy.backups
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
@@ -14,9 +15,13 @@ from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 from homeassistant import config_entries
 from homeassistant.components import onboarding, usb, zeroconf
 from homeassistant.components.file_upload import process_uploaded_file
+from homeassistant.components.hassio import AddonError, AddonState
+from homeassistant.components.homeassistant_hardware import silabs_multiprotocol_addon
+from homeassistant.components.homeassistant_yellow import hardware
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import FileSelector, FileSelectorConfig
 from homeassistant.util import dt
 
@@ -72,6 +77,41 @@ def _format_backup_choice(
     return f"{dt.as_local(backup.backup_time).strftime('%c')} ({identifier})"
 
 
+async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
+    """List all serial ports, including the Yellow radio and the multi-PAN addon."""
+    ports = await hass.async_add_executor_job(serial.tools.list_ports.comports)
+
+    # Add useful info to the Yellow's serial port selection screen
+    try:
+        hardware.async_info(hass)
+    except HomeAssistantError:
+        pass
+    else:
+        yellow_radio = next(p for p in ports if p.device == "/dev/ttyAMA1")
+        yellow_radio.description = "Yellow Radio"
+        yellow_radio.manufacturer = "Nabu Casa"
+
+    # Present the multi-PAN addon as a setup option, if it's available
+    addon_manager = silabs_multiprotocol_addon.get_addon_manager(hass)
+
+    try:
+        addon_info = await addon_manager.async_get_addon_info()
+    except AddonError:
+        addon_info = None
+
+    if addon_info is not None and addon_info.state != AddonState.NOT_INSTALLED:
+        addon_port = ListPortInfo(
+            device=silabs_multiprotocol_addon.get_zigbee_socket(hass, addon_info),
+            skip_link_detection=True,
+        )
+
+        addon_port.description = "Multi-PAN Addon"
+        addon_port.manufacturer = "Nabu Casa"
+        ports.append(addon_port)
+
+    return ports
+
+
 class BaseZhaFlow(FlowHandler):
     """Mixin for common ZHA flow steps and forms."""
 
@@ -120,7 +160,7 @@ class BaseZhaFlow(FlowHandler):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Choose a serial port."""
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        ports = await list_serial_ports(self.hass)
         list_of_ports = [
             f"{p}, s/n: {p.serial_number or 'n/a'}"
             + (f" - {p.manufacturer}" if p.manufacturer else "")

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -162,7 +162,7 @@ class BaseZhaFlow(FlowHandler):
         """Choose a serial port."""
         ports = await list_serial_ports(self.hass)
         list_of_ports = [
-            f"{p}, s/n: {p.serial_number or 'n/a'}"
+            f"{p}{', s/n: ' + p.serial_number if p.serial_number else ''}"
             + (f" - {p.manufacturer}" if p.manufacturer else "")
             for p in ports
         ]
@@ -186,7 +186,7 @@ class BaseZhaFlow(FlowHandler):
                 return await self.async_step_manual_pick_radio_type()
 
             self._title = (
-                f"{port.description}, s/n: {port.serial_number or 'n/a'}"
+                f"{port.description}{', s/n: ' + port.serial_number if port.serial_number else ''}"
                 f" - {port.manufacturer}"
                 if port.manufacturer
                 else ""

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -1,7 +1,13 @@
 {
   "domain": "zha",
   "name": "Zigbee Home Automation",
-  "after_dependencies": ["onboarding", "usb", "zeroconf"],
+  "after_dependencies": [
+    "onboarding",
+    "usb",
+    "zeroconf",
+    "homeassistant_hardware",
+    "homeassistant_yellow"
+  ],
   "codeowners": ["@dmulcahey", "@adminiuga", "@puddly"],
   "config_flow": true,
   "dependencies": ["file_upload"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expose the Yellow-internal radio and multi-PAN addon (if installed) as named serial ports:

<img width="565" alt="image" src="https://user-images.githubusercontent.com/32534428/219156809-62f9824d-0bfa-4bbf-9bf4-08a7ec18c361.png">

I've also removed `s/n: n/a` from the port list. If a port has no serial number, that information isn't displayed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
