### PR TITLE
Add type hints to integration tests (part 21)

### DIFF
--- a/tests/components/soundtouch/test_config_flow.py
+++ b/tests/components/soundtouch/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from requests import RequestException
+import requests_mock
 from requests_mock import ANY, Mocker
 
 from homeassistant.components.soundtouch.const import DOMAIN
@@ -49,7 +50,7 @@ async def test_user_flow_create_entry(
 
 
 async def test_user_flow_cannot_connect(
-    hass: HomeAssistant, requests_mock: Mocker
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
     """Test a manual user flow with an invalid host."""
     requests_mock.get(ANY, exc=RequestException())

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -66,7 +66,7 @@ async def test_playing_media(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
-):
+) -> None:
     """Test playing media info."""
     await setup_soundtouch(hass, device1_config)
 
@@ -83,7 +83,7 @@ async def test_playing_radio(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_radio,
-):
+) -> None:
     """Test playing radio info."""
     await setup_soundtouch(hass, device1_config)
 
@@ -96,7 +96,7 @@ async def test_playing_aux(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_aux,
-):
+) -> None:
     """Test playing AUX info."""
     await setup_soundtouch(hass, device1_config)
 
@@ -109,7 +109,7 @@ async def test_playing_bluetooth(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_bluetooth,
-):
+) -> None:
     """Test playing Bluetooth info."""
     await setup_soundtouch(hass, device1_config)
 
@@ -125,7 +125,7 @@ async def test_get_volume_level(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
-):
+) -> None:
     """Test volume level."""
     await setup_soundtouch(hass, device1_config)
 
@@ -137,7 +137,7 @@ async def test_get_state_off(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
-):
+) -> None:
     """Test state device is off."""
     await setup_soundtouch(hass, device1_config)
 
@@ -149,7 +149,7 @@ async def test_get_state_pause(
     hass: HomeAssistant,
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp_paused,
-):
+) -> None:
     """Test state device is paused."""
     await setup_soundtouch(hass, device1_config)
 
@@ -162,7 +162,7 @@ async def test_is_muted(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_volume_muted: str,
-):
+) -> None:
     """Test device volume is muted."""
     with Mocker(real_http=True) as mocker:
         mocker.get("/volume", text=device1_volume_muted)
@@ -178,7 +178,7 @@ async def test_should_turn_off(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test device is turned off."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -195,7 +195,7 @@ async def test_should_turn_on(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_key,
-):
+) -> None:
     """Test device is turned on."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -212,7 +212,7 @@ async def test_volume_up(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test volume up."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -229,7 +229,7 @@ async def test_volume_down(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test volume down."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -246,7 +246,7 @@ async def test_set_volume_level(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_volume,
-):
+) -> None:
     """Test set volume level."""
     await setup_soundtouch(hass, device1_config)
 
@@ -266,7 +266,7 @@ async def test_mute(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test mute volume."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -283,7 +283,7 @@ async def test_play(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp_paused,
     device1_requests_mock_key,
-):
+) -> None:
     """Test play command."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -300,7 +300,7 @@ async def test_pause(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test pause command."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -317,7 +317,7 @@ async def test_play_pause(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test play/pause."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -334,7 +334,7 @@ async def test_next_previous_track(
     device1_config: MockConfigEntry,
     device1_requests_mock_upnp,
     device1_requests_mock_key,
-):
+) -> None:
     """Test next/previous track."""
     await setup_soundtouch(hass, device1_config)
     await _test_key_service(
@@ -359,7 +359,7 @@ async def test_play_media(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_select,
-):
+) -> None:
     """Test play preset 1."""
     await setup_soundtouch(hass, device1_config)
 
@@ -399,7 +399,7 @@ async def test_play_media_url(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_dlna,
-):
+) -> None:
     """Test play preset 1."""
     await setup_soundtouch(hass, device1_config)
 
@@ -423,7 +423,7 @@ async def test_select_source_aux(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_select,
-):
+) -> None:
     """Test select AUX."""
     await setup_soundtouch(hass, device1_config)
 
@@ -443,7 +443,7 @@ async def test_select_source_bluetooth(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_select,
-):
+) -> None:
     """Test select Bluetooth."""
     await setup_soundtouch(hass, device1_config)
 
@@ -463,7 +463,7 @@ async def test_select_source_invalid_source(
     device1_config: MockConfigEntry,
     device1_requests_mock_standby,
     device1_requests_mock_select,
-):
+) -> None:
     """Test select unsupported source."""
     await setup_soundtouch(hass, device1_config)
 
@@ -487,7 +487,7 @@ async def test_play_everywhere(
     device1_requests_mock_standby,
     device2_requests_mock_standby,
     device1_requests_mock_set_zone,
-):
+) -> None:
     """Test play everywhere."""
     await setup_soundtouch(hass, device1_config)
 
@@ -528,7 +528,7 @@ async def test_create_zone(
     device1_requests_mock_standby,
     device2_requests_mock_standby,
     device1_requests_mock_set_zone,
-):
+) -> None:
     """Test creating a zone."""
     await setup_soundtouch(hass, device1_config, device2_config)
 
@@ -572,7 +572,7 @@ async def test_remove_zone_slave(
     device1_requests_mock_standby,
     device2_requests_mock_standby,
     device1_requests_mock_remove_zone_slave,
-):
+) -> None:
     """Test removing a slave from an existing zone."""
     await setup_soundtouch(hass, device1_config, device2_config)
 
@@ -614,7 +614,7 @@ async def test_add_zone_slave(
     device1_requests_mock_standby,
     device2_requests_mock_standby,
     device1_requests_mock_add_zone_slave,
-):
+) -> None:
     """Test adding a slave to a zone."""
     await setup_soundtouch(hass, device1_config, device2_config)
 
@@ -655,7 +655,7 @@ async def test_zone_attributes(
     device2_config: MockConfigEntry,
     device1_requests_mock_standby,
     device2_requests_mock_standby,
-):
+) -> None:
     """Test zone attributes."""
     await setup_soundtouch(hass, device1_config, device2_config)
 

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.spaceapi import DOMAIN, SPACEAPI_VERSION, URL_API_SPACEAPI
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
@@ -102,7 +103,7 @@ def mock_client(hass, hass_client):
     return hass.loop.run_until_complete(hass_client())
 
 
-async def test_spaceapi_get(hass, mock_client):
+async def test_spaceapi_get(hass: HomeAssistant, mock_client) -> None:
     """Test response after start-up Home Assistant."""
     resp = await mock_client.get(URL_API_SPACEAPI)
     assert resp.status == HTTPStatus.OK
@@ -146,7 +147,7 @@ async def test_spaceapi_get(hass, mock_client):
     assert data["radio_show"][0]["end"] == "2019-09-02T12:00Z"
 
 
-async def test_spaceapi_state_get(hass, mock_client):
+async def test_spaceapi_state_get(hass: HomeAssistant, mock_client) -> None:
     """Test response if the state entity was set."""
     hass.states.async_set("test.test_door", True)
 
@@ -157,7 +158,7 @@ async def test_spaceapi_state_get(hass, mock_client):
     assert data["state"]["open"] == bool(1)
 
 
-async def test_spaceapi_sensors_get(hass, mock_client):
+async def test_spaceapi_sensors_get(hass: HomeAssistant, mock_client) -> None:
     """Test the response for the sensors."""
     resp = await mock_client.get(URL_API_SPACEAPI)
     assert resp.status == HTTPStatus.OK

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import mock_coro
 
 
-async def test_valid_device_config(hass, monkeypatch):
+async def test_valid_device_config(hass: HomeAssistant, monkeypatch) -> None:
     """Test valid device config."""
     config = {"spc": {"api_url": "http://localhost/", "ws_url": "ws://localhost/"}}
 
@@ -20,7 +20,7 @@ async def test_valid_device_config(hass, monkeypatch):
         assert await async_setup_component(hass, "spc", config) is True
 
 
-async def test_invalid_device_config(hass, monkeypatch):
+async def test_invalid_device_config(hass: HomeAssistant, monkeypatch) -> None:
     """Test valid device config."""
     config = {"spc": {"api_url": "http://localhost/"}}
 

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.spider.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -25,7 +26,7 @@ def spider_fixture() -> Mock:
         yield spider
 
 
-async def test_user(hass, spider):
+async def test_user(hass: HomeAssistant, spider) -> None:
     """Test user config."""
 
     result = await hass.config_entries.flow.async_init(
@@ -55,7 +56,7 @@ async def test_user(hass, spider):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_import(hass, spider):
+async def test_import(hass: HomeAssistant, spider) -> None:
     """Test import step."""
 
     with patch(
@@ -82,7 +83,7 @@ async def test_import(hass, spider):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_abort_if_already_setup(hass, spider):
+async def test_abort_if_already_setup(hass: HomeAssistant, spider) -> None:
     """Test we abort if Spider is already setup."""
     MockConfigEntry(domain=DOMAIN, data=SPIDER_USER_DATA).add_to_hass(hass)
 

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -18,6 +18,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 BLANK_ZEROCONF_INFO = zeroconf.ZeroconfServiceInfo(
     host="1.2.3.4",
@@ -73,12 +75,12 @@ async def test_zeroconf_abort_if_existing_entry(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow(
-    hass,
+    hass: HomeAssistant,
     component_setup,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
-):
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check a full flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -139,12 +141,12 @@ async def test_full_flow(
 
 
 async def test_abort_if_spotify_error(
-    hass,
+    hass: HomeAssistant,
     component_setup,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
-):
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check Spotify errors causes flow to abort."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -181,12 +183,12 @@ async def test_abort_if_spotify_error(
 
 
 async def test_reauthentication(
-    hass,
+    hass: HomeAssistant,
     component_setup,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
-):
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test Spotify reauthentication."""
     old_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -248,12 +250,12 @@ async def test_reauthentication(
 
 
 async def test_reauth_account_mismatch(
-    hass,
+    hass: HomeAssistant,
     component_setup,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
-):
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test Spotify reauthentication with different account."""
     old_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -1,12 +1,12 @@
 """Test the SQL config flow."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from homeassistant import config_entries
-from homeassistant.components.recorder import DEFAULT_DB_FILE, DEFAULT_URL
+from homeassistant.components.recorder import DEFAULT_DB_FILE, DEFAULT_URL, Recorder
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -21,7 +21,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_form(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -53,7 +53,7 @@ async def test_form(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_fails_db_url(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_flow_fails_db_url(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test config flow fails incorrect db url."""
     result4 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -75,7 +75,7 @@ async def test_flow_fails_db_url(recorder_mock: AsyncMock, hass: HomeAssistant) 
 
 
 async def test_flow_fails_invalid_query(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test config flow fails incorrect db url."""
     result4 = await hass.config_entries.flow.async_init(
@@ -122,7 +122,7 @@ async def test_flow_fails_invalid_query(
     }
 
 
-async def test_options_flow(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -171,7 +171,7 @@ async def test_options_flow(recorder_mock: AsyncMock, hass: HomeAssistant) -> No
 
 
 async def test_options_flow_name_previously_removed(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test options config flow where the name was missing."""
     entry = MockConfigEntry(
@@ -223,7 +223,7 @@ async def test_options_flow_name_previously_removed(
 
 
 async def test_options_flow_fails_db_url(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test options flow fails incorrect db url."""
     entry = MockConfigEntry(
@@ -267,7 +267,7 @@ async def test_options_flow_fails_db_url(
 
 
 async def test_options_flow_fails_invalid_query(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test options flow fails incorrect query and template."""
     entry = MockConfigEntry(
@@ -324,7 +324,7 @@ async def test_options_flow_fails_invalid_query(
 
 
 async def test_options_flow_db_url_empty(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test options config flow with leaving db_url empty."""
     entry = MockConfigEntry(

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -1,12 +1,13 @@
 """Test for SQL component Init."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.sql import validate_sql_select
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -15,13 +16,13 @@ from homeassistant.setup import async_setup_component
 from . import YAML_CONFIG_INVALID, YAML_CONFIG_NO_DB, init_integration
 
 
-async def test_setup_entry(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test setup entry."""
     config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_unload_entry(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_unload_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test unload an entry."""
     config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
@@ -31,7 +32,7 @@ async def test_unload_entry(recorder_mock: AsyncMock, hass: HomeAssistant) -> No
     assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_config(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_setup_config(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test setup from yaml config."""
     with patch(
         "homeassistant.components.sql.config_flow.sqlalchemy.create_engine",
@@ -41,7 +42,7 @@ async def test_setup_config(recorder_mock: AsyncMock, hass: HomeAssistant) -> No
 
 
 async def test_setup_invalid_config(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test setup from yaml with invalid config."""
     with patch(

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import text as sql_text
 from sqlalchemy.exc import SQLAlchemyError
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import STATE_UNKNOWN
@@ -20,7 +21,7 @@ from . import YAML_CONFIG, init_integration
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_query(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_query(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the SQL sensor."""
     config = {
         "db_url": "sqlite://",
@@ -36,7 +37,7 @@ async def test_query(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
 
 
 async def test_query_value_template(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor."""
     config = {
@@ -53,7 +54,7 @@ async def test_query_value_template(
 
 
 async def test_query_value_template_invalid(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor."""
     config = {
@@ -69,7 +70,7 @@ async def test_query_value_template_invalid(
     assert state.state == "5.01"
 
 
-async def test_query_limit(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_query_limit(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the SQL sensor with a query containing 'LIMIT' in lowercase."""
     config = {
         "db_url": "sqlite://",
@@ -85,7 +86,7 @@ async def test_query_limit(recorder_mock: AsyncMock, hass: HomeAssistant) -> Non
 
 
 async def test_query_no_value(
-    recorder_mock: AsyncMock, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the SQL sensor with a query that returns no value."""
     config = {
@@ -104,7 +105,7 @@ async def test_query_no_value(
 
 
 async def test_query_mssql_no_result(
-    recorder_mock: AsyncMock, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the SQL sensor with a query that returns no value."""
     config = {
@@ -142,13 +143,13 @@ async def test_query_mssql_no_result(
     ],
 )
 async def test_invalid_url_setup(
-    recorder_mock: AsyncMock,
+    recorder_mock: Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     url: str,
     expected_patterns: str,
     not_expected_patterns: str,
-):
+) -> None:
     """Test invalid db url with redacted credentials."""
     config = {
         "db_url": url,
@@ -182,7 +183,7 @@ async def test_invalid_url_setup(
 async def test_invalid_url_on_update(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Test invalid db url with redacted credentials on retry."""
     config = {
         "db_url": "sqlite://",
@@ -221,7 +222,7 @@ async def test_invalid_url_on_update(
     assert "sqlite://****:****@homeassistant.local" in caplog.text
 
 
-async def test_query_from_yaml(recorder_mock: AsyncMock, hass: HomeAssistant) -> None:
+async def test_query_from_yaml(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the SQL sensor from yaml config."""
 
     assert await async_setup_component(hass, DOMAIN, YAML_CONFIG)
@@ -232,7 +233,7 @@ async def test_query_from_yaml(recorder_mock: AsyncMock, hass: HomeAssistant) ->
 
 
 async def test_config_from_old_yaml(
-    recorder_mock: AsyncMock, hass: HomeAssistant
+    recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor from old yaml config does not create any entity."""
     config = {
@@ -271,13 +272,13 @@ async def test_config_from_old_yaml(
     ],
 )
 async def test_invalid_url_setup_from_yaml(
-    recorder_mock: AsyncMock,
+    recorder_mock: Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     url: str,
     expected_patterns: str,
     not_expected_patterns: str,
-):
+) -> None:
     """Test invalid db url with redacted credentials from yaml setup."""
     config = {
         "sql": {

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,6 +1,4 @@
 """Test the SSDP integration."""
-
-
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
 from unittest.mock import ANY, AsyncMock, patch
@@ -23,6 +21,7 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 def _ssdp_headers(headers):
@@ -43,7 +42,9 @@ async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
     return_value={"mock-domain": [{"st": "mock-st"}]},
 )
 @pytest.mark.usefixtures("mock_get_source_ip")
-async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow_init):
+async def test_ssdp_flow_dispatched_on_st(
+    mock_get_ssdp, hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_flow_init
+) -> None:
     """Test matching based on ST."""
     mock_ssdp_search_response = _ssdp_headers(
         {
@@ -84,8 +85,8 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
 )
 @pytest.mark.usefixtures("mock_get_source_ip")
 async def test_ssdp_flow_dispatched_on_manufacturer_url(
-    mock_get_ssdp, hass, caplog, mock_flow_init
-):
+    mock_get_ssdp, hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_flow_init
+) -> None:
     """Test matching based on manufacturerURL."""
     mock_ssdp_search_response = _ssdp_headers(
         {
@@ -127,8 +128,11 @@ async def test_ssdp_flow_dispatched_on_manufacturer_url(
     return_value={"mock-domain": [{"manufacturer": "Paulus"}]},
 )
 async def test_scan_match_upnp_devicedesc_manufacturer(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test matching based on UPnP device description data."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -168,8 +172,11 @@ async def test_scan_match_upnp_devicedesc_manufacturer(
     return_value={"mock-domain": [{"deviceType": "Paulus"}]},
 )
 async def test_scan_match_upnp_devicedesc_devicetype(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test matching based on UPnP device description data."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -217,8 +224,11 @@ async def test_scan_match_upnp_devicedesc_devicetype(
     },
 )
 async def test_scan_not_all_present(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test match fails if some specified attributes are not present."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -257,7 +267,12 @@ async def test_scan_not_all_present(
         ]
     },
 )
-async def test_scan_not_all_match(mock_get_ssdp, hass, aioclient_mock, mock_flow_init):
+async def test_scan_not_all_match(
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test match fails if some specified attribute values differ."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -292,8 +307,11 @@ async def test_scan_not_all_match(mock_get_ssdp, hass, aioclient_mock, mock_flow
     return_value={"mock-domain": [{"deviceType": "Paulus"}]},
 )
 async def test_flow_start_only_alive(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test config flow is only started for alive devices."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -363,8 +381,11 @@ async def test_flow_start_only_alive(
     return_value={},
 )
 async def test_discovery_from_advertisement_sets_ssdp_st(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test discovery from advertisement sets `ssdp_st` for more compatibility."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -412,7 +433,7 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
     return_value={IPv4Address("192.168.1.1")},
 )
 @pytest.mark.usefixtures("mock_get_source_ip")
-async def test_start_stop_scanner(mock_source_set, hass):
+async def test_start_stop_scanner(mock_source_set, hass: HomeAssistant) -> None:
     """Test we start and stop the scanner."""
     ssdp_listener = await init_ssdp_component(hass)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -436,8 +457,11 @@ async def test_start_stop_scanner(mock_source_set, hass):
 @pytest.mark.usefixtures("mock_get_source_ip")
 @patch("homeassistant.components.ssdp.async_get_ssdp", return_value={})
 async def test_scan_with_registered_callback(
-    mock_get_ssdp, hass, aioclient_mock, caplog
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test matching based on callback."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -530,8 +554,11 @@ async def test_scan_with_registered_callback(
     return_value={"mock-domain": [{"st": "mock-st"}]},
 )
 async def test_getting_existing_headers(
-    mock_get_ssdp, hass, aioclient_mock, mock_flow_init
-):
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init,
+) -> None:
     """Test getting existing/previously scanned headers."""
     aioclient_mock.get(
         "http://1.1.1.1",
@@ -665,8 +692,8 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
 )
 async def test_async_detect_interfaces_setting_empty_route(
-    mock_get_adapters, mock_get_ssdp, hass
-):
+    mock_get_adapters, mock_get_ssdp, hass: HomeAssistant
+) -> None:
     """Test without default interface config and the route returns nothing."""
     await init_ssdp_component(hass)
 
@@ -691,8 +718,11 @@ async def test_async_detect_interfaces_setting_empty_route(
     return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
 )
 async def test_bind_failure_skips_adapter(
-    mock_get_adapters, mock_get_ssdp, hass, caplog
-):
+    mock_get_adapters,
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that an adapter with a bind failure is skipped."""
 
     async def _async_start(self):
@@ -736,8 +766,8 @@ async def test_bind_failure_skips_adapter(
     return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
 )
 async def test_ipv4_does_additional_search_for_sonos(
-    mock_get_adapters, mock_get_ssdp, hass
-):
+    mock_get_adapters, mock_get_ssdp, hass: HomeAssistant
+) -> None:
     """Test that only ipv4 does an additional search for Sonos."""
     ssdp_listener = await init_ssdp_component(hass)
 

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 from homeassistant import config as hass_config
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -36,7 +37,7 @@ VALUES_BINARY = ["on", "off", "on", "off", "on", "off", "on", "off", "on"]
 VALUES_NUMERIC = [17, 20, 15.2, 5, 3.8, 9.2, 6.7, 14, 6]
 
 
-async def test_unique_id(hass: HomeAssistant):
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test configuration defined unique_id."""
     assert await async_setup_component(
         hass,
@@ -63,7 +64,7 @@ async def test_unique_id(hass: HomeAssistant):
     assert entity_id == "sensor.test"
 
 
-async def test_sensor_defaults_numeric(hass: HomeAssistant):
+async def test_sensor_defaults_numeric(hass: HomeAssistant) -> None:
     """Test the general behavior of the sensor, with numeric source sensor."""
     assert await async_setup_component(
         hass,
@@ -164,7 +165,7 @@ async def test_sensor_defaults_numeric(hass: HomeAssistant):
     assert new_state.attributes.get("source_value_valid") is False
 
 
-async def test_sensor_defaults_binary(hass: HomeAssistant):
+async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
     """Test the general behavior of the sensor, with binary source sensor."""
     assert await async_setup_component(
         hass,
@@ -201,7 +202,7 @@ async def test_sensor_defaults_binary(hass: HomeAssistant):
     assert "age_coverage_ratio" not in state.attributes
 
 
-async def test_sensor_source_with_force_update(hass: HomeAssistant):
+async def test_sensor_source_with_force_update(hass: HomeAssistant) -> None:
     """Test the behavior of the sensor when the source sensor force-updates with same value."""
     repeating_values = [18, 0, 0, 0, 0, 0, 0, 0, 9]
     assert await async_setup_component(
@@ -251,7 +252,7 @@ async def test_sensor_source_with_force_update(hass: HomeAssistant):
     assert state_force.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
 
 
-async def test_sampling_boundaries_given(hass: HomeAssistant):
+async def test_sampling_boundaries_given(hass: HomeAssistant) -> None:
     """Test if either sampling_size or max_age are given."""
     assert await async_setup_component(
         hass,
@@ -308,7 +309,7 @@ async def test_sampling_boundaries_given(hass: HomeAssistant):
     assert state is not None
 
 
-async def test_sampling_size_reduced(hass: HomeAssistant):
+async def test_sampling_size_reduced(hass: HomeAssistant) -> None:
     """Test limited buffer size."""
     assert await async_setup_component(
         hass,
@@ -342,7 +343,7 @@ async def test_sampling_size_reduced(hass: HomeAssistant):
     assert state.attributes.get("buffer_usage_ratio") == round(5 / 5, 2)
 
 
-async def test_sampling_size_1(hass: HomeAssistant):
+async def test_sampling_size_1(hass: HomeAssistant) -> None:
     """Test validity of stats requiring only one sample."""
     assert await async_setup_component(
         hass,
@@ -376,7 +377,7 @@ async def test_sampling_size_1(hass: HomeAssistant):
     assert state.attributes.get("buffer_usage_ratio") == round(1 / 1, 2)
 
 
-async def test_age_limit_expiry(hass: HomeAssistant):
+async def test_age_limit_expiry(hass: HomeAssistant) -> None:
     """Test that values are removed with given max age."""
     now = dt_util.utcnow()
     mock_data = {
@@ -465,7 +466,7 @@ async def test_age_limit_expiry(hass: HomeAssistant):
         assert state.attributes.get("age_coverage_ratio") is None
 
 
-async def test_precision(hass: HomeAssistant):
+async def test_precision(hass: HomeAssistant) -> None:
     """Test correct results with precision set."""
     assert await async_setup_component(
         hass,
@@ -510,7 +511,7 @@ async def test_precision(hass: HomeAssistant):
     assert state.state == str(round(mean, 3))
 
 
-async def test_percentile(hass: HomeAssistant):
+async def test_percentile(hass: HomeAssistant) -> None:
     """Test correct results for percentile characteristic."""
     assert await async_setup_component(
         hass,
@@ -564,7 +565,7 @@ async def test_percentile(hass: HomeAssistant):
     assert state.state == str(2.72)
 
 
-async def test_device_class(hass: HomeAssistant):
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test device class, which depends on the source entity."""
     assert await async_setup_component(
         hass,
@@ -643,7 +644,7 @@ async def test_device_class(hass: HomeAssistant):
     assert state.attributes.get(ATTR_DEVICE_CLASS) is None
 
 
-async def test_state_class(hass: HomeAssistant):
+async def test_state_class(hass: HomeAssistant) -> None:
     """Test state class, which depends on the characteristic configured."""
     assert await async_setup_component(
         hass,
@@ -710,7 +711,7 @@ async def test_state_class(hass: HomeAssistant):
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
 
 
-async def test_unitless_source_sensor(hass: HomeAssistant):
+async def test_unitless_source_sensor(hass: HomeAssistant) -> None:
     """Statistics for a unitless source sensor should never have a unit."""
     assert await async_setup_component(
         hass,
@@ -781,7 +782,7 @@ async def test_unitless_source_sensor(hass: HomeAssistant):
     assert state and state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "%"
 
 
-async def test_state_characteristics(hass: HomeAssistant):
+async def test_state_characteristics(hass: HomeAssistant) -> None:
     """Test configured state characteristic for value and unit."""
     now = dt_util.utcnow()
     start_datetime = datetime(now.year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
@@ -1209,7 +1210,7 @@ async def test_state_characteristics(hass: HomeAssistant):
             )
 
 
-async def test_invalid_state_characteristic(hass: HomeAssistant):
+async def test_invalid_state_characteristic(hass: HomeAssistant) -> None:
     """Test the detection of wrong state_characteristics selected."""
     assert await async_setup_component(
         hass,
@@ -1248,7 +1249,9 @@ async def test_invalid_state_characteristic(hass: HomeAssistant):
     assert state is None
 
 
-async def test_initialize_from_database(recorder_mock, hass: HomeAssistant):
+async def test_initialize_from_database(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test initializing the statistics from the recorder database."""
     # enable and pre-fill the recorder
     await hass.async_block_till_done()
@@ -1287,7 +1290,9 @@ async def test_initialize_from_database(recorder_mock, hass: HomeAssistant):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
 
-async def test_initialize_from_database_with_maxage(recorder_mock, hass: HomeAssistant):
+async def test_initialize_from_database_with_maxage(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test initializing the statistics from the database."""
     now = dt_util.utcnow()
     mock_data = {
@@ -1347,7 +1352,7 @@ async def test_initialize_from_database_with_maxage(recorder_mock, hass: HomeAss
     ) + timedelta(hours=1)
 
 
-async def test_reload(recorder_mock, hass: HomeAssistant):
+async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload statistics sensors."""
 
     await async_setup_component(

--- a/tests/components/statsd/test_init.py
+++ b/tests/components/statsd/test_init.py
@@ -59,7 +59,7 @@ async def test_statsd_setup_defaults(hass: HomeAssistant) -> None:
     assert hass.bus.listen.called
 
 
-async def test_event_listener_defaults(hass, mock_client):
+async def test_event_listener_defaults(hass: HomeAssistant, mock_client) -> None:
     """Test event listener."""
     config = {"statsd": {"host": "host", "value_mapping": {"custom": 3}}}
 
@@ -94,7 +94,7 @@ async def test_event_listener_defaults(hass, mock_client):
         assert mock_client.incr.called
 
 
-async def test_event_listener_attr_details(hass, mock_client):
+async def test_event_listener_attr_details(hass: HomeAssistant, mock_client) -> None:
     """Test event listener."""
     config = {"statsd": {"host": "host", "log_attributes": True}}
 

--- a/tests/components/steamist/test_config_flow.py
+++ b/tests/components/steamist/test_config_flow.py
@@ -339,8 +339,8 @@ async def test_discovered_by_dhcp_discovery_finds_non_steamist_device(
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we can setup when discovered from dhcp or discovery and add a missing unique id."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: DEVICE_IP_ADDRESS})
     config_entry.add_to_hass(hass)
@@ -371,8 +371,8 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
     ],
 )
 async def test_discovered_by_dhcp_or_discovery_existing_unique_id_does_not_reload(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we can setup when discovered from dhcp or discovery and it does not reload."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=DEFAULT_ENTRY_DATA, unique_id=FORMATTED_MAC_ADDRESS

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -17,6 +17,7 @@ from homeassistant.components.stream.const import (
     NUM_PLAYLIST_SEGMENTS,
 )
 from homeassistant.components.stream.core import Orientation, Part
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -28,6 +29,7 @@ from .common import (
 )
 
 from tests.common import async_fire_time_changed
+from tests.typing import ClientSessionGenerator
 
 STREAM_SOURCE = "some-stream-source"
 INIT_BYTES = b"\x00\x00\x00\x08moov"
@@ -134,8 +136,8 @@ def make_playlist(
 
 
 async def test_hls_stream(
-    hass, setup_component, hls_stream, stream_worker_sync, h264_video
-):
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync, h264_video
+) -> None:
     """Test hls stream.
 
     Purposefully not mocking anything here to test full
@@ -193,8 +195,12 @@ async def test_hls_stream(
 
 
 async def test_stream_timeout(
-    hass, hass_client, setup_component, stream_worker_sync, h264_video
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup_component,
+    stream_worker_sync,
+    h264_video,
+) -> None:
     """Test hls stream timeout."""
     stream_worker_sync.pause()
 
@@ -246,8 +252,12 @@ async def test_stream_timeout(
 
 
 async def test_stream_timeout_after_stop(
-    hass, hass_client, setup_component, stream_worker_sync, h264_video
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup_component,
+    stream_worker_sync,
+    h264_video,
+) -> None:
     """Test hls stream timeout after the stream has been stopped already."""
     stream_worker_sync.pause()
 
@@ -268,7 +278,9 @@ async def test_stream_timeout_after_stop(
     await hass.async_block_till_done()
 
 
-async def test_stream_retries(hass, setup_component, should_retry):
+async def test_stream_retries(
+    hass: HomeAssistant, setup_component, should_retry
+) -> None:
     """Test hls stream is retried on failure."""
     # Setup demo HLS track
     source = "test_stream_keepalive_source"
@@ -318,7 +330,9 @@ async def test_stream_retries(hass, setup_component, should_retry):
     assert available_states == [True, False, True]
 
 
-async def test_hls_playlist_view_no_output(hass, setup_component, hls_stream):
+async def test_hls_playlist_view_no_output(
+    hass: HomeAssistant, setup_component, hls_stream
+) -> None:
     """Test rendering the hls playlist with no output segments."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream.add_provider(HLS_PROVIDER)
@@ -330,7 +344,9 @@ async def test_hls_playlist_view_no_output(hass, setup_component, hls_stream):
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_hls_playlist_view(hass, setup_component, hls_stream, stream_worker_sync):
+async def test_hls_playlist_view(
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync
+) -> None:
     """Test rendering the hls playlist with 1 and 2 output segments."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream_worker_sync.pause()
@@ -361,7 +377,9 @@ async def test_hls_playlist_view(hass, setup_component, hls_stream, stream_worke
     await stream.stop()
 
 
-async def test_hls_max_segments(hass, setup_component, hls_stream, stream_worker_sync):
+async def test_hls_max_segments(
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync
+) -> None:
     """Test rendering the hls playlist with more segments than the segment deque can hold."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream_worker_sync.pause()
@@ -411,8 +429,8 @@ async def test_hls_max_segments(hass, setup_component, hls_stream, stream_worker
 
 
 async def test_hls_playlist_view_discontinuity(
-    hass, setup_component, hls_stream, stream_worker_sync
-):
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync
+) -> None:
     """Test a discontinuity across segments in the stream with 3 segments."""
 
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
@@ -449,8 +467,8 @@ async def test_hls_playlist_view_discontinuity(
 
 
 async def test_hls_max_segments_discontinuity(
-    hass, setup_component, hls_stream, stream_worker_sync
-):
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync
+) -> None:
     """Test a discontinuity with more segments than the segment deque can hold."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream_worker_sync.pause()
@@ -492,8 +510,8 @@ async def test_hls_max_segments_discontinuity(
 
 
 async def test_remove_incomplete_segment_on_exit(
-    hass, setup_component, stream_worker_sync
-):
+    hass: HomeAssistant, setup_component, stream_worker_sync
+) -> None:
     """Test that the incomplete segment gets removed when the worker thread quits."""
     stream = create_stream(hass, STREAM_SOURCE, {}, dynamic_stream_settings())
     stream_worker_sync.pause()
@@ -524,8 +542,8 @@ async def test_remove_incomplete_segment_on_exit(
 
 
 async def test_hls_stream_rotate(
-    hass, setup_component, hls_stream, stream_worker_sync, h264_video
-):
+    hass: HomeAssistant, setup_component, hls_stream, stream_worker_sync, h264_video
+) -> None:
     """Test hls stream with rotation applied.
 
     Purposefully not mocking anything here to test full

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -20,6 +20,7 @@ from homeassistant.components.stream.const import (
     HLS_PROVIDER,
 )
 from homeassistant.components.stream.core import Part
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -114,7 +115,9 @@ def make_hint(segment, part):
     return f'#EXT-X-PRELOAD-HINT:TYPE=PART,URI="./segment/{segment}.{part}.m4s"'
 
 
-async def test_ll_hls_stream(hass, hls_stream, stream_worker_sync):
+async def test_ll_hls_stream(
+    hass: HomeAssistant, hls_stream, stream_worker_sync
+) -> None:
     """Test hls stream.
 
     Purposefully not mocking anything here to test full
@@ -249,7 +252,9 @@ async def test_ll_hls_stream(hass, hls_stream, stream_worker_sync):
     assert fail_response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_ll_hls_playlist_view(hass, hls_stream, stream_worker_sync):
+async def test_ll_hls_playlist_view(
+    hass: HomeAssistant, hls_stream, stream_worker_sync
+) -> None:
     """Test rendering the hls playlist with 1 and 2 output segments."""
     await async_setup_component(
         hass,
@@ -318,7 +323,9 @@ async def test_ll_hls_playlist_view(hass, hls_stream, stream_worker_sync):
     await stream.stop()
 
 
-async def test_ll_hls_msn(hass, hls_stream, stream_worker_sync, hls_sync):
+async def test_ll_hls_msn(
+    hass: HomeAssistant, hls_stream, stream_worker_sync, hls_sync
+) -> None:
     """Test that requests using _HLS_msn get held and returned or rejected."""
     await async_setup_component(
         hass,
@@ -382,7 +389,9 @@ async def test_ll_hls_msn(hass, hls_stream, stream_worker_sync, hls_sync):
     stream_worker_sync.resume()
 
 
-async def test_ll_hls_playlist_bad_msn_part(hass, hls_stream, stream_worker_sync):
+async def test_ll_hls_playlist_bad_msn_part(
+    hass: HomeAssistant, hls_stream, stream_worker_sync
+) -> None:
     """Test some playlist requests with invalid _HLS_msn/_HLS_part."""
 
     await async_setup_component(
@@ -450,8 +459,8 @@ async def test_ll_hls_playlist_bad_msn_part(hass, hls_stream, stream_worker_sync
 
 
 async def test_ll_hls_playlist_rollover_part(
-    hass, hls_stream, stream_worker_sync, hls_sync
-):
+    hass: HomeAssistant, hls_stream, stream_worker_sync, hls_sync
+) -> None:
     """Test playlist request rollover."""
 
     await async_setup_component(
@@ -530,7 +539,9 @@ async def test_ll_hls_playlist_rollover_part(
     stream_worker_sync.resume()
 
 
-async def test_ll_hls_playlist_msn_part(hass, hls_stream, stream_worker_sync, hls_sync):
+async def test_ll_hls_playlist_msn_part(
+    hass: HomeAssistant, hls_stream, stream_worker_sync, hls_sync
+) -> None:
     """Test that requests using _HLS_msn and _HLS_part get held and returned."""
 
     await async_setup_component(
@@ -597,7 +608,9 @@ async def test_ll_hls_playlist_msn_part(hass, hls_stream, stream_worker_sync, hl
     stream_worker_sync.resume()
 
 
-async def test_get_part_segments(hass, hls_stream, stream_worker_sync, hls_sync):
+async def test_get_part_segments(
+    hass: HomeAssistant, hls_stream, stream_worker_sync, hls_sync
+) -> None:
     """Test requests for part segments and hinted parts."""
     await async_setup_component(
         hass,

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -16,6 +16,7 @@ from homeassistant.components.stream.const import (
 )
 from homeassistant.components.stream.core import Orientation, Part
 from homeassistant.components.stream.fmp4utils import find_box
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -43,7 +44,7 @@ def filename(tmpdir):
     return f"{tmpdir}/test.mp4"
 
 
-async def test_record_stream(hass, filename, h264_video):
+async def test_record_stream(hass: HomeAssistant, filename, h264_video) -> None:
     """Test record stream."""
 
     worker_finished = asyncio.Event()
@@ -77,7 +78,7 @@ async def test_record_stream(hass, filename, h264_video):
     assert os.path.exists(filename)
 
 
-async def test_record_lookback(hass, filename, h264_video):
+async def test_record_lookback(hass: HomeAssistant, filename, h264_video) -> None:
     """Exercise record with lookback."""
 
     stream = create_stream(hass, h264_video, {}, dynamic_stream_settings())
@@ -94,7 +95,7 @@ async def test_record_lookback(hass, filename, h264_video):
     await stream.stop()
 
 
-async def test_record_path_not_allowed(hass, h264_video):
+async def test_record_path_not_allowed(hass: HomeAssistant, h264_video) -> None:
     """Test where the output path is not allowed by home assistant configuration."""
 
     stream = create_stream(hass, h264_video, {}, dynamic_stream_settings())
@@ -118,7 +119,9 @@ def add_parts_to_segment(segment, source):
     ]
 
 
-async def test_recorder_discontinuity(hass, filename, h264_video):
+async def test_recorder_discontinuity(
+    hass: HomeAssistant, filename, h264_video
+) -> None:
     """Test recorder save across a discontinuity."""
 
     # Run
@@ -164,7 +167,7 @@ async def test_recorder_discontinuity(hass, filename, h264_video):
     assert os.path.exists(filename)
 
 
-async def test_recorder_no_segments(hass, filename):
+async def test_recorder_no_segments(hass: HomeAssistant, filename) -> None:
     """Test recorder behavior with a stream failure which causes no segments."""
 
     stream = create_stream(hass, BytesIO(), {}, dynamic_stream_settings())
@@ -193,12 +196,12 @@ def h264_mov_video():
     ],
 )
 async def test_record_stream_audio(
-    hass,
+    hass: HomeAssistant,
     filename,
     audio_codec,
     expected_audio_streams,
     h264_mov_video,
-):
+) -> None:
     """Test treatment of different audio inputs.
 
     Record stream output should have an audio channel when input has
@@ -250,7 +253,9 @@ async def test_record_stream_audio(
     await hass.async_block_till_done()
 
 
-async def test_recorder_log(hass, filename, caplog):
+async def test_recorder_log(
+    hass: HomeAssistant, filename, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test starting a stream to record logs the url without username and password."""
     stream = create_stream(
         hass, "https://abcd:efgh@foo.bar", {}, dynamic_stream_settings()
@@ -261,7 +266,7 @@ async def test_recorder_log(hass, filename, caplog):
     assert "https://****:****@foo.bar" in caplog.text
 
 
-async def test_record_stream_rotate(hass, filename, h264_video):
+async def test_record_stream_rotate(hass: HomeAssistant, filename, h264_video) -> None:
     """Test record stream with rotation."""
 
     worker_finished = asyncio.Event()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -750,7 +750,9 @@ test_worker_log_cases = (
 
 
 @pytest.mark.parametrize(("stream_url", "redacted_url"), test_worker_log_cases)
-async def test_worker_log(hass, caplog, stream_url, redacted_url):
+async def test_worker_log(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, stream_url, redacted_url
+) -> None:
     """Test that the worker logs the url without username and password."""
     stream = Stream(
         hass,
@@ -787,7 +789,7 @@ def worker_finished_stream():
     return worker_finished, MockStream
 
 
-async def test_durations(hass, worker_finished_stream):
+async def test_durations(hass: HomeAssistant, worker_finished_stream) -> None:
     """Test that the duration metadata matches the media."""
 
     # Use a target part duration which has a slight mismatch
@@ -869,7 +871,9 @@ async def test_durations(hass, worker_finished_stream):
     await stream.stop()
 
 
-async def test_has_keyframe(hass, h264_video, worker_finished_stream):
+async def test_has_keyframe(
+    hass: HomeAssistant, h264_video, worker_finished_stream
+) -> None:
     """Test that the has_keyframe metadata matches the media."""
     await async_setup_component(
         hass,
@@ -913,7 +917,7 @@ async def test_has_keyframe(hass, h264_video, worker_finished_stream):
     await stream.stop()
 
 
-async def test_h265_video_is_hvc1(hass, worker_finished_stream):
+async def test_h265_video_is_hvc1(hass: HomeAssistant, worker_finished_stream) -> None:
     """Test that a h265 video gets muxed as hvc1."""
     await async_setup_component(
         hass,
@@ -960,7 +964,7 @@ async def test_h265_video_is_hvc1(hass, worker_finished_stream):
     }
 
 
-async def test_get_image(hass, h264_video, filename):
+async def test_get_image(hass: HomeAssistant, h264_video, filename) -> None:
     """Test that the has_keyframe metadata matches the media."""
     await async_setup_component(hass, "stream", {"stream": {}})
 
@@ -1002,7 +1006,7 @@ async def test_worker_disable_ll_hls(hass: HomeAssistant) -> None:
     assert stream_settings.ll_hls is False
 
 
-async def test_get_image_rotated(hass, h264_video, filename):
+async def test_get_image_rotated(hass: HomeAssistant, h264_video, filename) -> None:
     """Test that the has_keyframe metadata matches the media."""
     await async_setup_component(hass, "stream", {"stream": {}})
 

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant import config_entries
 from homeassistant.components.subaru import config_flow
 from homeassistant.components.subaru.const import CONF_UPDATE_ENABLED, DOMAIN
 from homeassistant.const import CONF_DEVICE_ID, CONF_PIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
@@ -37,7 +38,7 @@ MOCK_2FA_CONTACTS = {
 }
 
 
-async def test_user_form_init(user_form):
+async def test_user_form_init(user_form) -> None:
     """Test the initial user form for first step of the config flow."""
     assert user_form["description_placeholders"] is None
     assert user_form["errors"] is None
@@ -46,7 +47,7 @@ async def test_user_form_init(user_form):
     assert user_form["type"] == "form"
 
 
-async def test_user_form_repeat_identifier(hass, user_form):
+async def test_user_form_repeat_identifier(hass: HomeAssistant, user_form) -> None:
     """Test we handle repeat identifiers."""
     entry = MockConfigEntry(
         domain=DOMAIN, title=TEST_USERNAME, data=TEST_CREDS, options=None
@@ -66,7 +67,7 @@ async def test_user_form_repeat_identifier(hass, user_form):
     assert result["reason"] == "already_configured"
 
 
-async def test_user_form_cannot_connect(hass, user_form):
+async def test_user_form_cannot_connect(hass: HomeAssistant, user_form) -> None:
     """Test we handle cannot connect error."""
     with patch(
         MOCK_API_CONNECT,
@@ -81,7 +82,7 @@ async def test_user_form_cannot_connect(hass, user_form):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_user_form_invalid_auth(hass, user_form):
+async def test_user_form_invalid_auth(hass: HomeAssistant, user_form) -> None:
     """Test we handle invalid auth."""
     with patch(
         MOCK_API_CONNECT,
@@ -96,7 +97,9 @@ async def test_user_form_invalid_auth(hass, user_form):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_form_pin_not_required(hass, two_factor_verify_form):
+async def test_user_form_pin_not_required(
+    hass: HomeAssistant, two_factor_verify_form
+) -> None:
     """Test successful login when no PIN is required."""
     with patch(
         MOCK_API_2FA_VERIFY,
@@ -134,7 +137,7 @@ async def test_user_form_pin_not_required(hass, two_factor_verify_form):
     assert result == expected
 
 
-async def test_registered_pin_required(hass, user_form):
+async def test_registered_pin_required(hass: HomeAssistant, user_form) -> None:
     """Test if the device is already registered and PIN required."""
     with patch(MOCK_API_CONNECT, return_value=True), patch(
         MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
@@ -145,7 +148,7 @@ async def test_registered_pin_required(hass, user_form):
         )
 
 
-async def test_registered_no_pin_required(hass, user_form):
+async def test_registered_no_pin_required(hass: HomeAssistant, user_form) -> None:
     """Test if the device is already registered and PIN not required."""
     with patch(MOCK_API_CONNECT, return_value=True), patch(
         MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
@@ -156,7 +159,9 @@ async def test_registered_no_pin_required(hass, user_form):
         )
 
 
-async def test_two_factor_request_success(hass, two_factor_start_form):
+async def test_two_factor_request_success(
+    hass: HomeAssistant, two_factor_start_form
+) -> None:
     """Test two factor contact method selection."""
     with patch(
         MOCK_API_2FA_REQUEST,
@@ -172,7 +177,9 @@ async def test_two_factor_request_success(hass, two_factor_start_form):
     assert len(mock_two_factor_request.mock_calls) == 1
 
 
-async def test_two_factor_request_fail(hass, two_factor_start_form):
+async def test_two_factor_request_fail(
+    hass: HomeAssistant, two_factor_start_form
+) -> None:
     """Test two factor auth request failure."""
     with patch(
         MOCK_API_2FA_REQUEST,
@@ -190,7 +197,9 @@ async def test_two_factor_request_fail(hass, two_factor_start_form):
     assert result["reason"] == "two_factor_request_failed"
 
 
-async def test_two_factor_verify_success(hass, two_factor_verify_form):
+async def test_two_factor_verify_success(
+    hass: HomeAssistant, two_factor_verify_form
+) -> None:
     """Test two factor verification."""
     with patch(
         MOCK_API_2FA_VERIFY,
@@ -206,7 +215,9 @@ async def test_two_factor_verify_success(hass, two_factor_verify_form):
     assert len(mock_is_in_required.mock_calls) == 1
 
 
-async def test_two_factor_verify_bad_format(hass, two_factor_verify_form):
+async def test_two_factor_verify_bad_format(
+    hass: HomeAssistant, two_factor_verify_form
+) -> None:
     """Test two factor verification bad format."""
     with patch(
         MOCK_API_2FA_VERIFY,
@@ -223,7 +234,9 @@ async def test_two_factor_verify_bad_format(hass, two_factor_verify_form):
     assert result["errors"] == {"base": "bad_validation_code_format"}
 
 
-async def test_two_factor_verify_fail(hass, two_factor_verify_form):
+async def test_two_factor_verify_fail(
+    hass: HomeAssistant, two_factor_verify_form
+) -> None:
     """Test two factor verification failure."""
     with patch(
         MOCK_API_2FA_VERIFY,
@@ -240,7 +253,7 @@ async def test_two_factor_verify_fail(hass, two_factor_verify_form):
     assert result["errors"] == {"base": "incorrect_validation_code"}
 
 
-async def test_pin_form_init(pin_form):
+async def test_pin_form_init(pin_form) -> None:
     """Test the pin entry form for second step of the config flow."""
     expected = {
         "data_schema": config_flow.PIN_SCHEMA,
@@ -255,7 +268,7 @@ async def test_pin_form_init(pin_form):
     assert pin_form == expected
 
 
-async def test_pin_form_bad_pin_format(hass, pin_form):
+async def test_pin_form_bad_pin_format(hass: HomeAssistant, pin_form) -> None:
     """Test we handle invalid pin."""
     with patch(
         MOCK_API_TEST_PIN,
@@ -272,7 +285,7 @@ async def test_pin_form_bad_pin_format(hass, pin_form):
     assert result["errors"] == {"base": "bad_pin_format"}
 
 
-async def test_pin_form_success(hass, pin_form):
+async def test_pin_form_success(hass: HomeAssistant, pin_form) -> None:
     """Test successful PIN entry."""
     with patch(
         MOCK_API_TEST_PIN,
@@ -307,7 +320,7 @@ async def test_pin_form_success(hass, pin_form):
     assert result == expected
 
 
-async def test_pin_form_incorrect_pin(hass, pin_form):
+async def test_pin_form_incorrect_pin(hass: HomeAssistant, pin_form) -> None:
     """Test we handle invalid pin."""
     with patch(
         MOCK_API_TEST_PIN,
@@ -325,7 +338,7 @@ async def test_pin_form_incorrect_pin(hass, pin_form):
     assert result["errors"] == {"base": "incorrect_pin"}
 
 
-async def test_option_flow_form(options_form):
+async def test_option_flow_form(options_form) -> None:
     """Test config flow options form."""
     assert options_form["description_placeholders"] is None
     assert options_form["errors"] is None
@@ -333,7 +346,7 @@ async def test_option_flow_form(options_form):
     assert options_form["type"] == "form"
 
 
-async def test_option_flow(hass, options_form):
+async def test_option_flow(hass: HomeAssistant, options_form) -> None:
     """Test config flow options."""
     result = await hass.config_entries.options.async_configure(
         options_form["flow_id"],

--- a/tests/components/subaru/test_diagnostics.py
+++ b/tests/components/subaru/test_diagnostics.py
@@ -16,9 +16,12 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 
-async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, ev_entry):
+async def test_config_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, ev_entry
+) -> None:
     """Test config entry diagnostics."""
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -33,7 +36,9 @@ async def test_config_entry_diagnostics(hass: HomeAssistant, hass_client, ev_ent
     )
 
 
-async def test_device_diagnostics(hass: HomeAssistant, hass_client, ev_entry):
+async def test_device_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, ev_entry
+) -> None:
     """Test device diagnostics."""
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -53,8 +58,8 @@ async def test_device_diagnostics(hass: HomeAssistant, hass_client, ev_entry):
 
 
 async def test_device_diagnostics_vehicle_not_found(
-    hass: HomeAssistant, hass_client, ev_entry
-):
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, ev_entry
+) -> None:
     """Test device diagnostics when the vehicle cannot be found."""
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -36,14 +36,14 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     assert DOMAIN not in hass.config_entries.async_domains()
 
 
-async def test_setup_ev(hass, ev_entry):
+async def test_setup_ev(hass: HomeAssistant, ev_entry) -> None:
     """Test setup with an EV vehicle."""
     check_entry = hass.config_entries.async_get_entry(ev_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_g2(hass, subaru_config_entry):
+async def test_setup_g2(hass: HomeAssistant, subaru_config_entry) -> None:
     """Test setup with a G2 vehcile ."""
     await setup_subaru_config_entry(
         hass,
@@ -57,7 +57,7 @@ async def test_setup_g2(hass, subaru_config_entry):
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_setup_g1(hass, subaru_config_entry):
+async def test_setup_g1(hass: HomeAssistant, subaru_config_entry) -> None:
     """Test setup with a G1 vehicle."""
     await setup_subaru_config_entry(
         hass,
@@ -70,7 +70,7 @@ async def test_setup_g1(hass, subaru_config_entry):
     assert check_entry.state is ConfigEntryState.LOADED
 
 
-async def test_unsuccessful_connect(hass, subaru_config_entry):
+async def test_unsuccessful_connect(hass: HomeAssistant, subaru_config_entry) -> None:
     """Test unsuccessful connect due to connectivity."""
     await setup_subaru_config_entry(
         hass,
@@ -85,7 +85,7 @@ async def test_unsuccessful_connect(hass, subaru_config_entry):
     assert check_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_invalid_credentials(hass, subaru_config_entry):
+async def test_invalid_credentials(hass: HomeAssistant, subaru_config_entry) -> None:
     """Test invalid credentials."""
     await setup_subaru_config_entry(
         hass,
@@ -100,7 +100,9 @@ async def test_invalid_credentials(hass, subaru_config_entry):
     assert check_entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_update_skip_unsubscribed(hass, subaru_config_entry):
+async def test_update_skip_unsubscribed(
+    hass: HomeAssistant, subaru_config_entry
+) -> None:
     """Test update function skips vehicles without subscription."""
     await setup_subaru_config_entry(
         hass,
@@ -121,7 +123,7 @@ async def test_update_skip_unsubscribed(hass, subaru_config_entry):
         mock_fetch.assert_not_called()
 
 
-async def test_update_disabled(hass, ev_entry):
+async def test_update_disabled(hass: HomeAssistant, ev_entry) -> None:
     """Test update function disable option."""
     with patch(
         MOCK_API_FETCH,
@@ -139,7 +141,7 @@ async def test_update_disabled(hass, ev_entry):
         mock_update.assert_not_called()
 
 
-async def test_fetch_failed(hass, subaru_config_entry):
+async def test_fetch_failed(hass: HomeAssistant, subaru_config_entry) -> None:
     """Tests when fetch fails."""
     await setup_subaru_config_entry(
         hass,
@@ -154,7 +156,7 @@ async def test_fetch_failed(hass, subaru_config_entry):
     assert test_entity.state == "unavailable"
 
 
-async def test_unload_entry(hass, ev_entry):
+async def test_unload_entry(hass: HomeAssistant, ev_entry) -> None:
     """Test that entry is unloaded."""
     assert ev_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(ev_entry.entry_id)

--- a/tests/components/subaru/test_lock.py
+++ b/tests/components/subaru/test_lock.py
@@ -12,6 +12,7 @@ from homeassistant.components.subaru.const import (
     UNLOCK_DOOR_DRIVERS,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -22,14 +23,14 @@ MOCK_API_UNLOCK = f"{MOCK_API}unlock"
 DEVICE_ID = "lock.test_vehicle_2_door_locks"
 
 
-async def test_device_exists(hass, ev_entry):
+async def test_device_exists(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru lock entity exists."""
     entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry
 
 
-async def test_lock_cmd(hass, ev_entry):
+async def test_lock_cmd(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru lock function."""
     with patch(MOCK_API_LOCK) as mock_lock:
         await hass.services.async_call(
@@ -39,7 +40,7 @@ async def test_lock_cmd(hass, ev_entry):
         mock_lock.assert_called_once()
 
 
-async def test_unlock_cmd(hass, ev_entry):
+async def test_unlock_cmd(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru unlock function."""
     with patch(MOCK_API_UNLOCK) as mock_unlock:
         await hass.services.async_call(
@@ -49,7 +50,7 @@ async def test_unlock_cmd(hass, ev_entry):
         mock_unlock.assert_called_once()
 
 
-async def test_lock_cmd_fails(hass, ev_entry):
+async def test_lock_cmd_fails(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru lock request that initiates but fails."""
     with patch(MOCK_API_LOCK, return_value=False) as mock_lock, pytest.raises(
         HomeAssistantError
@@ -61,7 +62,7 @@ async def test_lock_cmd_fails(hass, ev_entry):
         mock_lock.assert_called_once()
 
 
-async def test_unlock_specific_door(hass, ev_entry):
+async def test_unlock_specific_door(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru unlock specific door function."""
     with patch(MOCK_API_UNLOCK) as mock_unlock:
         await hass.services.async_call(
@@ -74,7 +75,7 @@ async def test_unlock_specific_door(hass, ev_entry):
         mock_unlock.assert_called_once()
 
 
-async def test_unlock_specific_door_invalid(hass, ev_entry):
+async def test_unlock_specific_door_invalid(hass: HomeAssistant, ev_entry) -> None:
     """Test subaru unlock specific door function."""
     with patch(MOCK_API_UNLOCK) as mock_unlock, pytest.raises(MultipleInvalid):
         await hass.services.async_call(

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.subaru.sensor import (
     EV_SENSORS,
     SAFETY_SENSORS,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -30,7 +31,7 @@ from .conftest import (
 )
 
 
-async def test_sensors_ev_imperial(hass, ev_entry):
+async def test_sensors_ev_imperial(hass: HomeAssistant, ev_entry) -> None:
     """Test sensors supporting imperial units."""
     hass.config.units = US_CUSTOMARY_SYSTEM
 
@@ -43,12 +44,12 @@ async def test_sensors_ev_imperial(hass, ev_entry):
     _assert_data(hass, EXPECTED_STATE_EV_IMPERIAL)
 
 
-async def test_sensors_ev_metric(hass, ev_entry):
+async def test_sensors_ev_metric(hass: HomeAssistant, ev_entry) -> None:
     """Test sensors supporting metric units."""
     _assert_data(hass, EXPECTED_STATE_EV_METRIC)
 
 
-async def test_sensors_missing_vin_data(hass, ev_entry):
+async def test_sensors_missing_vin_data(hass: HomeAssistant, ev_entry) -> None:
     """Test for missing VIN dataset."""
     with patch(MOCK_API_FETCH), patch(MOCK_API_GET_DATA, return_value=None):
         advance_time_to_next_fetch(hass)
@@ -72,7 +73,7 @@ async def test_sensors_missing_vin_data(hass, ev_entry):
     ],
 )
 async def test_sensor_migrate_unique_ids(
-    hass, entitydata, old_unique_id, new_unique_id, subaru_config_entry
+    hass: HomeAssistant, entitydata, old_unique_id, new_unique_id, subaru_config_entry
 ) -> None:
     """Test successful migration of entity unique_ids."""
     entity_registry = er.async_get(hass)
@@ -104,7 +105,7 @@ async def test_sensor_migrate_unique_ids(
     ],
 )
 async def test_sensor_migrate_unique_ids_duplicate(
-    hass, entitydata, old_unique_id, new_unique_id, subaru_config_entry
+    hass: HomeAssistant, entitydata, old_unique_id, new_unique_id, subaru_config_entry
 ) -> None:
     """Test unsuccessful migration of entity unique_ids due to duplicate."""
     entity_registry = er.async_get(hass)

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -212,7 +212,7 @@ async def test_state_change_count(hass: HomeAssistant) -> None:
     assert len(events) < 721
 
 
-async def test_setup_and_remove_config_entry(hass: ha.HomeAssistant) -> None:
+async def test_setup_and_remove_config_entry(hass: HomeAssistant) -> None:
     """Test setting up and removing a config entry."""
     # Setup the config entry
     config_entry = MockConfigEntry(domain=sun.DOMAIN)

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.sun import (
@@ -18,7 +19,7 @@ from homeassistant.components.sun import (
     STATE_ATTR_RISING,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -26,7 +27,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test sun attributes to be excluded."""
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -36,7 +37,7 @@ def setup_comp(hass):
     )
 
 
-async def test_sunset_trigger(hass, calls):
+async def test_sunset_trigger(hass: HomeAssistant, calls) -> None:
     """Test the sunset trigger."""
     now = datetime(2015, 9, 15, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 2, tzinfo=dt_util.UTC)
@@ -81,7 +82,7 @@ async def test_sunset_trigger(hass, calls):
         assert calls[0].data["id"] == 0
 
 
-async def test_sunrise_trigger(hass, calls):
+async def test_sunrise_trigger(hass: HomeAssistant, calls) -> None:
     """Test the sunrise trigger."""
     now = datetime(2015, 9, 13, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 14, tzinfo=dt_util.UTC)
@@ -103,7 +104,7 @@ async def test_sunrise_trigger(hass, calls):
         assert len(calls) == 1
 
 
-async def test_sunset_trigger_with_offset(hass, calls):
+async def test_sunset_trigger_with_offset(hass: HomeAssistant, calls) -> None:
     """Test the sunset trigger with offset."""
     now = datetime(2015, 9, 15, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 2, 30, tzinfo=dt_util.UTC)
@@ -136,7 +137,7 @@ async def test_sunset_trigger_with_offset(hass, calls):
         assert calls[0].data["some"] == "sun - sunset - 0:30:00"
 
 
-async def test_sunrise_trigger_with_offset(hass, calls):
+async def test_sunrise_trigger_with_offset(hass: HomeAssistant, calls) -> None:
     """Test the sunrise trigger with offset."""
     now = datetime(2015, 9, 13, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 13, 30, tzinfo=dt_util.UTC)

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """The tests for the Sure Petcare binary sensor platform."""
-
 from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -15,7 +15,7 @@ EXPECTED_ENTITY_IDS = {
 }
 
 
-async def test_binary_sensors(hass, surepetcare) -> None:
+async def test_binary_sensors(hass: HomeAssistant, surepetcare) -> None:
     """Test the generation of unique ids."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -115,7 +115,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
 
 
 async def test_flow_entry_already_exists(
-    hass, surepetcare: NonCallableMagicMock
+    hass: HomeAssistant, surepetcare: NonCallableMagicMock
 ) -> None:
     """Test user input for config_entry that already exists."""
     first_entry = MockConfigEntry(

--- a/tests/components/surepetcare/test_lock.py
+++ b/tests/components/surepetcare/test_lock.py
@@ -3,6 +3,7 @@ import pytest
 from surepy.exceptions import SurePetcareError
 
 from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -18,7 +19,7 @@ EXPECTED_ENTITY_IDS = {
 }
 
 
-async def test_locks(hass, surepetcare) -> None:
+async def test_locks(hass: HomeAssistant, surepetcare) -> None:
     """Test the generation of unique ids."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -77,7 +78,7 @@ async def test_locks(hass, surepetcare) -> None:
         assert surepetcare.unlock.call_count == 1
 
 
-async def test_lock_failing(hass, surepetcare) -> None:
+async def test_lock_failing(hass: HomeAssistant, surepetcare) -> None:
     """Test handling of lock failing."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -95,7 +96,7 @@ async def test_lock_failing(hass, surepetcare) -> None:
         assert state.state == "unlocked"
 
 
-async def test_unlock_failing(hass, surepetcare) -> None:
+async def test_unlock_failing(hass: HomeAssistant, surepetcare) -> None:
     """Test handling of unlock failing."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -1,5 +1,6 @@
 """Test the surepetcare sensor platform."""
 from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -13,7 +14,7 @@ EXPECTED_ENTITY_IDS = {
 }
 
 
-async def test_sensors(hass, surepetcare) -> None:
+async def test_sensors(hass: HomeAssistant, surepetcare) -> None:
     """Test the generation of unique ids."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -5,7 +5,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +25,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a switch."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -62,12 +67,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -100,7 +105,9 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass, calls, enable_custom_integrations):
+async def test_action(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off actions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -8,7 +8,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a switch."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_get_condition_capabilities(hass, device_registry, entity_registry):
+async def test_get_condition_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a switch condition."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_condition_capabilities(hass, device_registry, entity_registry
         assert capabilities == expected_capabilities
 
 
-async def test_if_state(hass, calls, enable_custom_integrations):
+async def test_if_state(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -205,7 +216,9 @@ async def test_if_state(hass, calls, enable_custom_integrations):
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
-async def test_if_fires_on_for_condition(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_for_condition(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a switch."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a switch trigger."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,7 +140,9 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations):
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
@@ -243,8 +254,8 @@ async def test_if_fires_on_state_change(hass, calls, enable_custom_integrations)
 
 
 async def test_if_fires_on_state_change_with_for(
-    hass, calls, enable_custom_integrations
-):
+    hass: HomeAssistant, calls, enable_custom_integrations: None
+) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -4,9 +4,12 @@ import pytest
 from homeassistant import core
 from homeassistant.components import switch
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import common
+
+from tests.common import MockUser
 
 
 @pytest.fixture(autouse=True)
@@ -17,7 +20,9 @@ def entities(hass):
     return platform.ENTITIES
 
 
-async def test_methods(hass, entities, enable_custom_integrations):
+async def test_methods(
+    hass: HomeAssistant, entities, enable_custom_integrations: None
+) -> None:
     """Test is_on, turn_on, turn_off methods."""
     switch_1, switch_2, switch_3 = entities
     assert await async_setup_component(
@@ -50,8 +55,11 @@ async def test_methods(hass, entities, enable_custom_integrations):
 
 
 async def test_switch_context(
-    hass, entities, hass_admin_user, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    entities,
+    hass_admin_user: MockUser,
+    enable_custom_integrations: None,
+) -> None:
     """Test that switch context works."""
     assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})
 

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -1,6 +1,4 @@
 """Test the switchbot sensors."""
-
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.switchbot.const import DOMAIN
 from homeassistant.const import (
@@ -11,6 +9,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SENSOR_TYPE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import WOHAND_SERVICE_INFO
@@ -19,7 +18,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass, entity_registry_enabled_by_default):
+async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
     """Test setting up creates the sensors."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, WOHAND_SERVICE_INFO)

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -28,7 +28,9 @@ SWING_OFF_EID = BASE_ENTITY_ID + "_vertical_swing_off"
     ],
 )
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_assume_button(hass: HomeAssistant, entity, state, mock_bridge, mock_api):
+async def test_assume_button(
+    hass: HomeAssistant, entity, state, mock_bridge, mock_api
+) -> None:
     """Test assume on/off button."""
     await init_integration(hass)
     assert mock_bridge
@@ -61,7 +63,7 @@ async def test_assume_button(hass: HomeAssistant, entity, state, mock_bridge, mo
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_swing_button(
     hass: HomeAssistant, entity, swing, mock_bridge, mock_api, monkeypatch
-):
+) -> None:
     """Test vertical swing on/off button."""
     monkeypatch.setattr(DEVICE, "remote_id", "ELEC7022")
     await init_integration(hass)
@@ -86,7 +88,9 @@ async def test_swing_button(
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_control_device_fail(hass, mock_bridge, mock_api, monkeypatch):
+async def test_control_device_fail(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test control device fail."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_climate.py
+++ b/tests/components/switcher_kis/test_climate.py
@@ -24,6 +24,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
@@ -34,7 +35,9 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{slugify(DEVICE.name)}"
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_climate_hvac_mode(hass, mock_bridge, mock_api, monkeypatch):
+async def test_climate_hvac_mode(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test climate hvac mode service."""
     await init_integration(hass)
     assert mock_bridge
@@ -87,7 +90,9 @@ async def test_climate_hvac_mode(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_climate_temperature(hass, mock_bridge, mock_api, monkeypatch):
+async def test_climate_temperature(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test climate temperature service."""
     await init_integration(hass)
     assert mock_bridge
@@ -137,7 +142,9 @@ async def test_climate_temperature(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_climate_fan_level(hass, mock_bridge, mock_api, monkeypatch):
+async def test_climate_fan_level(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test climate fan level service."""
     await init_integration(hass)
     assert mock_bridge
@@ -170,7 +177,9 @@ async def test_climate_fan_level(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_climate_swing(hass, mock_bridge, mock_api, monkeypatch):
+async def test_climate_swing(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test climate swing service."""
     await init_integration(hass)
     assert mock_bridge
@@ -224,7 +233,9 @@ async def test_climate_swing(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_control_device_fail(hass, mock_bridge, mock_api, monkeypatch):
+async def test_control_device_fail(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test control device fail."""
     await init_integration(hass)
     assert mock_bridge
@@ -282,7 +293,9 @@ async def test_control_device_fail(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_bad_update_discard(hass, mock_bridge, mock_api, monkeypatch):
+async def test_bad_update_discard(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test that a bad update from device is discarded."""
     await init_integration(hass)
     assert mock_bridge
@@ -303,7 +316,9 @@ async def test_bad_update_discard(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_climate_control_errors(hass, mock_bridge, mock_api, monkeypatch):
+async def test_climate_control_errors(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test control with settings not supported by device."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_import(hass: HomeAssistant) -> None:
     ],
     indirect=True,
 )
-async def test_user_setup(hass, mock_bridge):
+async def test_user_setup(hass: HomeAssistant, mock_bridge) -> None:
     """Test we can finish a config flow."""
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
         result = await hass.config_entries.flow.async_init(
@@ -64,7 +64,9 @@ async def test_user_setup(hass, mock_bridge):
     assert result2["result"].data == {}
 
 
-async def test_user_setup_abort_no_devices_found(hass, mock_bridge):
+async def test_user_setup_abort_no_devices_found(
+    hass: HomeAssistant, mock_bridge
+) -> None:
     """Test we abort a config flow if no devices found."""
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
         result = await hass.config_entries.flow.async_init(
@@ -92,7 +94,7 @@ async def test_user_setup_abort_no_devices_found(hass, mock_bridge):
         config_entries.SOURCE_USER,
     ],
 )
-async def test_single_instance(hass, source):
+async def test_single_instance(hass: HomeAssistant, source) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     await hass.async_block_till_done()

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -19,6 +19,7 @@ from homeassistant.components.cover import (
     STATE_OPENING,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
@@ -29,7 +30,7 @@ ENTITY_ID = f"{COVER_DOMAIN}.{slugify(DEVICE.name)}"
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_cover(hass, mock_bridge, mock_api, monkeypatch):
+async def test_cover(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch) -> None:
     """Test cover services."""
     await init_integration(hass)
     assert mock_bridge
@@ -130,7 +131,7 @@ async def test_cover(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_cover_control_fail(hass, mock_bridge, mock_api):
+async def test_cover_control_fail(hass: HomeAssistant, mock_bridge, mock_api) -> None:
     """Test cover control fail."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.switcher_kis.const import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt, slugify
 
@@ -22,7 +23,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)
-async def test_async_setup_yaml_config(hass, mock_bridge) -> None:
+async def test_async_setup_yaml_config(hass: HomeAssistant, mock_bridge) -> None:
     """Test setup started by configuration from YAML."""
     assert await async_setup_component(hass, DOMAIN, YAML_CONFIG)
     await hass.async_block_till_done()
@@ -33,7 +34,7 @@ async def test_async_setup_yaml_config(hass, mock_bridge) -> None:
 
 
 @pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)
-async def test_async_setup_user_config_flow(hass, mock_bridge) -> None:
+async def test_async_setup_user_config_flow(hass: HomeAssistant, mock_bridge) -> None:
     """Test setup started by user config flow."""
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
         result = await hass.config_entries.flow.async_init(
@@ -47,7 +48,9 @@ async def test_async_setup_user_config_flow(hass, mock_bridge) -> None:
     assert len(hass.data[DOMAIN][DATA_DEVICE]) == 2
 
 
-async def test_update_fail(hass, mock_bridge, caplog):
+async def test_update_fail(
+    hass: HomeAssistant, mock_bridge, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test entities state unavailable when updates fail.."""
     await init_integration(hass)
     assert mock_bridge
@@ -94,7 +97,7 @@ async def test_update_fail(hass, mock_bridge, caplog):
         assert state.state != STATE_UNAVAILABLE
 
 
-async def test_entry_unload(hass, mock_bridge):
+async def test_entry_unload(hass: HomeAssistant, mock_bridge) -> None:
     """Test entry unload."""
     entry = await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_sensor.py
+++ b/tests/components/switcher_kis/test_sensor.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.components.switcher_kis.const import DATA_DEVICE, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
@@ -28,7 +29,7 @@ DEVICE_SENSORS_TUPLE = (
 
 
 @pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)
-async def test_sensor_platform(hass, mock_bridge):
+async def test_sensor_platform(hass: HomeAssistant, mock_bridge) -> None:
     """Test sensor platform."""
     await init_integration(hass)
     assert mock_bridge
@@ -44,7 +45,7 @@ async def test_sensor_platform(hass, mock_bridge):
             assert state.state == str(getattr(device, sensor))
 
 
-async def test_sensor_disabled(hass, mock_bridge):
+async def test_sensor_disabled(hass: HomeAssistant, mock_bridge) -> None:
     """Test sensor disabled by default."""
     await init_integration(hass)
     assert mock_bridge
@@ -73,7 +74,7 @@ async def test_sensor_disabled(hass, mock_bridge):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_sensor_update(hass, mock_bridge, monkeypatch):
+async def test_sensor_update(hass: HomeAssistant, mock_bridge, monkeypatch) -> None:
     """Test sensor update."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -14,6 +14,7 @@ from homeassistant.components.switcher_kis.const import (
     SERVICE_TURN_ON_WITH_TIMER_NAME,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.util import slugify
 
@@ -27,7 +28,9 @@ from .consts import (
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_turn_on_with_timer_service(hass, mock_bridge, mock_api, monkeypatch):
+async def test_turn_on_with_timer_service(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+) -> None:
     """Test the turn on with timer service."""
     await init_integration(hass)
     assert mock_bridge
@@ -65,7 +68,7 @@ async def test_turn_on_with_timer_service(hass, mock_bridge, mock_api, monkeypat
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_set_auto_off_service(hass, mock_bridge, mock_api):
+async def test_set_auto_off_service(hass: HomeAssistant, mock_bridge, mock_api) -> None:
     """Test the set auto off service."""
     await init_integration(hass)
     assert mock_bridge
@@ -90,7 +93,9 @@ async def test_set_auto_off_service(hass, mock_bridge, mock_api):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_set_auto_off_service_fail(hass, mock_bridge, mock_api, caplog):
+async def test_set_auto_off_service_fail(
+    hass: HomeAssistant, mock_bridge, mock_api, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test set auto off service failed."""
     await init_integration(hass)
     assert mock_bridge
@@ -122,7 +127,9 @@ async def test_set_auto_off_service_fail(hass, mock_bridge, mock_api, caplog):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_PLUG_DEVICE]], indirect=True)
-async def test_plug_unsupported_services(hass, mock_bridge, mock_api, caplog):
+async def test_plug_unsupported_services(
+    hass: HomeAssistant, mock_bridge, mock_api, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test plug device unsupported services."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 from . import init_integration
@@ -21,7 +22,7 @@ from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_switch(hass, mock_bridge, mock_api, monkeypatch):
+async def test_switch(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch) -> None:
     """Test the switch."""
     await init_integration(hass)
     assert mock_bridge
@@ -69,7 +70,13 @@ async def test_switch(hass, mock_bridge, mock_api, monkeypatch):
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_PLUG_DEVICE]], indirect=True)
-async def test_switch_control_fail(hass, mock_bridge, mock_api, monkeypatch, caplog):
+async def test_switch_control_fail(
+    hass: HomeAssistant,
+    mock_bridge,
+    mock_api,
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test switch control fail."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -147,7 +147,7 @@ def mock_controller_service_failed():
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_user(hass: HomeAssistant, service: MagicMock):
+async def test_user(hass: HomeAssistant, service: MagicMock) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=None
@@ -219,7 +219,7 @@ async def test_user(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
+async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock) -> None:
     """Test user with 2sa authentication config."""
     with patch(
         "homeassistant.components.synology_dsm.config_flow.SynologyDSM",
@@ -272,7 +272,7 @@ async def test_user_2sa(hass: HomeAssistant, service_2sa: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
+async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock) -> None:
     """Test user config."""
     with patch(
         "homeassistant.components.synology_dsm.config_flow.SynologyDSM",
@@ -317,7 +317,7 @@ async def test_user_vdsm(hass: HomeAssistant, service_vdsm: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_reauth(hass: HomeAssistant, service: MagicMock):
+async def test_reauth(hass: HomeAssistant, service: MagicMock) -> None:
     """Test reauthentication."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -367,7 +367,7 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
+async def test_reconfig_user(hass: HomeAssistant, service: MagicMock) -> None:
     """Test re-configuration of already existing entry by user."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -396,7 +396,7 @@ async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_login_failed(hass: HomeAssistant, service: MagicMock):
+async def test_login_failed(hass: HomeAssistant, service: MagicMock) -> None:
     """Test when we have errors during login."""
     service.return_value.login = Mock(
         side_effect=(SynologyDSMLoginInvalidException(USERNAME))
@@ -412,7 +412,7 @@ async def test_login_failed(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_connection_failed(hass: HomeAssistant, service: MagicMock):
+async def test_connection_failed(hass: HomeAssistant, service: MagicMock) -> None:
     """Test when we have errors during connection."""
     service.return_value.login = Mock(
         side_effect=SynologyDSMRequestException(OSError("arg"))
@@ -429,7 +429,7 @@ async def test_connection_failed(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_unknown_failed(hass: HomeAssistant, service: MagicMock):
+async def test_unknown_failed(hass: HomeAssistant, service: MagicMock) -> None:
     """Test when we have an unknown error."""
     service.return_value.login = Mock(side_effect=SynologyDSMException(None, None))
 
@@ -444,7 +444,9 @@ async def test_unknown_failed(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_missing_data_after_login(hass: HomeAssistant, service_failed: MagicMock):
+async def test_missing_data_after_login(
+    hass: HomeAssistant, service_failed: MagicMock
+) -> None:
     """Test when we have errors during connection."""
     with patch(
         "homeassistant.components.synology_dsm.config_flow.SynologyDSM",
@@ -460,7 +462,7 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
+async def test_form_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
     """Test we can setup from ssdp."""
 
     result = await hass.config_entries.flow.async_init(
@@ -504,7 +506,7 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
+async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
     """Test re-configuration of already existing entry by ssdp."""
 
     MockConfigEntry(
@@ -537,7 +539,7 @@ async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
+async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
     """Test re-configuration of already existing entry by ssdp."""
 
     MockConfigEntry(
@@ -570,7 +572,7 @@ async def test_skip_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
+async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock) -> None:
     """Test abort of already existing entry by ssdp."""
 
     MockConfigEntry(
@@ -603,7 +605,7 @@ async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_options_flow(hass: HomeAssistant, service: MagicMock):
+async def test_options_flow(hass: HomeAssistant, service: MagicMock) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -647,7 +649,7 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock):
+async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock) -> None:
     """Test we can setup from zeroconf."""
 
     result = await hass.config_entries.flow.async_init(
@@ -695,7 +697,7 @@ async def test_discovered_via_zeroconf(hass: HomeAssistant, service: MagicMock):
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_discovered_via_zeroconf_missing_mac(
     hass: HomeAssistant, service: MagicMock
-):
+) -> None:
     """Test we abort if the mac address is missing."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/synology_dsm/test_init.py
+++ b/tests/components/synology_dsm/test_init.py
@@ -20,7 +20,7 @@ from .consts import HOST, MACS, PASSWORD, PORT, USE_SSL, USERNAME
 from tests.common import MockConfigEntry
 
 
-async def test_services_registered(hass: HomeAssistant, mock_dsm: MagicMock):
+async def test_services_registered(hass: HomeAssistant, mock_dsm: MagicMock) -> None:
     """Test if all services are registered."""
     with patch(
         "homeassistant.components.synology_dsm.common.SynologyDSM",
@@ -43,7 +43,7 @@ async def test_services_registered(hass: HomeAssistant, mock_dsm: MagicMock):
             assert hass.services.has_service(DOMAIN, service)
 
 
-async def test_reauth_triggered(hass: HomeAssistant):
+async def test_reauth_triggered(hass: HomeAssistant) -> None:
     """Test if reauthentication flow is triggered."""
     with patch(
         "homeassistant.components.synology_dsm.SynoApi.async_setup",

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_system_health_info, mock_platform
+from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
 
@@ -119,7 +120,11 @@ async def test_info_endpoint_register_callback_exc(
     assert data == {"info": {"error": {"type": "failed", "error": "unknown"}}}
 
 
-async def test_platform_loading(hass, hass_ws_client, aioclient_mock):
+async def test_platform_loading(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test registering via platform."""
     aioclient_mock.get("http://example.com/status", text="")
     aioclient_mock.get("http://example.com/status_fail", exc=ClientError)

--- a/tests/components/tag/test_init.py
+++ b/tests/components/tag/test_init.py
@@ -4,9 +4,12 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.tag import DOMAIN, TAGS, async_scan_tag
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import collection
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -28,7 +31,9 @@ def storage_setup(hass, hass_storage):
     return _storage
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing tags via WS."""
     assert await storage_setup()
 
@@ -44,7 +49,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert "test tag" in result
 
 
-async def test_ws_update(hass, hass_ws_client, storage_setup):
+async def test_ws_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing tags via WS."""
     assert await storage_setup()
     await async_scan_tag(hass, "test tag", "some_scanner")
@@ -68,7 +75,9 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
     assert item["name"] == "New name"
 
 
-async def test_tag_scanned(hass, hass_ws_client, storage_setup):
+async def test_tag_scanned(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test scanning tags."""
     assert await storage_setup()
 
@@ -111,7 +120,9 @@ def track_changes(coll: collection.ObservableCollection):
     return changes
 
 
-async def test_tag_id_exists(hass, hass_ws_client, storage_setup):
+async def test_tag_id_exists(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test scanning tags."""
     assert await storage_setup()
     changes = track_changes(hass.data[DOMAIN][TAGS])

--- a/tests/components/tag/test_trigger.py
+++ b/tests/components/tag/test_trigger.py
@@ -1,11 +1,11 @@
 """Tests for tag triggers."""
-
 import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.tag import async_scan_tag
 from homeassistant.components.tag.const import DEVICE_ID, DOMAIN, TAG_ID
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
@@ -37,7 +37,7 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_triggers(hass, tag_setup, calls):
+async def test_triggers(hass: HomeAssistant, tag_setup, calls) -> None:
     """Test tag triggers."""
     assert await tag_setup()
     assert await async_setup_component(
@@ -82,7 +82,9 @@ async def test_triggers(hass, tag_setup, calls):
     assert len(calls) == 1
 
 
-async def test_exception_bad_trigger(hass, calls, caplog):
+async def test_exception_bad_trigger(
+    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for exception on event triggers firing."""
 
     await async_setup_component(
@@ -104,7 +106,9 @@ async def test_exception_bad_trigger(hass, calls, caplog):
     assert "Unnamed automation could not be validated" in caplog.text
 
 
-async def test_multiple_tags_and_devices_trigger(hass, tag_setup, calls):
+async def test_multiple_tags_and_devices_trigger(
+    hass: HomeAssistant, tag_setup, calls
+) -> None:
     """Test multiple tags and devices triggers."""
     assert await tag_setup()
     assert await async_setup_component(

--- a/tests/components/tailscale/test_diagnostics.py
+++ b/tests/components/tailscale/test_diagnostics.py
@@ -12,7 +12,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -70,7 +70,7 @@ MOCK_NEARVY_STATIONS_OK = {
 }
 
 
-async def test_user(hass: HomeAssistant):
+async def test_user(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -110,7 +110,7 @@ async def test_user(hass: HomeAssistant):
     assert mock_setup_entry.called
 
 
-async def test_user_already_configured(hass: HomeAssistant):
+async def test_user_already_configured(hass: HomeAssistant) -> None:
     """Test starting a flow by user with an already configured region."""
 
     mock_config = MockConfigEntry(
@@ -134,7 +134,7 @@ async def test_user_already_configured(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_exception_security(hass: HomeAssistant):
+async def test_exception_security(hass: HomeAssistant) -> None:
     """Test starting a flow by user with invalid api key."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -154,7 +154,7 @@ async def test_exception_security(hass: HomeAssistant):
         assert result["errors"][CONF_API_KEY] == "invalid_auth"
 
 
-async def test_user_no_stations(hass: HomeAssistant):
+async def test_user_no_stations(hass: HomeAssistant) -> None:
     """Test starting a flow by user which does not find any station."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -174,7 +174,7 @@ async def test_user_no_stations(hass: HomeAssistant):
         assert result["errors"][CONF_RADIUS] == "no_stations"
 
 
-async def test_reauth(hass: HomeAssistant):
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test starting a flow by user to re-auth."""
 
     mock_config = MockConfigEntry(
@@ -227,7 +227,7 @@ async def test_reauth(hass: HomeAssistant):
     assert entry.data[CONF_API_KEY] == "269534f6-aaaa-bbbb-cccc-yyyyzzzzxxxx"
 
 
-async def test_options_flow(hass: HomeAssistant):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options flow."""
 
     mock_config = MockConfigEntry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
