### PR TITLE
Fix restore of MQTT subscriptions from reload

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -732,7 +732,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await mqtt_client.async_disconnect()
     # Store remaining subscriptions to be able to restore or reload them
     # when the entry is set up again
-    if mqtt_client.subscriptions:
-        mqtt_data.subscriptions_to_restore = mqtt_client.subscriptions
+    if subscriptions := mqtt_client.subscriptions:
+        mqtt_data.subscriptions_to_restore = subscriptions
 
     return True

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -369,7 +369,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     mqtt_data.client = MQTT(hass, entry, conf)
     # Restore saved subscriptions
     if mqtt_data.subscriptions_to_restore:
-        mqtt_data.client.async_restore_subscriptions(mqtt_data.subscriptions_to_restore)
+        mqtt_data.client.async_restore_tracked_subscriptions(
+            mqtt_data.subscriptions_to_restore
+        )
         mqtt_data.subscriptions_to_restore = []
     mqtt_data.reload_dispatchers.append(
         entry.add_update_listener(_async_config_entry_updated)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -369,7 +369,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     mqtt_data.client = MQTT(hass, entry, conf)
     # Restore saved subscriptions
     if mqtt_data.subscriptions_to_restore:
-        mqtt_data.client.subscriptions = mqtt_data.subscriptions_to_restore
+        mqtt_data.client.async_restore_subscriptions(mqtt_data.subscriptions_to_restore)
         mqtt_data.subscriptions_to_restore = []
     mqtt_data.reload_dispatchers.append(
         entry.add_update_listener(_async_config_entry_updated)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -497,8 +497,10 @@ class MQTT:
             await self.hass.async_add_executor_job(stop)
 
     @callback
-    def async_restore_subscriptions(self, subscriptions: list[Subscription]) -> None:
-        """Restore subscriptions after reconnect."""
+    def async_restore_tracked_subscriptions(
+        self, subscriptions: list[Subscription]
+    ) -> None:
+        """Restore tracked subscriptions after reconnect."""
         for subscription in subscriptions:
             self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -499,7 +499,7 @@ class MQTT:
     @callback
     def async_restore_subscriptions(self, subscriptions: list[Subscription]) -> None:
         """Restore subscriptions after reconnect."""
-        for subscription in self.subscriptions:
+        for subscription in subscriptions:
             self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -536,9 +536,10 @@ class MQTT:
         topic = subscription.topic
         try:
             if _is_simple_match(topic):
-                self._simple_subscriptions[topic].remove(subscription)
-                if not self._simple_subscriptions[topic]:
-                    del self._simple_subscriptions[topic]
+                simple_subscriptions = self._simple_subscriptions
+                simple_subscriptions[topic].remove(subscription)
+                if not simple_subscriptions[topic]:
+                    del simple_subscriptions[topic]
             else:
                 self._wildcard_subscriptions.remove(subscription)
         except (KeyError, ValueError) as ex:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -510,6 +510,8 @@ class MQTT:
         """Track a subscription.
 
         This method does not send a SUBSCRIBE message to the broker.
+
+        The caller is responsible clearing the cache of _matching_subscriptions.
         """
         if "+" not in subscription.topic and "#" not in subscription.topic:
             self._simple_subscriptions.setdefault(subscription.topic, []).append(
@@ -523,6 +525,8 @@ class MQTT:
         """Untrack a subscription.
 
         This method does not send an UNSUBSCRIBE message to the broker.
+
+        The caller is responsible clearing the cache of _matching_subscriptions.
         """
         topic = subscription.topic
         try:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -341,6 +341,11 @@ class MqttClientSetup:
         return self._client
 
 
+def _is_simple_match(topic: str) -> bool:
+    """Return if a topic is a simple match."""
+    return not ("+" in topic or "#" in topic)
+
+
 class MQTT:
     """Home Assistant MQTT client."""
 
@@ -513,7 +518,7 @@ class MQTT:
 
         The caller is responsible clearing the cache of _matching_subscriptions.
         """
-        if "+" not in subscription.topic and "#" not in subscription.topic:
+        if _is_simple_match(subscription.topic):
             self._simple_subscriptions.setdefault(subscription.topic, []).append(
                 subscription
             )
@@ -530,7 +535,7 @@ class MQTT:
         """
         topic = subscription.topic
         try:
-            if "+" not in subscription.topic and "#" not in subscription.topic:
+            if _is_simple_match(topic):
                 self._simple_subscriptions[topic].remove(subscription)
                 if not self._simple_subscriptions[topic]:
                     del self._simple_subscriptions[topic]

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -533,13 +533,12 @@ class MQTT:
         """
         if not isinstance(topic, str):
             raise HomeAssistantError("Topic needs to be a string!")
-        matching_subscriptions = self._matching_subscriptions
 
         subscription = Subscription(
             topic, _matcher_for_topic(topic), HassJob(msg_callback), qos, encoding
         )
         _is_simple = self._async_add_subscription(subscription)
-        matching_subscriptions.cache_clear()
+        self._matching_subscriptions.cache_clear()
 
         # Only subscribe if currently connected.
         if self.connected:
@@ -558,7 +557,7 @@ class MQTT:
                     self._wildcard_subscriptions.remove(subscription)
             except (KeyError, ValueError) as ex:
                 raise HomeAssistantError("Can't remove subscription twice") from ex
-            matching_subscriptions.cache_clear()
+            self._matching_subscriptions.cache_clear()
 
             # Only unsubscribe if currently connected
             if self.connected:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -396,7 +396,7 @@ class MQTT:
 
     @property
     def subscriptions(self) -> list[Subscription]:
-        """Return the subscriptions."""
+        """Return the tracked subscriptions."""
         return [
             *chain.from_iterable(self._simple_subscriptions.values()),
             *self._wildcard_subscriptions,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -505,7 +505,7 @@ class MQTT:
     def async_restore_tracked_subscriptions(
         self, subscriptions: list[Subscription]
     ) -> None:
-        """Restore tracked subscriptions after reconnect."""
+        """Restore tracked subscriptions after reload."""
         for subscription in subscriptions:
             self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -500,12 +500,12 @@ class MQTT:
     def async_restore_subscriptions(self, subscriptions: list[Subscription]) -> None:
         """Restore subscriptions after reconnect."""
         for subscription in self.subscriptions:
-            self._async_add_subscription(subscription)
+            self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
 
     @callback
-    def _async_add_subscription(self, subscription: Subscription) -> None:
-        """Add a subscription.
+    def _async_track_subscription(self, subscription: Subscription) -> None:
+        """Track a subscription.
 
         This method does not send a SUBSCRIBE message to the broker.
         """
@@ -517,8 +517,8 @@ class MQTT:
             self._wildcard_subscriptions.append(subscription)
 
     @callback
-    def _async_remove_subscription(self, subscription: Subscription) -> None:
-        """Remove a subscription.
+    def _async_untrack_subscription(self, subscription: Subscription) -> None:
+        """Untrack a subscription.
 
         This method does not send an UNSUBSCRIBE message to the broker.
         """
@@ -550,7 +550,7 @@ class MQTT:
         subscription = Subscription(
             topic, _matcher_for_topic(topic), HassJob(msg_callback), qos, encoding
         )
-        self._async_add_subscription(subscription)
+        self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
 
         # Only subscribe if currently connected.
@@ -561,7 +561,7 @@ class MQTT:
         @callback
         def async_remove() -> None:
             """Remove subscription."""
-            self._async_remove_subscription(subscription)
+            self._async_untrack_subscription(subscription)
             self._matching_subscriptions.cache_clear()
 
             # Only unsubscribe if currently connected

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -389,6 +389,14 @@ class MQTT:
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
         )
 
+    @property
+    def subscriptions(self) -> list[Subscription]:
+        """Return the subscriptions."""
+        return [
+            *chain.from_iterable(self._simple_subscriptions.values()),
+            *self._wildcard_subscriptions,
+        ]
+
     def cleanup(self) -> None:
         """Clean up listeners."""
         while self._cleanup_on_unload:
@@ -666,14 +674,7 @@ class MQTT:
                 # Re-subscribe with the highest requested qos
                 (topic, max(subscription.qos for subscription in subs))
                 for topic, subs in groupby(
-                    sorted(
-                        (
-                            *chain.from_iterable(self._simple_subscriptions.values()),
-                            *self._wildcard_subscriptions,
-                        ),
-                        key=keyfunc,
-                    ),
-                    keyfunc,
+                    sorted(self.subscriptions, key=keyfunc), keyfunc
                 )
             ]
         )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1490,6 +1490,23 @@ async def test_reload_entry_with_restored_subscriptions(
     assert calls[0].payload == "test-payload2"
     assert calls[1].topic == "wild/any/card"
     assert calls[1].payload == "wild-card-payload2"
+    calls.clear()
+
+    # Reload the entry again
+    config_yaml_new = {}
+    await help_test_entry_reload_with_new_config(hass, tmp_path, config_yaml_new)
+
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload3")
+    async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload3")
+
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload3"
+    assert calls[1].topic == "wild/any/card"
+    assert calls[1].payload == "wild-card-payload3"
 
 
 async def test_initial_setup_logs_error(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2051,19 +2051,16 @@ async def test_mqtt_subscribes_topics_on_connect(
     await mqtt.async_subscribe(hass, "still/pending", record_calls)
     await mqtt.async_subscribe(hass, "still/pending", record_calls, 1)
 
-    with patch.object(hass, "add_job") as hass_jobs:
-        mqtt_client_mock.on_connect(None, None, 0, 0)
+    mqtt_client_mock.on_connect(None, None, 0, 0)
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-        assert mqtt_client_mock.disconnect.call_count == 0
+    assert mqtt_client_mock.disconnect.call_count == 0
 
-        assert len(hass_jobs.mock_calls) == 1
-        assert set(hass_jobs.mock_calls[0][1][1]) == {
-            ("home/sensor", 2),
-            ("still/pending", 1),
-            ("topic/test", 0),
-        }
+    assert mqtt_client_mock.subscribe.call_count == 3
+    mqtt_client_mock.subscribe.assert_any_call("topic/test", 0)
+    mqtt_client_mock.subscribe.assert_any_call("home/sensor", 2)
+    mqtt_client_mock.subscribe.assert_any_call("still/pending", 1)
 
 
 async def test_setup_entry_with_config_override(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1462,13 +1462,18 @@ async def test_reload_entry_with_restored_subscriptions(
     await hass.async_block_till_done()
 
     await mqtt.async_subscribe(hass, "test-topic", record_calls)
+    await mqtt.async_subscribe(hass, "wild/+/card", record_calls)
 
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
+    async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].topic == "test-topic"
     assert calls[0].payload == "test-payload"
+    assert calls[1].topic == "wild/any/card"
+    assert calls[1].payload == "wild-card-payload"
+    calls.clear()
 
     # Reload the entry
     config_yaml_new = {}
@@ -1477,11 +1482,14 @@ async def test_reload_entry_with_restored_subscriptions(
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "test-topic", "test-payload2")
+    async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload2")
 
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].topic == "test-topic"
-    assert calls[1].payload == "test-payload2"
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload2"
+    assert calls[1].topic == "wild/any/card"
+    assert calls[1].payload == "wild-card-payload2"
 
 
 async def test_initial_setup_logs_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes `subscriptions_to_restore` not being added to 
`_wildcard_subscriptions` and `_simple_subscriptions`

We now have `_wildcard_subscriptions` and `_simple_subscriptions`
and can get rid of updating `self.subscriptions` and instead
build it on demand since its only used on reconnects

Refactors resubscribe into its own `_async_resubscribe` function
to ensure we are only iterating the subscriptions in the main
thread to avoid races (there are probably still some that need to be looked at)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
