### PR TITLE
Enable Ruff RUF006; Hard reference to asyncio.create_task return value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ select = [
     "SIM401", # Use get from dict with default instead of an if block
     "T20",  # flake8-print
     "TRY004", # Prefer TypeError exception for invalid type
+    "RUF006", # Store a reference to the return value of asyncio.create_task
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

RUF006: Store a reference to the return value of asyncio.create_task

Ref: https://beta.ruff.rs/docs/rules/asyncio-dangling-task/

This PR is to track progress on resolving the violations.

Violations:
- [x] Core:
  Refs:
    - `homeassistant/components/homeassistant/__init__.py:159:13` #88288
    - `homeassistant/components/homeassistant/__init__.py:182:13` #88288
    - `homeassistant/components/websocket_api/decorators.py:45:9` #88265
    - `homeassistant/util/timeout.py:226:13`
    - `tests/test_runner.py:130:9`
- [x] `bluetooth_le_tracker`:
  PR: #88284
  Ref: `homeassistant/components/bluetooth_le_tracker/device_tracker.py:188:17`
- [x] `cast`:
  PR: #88285
  Ref: `homeassistant/components/cast/media_player.py:191:9`
- [x] `crownstone`:
  PR:  #88292
  Ref: `homeassistant/components/crownstone/entry_manager.py:90:9`
- [x] `elkm1`:
  PR: #88286
  Ref: `homeassistant/components/elkm1/__init__.py:190:5`
- [x] `homekit`:
  PR: #88289
  Ref: `homeassistant/components/homekit/type_cameras.py:446:13`
- [x] `insteon`
  PR: #88293
  Ref: `homeassistant/components/insteon/__init__.py:176:5`
- [x] `livisi`
  PR: #88294
  Ref: `homeassistant/components/livisi/__init__.py:44:5`
- [x] `mysensors`:
  PR: #88290
  Ref: `homeassistant/components/mysensors/gateway.py:119:13`
- [x] `plum_lightpad`
  PR: #88295
  Ref: `homeassistant/components/plum_lightpad/light.py:54:5`
- [x] `roon`
  PR: #88291
  Ref: `homeassistant/components/roon/server.py:69:9`
- [x] `sense`:
  PR: #88296
  Ref: `homeassistant/components/sense/__init__.py:127:5`
- [x] `smart_meter_texas`
  PR: #88297
  Ref: `homeassistant/components/smart_meter_texas/__init__.py:81:5`
- [x] `sonos`:
  PR: #88298
  Ref: `homeassistant/components/sonos/__init__.py:486:9`
- [x] `squeezebox`:
  PR: #88299
  Refs:
    - `homeassistant/components/squeezebox/media_player.py:173:5`
    - `homeassistant/components/squeezebox/media_player.py:206:9`
- [x] `unifiprotect`
  PR: #88300
  Ref: `homeassistant/components/unifiprotect/discovery.py:37:5`
- [x] `wiz`
  PR: #88301
  Ref: `homeassistant/components/wiz/__init__.py:54:5`
- [x] `wled`
  PR: #88257
  Ref: `homeassistant/components/wled/coordinator.py:98:9`
- [x] `zeroconf`
  PR: #88204
  Ref: `homeassistant/components/zeroconf/__init__.py:401:9`
- [x] `zha`
  PR: #88302
  Refs:
    - `homeassistant/components/zha/core/channels/security.py:354:13`
    - `homeassistant/components/zha/core/gateway.py:257:9`
    - `homeassistant/components/zha/light.py:616:17`
  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
