### PR TITLE
Add type hints to integration tests (part 22)

### DIFF
--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -10,6 +10,7 @@ from hatasmota.utils import (
     get_topic_tele_sensor,
     get_topic_tele_will,
 )
+import pytest
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import (
@@ -21,6 +22,7 @@ from homeassistant.const import (
     Platform,
 )
 import homeassistant.core as ha
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .test_common import (
@@ -37,9 +39,12 @@ from .test_common import (
 )
 
 from tests.common import async_fire_mqtt_message, async_fire_time_changed
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 
-async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -104,7 +109,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert entity.force_update
 
 
-async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_switchname(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -164,7 +171,9 @@ async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasm
     assert state.state == STATE_OFF
 
 
-async def test_pushon_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_pushon_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 13
@@ -213,7 +222,9 @@ async def test_pushon_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
     assert state.state == STATE_OFF
 
 
-async def test_friendly_names(hass, mqtt_mock, setup_tasmota):
+async def test_friendly_names(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -237,7 +248,9 @@ async def test_friendly_names(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("friendly_name") == "Beer"
 
 
-async def test_off_delay(hass, mqtt_mock, setup_tasmota):
+async def test_off_delay(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test off_delay option."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 13  # PUSHON: 1s off_delay
@@ -286,8 +299,11 @@ async def test_off_delay(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -297,7 +313,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -305,7 +323,9 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     await help_test_availability(hass, mqtt_mock, Platform.BINARY_SENSOR, config)
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -316,8 +336,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -334,7 +357,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_binary_sensor(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered binary_sensor."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config2 = copy.deepcopy(DEFAULT_CONFIG)
@@ -349,8 +377,11 @@ async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog, setup_ta
 
 
 async def test_discovery_update_unchanged_binary_sensor(
-    hass, mqtt_mock, caplog, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered binary_sensor."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -363,7 +394,9 @@ async def test_discovery_update_unchanged_binary_sensor(
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -373,7 +406,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
@@ -389,7 +424,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1

--- a/tests/components/tasmota/test_config_flow.py
+++ b/tests/components/tasmota/test_config_flow.py
@@ -1,11 +1,15 @@
 """Test config flow."""
 from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 
 from tests.common import MockConfigEntry
+from tests.typing import MqttMockHAClient
 
 
-async def test_mqtt_abort_if_existing_entry(hass, mqtt_mock):
+async def test_mqtt_abort_if_existing_entry(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Check MQTT flow aborts when an entry already exist."""
     MockConfigEntry(domain="tasmota").add_to_hass(hass)
 
@@ -17,7 +21,9 @@ async def test_mqtt_abort_if_existing_entry(hass, mqtt_mock):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_mqtt_abort_invalid_topic(hass, mqtt_mock):
+async def test_mqtt_abort_invalid_topic(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Check MQTT flow aborts if discovery topic is invalid."""
     discovery_info = MqttServiceInfo(
         topic="tasmota/discovery/DC4F220848A2/bla",
@@ -79,7 +85,7 @@ async def test_mqtt_abort_invalid_topic(hass, mqtt_mock):
     assert result["type"] == "form"
 
 
-async def test_mqtt_setup(hass, mqtt_mock) -> None:
+async def test_mqtt_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> None:
     """Test we can finish a config flow through MQTT with custom prefix."""
     discovery_info = MqttServiceInfo(
         topic="tasmota/discovery/DC4F220848A2/config",
@@ -109,7 +115,7 @@ async def test_mqtt_setup(hass, mqtt_mock) -> None:
     assert result["result"].data == {"discovery_prefix": "tasmota/discovery"}
 
 
-async def test_user_setup(hass, mqtt_mock):
+async def test_user_setup(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
         "tasmota", context={"source": config_entries.SOURCE_USER}
@@ -124,7 +130,9 @@ async def test_user_setup(hass, mqtt_mock):
     }
 
 
-async def test_user_setup_advanced(hass, mqtt_mock):
+async def test_user_setup_advanced(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
         "tasmota",
@@ -142,7 +150,9 @@ async def test_user_setup_advanced(hass, mqtt_mock):
     }
 
 
-async def test_user_setup_advanced_strip_wildcard(hass, mqtt_mock):
+async def test_user_setup_advanced_strip_wildcard(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
         "tasmota",
@@ -160,7 +170,9 @@ async def test_user_setup_advanced_strip_wildcard(hass, mqtt_mock):
     }
 
 
-async def test_user_setup_invalid_topic_prefix(hass, mqtt_mock):
+async def test_user_setup_invalid_topic_prefix(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Test abort on invalid discovery topic."""
     result = await hass.config_entries.flow.async_init(
         "tasmota",
@@ -176,7 +188,9 @@ async def test_user_setup_invalid_topic_prefix(hass, mqtt_mock):
     assert result["errors"]["base"] == "invalid_discovery_topic"
 
 
-async def test_user_single_instance(hass, mqtt_mock):
+async def test_user_single_instance(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain="tasmota").add_to_hass(hass)
 

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -14,6 +14,7 @@ import pytest
 from homeassistant.components import cover
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -29,6 +30,7 @@ from .test_common import (
 )
 
 from tests.common import async_fire_mqtt_message
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 COVER_SUPPORT = (
     cover.SUPPORT_OPEN
@@ -44,7 +46,9 @@ TILT_SUPPORT = (
 )
 
 
-async def test_missing_relay(hass, mqtt_mock, setup_tasmota):
+async def test_missing_relay(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test no cover is discovered if relays are missing."""
 
 
@@ -58,8 +62,12 @@ async def test_missing_relay(hass, mqtt_mock, setup_tasmota):
     ],
 )
 async def test_multiple_covers(
-    hass, mqtt_mock, setup_tasmota, relay_config, num_covers
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+    relay_config,
+    num_covers,
+) -> None:
     """Test discovery of multiple covers."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"] = relay_config
@@ -77,7 +85,9 @@ async def test_multiple_covers(
     assert len(hass.states.async_all("cover")) == num_covers
 
 
-async def test_tilt_support(hass, mqtt_mock, setup_tasmota):
+async def test_tilt_support(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test tilt support detection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"] = [3, 3, 3, 3, 3, 3, 3, 3]
@@ -111,7 +121,9 @@ async def test_tilt_support(hass, mqtt_mock, setup_tasmota):
     assert state.attributes["supported_features"] == COVER_SUPPORT
 
 
-async def test_controlling_state_via_mqtt_tilt(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_tilt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 3
@@ -283,8 +295,8 @@ async def test_controlling_state_via_mqtt_tilt(hass, mqtt_mock, setup_tasmota):
 
 @pytest.mark.parametrize("tilt", ("", ',"Tilt":0'))
 async def test_controlling_state_via_mqtt_inverted(
-    hass, mqtt_mock, setup_tasmota, tilt
-):
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota, tilt
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 3
@@ -458,7 +470,9 @@ async def call_service(hass, entity_id, service, **kwargs):
     )
 
 
-async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -561,7 +575,9 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_mqtt_commands_inverted(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_inverted(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -626,8 +642,11 @@ async def test_sending_mqtt_commands_inverted(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -643,7 +662,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -654,7 +675,9 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -666,8 +689,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 3
@@ -678,7 +704,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_cover(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_cover(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered cover."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["dn"] = "Test"
@@ -701,7 +732,12 @@ async def test_discovery_removal_cover(hass, mqtt_mock, caplog, setup_tasmota):
     )
 
 
-async def test_discovery_update_unchanged_cover(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_update_unchanged_cover(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered cover."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -722,7 +758,9 @@ async def test_discovery_update_unchanged_cover(hass, mqtt_mock, caplog, setup_t
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -734,7 +772,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -751,7 +791,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -10,6 +10,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.tasmota import _LOGGER
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -22,9 +23,16 @@ from tests.common import (
     async_get_device_automations,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
+from tests.typing import MqttMockHAClient, WebSocketGenerator
 
 
-async def test_get_triggers_btn(hass, device_reg, entity_reg, mqtt_mock, setup_tasmota):
+async def test_get_triggers_btn(
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test we get the expected triggers from a discovered mqtt device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["btn"][0] = 1
@@ -65,7 +73,13 @@ async def test_get_triggers_btn(hass, device_reg, entity_reg, mqtt_mock, setup_t
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_swc(hass, device_reg, entity_reg, mqtt_mock, setup_tasmota):
+async def test_get_triggers_swc(
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test we get the expected triggers from a discovered mqtt device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 0
@@ -95,8 +109,12 @@ async def test_get_triggers_swc(hass, device_reg, entity_reg, mqtt_mock, setup_t
 
 
 async def test_get_unknown_triggers(
-    hass, device_reg, entity_reg, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test we don't get unknown triggers."""
     # Discover a device without device triggers
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -140,8 +158,12 @@ async def test_get_unknown_triggers(
 
 
 async def test_get_non_existing_triggers(
-    hass, device_reg, entity_reg, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test getting non existing triggers."""
     # Discover a device without device triggers
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -162,8 +184,12 @@ async def test_get_non_existing_triggers(
 
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_triggers(
-    hass, device_reg, entity_reg, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test exception handling when discovering trigger."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 0
@@ -245,8 +271,12 @@ async def test_discover_bad_triggers(
 
 
 async def test_update_remove_triggers(
-    hass, device_reg, entity_reg, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test triggers can be updated and removed."""
     # Discover a device with toggle + hold trigger
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -318,8 +348,8 @@ async def test_update_remove_triggers(
 
 
 async def test_if_fires_on_mqtt_message_btn(
-    hass, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test button triggers firing."""
     # Discover a device with 2 device triggers
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -389,8 +419,8 @@ async def test_if_fires_on_mqtt_message_btn(
 
 
 async def test_if_fires_on_mqtt_message_swc(
-    hass, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test switch triggers firing."""
     # Discover a device with 2 device triggers
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -483,8 +513,8 @@ async def test_if_fires_on_mqtt_message_swc(
 
 
 async def test_if_fires_on_mqtt_message_late_discover(
-    hass, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test triggers firing of MQTT device triggers discovered after setup."""
     # Discover a device without device triggers
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -562,8 +592,8 @@ async def test_if_fires_on_mqtt_message_late_discover(
 
 
 async def test_if_fires_on_mqtt_message_after_update(
-    hass, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test triggers firing after update."""
     # Discover a device with device trigger
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -643,7 +673,9 @@ async def test_if_fires_on_mqtt_message_after_update(
     assert len(calls) == 3
 
 
-async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_no_resubscribe_same_topic(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test subscription to topics without change."""
     # Discover a device with device trigger
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -690,8 +722,8 @@ async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock, setup_tasm
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
-    hass, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test triggers not firing after removal."""
     # Discover a device with device trigger
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -761,8 +793,13 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
-    hass, hass_ws_client, device_reg, calls, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_reg,
+    calls,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test triggers not firing after removal."""
     assert await async_setup_component(hass, "config", {})
     # Discover a device with device trigger
@@ -820,7 +857,9 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     assert len(calls) == 1
 
 
-async def test_attach_remove(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_attach_remove(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test attach and removal of trigger."""
     # Discover a device with device trigger
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -879,7 +918,9 @@ async def test_attach_remove(hass, device_reg, mqtt_mock, setup_tasmota):
     assert len(calls) == 1
 
 
-async def test_attach_remove_late(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_attach_remove_late(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test attach and removal of trigger."""
     # Discover a device without device triggers
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -950,7 +991,9 @@ async def test_attach_remove_late(hass, device_reg, mqtt_mock, setup_tasmota):
     assert len(calls) == 1
 
 
-async def test_attach_remove_late2(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_attach_remove_late2(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test attach and removal of trigger."""
     # Discover a device without device triggers
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -1006,7 +1049,9 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock, setup_tasmota):
     assert len(calls) == 0
 
 
-async def test_attach_remove_unknown1(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_attach_remove_unknown1(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test attach and removal of unknown trigger."""
     # Discover a device without device triggers
     config1 = copy.deepcopy(DEFAULT_CONFIG)
@@ -1044,8 +1089,12 @@ async def test_attach_remove_unknown1(hass, device_reg, mqtt_mock, setup_tasmota
 
 
 async def test_attach_unknown_remove_device_from_registry(
-    hass, hass_ws_client, device_reg, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_reg,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test attach and removal of device with unknown trigger."""
     assert await async_setup_component(hass, "config", {})
     # Discover a device without device triggers
@@ -1092,7 +1141,9 @@ async def test_attach_unknown_remove_device_from_registry(
     await hass.async_block_till_done()
 
 
-async def test_attach_remove_config_entry(hass, device_reg, mqtt_mock, setup_tasmota):
+async def test_attach_remove_config_entry(
+    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test trigger cleanup when removing a Tasmota config entry."""
     # Discover a device with device trigger
     config = copy.deepcopy(DEFAULT_CONFIG)

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -3,8 +3,11 @@ import copy
 import json
 from unittest.mock import ANY, patch
 
+import pytest
+
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.components.tasmota.discovery import ALREADY_DISCOVERED
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -16,9 +19,12 @@ from .conftest import setup_tasmota_helper
 from .test_common import DEFAULT_CONFIG, DEFAULT_CONFIG_9_0_0_3, remove_device
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
+from tests.typing import MqttMockHAClient, WebSocketGenerator
 
 
-async def test_subscribing_config_topic(hass, mqtt_mock, setup_tasmota):
+async def test_subscribing_config_topic(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test setting up discovery."""
     discovery_topic = DEFAULT_PREFIX
 
@@ -26,7 +32,9 @@ async def test_subscribing_config_topic(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_subscribe.assert_any_call(discovery_topic + "/#", ANY, 0, "utf-8")
 
 
-async def test_future_discovery_message(hass, mqtt_mock, caplog):
+async def test_future_discovery_message(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we handle backwards compatible discovery messages."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["future_option"] = "BEST_SINCE_SLICED_BREAD"
@@ -45,7 +53,9 @@ async def test_future_discovery_message(hass, mqtt_mock, caplog):
         assert mock_tasmota_get_device_config.called
 
 
-async def test_valid_discovery_message(hass, mqtt_mock, caplog):
+async def test_valid_discovery_message(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test discovery callback called."""
     config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -62,7 +72,7 @@ async def test_valid_discovery_message(hass, mqtt_mock, caplog):
         assert mock_tasmota_get_device_config.called
 
 
-async def test_invalid_topic(hass, mqtt_mock):
+async def test_invalid_topic(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> None:
     """Test receiving discovery message on wrong topic."""
     with patch(
         "homeassistant.components.tasmota.discovery.tasmota_get_device_config"
@@ -74,7 +84,9 @@ async def test_invalid_topic(hass, mqtt_mock):
         assert not mock_tasmota_get_device_config.called
 
 
-async def test_invalid_message(hass, mqtt_mock, caplog):
+async def test_invalid_message(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test receiving an invalid message."""
     with patch(
         "homeassistant.components.tasmota.discovery.tasmota_get_device_config"
@@ -87,7 +99,9 @@ async def test_invalid_message(hass, mqtt_mock, caplog):
         assert not mock_tasmota_get_device_config.called
 
 
-async def test_invalid_mac(hass, mqtt_mock, caplog):
+async def test_invalid_mac(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test topic is not matching device MAC."""
     config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -105,8 +119,13 @@ async def test_invalid_mac(hass, mqtt_mock, caplog):
 
 
 async def test_correct_config_discovery(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test receiving valid discovery message."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -135,8 +154,13 @@ async def test_correct_config_discovery(
 
 
 async def test_device_discover(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test setting up a device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]
@@ -161,8 +185,13 @@ async def test_device_discover(
 
 
 async def test_device_discover_deprecated(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test setting up a device with deprecated discovery message."""
     config = copy.deepcopy(DEFAULT_CONFIG_9_0_0_3)
     mac = config["mac"]
@@ -186,8 +215,13 @@ async def test_device_discover_deprecated(
 
 
 async def test_device_update(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test updating a device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["md"] = "Model 1"
@@ -231,8 +265,13 @@ async def test_device_update(
 
 
 async def test_device_remove(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a discovered device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]
@@ -265,8 +304,13 @@ async def test_device_remove(
 
 
 async def test_device_remove_multiple_config_entries_1(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a discovered device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]
@@ -311,8 +355,13 @@ async def test_device_remove_multiple_config_entries_1(
 
 
 async def test_device_remove_multiple_config_entries_2(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a discovered device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]
@@ -370,8 +419,13 @@ async def test_device_remove_multiple_config_entries_2(
 
 
 async def test_device_remove_stale(
-    hass, hass_ws_client, mqtt_mock, caplog, device_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a stale (undiscovered) device does not throw."""
     assert await async_setup_component(hass, "config", {})
     mac = "00000049A3BC"
@@ -401,8 +455,13 @@ async def test_device_remove_stale(
 
 
 async def test_device_rediscover(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a device."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]
@@ -448,7 +507,12 @@ async def test_device_rediscover(
     assert device_entry1.id == device_entry.id
 
 
-async def test_entity_duplicate_discovery(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_entity_duplicate_discovery(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test entities are not duplicated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -478,7 +542,12 @@ async def test_entity_duplicate_discovery(hass, mqtt_mock, caplog, setup_tasmota
     )
 
 
-async def test_entity_duplicate_removal(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_entity_duplicate_removal(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removing entity twice."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -502,8 +571,13 @@ async def test_entity_duplicate_removal(hass, mqtt_mock, caplog, setup_tasmota):
 
 
 async def test_same_topic(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test detecting devices with same topic."""
     configs = [
         copy.deepcopy(DEFAULT_CONFIG),
@@ -621,8 +695,13 @@ async def test_same_topic(
 
 
 async def test_topic_no_prefix(
-    hass, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test detecting devices with same topic."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1

--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -14,6 +14,7 @@ from voluptuous import MultipleInvalid
 from homeassistant.components import fan
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -30,9 +31,12 @@ from .test_common import (
 
 from tests.common import async_fire_mqtt_message
 from tests.components.fan import common
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 
-async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["if"] = 1
@@ -88,7 +92,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.attributes["percentage"] == 0
 
 
-async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["if"] = 1
@@ -182,7 +188,9 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_invalid_fan_speed_percentage(hass, mqtt_mock, setup_tasmota):
+async def test_invalid_fan_speed_percentage(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["if"] = 1
@@ -211,8 +219,11 @@ async def test_invalid_fan_speed_percentage(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -222,7 +233,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -230,7 +243,9 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     await help_test_availability(hass, mqtt_mock, Platform.FAN, config)
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -239,8 +254,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["if"] = 1
@@ -250,7 +268,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_fan(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_fan(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered fan."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["dn"] = "Test"
@@ -264,7 +287,12 @@ async def test_discovery_removal_fan(hass, mqtt_mock, caplog, setup_tasmota):
     )
 
 
-async def test_discovery_update_unchanged_fan(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_update_unchanged_fan(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered fan."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -277,7 +305,9 @@ async def test_discovery_update_unchanged_fan(hass, mqtt_mock, caplog, setup_tas
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -288,7 +318,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
@@ -303,7 +335,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -3,7 +3,10 @@ import copy
 import json
 from unittest.mock import call
 
+import pytest
+
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -15,11 +18,18 @@ from tests.common import (
     async_fire_mqtt_message,
     mock_integration,
 )
+from tests.typing import MqttMockHAClient, WebSocketGenerator
 
 
 async def test_device_remove(
-    hass, hass_ws_client, mqtt_mock, caplog, device_reg, entity_reg, setup_tasmota
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    device_reg,
+    entity_reg,
+    setup_tasmota,
+) -> None:
     """Test removing a discovered device through device registry."""
     assert await async_setup_component(hass, "config", {})
     config = copy.deepcopy(DEFAULT_CONFIG)
@@ -58,8 +68,12 @@ async def test_device_remove(
 
 
 async def test_device_remove_non_tasmota_device(
-    hass, device_reg, hass_ws_client, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test removing a non Tasmota device through device registry."""
     assert await async_setup_component(hass, "config", {})
 
@@ -99,8 +113,12 @@ async def test_device_remove_non_tasmota_device(
 
 
 async def test_device_remove_stale_tasmota_device(
-    hass, device_reg, hass_ws_client, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test removing a stale (undiscovered) Tasmota device through device registry."""
     assert await async_setup_component(hass, "config", {})
     config_entry = hass.config_entries.async_entries("tasmota")[0]
@@ -126,8 +144,13 @@ async def test_device_remove_stale_tasmota_device(
 
 
 async def test_tasmota_ws_remove_discovered_device(
-    hass, device_reg, entity_reg, hass_ws_client, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    device_reg,
+    entity_reg,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test Tasmota websocket device removal."""
     assert await async_setup_component(hass, "config", {})
     config = copy.deepcopy(DEFAULT_CONFIG)

--- a/tests/components/tasmota/test_light.py
+++ b/tests/components/tasmota/test_light.py
@@ -9,10 +9,12 @@ from hatasmota.utils import (
     get_topic_tele_state,
     get_topic_tele_will,
 )
+import pytest
 
 from homeassistant.components.light import LightEntityFeature
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -29,9 +31,12 @@ from .test_common import (
 
 from tests.common import async_fire_mqtt_message
 from tests.components.light import common
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 
-async def test_attributes_on_off(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_on_off(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -57,7 +62,9 @@ async def test_attributes_on_off(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "onoff"
 
 
-async def test_attributes_dimmer_tuya(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_dimmer_tuya(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -84,7 +91,9 @@ async def test_attributes_dimmer_tuya(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "brightness"
 
 
-async def test_attributes_dimmer(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_dimmer(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -110,7 +119,9 @@ async def test_attributes_dimmer(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "brightness"
 
 
-async def test_attributes_ct(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_ct(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -136,7 +147,9 @@ async def test_attributes_ct(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "color_temp"
 
 
-async def test_attributes_ct_reduced(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_ct_reduced(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -163,7 +176,9 @@ async def test_attributes_ct_reduced(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "color_temp"
 
 
-async def test_attributes_rgb(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_rgb(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -198,7 +213,9 @@ async def test_attributes_rgb(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "hs"
 
 
-async def test_attributes_rgbw(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_rgbw(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -233,7 +250,9 @@ async def test_attributes_rgbw(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "hs"
 
 
-async def test_attributes_rgbww(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_rgbww(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -268,7 +287,9 @@ async def test_attributes_rgbww(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "color_temp"
 
 
-async def test_attributes_rgbww_reduced(hass, mqtt_mock, setup_tasmota):
+async def test_attributes_rgbww_reduced(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -304,7 +325,9 @@ async def test_attributes_rgbww_reduced(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "color_temp"
 
 
-async def test_controlling_state_via_mqtt_on_off(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_on_off(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -353,7 +376,9 @@ async def test_controlling_state_via_mqtt_on_off(hass, mqtt_mock, setup_tasmota)
     assert "color_mode" not in state.attributes
 
 
-async def test_controlling_state_via_mqtt_ct(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_ct(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -416,7 +441,9 @@ async def test_controlling_state_via_mqtt_ct(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("color_mode") == "color_temp"
 
 
-async def test_controlling_state_via_mqtt_rgbw(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_rgbw(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -515,7 +542,9 @@ async def test_controlling_state_via_mqtt_rgbw(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
 
-async def test_controlling_state_via_mqtt_rgbww(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_rgbww(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -614,7 +643,9 @@ async def test_controlling_state_via_mqtt_rgbww(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
 
-async def test_controlling_state_via_mqtt_rgbww_tuya(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt_rgbww_tuya(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -723,7 +754,9 @@ async def test_controlling_state_via_mqtt_rgbww_tuya(hass, mqtt_mock, setup_tasm
     assert state.state == STATE_OFF
 
 
-async def test_sending_mqtt_commands_on_off(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_on_off(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -764,7 +797,9 @@ async def test_sending_mqtt_commands_on_off(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_mqtt_commands_rgbww_tuya(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_rgbww_tuya(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -812,7 +847,9 @@ async def test_sending_mqtt_commands_rgbww_tuya(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_sending_mqtt_commands_rgbw_legacy(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_rgbw_legacy(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["sw"] = "9.4.0.3"  # RGBW support was added in 9.4.0.4
@@ -910,7 +947,9 @@ async def test_sending_mqtt_commands_rgbw_legacy(hass, mqtt_mock, setup_tasmota)
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_mqtt_commands_rgbw(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_rgbw(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1007,7 +1046,9 @@ async def test_sending_mqtt_commands_rgbw(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_mqtt_commands_rgbww(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_rgbww(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1082,7 +1123,9 @@ async def test_sending_mqtt_commands_rgbww(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_sending_mqtt_commands_power_unlinked(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands_power_unlinked(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands to a light with unlinked dimlevel and power."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1134,7 +1177,9 @@ async def test_sending_mqtt_commands_power_unlinked(hass, mqtt_mock, setup_tasmo
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_transition(hass, mqtt_mock, setup_tasmota):
+async def test_transition(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test transition commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1324,7 +1369,9 @@ async def test_transition(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_transition_fixed(hass, mqtt_mock, setup_tasmota):
+async def test_transition_fixed(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test transition commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1398,7 +1445,9 @@ async def test_transition_fixed(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
-async def test_relay_as_light(hass, mqtt_mock, setup_tasmota):
+async def test_relay_as_light(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test relay show up as light in light mode."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -1459,7 +1508,9 @@ async def _test_split_light(hass, mqtt_mock, config, num_lights, num_switches):
         )
 
 
-async def test_split_light(hass, mqtt_mock, setup_tasmota):
+async def test_split_light(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test multi-channel light split to single-channel dimmers."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1473,7 +1524,9 @@ async def test_split_light(hass, mqtt_mock, setup_tasmota):
     await _test_split_light(hass, mqtt_mock, config, 5, 0)
 
 
-async def test_split_light2(hass, mqtt_mock, setup_tasmota):
+async def test_split_light2(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test multi-channel light split to single-channel dimmers."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -1531,7 +1584,9 @@ async def _test_unlinked_light(hass, mqtt_mock, config, num_switches):
         )
 
 
-async def test_unlinked_light(hass, mqtt_mock, setup_tasmota):
+async def test_unlinked_light(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test rgbww light split to rgb+ww."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1542,7 +1597,9 @@ async def test_unlinked_light(hass, mqtt_mock, setup_tasmota):
     await _test_unlinked_light(hass, mqtt_mock, config, 0)
 
 
-async def test_unlinked_light2(hass, mqtt_mock, setup_tasmota):
+async def test_unlinked_light2(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test rgbww light split to rgb+ww."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -1556,8 +1613,11 @@ async def test_unlinked_light2(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_discovery_update_reconfigure_light(
-    hass, mqtt_mock, caplog, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test reconfigure of discovered light."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1587,8 +1647,11 @@ async def test_discovery_update_reconfigure_light(
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1598,7 +1661,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1606,7 +1671,9 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     await help_test_availability(hass, mqtt_mock, Platform.LIGHT, config)
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1617,8 +1684,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1629,7 +1699,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_light(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered light."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["rl"][0] = 2
@@ -1643,7 +1718,12 @@ async def test_discovery_removal_light(hass, mqtt_mock, caplog, setup_tasmota):
     )
 
 
-async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_relay_as_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered relay as light."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["rl"][0] = 1
@@ -1658,8 +1738,11 @@ async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_t
 
 
 async def test_discovery_removal_relay_as_light2(
-    hass, mqtt_mock, caplog, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered relay as light."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["rl"][0] = 1
@@ -1673,7 +1756,12 @@ async def test_discovery_removal_relay_as_light2(
     )
 
 
-async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_update_unchanged_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered light."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1686,7 +1774,9 @@ async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog, setup_t
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1697,7 +1787,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_discovery_device_remove_relay_as_light(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove_relay_as_light(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -1708,7 +1800,9 @@ async def test_discovery_device_remove_relay_as_light(hass, mqtt_mock, setup_tas
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
@@ -1723,7 +1817,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2

--- a/tests/components/tasmota/test_mixins.py
+++ b/tests/components/tasmota/test_mixins.py
@@ -7,15 +7,20 @@ from hatasmota.const import CONF_MAC
 from hatasmota.utils import config_get_state_online, get_topic_tele_will
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
+from homeassistant.core import HomeAssistant
 
 from .test_common import DEFAULT_CONFIG
 
 from tests.common import async_fire_mqtt_message
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 
 async def test_availability_poll_state_once(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test several entities send a single message to update state."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant import config_entries
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -35,6 +36,7 @@ from .test_common import (
 )
 
 from tests.common import async_fire_mqtt_message, async_fire_time_changed
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 BAD_INDEXED_SENSOR_CONFIG_3 = {
     "sn": {
@@ -118,7 +120,9 @@ NESTED_SENSOR_CONFIG = {
 }
 
 
-async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -170,7 +174,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "20.0"
 
 
-async def test_nested_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_nested_sensor_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(NESTED_SENSOR_CONFIG)
@@ -216,7 +222,9 @@ async def test_nested_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "23.4"
 
 
-async def test_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_indexed_sensor_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(INDEXED_SENSOR_CONFIG)
@@ -262,7 +270,9 @@ async def test_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "7.8"
 
 
-async def test_indexed_sensor_state_via_mqtt2(hass, mqtt_mock, setup_tasmota):
+async def test_indexed_sensor_state_via_mqtt2(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT for sensor with last_reset property."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(INDEXED_SENSOR_CONFIG)
@@ -311,7 +321,9 @@ async def test_indexed_sensor_state_via_mqtt2(hass, mqtt_mock, setup_tasmota):
     assert state.state == "5.6"
 
 
-async def test_indexed_sensor_state_via_mqtt3(hass, mqtt_mock, setup_tasmota):
+async def test_indexed_sensor_state_via_mqtt3(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT for indexed sensor with last_reset property."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(INDEXED_SENSOR_CONFIG_2)
@@ -360,7 +372,9 @@ async def test_indexed_sensor_state_via_mqtt3(hass, mqtt_mock, setup_tasmota):
     assert state.state == "7.8"
 
 
-async def test_bad_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_bad_indexed_sensor_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT where sensor is not matching configuration."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(BAD_INDEXED_SENSOR_CONFIG_3)
@@ -473,7 +487,9 @@ async def test_bad_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
 
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])
-async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_status_sensor_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     entity_reg = er.async_get(hass)
 
@@ -533,7 +549,9 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])
-async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_single_shot_status_sensor_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     entity_reg = er.async_get(hass)
 
@@ -617,8 +635,8 @@ async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_t
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 @patch.object(hatasmota.status_sensor, "datetime", Mock(wraps=datetime.datetime))
 async def test_restart_time_status_sensor_state_via_mqtt(
-    hass, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     entity_reg = er.async_get(hass)
 
@@ -665,7 +683,9 @@ async def test_restart_time_status_sensor_state_via_mqtt(
     assert state.state == "2020-11-11T07:00:00+00:00"
 
 
-async def test_attributes(hass, mqtt_mock, setup_tasmota):
+async def test_attributes(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test correct attributes for sensors."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = {
@@ -703,7 +723,9 @@ async def test_attributes(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("unit_of_measurement") == "ppm"
 
 
-async def test_nested_sensor_attributes(hass, mqtt_mock, setup_tasmota):
+async def test_nested_sensor_attributes(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test correct attributes for sensors."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(NESTED_SENSOR_CONFIG)
@@ -735,7 +757,9 @@ async def test_nested_sensor_attributes(hass, mqtt_mock, setup_tasmota):
     assert state.attributes.get("unit_of_measurement") == " "
 
 
-async def test_indexed_sensor_attributes(hass, mqtt_mock, setup_tasmota):
+async def test_indexed_sensor_attributes(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test correct attributes for sensors."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = {
@@ -788,8 +812,13 @@ async def test_indexed_sensor_attributes(hass, mqtt_mock, setup_tasmota):
     ],
 )
 async def test_diagnostic_sensors(
-    hass, mqtt_mock, setup_tasmota, sensor_name, disabled, disabled_by
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+    sensor_name,
+    disabled,
+    disabled_by,
+) -> None:
     """Test properties of diagnostic sensors."""
     entity_reg = er.async_get(hass)
 
@@ -813,7 +842,9 @@ async def test_diagnostic_sensors(
 
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])
-async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
+async def test_enable_status_sensor(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test enabling status sensor."""
     entity_reg = er.async_get(hass)
 
@@ -868,8 +899,11 @@ async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -884,7 +918,9 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -898,7 +934,9 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -913,8 +951,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -931,7 +972,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_sensor(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_sensor(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered sensor."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config1 = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -951,8 +997,11 @@ async def test_discovery_removal_sensor(hass, mqtt_mock, caplog, setup_tasmota):
 
 
 async def test_discovery_update_unchanged_sensor(
-    hass, mqtt_mock, caplog, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered sensor."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -972,7 +1021,9 @@ async def test_discovery_update_unchanged_sensor(
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -982,7 +1033,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
@@ -1002,7 +1055,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)

--- a/tests/components/tasmota/test_switch.py
+++ b/tests/components/tasmota/test_switch.py
@@ -8,9 +8,11 @@ from hatasmota.utils import (
     get_topic_tele_state,
     get_topic_tele_will,
 )
+import pytest
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -27,9 +29,12 @@ from .test_common import (
 
 from tests.common import async_fire_mqtt_message
 from tests.components.switch import common
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
 
 
-async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
+async def test_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -73,7 +78,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
 
-async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -115,7 +122,9 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
 
-async def test_relay_as_light(hass, mqtt_mock, setup_tasmota):
+async def test_relay_as_light(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test relay does not show up as switch in light mode."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -136,8 +145,11 @@ async def test_relay_as_light(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_when_connection_lost(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -146,14 +158,18 @@ async def test_availability_when_connection_lost(
     )
 
 
-async def test_availability(hass, mqtt_mock, setup_tasmota):
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
     await help_test_availability(hass, mqtt_mock, Platform.SWITCH, config)
 
 
-async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -163,8 +179,11 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
 
 
 async def test_availability_poll_state(
-    hass, mqtt_client_mock, mqtt_mock, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -174,7 +193,12 @@ async def test_availability_poll_state(
     )
 
 
-async def test_discovery_removal_switch(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_switch(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered switch."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["rl"][0] = 1
@@ -186,7 +210,12 @@ async def test_discovery_removal_switch(hass, mqtt_mock, caplog, setup_tasmota):
     )
 
 
-async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_tasmota):
+async def test_discovery_removal_relay_as_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test removal of discovered relay as light."""
     config1 = copy.deepcopy(DEFAULT_CONFIG)
     config1["rl"][0] = 1
@@ -201,8 +230,11 @@ async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_t
 
 
 async def test_discovery_update_unchanged_switch(
-    hass, mqtt_mock, caplog, setup_tasmota
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
     """Test update of discovered switch."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -214,7 +246,9 @@ async def test_discovery_update_unchanged_switch(
         )
 
 
-async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test device registry remove."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -224,7 +258,9 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_subscriptions(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
@@ -238,7 +274,9 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota):
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1

--- a/tests/components/tcp/test_binary_sensor.py
+++ b/tests/components/tcp/test_binary_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -36,14 +37,14 @@ def now():
     return utcnow()
 
 
-async def test_setup_platform_valid_config(hass, mock_socket):
+async def test_setup_platform_valid_config(hass: HomeAssistant, mock_socket) -> None:
     """Check a valid configuration."""
     with assert_setup_component(1, "binary_sensor"):
         assert await async_setup_component(hass, "binary_sensor", TEST_CONFIG)
         await hass.async_block_till_done()
 
 
-async def test_setup_platform_invalid_config(hass, mock_socket):
+async def test_setup_platform_invalid_config(hass: HomeAssistant, mock_socket) -> None:
     """Check the invalid configuration."""
     with assert_setup_component(0):
         assert await async_setup_component(
@@ -54,7 +55,7 @@ async def test_setup_platform_invalid_config(hass, mock_socket):
         await hass.async_block_till_done()
 
 
-async def test_state(hass, mock_socket, now):
+async def test_state(hass: HomeAssistant, mock_socket, now) -> None:
     """Check the state and update of the binary sensor."""
     mock_socket.recv.return_value = b"off"
     assert await async_setup_component(hass, "binary_sensor", TEST_CONFIG)

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 import pytest
 
 import homeassistant.components.tcp.common as tcp
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
@@ -69,14 +70,14 @@ def mock_ssl_context_fixture():
         yield mock_ssl_context
 
 
-async def test_setup_platform_valid_config(hass, mock_socket):
+async def test_setup_platform_valid_config(hass: HomeAssistant, mock_socket) -> None:
     """Check a valid configuration and call add_entities with sensor."""
     with assert_setup_component(1, "sensor"):
         assert await async_setup_component(hass, "sensor", TEST_CONFIG)
         await hass.async_block_till_done()
 
 
-async def test_setup_platform_invalid_config(hass, mock_socket):
+async def test_setup_platform_invalid_config(hass: HomeAssistant, mock_socket) -> None:
     """Check an invalid configuration."""
     with assert_setup_component(0):
         assert await async_setup_component(
@@ -85,7 +86,7 @@ async def test_setup_platform_invalid_config(hass, mock_socket):
         await hass.async_block_till_done()
 
 
-async def test_state(hass, mock_socket, mock_select):
+async def test_state(hass: HomeAssistant, mock_socket, mock_select) -> None:
     """Return the contents of _state."""
     assert await async_setup_component(hass, "sensor", TEST_CONFIG)
     await hass.async_block_till_done()
@@ -111,7 +112,7 @@ async def test_state(hass, mock_socket, mock_select):
     assert mock_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])
 
 
-async def test_config_uses_defaults(hass, mock_socket):
+async def test_config_uses_defaults(hass: HomeAssistant, mock_socket) -> None:
     """Check if defaults were set."""
     config = copy(SENSOR_TEST_CONFIG)
 
@@ -132,7 +133,7 @@ async def test_config_uses_defaults(hass, mock_socket):
 
 
 @pytest.mark.parametrize("sock_attr", ["connect", "send"])
-async def test_update_socket_error(hass, mock_socket, sock_attr):
+async def test_update_socket_error(hass: HomeAssistant, mock_socket, sock_attr) -> None:
     """Test socket errors during update."""
     socket_method = getattr(mock_socket, sock_attr)
     socket_method.side_effect = OSError("Boom")
@@ -146,7 +147,9 @@ async def test_update_socket_error(hass, mock_socket, sock_attr):
     assert state.state == "unknown"
 
 
-async def test_update_select_fails(hass, mock_socket, mock_select):
+async def test_update_select_fails(
+    hass: HomeAssistant, mock_socket, mock_select
+) -> None:
     """Test select fails to return a socket for reading."""
     mock_select.return_value = (False, False, False)
 
@@ -159,7 +162,9 @@ async def test_update_select_fails(hass, mock_socket, mock_select):
     assert state.state == "unknown"
 
 
-async def test_update_returns_if_template_render_fails(hass, mock_socket):
+async def test_update_returns_if_template_render_fails(
+    hass: HomeAssistant, mock_socket
+) -> None:
     """Return None if rendering the template fails."""
     config = copy(SENSOR_TEST_CONFIG)
     config[tcp.CONF_VALUE_TEMPLATE] = "{{ value / 0 }}"
@@ -173,7 +178,9 @@ async def test_update_returns_if_template_render_fails(hass, mock_socket):
     assert state.state == "unknown"
 
 
-async def test_ssl_state(hass, mock_socket, mock_select, mock_ssl_context):
+async def test_ssl_state(
+    hass: HomeAssistant, mock_socket, mock_select, mock_ssl_context
+) -> None:
     """Return the contents of _state, updated over SSL."""
     config = copy(SENSOR_TEST_CONFIG)
     config[tcp.CONF_SSL] = "on"
@@ -204,7 +211,9 @@ async def test_ssl_state(hass, mock_socket, mock_select, mock_ssl_context):
     assert mock_ssl_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])
 
 
-async def test_ssl_state_verify_off(hass, mock_socket, mock_select, mock_ssl_context):
+async def test_ssl_state_verify_off(
+    hass: HomeAssistant, mock_socket, mock_select, mock_ssl_context
+) -> None:
     """Return the contents of _state, updated over SSL (verify_ssl disabled)."""
     config = copy(SENSOR_TEST_CONFIG)
     config[tcp.CONF_SSL] = "on"

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -5,8 +5,10 @@ from telegram.ext.dispatcher import Dispatcher
 
 from homeassistant.components.telegram_bot import DOMAIN, SERVICE_SEND_MESSAGE
 from homeassistant.components.telegram_bot.webhooks import TELEGRAM_WEBHOOK_URL
+from homeassistant.core import HomeAssistant
 
 from tests.common import async_capture_events
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -18,19 +20,22 @@ def clear_dispatcher():
     Dispatcher._Dispatcher__singleton_semaphore.release()
 
 
-async def test_webhook_platform_init(hass, webhook_platform):
+async def test_webhook_platform_init(hass: HomeAssistant, webhook_platform) -> None:
     """Test initialization of the webhooks platform."""
     assert hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE) is True
 
 
-async def test_polling_platform_init(hass, polling_platform):
+async def test_polling_platform_init(hass: HomeAssistant, polling_platform) -> None:
     """Test initialization of the polling platform."""
     assert hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE) is True
 
 
 async def test_webhook_endpoint_generates_telegram_text_event(
-    hass, webhook_platform, hass_client, update_message_text
-):
+    hass: HomeAssistant,
+    webhook_platform,
+    hass_client: ClientSessionGenerator,
+    update_message_text,
+) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_text` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_text")
@@ -47,8 +52,11 @@ async def test_webhook_endpoint_generates_telegram_text_event(
 
 
 async def test_webhook_endpoint_generates_telegram_command_event(
-    hass, webhook_platform, hass_client, update_message_command
-):
+    hass: HomeAssistant,
+    webhook_platform,
+    hass_client: ClientSessionGenerator,
+    update_message_command,
+) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_command` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_command")
@@ -65,8 +73,11 @@ async def test_webhook_endpoint_generates_telegram_command_event(
 
 
 async def test_webhook_endpoint_generates_telegram_callback_event(
-    hass, webhook_platform, hass_client, update_callback_query
-):
+    hass: HomeAssistant,
+    webhook_platform,
+    hass_client: ClientSessionGenerator,
+    update_callback_query,
+) -> None:
     """POST to the configured webhook endpoint and assert fired `telegram_callback` event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_callback")
@@ -83,8 +94,8 @@ async def test_webhook_endpoint_generates_telegram_callback_event(
 
 
 async def test_polling_platform_message_text_update(
-    hass, polling_platform, update_message_text
-):
+    hass: HomeAssistant, polling_platform, update_message_text
+) -> None:
     """Provide the `PollBot`s `Dispatcher` with an `Update` and assert fired `telegram_text` event."""
     events = async_capture_events(hass, "telegram_text")
 
@@ -104,8 +115,11 @@ async def test_polling_platform_message_text_update(
 
 
 async def test_webhook_endpoint_unauthorized_update_doesnt_generate_telegram_text_event(
-    hass, webhook_platform, hass_client, unauthorized_update_message_text
-):
+    hass: HomeAssistant,
+    webhook_platform,
+    hass_client: ClientSessionGenerator,
+    unauthorized_update_message_text,
+) -> None:
     """Update with unauthorized user/chat should not trigger event."""
     client = await hass_client()
     events = async_capture_events(hass, "telegram_text")

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -72,7 +72,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_setup"
 
 
-async def test_full_flow_implementation(hass, mock_tellduslive):
+async def test_full_flow_implementation(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test registering an implementation and finishing flow works."""
     flow = init_config_flow(hass)
     flow.context = {"source": SOURCE_DISCOVERY}
@@ -101,7 +101,7 @@ async def test_full_flow_implementation(hass, mock_tellduslive):
     assert result["data"]["session"] == {"token": "token", "host": "localhost"}
 
 
-async def test_step_import(hass, mock_tellduslive):
+async def test_step_import(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test that we trigger auth when configuring from import."""
     flow = init_config_flow(hass)
 
@@ -110,7 +110,7 @@ async def test_step_import(hass, mock_tellduslive):
     assert result["step_id"] == "auth"
 
 
-async def test_step_import_add_host(hass, mock_tellduslive):
+async def test_step_import_add_host(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test that we add host and trigger user when configuring from import."""
     flow = init_config_flow(hass)
 
@@ -121,7 +121,9 @@ async def test_step_import_add_host(hass, mock_tellduslive):
     assert result["step_id"] == "user"
 
 
-async def test_step_import_no_config_file(hass, mock_tellduslive):
+async def test_step_import_no_config_file(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test that we trigger user with no config_file configuring from import."""
     flow = init_config_flow(hass)
 
@@ -132,7 +134,9 @@ async def test_step_import_no_config_file(hass, mock_tellduslive):
     assert result["step_id"] == "user"
 
 
-async def test_step_import_load_json_matching_host(hass, mock_tellduslive):
+async def test_step_import_load_json_matching_host(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test that we add host and trigger user when configuring from import."""
     flow = init_config_flow(hass)
 
@@ -147,7 +151,7 @@ async def test_step_import_load_json_matching_host(hass, mock_tellduslive):
     assert result["step_id"] == "user"
 
 
-async def test_step_import_load_json(hass, mock_tellduslive):
+async def test_step_import_load_json(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test that we create entry when configuring from import."""
     flow = init_config_flow(hass)
 
@@ -166,7 +170,7 @@ async def test_step_import_load_json(hass, mock_tellduslive):
 
 
 @pytest.mark.parametrize("supports_local_api", [False])
-async def test_step_disco_no_local_api(hass, mock_tellduslive):
+async def test_step_disco_no_local_api(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test that we trigger when configuring from discovery, not supporting local api."""
     flow = init_config_flow(hass)
     flow.context = {"source": SOURCE_DISCOVERY}
@@ -177,7 +181,7 @@ async def test_step_disco_no_local_api(hass, mock_tellduslive):
     assert len(flow._hosts) == 1
 
 
-async def test_step_auth(hass, mock_tellduslive):
+async def test_step_auth(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test that create cloud entity from auth."""
     flow = init_config_flow(hass)
 
@@ -194,7 +198,9 @@ async def test_step_auth(hass, mock_tellduslive):
 
 
 @pytest.mark.parametrize("authorize", [False])
-async def test_wrong_auth_flow_implementation(hass, mock_tellduslive):
+async def test_wrong_auth_flow_implementation(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test wrong auth."""
     flow = init_config_flow(hass)
 
@@ -205,7 +211,7 @@ async def test_wrong_auth_flow_implementation(hass, mock_tellduslive):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_not_pick_host_if_only_one(hass, mock_tellduslive):
+async def test_not_pick_host_if_only_one(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test not picking host if we have just one."""
     flow = init_config_flow(hass)
 
@@ -214,7 +220,9 @@ async def test_not_pick_host_if_only_one(hass, mock_tellduslive):
     assert result["step_id"] == "auth"
 
 
-async def test_abort_if_timeout_generating_auth_url(hass, mock_tellduslive):
+async def test_abort_if_timeout_generating_auth_url(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test abort if generating authorize url timeout."""
     flow = init_config_flow(hass, side_effect=asyncio.TimeoutError)
 
@@ -223,7 +231,7 @@ async def test_abort_if_timeout_generating_auth_url(hass, mock_tellduslive):
     assert result["reason"] == "authorize_url_timeout"
 
 
-async def test_abort_no_auth_url(hass, mock_tellduslive):
+async def test_abort_no_auth_url(hass: HomeAssistant, mock_tellduslive) -> None:
     """Test abort if generating authorize url returns none."""
     flow = init_config_flow(hass)
     flow._get_auth_url = Mock(return_value=False)
@@ -233,7 +241,9 @@ async def test_abort_no_auth_url(hass, mock_tellduslive):
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
-async def test_abort_if_exception_generating_auth_url(hass, mock_tellduslive):
+async def test_abort_if_exception_generating_auth_url(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test we abort if generating authorize url blows up."""
     flow = init_config_flow(hass, side_effect=ValueError)
 
@@ -242,7 +252,9 @@ async def test_abort_if_exception_generating_auth_url(hass, mock_tellduslive):
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
-async def test_discovery_already_configured(hass, mock_tellduslive):
+async def test_discovery_already_configured(
+    hass: HomeAssistant, mock_tellduslive
+) -> None:
     """Test abort if already configured fires from discovery."""
     MockConfigEntry(domain="tellduslive", data={"host": "some-host"}).add_to_hass(hass)
     flow = init_config_flow(hass)

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
 TEMPLATE_NAME = "alarm_control_panel.test_template_panel"
 PANEL_NAME = "alarm_control_panel.test"
@@ -99,7 +99,7 @@ TEMPLATE_ALARM_CONFIG = {
         },
     ],
 )
-async def test_template_state_text(hass, start_ha):
+async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
     """Test the state text of a template."""
 
     for set_state in [
@@ -136,7 +136,7 @@ async def test_template_state_text(hass, start_ha):
         },
     ],
 )
-async def test_optimistic_states(hass, start_ha):
+async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
     """Test the optimistic state."""
 
     state = hass.states.get(TEMPLATE_NAME)
@@ -223,7 +223,9 @@ async def test_optimistic_states(hass, start_ha):
         ),
     ],
 )
-async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
+async def test_template_syntax_error(
+    hass: HomeAssistant, msg, start_ha, caplog_setup_text
+) -> None:
     """Test templating syntax error."""
     assert len(hass.states.async_all("alarm_control_panel")) == 0
     assert (msg) in caplog_setup_text
@@ -247,7 +249,7 @@ async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
         },
     ],
 )
-async def test_name(hass, start_ha):
+async def test_name(hass: HomeAssistant, start_ha) -> None:
     """Test the accessibility of the name attribute."""
     state = hass.states.get(TEMPLATE_NAME)
     assert state is not None
@@ -278,7 +280,7 @@ async def test_name(hass, start_ha):
         "alarm_trigger",
     ],
 )
-async def test_actions(hass, service, start_ha, service_calls):
+async def test_actions(hass: HomeAssistant, service, start_ha, service_calls) -> None:
     """Test alarm actions."""
     await hass.services.async_call(
         ALARM_DOMAIN, service, {"entity_id": TEMPLATE_NAME}, blocking=True
@@ -310,7 +312,7 @@ async def test_actions(hass, service, start_ha, service_calls):
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one alarm control panel per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -382,7 +384,9 @@ async def test_unique_id(hass, start_ha):
         ),
     ],
 )
-async def test_code_config(hass, code_format, code_arm_required, start_ha):
+async def test_code_config(
+    hass: HomeAssistant, code_format, code_arm_required, start_ha
+) -> None:
     """Test configuration options related to alarm code."""
     state = hass.states.get(TEMPLATE_NAME)
     assert state.attributes.get("code_format") == code_format

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -67,7 +67,9 @@ OFF = "off"
         ),
     ],
 )
-async def test_setup_minimal(hass, start_ha, entity_id, name, attributes):
+async def test_setup_minimal(
+    hass: HomeAssistant, start_ha, entity_id, name, attributes
+) -> None:
     """Test the setup."""
     state = hass.states.get(entity_id)
     assert state is not None
@@ -111,7 +113,7 @@ async def test_setup_minimal(hass, start_ha, entity_id, name, attributes):
         ),
     ],
 )
-async def test_setup(hass, start_ha, entity_id):
+async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
     """Test the setup."""
     state = hass.states.get(entity_id)
     assert state is not None
@@ -178,7 +180,7 @@ async def test_setup(hass, start_ha, entity_id):
         ),
     ],
 )
-async def test_setup_invalid_sensors(hass, count, start_ha):
+async def test_setup_invalid_sensors(hass: HomeAssistant, count, start_ha) -> None:
     """Test setup with no sensors."""
     assert len(hass.states.async_entity_ids("binary_sensor")) == count
 
@@ -224,7 +226,7 @@ async def test_setup_invalid_sensors(hass, count, start_ha):
         ),
     ],
 )
-async def test_icon_template(hass, start_ha, entity_id):
+async def test_icon_template(hass: HomeAssistant, start_ha, entity_id) -> None:
     """Test icon template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("icon") == ""
@@ -276,7 +278,9 @@ async def test_icon_template(hass, start_ha, entity_id):
         ),
     ],
 )
-async def test_entity_picture_template(hass, start_ha, entity_id):
+async def test_entity_picture_template(
+    hass: HomeAssistant, start_ha, entity_id
+) -> None:
     """Test entity_picture template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("entity_picture") == ""
@@ -324,7 +328,7 @@ async def test_entity_picture_template(hass, start_ha, entity_id):
         ),
     ],
 )
-async def test_attribute_templates(hass, start_ha, entity_id):
+async def test_attribute_templates(hass: HomeAssistant, start_ha, entity_id) -> None:
     """Test attribute_templates template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("test_attribute") == "It ."
@@ -368,7 +372,7 @@ async def setup_mock():
         },
     ],
 )
-async def test_match_all(hass, setup_mock, start_ha):
+async def test_match_all(hass: HomeAssistant, setup_mock, start_ha) -> None:
     """Test template that is rerendered on any state lifecycle."""
     init_calls = len(setup_mock.mock_calls)
 
@@ -395,7 +399,7 @@ async def test_match_all(hass, setup_mock, start_ha):
         },
     ],
 )
-async def test_event(hass, start_ha):
+async def test_event(hass: HomeAssistant, start_ha) -> None:
     """Test the event."""
     state = hass.states.get("binary_sensor.test")
     assert state.state == OFF
@@ -505,7 +509,7 @@ async def test_event(hass, start_ha):
         ),
     ],
 )
-async def test_template_delay_on_off(hass, start_ha):
+async def test_template_delay_on_off(hass: HomeAssistant, start_ha) -> None:
     """Test binary sensor template delay on."""
     # Ensure the initial state is not on
     assert hass.states.get("binary_sensor.test_on").state != ON
@@ -583,7 +587,9 @@ async def test_template_delay_on_off(hass, start_ha):
         ),
     ],
 )
-async def test_available_without_availability_template(hass, start_ha, entity_id):
+async def test_available_without_availability_template(
+    hass: HomeAssistant, start_ha, entity_id
+) -> None:
     """Ensure availability is true without an availability_template."""
     state = hass.states.get(entity_id)
 
@@ -630,7 +636,7 @@ async def test_available_without_availability_template(hass, start_ha, entity_id
         ),
     ],
 )
-async def test_availability_template(hass, start_ha, entity_id):
+async def test_availability_template(hass: HomeAssistant, start_ha, entity_id) -> None:
     """Test availability template."""
     hass.states.async_set("sensor.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -665,7 +671,9 @@ async def test_availability_template(hass, start_ha, entity_id):
         },
     ],
 )
-async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
+async def test_invalid_attribute_template(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("binary_sensor.test_sensor", "true")
     assert len(hass.states.async_all()) == 2
@@ -691,8 +699,8 @@ async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
 
     assert hass.states.get("binary_sensor.my_sensor").state != STATE_UNAVAILABLE
@@ -796,7 +804,7 @@ async def test_no_update_template_match_all(
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one binary sensor per id."""
     assert len(hass.states.async_all()) == 2
 
@@ -835,7 +843,9 @@ async def test_unique_id(hass, start_ha):
         },
     ],
 )
-async def test_template_validation_error(hass, caplog, start_ha):
+async def test_template_validation_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha
+) -> None:
     """Test binary sensor template delay on."""
     caplog.set_level(logging.ERROR)
     state = hass.states.get("binary_sensor.test")
@@ -897,7 +907,9 @@ async def test_template_validation_error(hass, caplog, start_ha):
         ),
     ],
 )
-async def test_availability_icon_picture(hass, start_ha, entity_id):
+async def test_availability_icon_picture(
+    hass: HomeAssistant, start_ha, entity_id
+) -> None:
     """Test name, icon and picture templates are rendered at setup."""
     state = hass.states.get(entity_id)
     assert state.state == "unavailable"
@@ -951,8 +963,14 @@ async def test_availability_icon_picture(hass, start_ha, entity_id):
     ],
 )
 async def test_restore_state(
-    hass, count, domain, config, extra_config, restored_state, initial_state
-):
+    hass: HomeAssistant,
+    count,
+    domain,
+    config,
+    extra_config,
+    restored_state,
+    initial_state,
+) -> None:
     """Test restoring template binary sensor."""
 
     fake_state = State(
@@ -1034,7 +1052,7 @@ async def test_restore_state(
         },
     ],
 )
-async def test_trigger_entity(hass, start_ha):
+async def test_trigger_entity(hass: HomeAssistant, start_ha) -> None:
     """Test trigger entity works."""
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.hello_name")
@@ -1103,7 +1121,9 @@ async def test_trigger_entity(hass, start_ha):
         },
     ],
 )
-async def test_template_with_trigger_templated_delay_on(hass, start_ha):
+async def test_template_with_trigger_templated_delay_on(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test binary sensor template with template delay on."""
     state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_UNKNOWN
@@ -1165,8 +1185,14 @@ async def test_template_with_trigger_templated_delay_on(hass, start_ha):
     ],
 )
 async def test_trigger_entity_restore_state(
-    hass, count, domain, config, restored_state, initial_state, initial_attributes
-):
+    hass: HomeAssistant,
+    count,
+    domain,
+    config,
+    restored_state,
+    initial_state,
+    initial_attributes,
+) -> None:
     """Test restoring trigger template binary sensor."""
 
     restored_attributes = {
@@ -1234,8 +1260,8 @@ async def test_trigger_entity_restore_state(
 )
 @pytest.mark.parametrize("restored_state", [ON, OFF])
 async def test_trigger_entity_restore_state_auto_off(
-    hass, count, domain, config, restored_state, freezer
-):
+    hass: HomeAssistant, count, domain, config, restored_state, freezer
+) -> None:
     """Test restoring trigger template binary sensor."""
 
     freezer.move_to("2022-02-02 12:02:00+00:00")
@@ -1294,8 +1320,8 @@ async def test_trigger_entity_restore_state_auto_off(
     ],
 )
 async def test_trigger_entity_restore_state_auto_off_expired(
-    hass, count, domain, config, freezer
-):
+    hass: HomeAssistant, count, domain, config, freezer
+) -> None:
     """Test restoring trigger template binary sensor."""
 
     freezer.move_to("2022-02-02 12:02:00+00:00")

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -59,7 +59,7 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
     assert hass.states.async_all("button") == []
 
 
-async def test_all_optional_config(hass, calls):
+async def test_all_optional_config(hass: HomeAssistant, calls) -> None:
     """Test: including all optional templates is ok."""
     with assert_setup_component(1, "template"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import assert_setup_component
 
@@ -130,7 +131,9 @@ OPEN_CLOSE_COVER_CONFIG = {
         ),
     ],
 )
-async def test_template_state_text(hass, states, start_ha, caplog):
+async def test_template_state_text(
+    hass: HomeAssistant, states, start_ha, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the state text of a template."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -162,7 +165,7 @@ async def test_template_state_text(hass, states, start_ha, caplog):
         },
     ],
 )
-async def test_template_state_boolean(hass, start_ha):
+async def test_template_state_boolean(hass: HomeAssistant, start_ha) -> None:
     """Test the value_template attribute."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -187,7 +190,7 @@ async def test_template_state_boolean(hass, start_ha):
         },
     ],
 )
-async def test_template_position(hass, start_ha):
+async def test_template_position(hass: HomeAssistant, start_ha) -> None:
     """Test the position_template attribute."""
     hass.states.async_set("cover.test", STATE_OPEN)
     attrs = {}
@@ -222,7 +225,7 @@ async def test_template_position(hass, start_ha):
         },
     ],
 )
-async def test_template_tilt(hass, start_ha):
+async def test_template_tilt(hass: HomeAssistant, start_ha) -> None:
     """Test the tilt_template attribute."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") == 42.0
@@ -264,7 +267,7 @@ async def test_template_tilt(hass, start_ha):
         },
     ],
 )
-async def test_template_out_of_bounds(hass, start_ha):
+async def test_template_out_of_bounds(hass: HomeAssistant, start_ha) -> None:
     """Test template out-of-bounds condition."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") is None
@@ -300,7 +303,9 @@ async def test_template_out_of_bounds(hass, start_ha):
         },
     ],
 )
-async def test_template_open_or_position(hass, start_ha, caplog_setup_text):
+async def test_template_open_or_position(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that at least one of open_cover or set_position is used."""
     assert hass.states.async_all("cover") == []
     assert "Invalid config for [cover.template]" in caplog_setup_text
@@ -323,7 +328,7 @@ async def test_template_open_or_position(hass, start_ha, caplog_setup_text):
         },
     ],
 )
-async def test_open_action(hass, start_ha, calls):
+async def test_open_action(hass: HomeAssistant, start_ha, calls) -> None:
     """Test the open_cover command."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_CLOSED
@@ -362,7 +367,7 @@ async def test_open_action(hass, start_ha, calls):
         },
     ],
 )
-async def test_close_stop_action(hass, start_ha, calls):
+async def test_close_stop_action(hass: HomeAssistant, start_ha, calls) -> None:
     """Test the close-cover and stop_cover commands."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -391,7 +396,7 @@ async def test_close_stop_action(hass, start_ha, calls):
         {"input_number": {"test": {"min": "0", "max": "100", "initial": "42"}}},
     ],
 )
-async def test_set_position(hass, start_ha, calls):
+async def test_set_position(hass: HomeAssistant, start_ha, calls) -> None:
     """Test the set_position command."""
     with assert_setup_component(1, "cover"):
         assert await setup.async_setup_component(
@@ -520,7 +525,9 @@ async def test_set_position(hass, start_ha, calls):
         (SERVICE_CLOSE_COVER_TILT, {ATTR_ENTITY_ID: ENTITY_COVER}, 0),
     ],
 )
-async def test_set_tilt_position(hass, service, attr, start_ha, calls, tilt_position):
+async def test_set_tilt_position(
+    hass: HomeAssistant, service, attr, start_ha, calls, tilt_position
+) -> None:
     """Test the set_tilt_position command."""
     await hass.services.async_call(
         DOMAIN,
@@ -552,7 +559,7 @@ async def test_set_tilt_position(hass, service, attr, start_ha, calls, tilt_posi
         },
     ],
 )
-async def test_set_position_optimistic(hass, start_ha, calls):
+async def test_set_position_optimistic(hass: HomeAssistant, start_ha, calls) -> None:
     """Test optimistic position mode."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_position") is None
@@ -599,7 +606,9 @@ async def test_set_position_optimistic(hass, start_ha, calls):
         },
     ],
 )
-async def test_set_tilt_position_optimistic(hass, start_ha, calls):
+async def test_set_tilt_position_optimistic(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test the optimistic tilt_position mode."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") is None
@@ -648,7 +657,7 @@ async def test_set_tilt_position_optimistic(hass, start_ha, calls):
         },
     ],
 )
-async def test_icon_template(hass, start_ha):
+async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
     """Test icon template."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("icon") == ""
@@ -683,7 +692,7 @@ async def test_icon_template(hass, start_ha):
         },
     ],
 )
-async def test_entity_picture_template(hass, start_ha):
+async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
     """Test icon template."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("entity_picture") == ""
@@ -716,7 +725,7 @@ async def test_entity_picture_template(hass, start_ha):
         },
     ],
 )
-async def test_availability_template(hass, start_ha):
+async def test_availability_template(hass: HomeAssistant, start_ha) -> None:
     """Test availability template."""
     hass.states.async_set("availability_state.state", STATE_OFF)
     await hass.async_block_till_done()
@@ -746,7 +755,9 @@ async def test_availability_template(hass, start_ha):
         },
     ],
 )
-async def test_availability_without_availability_template(hass, start_ha):
+async def test_availability_without_availability_template(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test that component is available if there is no."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state != STATE_UNAVAILABLE
@@ -771,8 +782,8 @@ async def test_availability_without_availability_template(hass, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("cover.test_template_cover") != STATE_UNAVAILABLE
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
@@ -796,7 +807,7 @@ async def test_invalid_availability_template_keeps_component_available(
         },
     ],
 )
-async def test_device_class(hass, start_ha):
+async def test_device_class(hass: HomeAssistant, start_ha) -> None:
     """Test device class."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("device_class") == "door"
@@ -820,7 +831,7 @@ async def test_device_class(hass, start_ha):
         },
     ],
 )
-async def test_invalid_device_class(hass, start_ha):
+async def test_invalid_device_class(hass: HomeAssistant, start_ha) -> None:
     """Test device class."""
     state = hass.states.get("cover.test_template_cover")
     assert not state
@@ -849,7 +860,7 @@ async def test_invalid_device_class(hass, start_ha):
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one cover per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -874,7 +885,7 @@ async def test_unique_id(hass, start_ha):
         },
     ],
 )
-async def test_state_gets_lowercased(hass, start_ha):
+async def test_state_gets_lowercased(hass: HomeAssistant, start_ha) -> None:
     """Test True/False is lowercased."""
 
     hass.states.async_set("binary_sensor.garage_door_sensor", "off")
@@ -921,8 +932,8 @@ async def test_state_gets_lowercased(hass, start_ha):
     ],
 )
 async def test_self_referencing_icon_with_no_template_is_not_a_loop(
-    hass, start_ha, caplog
-):
+    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a self referencing icon with no value template is not a loop."""
     assert len(hass.states.async_all()) == 1
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -14,6 +14,7 @@ from homeassistant.components.fan import (
     FanEntityFeature,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 from tests.common import assert_setup_component
 from tests.components.fan import common
@@ -51,7 +52,7 @@ _DIRECTION_INPUT_SELECT = "input_select.direction"
         },
     ],
 )
-async def test_missing_optional_config(hass, start_ha):
+async def test_missing_optional_config(hass: HomeAssistant, start_ha) -> None:
     """Test: missing optional template is ok."""
     _verify(hass, STATE_ON, None, None, None, None)
 
@@ -118,7 +119,7 @@ async def test_missing_optional_config(hass, start_ha):
         },
     ],
 )
-async def test_wrong_template_config(hass, start_ha):
+async def test_wrong_template_config(hass: HomeAssistant, start_ha) -> None:
     """Test: missing 'value_template' will fail."""
     assert hass.states.async_all("fan") == []
 
@@ -160,7 +161,7 @@ async def test_wrong_template_config(hass, start_ha):
         },
     ],
 )
-async def test_templates_with_entities(hass, start_ha):
+async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
     """Test tempalates with values from other entities."""
     _verify(hass, STATE_OFF, 0, None, None, None)
 
@@ -240,7 +241,9 @@ async def test_templates_with_entities(hass, start_ha):
         ),
     ],
 )
-async def test_templates_with_entities2(hass, entity, tests, start_ha):
+async def test_templates_with_entities2(
+    hass: HomeAssistant, entity, tests, start_ha
+) -> None:
     """Test templates with values from other entities."""
     for set_percentage, test_percentage, test_type in tests:
         hass.states.async_set(entity, set_percentage)
@@ -271,7 +274,9 @@ async def test_templates_with_entities2(hass, entity, tests, start_ha):
         },
     ],
 )
-async def test_availability_template_with_entities(hass, start_ha):
+async def test_availability_template_with_entities(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test availability tempalates with values from other entities."""
     for state, test_assert in [(STATE_ON, True), (STATE_OFF, False)]:
         hass.states.async_set(_STATE_AVAILABILITY_BOOLEAN, state)
@@ -354,7 +359,9 @@ async def test_availability_template_with_entities(hass, start_ha):
         ),
     ],
 )
-async def test_template_with_unavailable_entities(hass, states, start_ha):
+async def test_template_with_unavailable_entities(
+    hass: HomeAssistant, states, start_ha
+) -> None:
     """Test unavailability with value_template."""
     _verify(hass, states[0], states[1], states[2], states[3], None)
 
@@ -384,15 +391,15 @@ async def test_template_with_unavailable_entities(hass, states, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("fan.test_fan").state != STATE_UNAVAILABLE
     assert "TemplateError" in caplog_setup_text
     assert "x" in caplog_setup_text
 
 
-async def test_on_off(hass, calls):
+async def test_on_off(hass: HomeAssistant, calls) -> None:
     """Test turn on and turn off."""
     await _register_components(hass)
     expected_calls = 0
@@ -410,7 +417,9 @@ async def test_on_off(hass, calls):
         assert calls[-1].data["caller"] == _TEST_FAN
 
 
-async def test_set_invalid_direction_from_initial_stage(hass, calls):
+async def test_set_invalid_direction_from_initial_stage(
+    hass: HomeAssistant, calls
+) -> None:
     """Test set invalid direction when fan is in initial state."""
     await _register_components(hass)
 
@@ -421,7 +430,7 @@ async def test_set_invalid_direction_from_initial_stage(hass, calls):
     _verify(hass, STATE_ON, 0, None, None, None)
 
 
-async def test_set_osc(hass, calls):
+async def test_set_osc(hass: HomeAssistant, calls) -> None:
     """Test set oscillating."""
     await _register_components(hass)
     expected_calls = 0
@@ -439,7 +448,7 @@ async def test_set_osc(hass, calls):
         assert calls[-1].data["option"] == state
 
 
-async def test_set_direction(hass, calls):
+async def test_set_direction(hass: HomeAssistant, calls) -> None:
     """Test set valid direction."""
     await _register_components(hass)
     expected_calls = 0
@@ -457,7 +466,7 @@ async def test_set_direction(hass, calls):
         assert calls[-1].data["option"] == cmd
 
 
-async def test_set_invalid_direction(hass, calls):
+async def test_set_invalid_direction(hass: HomeAssistant, calls) -> None:
     """Test set invalid direction when fan has valid direction."""
     await _register_components(hass)
 
@@ -468,7 +477,7 @@ async def test_set_invalid_direction(hass, calls):
         _verify(hass, STATE_ON, 0, None, DIRECTION_FORWARD, None)
 
 
-async def test_preset_modes(hass, calls):
+async def test_preset_modes(hass: HomeAssistant, calls) -> None:
     """Test preset_modes."""
     await _register_components(
         hass, ["off", "low", "medium", "high", "auto", "smart"], ["auto", "smart"]
@@ -491,7 +500,7 @@ async def test_preset_modes(hass, calls):
     assert hass.states.get(_PRESET_MODE_INPUT_SELECT).state == "auto"
 
 
-async def test_set_percentage(hass, calls):
+async def test_set_percentage(hass: HomeAssistant, calls) -> None:
     """Test set valid speed percentage."""
     await _register_components(hass)
     expected_calls = 0
@@ -517,7 +526,7 @@ async def test_set_percentage(hass, calls):
     _verify(hass, STATE_ON, 50, None, None, None)
 
 
-async def test_increase_decrease_speed(hass, calls):
+async def test_increase_decrease_speed(hass: HomeAssistant, calls) -> None:
     """Test set valid increase and decrease speed."""
     await _register_components(hass, speed_count=3)
 
@@ -534,7 +543,7 @@ async def test_increase_decrease_speed(hass, calls):
         _verify(hass, state, value, None, None, None)
 
 
-async def test_no_value_template(hass, calls):
+async def test_no_value_template(hass: HomeAssistant, calls) -> None:
     """Test a fan without a value_template."""
     await _register_fan_sources(hass)
 
@@ -644,7 +653,9 @@ async def test_no_value_template(hass, calls):
     _verify(hass, STATE_OFF, percent, None, None, preset)
 
 
-async def test_increase_decrease_speed_default_speed_count(hass, calls):
+async def test_increase_decrease_speed_default_speed_count(
+    hass: HomeAssistant, calls
+) -> None:
     """Test set valid increase and decrease speed."""
     await _register_components(hass)
 
@@ -661,7 +672,7 @@ async def test_increase_decrease_speed_default_speed_count(hass, calls):
         _verify(hass, state, value, None, None, None)
 
 
-async def test_set_invalid_osc_from_initial_state(hass, calls):
+async def test_set_invalid_osc_from_initial_state(hass: HomeAssistant, calls) -> None:
     """Test set invalid oscillating when fan is in initial state."""
     await _register_components(hass)
 
@@ -672,7 +683,7 @@ async def test_set_invalid_osc_from_initial_state(hass, calls):
     _verify(hass, STATE_ON, 0, None, None, None)
 
 
-async def test_set_invalid_osc(hass, calls):
+async def test_set_invalid_osc(hass: HomeAssistant, calls) -> None:
     """Test set invalid oscillating when fan has valid osc."""
     await _register_components(hass)
 
@@ -926,7 +937,7 @@ async def _register_components(
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one fan per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -934,7 +945,9 @@ async def test_unique_id(hass, start_ha):
 @pytest.mark.parametrize(
     ("speed_count", "percentage_step"), [(0, 1), (100, 1), (3, 100 / 3)]
 )
-async def test_implemented_percentage(hass, speed_count, percentage_step):
+async def test_implemented_percentage(
+    hass: HomeAssistant, speed_count, percentage_step
+) -> None:
     """Test a fan that implements percentage."""
     await setup.async_setup_component(
         hass,
@@ -1066,7 +1079,7 @@ async def test_implemented_percentage(hass, speed_count, percentage_step):
         },
     ],
 )
-async def test_implemented_preset_mode(hass, start_ha):
+async def test_implemented_preset_mode(hass: HomeAssistant, start_ha) -> None:
     """Test a fan that implements preset_mode."""
     assert len(hass.states.async_all()) == 1
 

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant import config
 from homeassistant.components.template import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.reload import SERVICE_RELOAD
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -48,7 +49,7 @@ from tests.common import async_fire_time_changed, get_fixture_path
         },
     ],
 )
-async def test_reloadable(hass, start_ha):
+async def test_reloadable(hass: HomeAssistant, start_ha) -> None:
     """Test that we can reload."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -99,7 +100,7 @@ async def test_reloadable(hass, start_ha):
         },
     ],
 )
-async def test_reloadable_can_remove(hass, start_ha):
+async def test_reloadable_can_remove(hass: HomeAssistant, start_ha) -> None:
     """Test that we can reload and remove all template sensors."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -129,7 +130,9 @@ async def test_reloadable_can_remove(hass, start_ha):
         },
     ],
 )
-async def test_reloadable_stops_on_invalid_config(hass, start_ha):
+async def test_reloadable_stops_on_invalid_config(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test we stop the reload if configuration.yaml is completely broken."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -157,7 +160,9 @@ async def test_reloadable_stops_on_invalid_config(hass, start_ha):
         },
     ],
 )
-async def test_reloadable_handles_partial_valid_config(hass, start_ha):
+async def test_reloadable_handles_partial_valid_config(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test we can still setup valid sensors when configuration.yaml has a broken entry."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -188,7 +193,7 @@ async def test_reloadable_handles_partial_valid_config(hass, start_ha):
         },
     ],
 )
-async def test_reloadable_multiple_platforms(hass, start_ha):
+async def test_reloadable_multiple_platforms(hass: HomeAssistant, start_ha) -> None:
     """Test that we can reload."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await async_setup_component(
@@ -232,7 +237,9 @@ async def test_reloadable_multiple_platforms(hass, start_ha):
         },
     ],
 )
-async def test_reload_sensors_that_reference_other_template_sensors(hass, start_ha):
+async def test_reload_sensors_that_reference_other_template_sensors(
+    hass: HomeAssistant, start_ha
+) -> None:
     """Test that we can reload sensor that reference other template sensors."""
     await async_yaml_patch_helper(hass, "ref_configuration.yaml")
     assert len(hass.states.async_all()) == 3

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1,5 +1,4 @@
 """The tests for the  Template light platform."""
-
 import pytest
 
 import homeassistant.components.light as light
@@ -20,6 +19,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
@@ -125,8 +125,8 @@ async def setup_light(hass, count, light_config):
     ],
 )
 async def test_template_state_invalid(
-    hass, supported_features, supported_color_modes, setup_light
-):
+    hass: HomeAssistant, supported_features, supported_color_modes, setup_light
+) -> None:
     """Test template state with render error."""
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
@@ -147,7 +147,7 @@ async def test_template_state_invalid(
         },
     ],
 )
-async def test_template_state_text(hass, setup_light):
+async def test_template_state_text(hass: HomeAssistant, setup_light) -> None:
     """Test the state text of a template."""
     set_state = STATE_ON
     hass.states.async_set("light.test_state", set_state)
@@ -185,12 +185,12 @@ async def test_template_state_text(hass, setup_light):
     ],
 )
 async def test_templatex_state_boolean(
-    hass,
+    hass: HomeAssistant,
     expected_color_mode,
     expected_state,
     count,
     value_template,
-):
+) -> None:
     """Test the setting of the state with boolean on."""
     light_config = {
         "test_template_light": {
@@ -225,7 +225,7 @@ async def test_templatex_state_boolean(
         {"test_template_light": "Invalid"},
     ],
 )
-async def test_template_syntax_error(hass, setup_light):
+async def test_template_syntax_error(hass: HomeAssistant, setup_light) -> None:
     """Test templating syntax error."""
     assert hass.states.async_all("light") == []
 
@@ -254,7 +254,7 @@ async def test_template_syntax_error(hass, setup_light):
         ),
     ],
 )
-async def test_missing_key(hass, count, setup_light):
+async def test_missing_key(hass: HomeAssistant, count, setup_light) -> None:
     """Test missing template."""
     if count:
         assert hass.states.async_all("light") != []
@@ -274,7 +274,7 @@ async def test_missing_key(hass, count, setup_light):
         },
     ],
 )
-async def test_on_action(hass, setup_light, calls):
+async def test_on_action(hass: HomeAssistant, setup_light, calls) -> None:
     """Test on action."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -332,7 +332,9 @@ async def test_on_action(hass, setup_light, calls):
         },
     ],
 )
-async def test_on_action_with_transition(hass, setup_light, calls):
+async def test_on_action_with_transition(
+    hass: HomeAssistant, setup_light, calls
+) -> None:
     """Test on action with transition."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -371,10 +373,10 @@ async def test_on_action_with_transition(hass, setup_light, calls):
     ],
 )
 async def test_on_action_optimistic(
-    hass,
+    hass: HomeAssistant,
     setup_light,
     calls,
-):
+) -> None:
     """Test on action with optimistic state."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -431,7 +433,7 @@ async def test_on_action_optimistic(
         },
     ],
 )
-async def test_off_action(hass, setup_light, calls):
+async def test_off_action(hass: HomeAssistant, setup_light, calls) -> None:
     """Test off action."""
     hass.states.async_set("light.test_state", STATE_ON)
     await hass.async_block_till_done()
@@ -488,7 +490,9 @@ async def test_off_action(hass, setup_light, calls):
         },
     ],
 )
-async def test_off_action_with_transition(hass, setup_light, calls):
+async def test_off_action_with_transition(
+    hass: HomeAssistant, setup_light, calls
+) -> None:
     """Test off action with transition."""
     hass.states.async_set("light.test_state", STATE_ON)
     await hass.async_block_till_done()
@@ -525,7 +529,7 @@ async def test_off_action_with_transition(hass, setup_light, calls):
         },
     ],
 )
-async def test_off_action_optimistic(hass, setup_light, calls):
+async def test_off_action_optimistic(hass: HomeAssistant, setup_light, calls) -> None:
     """Test off action with optimistic state."""
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
@@ -561,10 +565,10 @@ async def test_off_action_optimistic(hass, setup_light, calls):
     ],
 )
 async def test_level_action_no_template(
-    hass,
+    hass: HomeAssistant,
     setup_light,
     calls,
-):
+) -> None:
     """Test setting brightness with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("brightness") is None
@@ -606,12 +610,12 @@ async def test_level_action_no_template(
     ],
 )
 async def test_level_template(
-    hass,
+    hass: HomeAssistant,
     expected_level,
     expected_color_mode,
     count,
     level_template,
-):
+) -> None:
     """Test the template for the level."""
     light_config = {
         "test_template_light": {
@@ -642,12 +646,12 @@ async def test_level_template(
     ],
 )
 async def test_temperature_template(
-    hass,
+    hass: HomeAssistant,
     expected_temp,
     expected_color_mode,
     count,
     temperature_template,
-):
+) -> None:
     """Test the template for the temperature."""
     light_config = {
         "test_template_light": {
@@ -678,10 +682,10 @@ async def test_temperature_template(
     ],
 )
 async def test_temperature_action_no_template(
-    hass,
+    hass: HomeAssistant,
     setup_light,
     calls,
-):
+) -> None:
     """Test setting temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("color_template") is None
@@ -720,7 +724,7 @@ async def test_temperature_action_no_template(
         },
     ],
 )
-async def test_friendly_name(hass, setup_light):
+async def test_friendly_name(hass: HomeAssistant, setup_light) -> None:
     """Test the accessibility of the friendly_name attribute."""
 
     state = hass.states.get("light.test_template_light")
@@ -745,7 +749,7 @@ async def test_friendly_name(hass, setup_light):
         },
     ],
 )
-async def test_icon_template(hass, setup_light):
+async def test_icon_template(hass: HomeAssistant, setup_light) -> None:
     """Test icon template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("icon") == ""
@@ -774,7 +778,7 @@ async def test_icon_template(hass, setup_light):
         },
     ],
 )
-async def test_entity_picture_template(hass, setup_light):
+async def test_entity_picture_template(hass: HomeAssistant, setup_light) -> None:
     """Test entity_picture template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("entity_picture") == ""
@@ -800,10 +804,10 @@ async def test_entity_picture_template(hass, setup_light):
     ],
 )
 async def test_color_action_no_template(
-    hass,
+    hass: HomeAssistant,
     setup_light,
     calls,
-):
+) -> None:
     """Test setting color with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
@@ -844,12 +848,12 @@ async def test_color_action_no_template(
     ],
 )
 async def test_color_template(
-    hass,
+    hass: HomeAssistant,
     expected_hs,
     expected_color_mode,
     count,
     color_template,
-):
+) -> None:
     """Test the template for the color."""
     light_config = {
         "test_template_light": {
@@ -896,7 +900,9 @@ async def test_color_template(
         },
     ],
 )
-async def test_color_and_temperature_actions_no_template(hass, setup_light, calls):
+async def test_color_and_temperature_actions_no_template(
+    hass: HomeAssistant, setup_light, calls
+) -> None:
     """Test setting color and color temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
@@ -1011,7 +1017,9 @@ async def test_color_and_temperature_actions_no_template(hass, setup_light, call
         },
     ],
 )
-async def test_effect_action_valid_effect(hass, setup_light, calls):
+async def test_effect_action_valid_effect(
+    hass: HomeAssistant, setup_light, calls
+) -> None:
     """Test setting valid effect with template."""
     state = hass.states.get("light.test_template_light")
     assert state is not None
@@ -1054,7 +1062,9 @@ async def test_effect_action_valid_effect(hass, setup_light, calls):
         },
     ],
 )
-async def test_effect_action_invalid_effect(hass, setup_light, calls):
+async def test_effect_action_invalid_effect(
+    hass: HomeAssistant, setup_light, calls
+) -> None:
     """Test setting invalid effect with template."""
     state = hass.states.get("light.test_template_light")
     assert state is not None
@@ -1095,8 +1105,8 @@ async def test_effect_action_invalid_effect(hass, setup_light, calls):
     ],
 )
 async def test_effect_list_template(
-    hass, expected_effect_list, count, effect_list_template
-):
+    hass: HomeAssistant, expected_effect_list, count, effect_list_template
+) -> None:
     """Test the template for the effect list."""
     light_config = {
         "test_template_light": {
@@ -1130,7 +1140,9 @@ async def test_effect_list_template(
         ("Strobe color", "{{ 'Strobe color' }}"),
     ],
 )
-async def test_effect_template(hass, expected_effect, count, effect_template):
+async def test_effect_template(
+    hass: HomeAssistant, expected_effect, count, effect_template
+) -> None:
     """Test the template for the effect."""
     light_config = {
         "test_template_light": {
@@ -1168,8 +1180,8 @@ async def test_effect_template(hass, expected_effect, count, effect_template):
     ],
 )
 async def test_min_mireds_template(
-    hass, expected_min_mireds, count, min_mireds_template
-):
+    hass: HomeAssistant, expected_min_mireds, count, min_mireds_template
+) -> None:
     """Test the template for the min mireds."""
     light_config = {
         "test_template_light": {
@@ -1205,8 +1217,8 @@ async def test_min_mireds_template(
     ],
 )
 async def test_max_mireds_template(
-    hass, expected_max_mireds, count, max_mireds_template
-):
+    hass: HomeAssistant, expected_max_mireds, count, max_mireds_template
+) -> None:
     """Test the template for the max mireds."""
     light_config = {
         "test_template_light": {
@@ -1242,8 +1254,11 @@ async def test_max_mireds_template(
     ],
 )
 async def test_supports_transition_template(
-    hass, expected_supports_transition, count, supports_transition_template
-):
+    hass: HomeAssistant,
+    expected_supports_transition,
+    count,
+    supports_transition_template,
+) -> None:
     """Test the template for the supports transition."""
     light_config = {
         "test_template_light": {
@@ -1288,7 +1303,9 @@ async def test_supports_transition_template(
         },
     ],
 )
-async def test_available_template_with_entities(hass, setup_light):
+async def test_available_template_with_entities(
+    hass: HomeAssistant, setup_light
+) -> None:
     """Test availability templates with values from other entities."""
     # When template returns true..
     hass.states.async_set(_STATE_AVAILABILITY_BOOLEAN, STATE_ON)
@@ -1318,8 +1335,8 @@ async def test_available_template_with_entities(hass, setup_light):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, setup_light, caplog_setup_text
-):
+    hass: HomeAssistant, setup_light, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("light.test_template_light").state != STATE_UNAVAILABLE
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
@@ -1341,6 +1358,6 @@ async def test_invalid_availability_template_keeps_component_available(
         },
     ],
 )
-async def test_unique_id(hass, setup_light):
+async def test_unique_id(hass: HomeAssistant, setup_light) -> None:
     """Test unique_id option only creates one light per id."""
     assert len(hass.states.async_all("light")) == 1

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant import setup
 from homeassistant.components import lock
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
 
 OPTIMISTIC_LOCK_CONFIG = {
     "platform": "template",
@@ -37,7 +38,7 @@ OPTIMISTIC_LOCK_CONFIG = {
         },
     ],
 )
-async def test_template_state(hass, start_ha):
+async def test_template_state(hass: HomeAssistant, start_ha) -> None:
     """Test template."""
     hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
@@ -64,7 +65,7 @@ async def test_template_state(hass, start_ha):
         },
     ],
 )
-async def test_template_state_boolean_on(hass, start_ha):
+async def test_template_state_boolean_on(hass: HomeAssistant, start_ha) -> None:
     """Test the setting of the state with boolean on."""
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_LOCKED
@@ -82,7 +83,7 @@ async def test_template_state_boolean_on(hass, start_ha):
         },
     ],
 )
-async def test_template_state_boolean_off(hass, start_ha):
+async def test_template_state_boolean_off(hass: HomeAssistant, start_ha) -> None:
     """Test the setting of the state with off."""
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_UNLOCKED
@@ -138,7 +139,7 @@ async def test_template_state_boolean_off(hass, start_ha):
         },
     ],
 )
-async def test_template_syntax_error(hass, start_ha):
+async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
     """Test templating syntax error."""
     assert hass.states.async_all("lock") == []
 
@@ -155,7 +156,7 @@ async def test_template_syntax_error(hass, start_ha):
         },
     ],
 )
-async def test_template_static(hass, start_ha):
+async def test_template_static(hass: HomeAssistant, start_ha) -> None:
     """Test that we allow static templates."""
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_UNLOCKED
@@ -178,7 +179,7 @@ async def test_template_static(hass, start_ha):
         },
     ],
 )
-async def test_lock_action(hass, start_ha, calls):
+async def test_lock_action(hass: HomeAssistant, start_ha, calls) -> None:
     """Test lock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_OFF)
@@ -209,7 +210,7 @@ async def test_lock_action(hass, start_ha, calls):
         },
     ],
 )
-async def test_unlock_action(hass, start_ha, calls):
+async def test_unlock_action(hass: HomeAssistant, start_ha, calls) -> None:
     """Test unlock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_ON)
@@ -243,7 +244,7 @@ async def test_unlock_action(hass, start_ha, calls):
 @pytest.mark.parametrize(
     "test_state", [lock.STATE_UNLOCKING, lock.STATE_LOCKING, lock.STATE_JAMMED]
 )
-async def test_lock_state(hass, test_state, start_ha):
+async def test_lock_state(hass: HomeAssistant, test_state, start_ha) -> None:
     """Test value template."""
     hass.states.async_set("input_select.test_state", test_state)
     await hass.async_block_till_done()
@@ -265,7 +266,7 @@ async def test_lock_state(hass, test_state, start_ha):
         },
     ],
 )
-async def test_available_template_with_entities(hass, start_ha):
+async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
     """Test availability templates with values from other entities."""
     # When template returns true..
     hass.states.async_set("availability_state.state", STATE_ON)
@@ -296,8 +297,8 @@ async def test_available_template_with_entities(hass, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("lock.template_lock").state != STATE_UNAVAILABLE
     assert ("UndefinedError: 'x' is undefined") in caplog_setup_text
@@ -317,7 +318,7 @@ async def test_invalid_availability_template_keeps_component_available(
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one lock per id."""
     await setup.async_setup_component(
         hass,

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -126,7 +126,7 @@ async def test_all_optional_config(hass: HomeAssistant) -> None:
     _verify(hass, 4, 1, 3, 5)
 
 
-async def test_templates_with_entities(hass, calls):
+async def test_templates_with_entities(hass: HomeAssistant, calls) -> None:
     """Test templates with values from other entities."""
     with assert_setup_component(4, "input_number"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -131,7 +131,7 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
     assert hass.states.async_all("select") == []
 
 
-async def test_templates_with_entities(hass, calls):
+async def test_templates_with_entities(hass: HomeAssistant, calls) -> None:
     """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -49,7 +49,7 @@ TEST_NAME = "sensor.test_template_sensor"
         },
     ],
 )
-async def test_template_legacy(hass, start_ha):
+async def test_template_legacy(hass: HomeAssistant, start_ha) -> None:
     """Test template."""
     assert hass.states.get(TEST_NAME).state == "It ."
 
@@ -78,7 +78,7 @@ async def test_template_legacy(hass, start_ha):
         },
     ],
 )
-async def test_icon_template(hass, start_ha):
+async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
     """Test icon template."""
     assert hass.states.get(TEST_NAME).attributes.get("icon") == ""
 
@@ -107,7 +107,7 @@ async def test_icon_template(hass, start_ha):
         },
     ],
 )
-async def test_entity_picture_template(hass, start_ha):
+async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
     """Test entity_picture template."""
     assert hass.states.get(TEST_NAME).attributes.get("entity_picture") == ""
 
@@ -186,7 +186,9 @@ async def test_entity_picture_template(hass, start_ha):
         ),
     ],
 )
-async def test_friendly_name_template(hass, attribute, expected, start_ha):
+async def test_friendly_name_template(
+    hass: HomeAssistant, attribute, expected, start_ha
+) -> None:
     """Test friendly_name template with an unknown value_template."""
     assert hass.states.get(TEST_NAME).attributes.get(attribute) == expected[0]
 
@@ -255,7 +257,7 @@ async def test_friendly_name_template(hass, attribute, expected, start_ha):
         },
     ],
 )
-async def test_template_syntax_error(hass, start_ha):
+async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
     """Test setup with invalid device_class."""
     assert hass.states.async_all("sensor") == []
 
@@ -277,7 +279,7 @@ async def test_template_syntax_error(hass, start_ha):
         },
     ],
 )
-async def test_template_attribute_missing(hass, start_ha):
+async def test_template_attribute_missing(hass: HomeAssistant, start_ha) -> None:
     """Test missing attribute template."""
     assert hass.states.get(TEST_NAME).state == STATE_UNAVAILABLE
 
@@ -303,7 +305,7 @@ async def test_template_attribute_missing(hass, start_ha):
         },
     ],
 )
-async def test_setup_valid_device_class(hass, start_ha):
+async def test_setup_valid_device_class(hass: HomeAssistant, start_ha) -> None:
     """Test setup with valid device_class."""
     hass.states.async_set("sensor.test_sensor", "75")
     await hass.async_block_till_done()
@@ -369,7 +371,7 @@ async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
         },
     ],
 )
-async def test_available_template_with_entities(hass, start_ha):
+async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
     """Test availability tempalates with values from other entities."""
     hass.states.async_set("sensor.availability_sensor", STATE_OFF)
 
@@ -407,7 +409,9 @@ async def test_available_template_with_entities(hass, start_ha):
         },
     ],
 )
-async def test_invalid_attribute_template(hass, caplog, start_ha, caplog_setup_text):
+async def test_invalid_attribute_template(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha, caplog_setup_text
+) -> None:
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("sensor.test_sensor", "startup")
     await hass.async_block_till_done()
@@ -438,8 +442,8 @@ async def test_invalid_attribute_template(hass, caplog, start_ha, caplog_setup_t
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("sensor.my_sensor").state != STATE_UNAVAILABLE
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
@@ -554,7 +558,7 @@ async def test_no_template_match_all(
         },
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one sensor per id."""
     assert len(hass.states.async_all()) == 2
 
@@ -591,7 +595,7 @@ async def test_unique_id(hass, start_ha):
         },
     ],
 )
-async def test_sun_renders_once_per_sensor(hass, start_ha):
+async def test_sun_renders_once_per_sensor(hass: HomeAssistant, start_ha) -> None:
     """Test sun change renders the template only once per sensor."""
 
     now = dt_util.utcnow()
@@ -660,7 +664,7 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
         },
     ],
 )
-async def test_this_variable(hass, start_ha):
+async def test_this_variable(hass: HomeAssistant, start_ha) -> None:
     """Test template."""
     assert hass.states.get(TEST_NAME).state == "It: " + TEST_NAME
 
@@ -687,7 +691,9 @@ async def test_this_variable(hass, start_ha):
         },
     ],
 )
-async def test_this_variable_early_hass_not_running(hass, config, count, domain):
+async def test_this_variable_early_hass_not_running(
+    hass: HomeAssistant, config, count, domain
+) -> None:
     """Test referencing 'this' variable before the entity is in the state machine.
 
     Hass is not yet started when the entity is added.
@@ -749,7 +755,9 @@ async def test_this_variable_early_hass_not_running(hass, config, count, domain)
         },
     ],
 )
-async def test_this_variable_early_hass_running(hass, config, count, domain):
+async def test_this_variable_early_hass_running(
+    hass: HomeAssistant, config, count, domain
+) -> None:
     """Test referencing 'this' variable before the entity is in the state machine.
 
     Hass is already started when the entity is added.
@@ -800,7 +808,9 @@ async def test_this_variable_early_hass_running(hass, config, count, domain):
         },
     ],
 )
-async def test_self_referencing_sensor_loop(hass, start_ha, caplog_setup_text):
+async def test_self_referencing_sensor_loop(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test a self referencing sensor does not loop forever."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
@@ -829,8 +839,8 @@ async def test_self_referencing_sensor_loop(hass, start_ha, caplog_setup_text):
     ],
 )
 async def test_self_referencing_sensor_with_icon_loop(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test a self referencing sensor loops forever with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
@@ -864,8 +874,8 @@ async def test_self_referencing_sensor_with_icon_loop(
     ],
 )
 async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test a self referencing sensor loop forevers with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
@@ -898,7 +908,9 @@ async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
         },
     ],
 )
-async def test_self_referencing_entity_picture_loop(hass, start_ha, caplog_setup_text):
+async def test_self_referencing_entity_picture_loop(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test a self referencing sensor does not loop forever with a looping self referencing entity picture."""
     assert len(hass.states.async_all()) == 1
     next_time = dt_util.utcnow() + timedelta(seconds=1.2)
@@ -1013,7 +1025,7 @@ async def test_self_referencing_icon_with_no_loop(
         },
     ],
 )
-async def test_duplicate_templates(hass, start_ha):
+async def test_duplicate_templates(hass: HomeAssistant, start_ha) -> None:
     """Test template entity where the value and friendly name as the same template."""
     hass.states.async_set("sensor.test_state", "Abc")
     await hass.async_block_till_done()
@@ -1082,7 +1094,7 @@ async def test_duplicate_templates(hass, start_ha):
         },
     ],
 )
-async def test_trigger_entity(hass, start_ha):
+async def test_trigger_entity(hass: HomeAssistant, start_ha) -> None:
     """Test trigger entity works."""
     state = hass.states.get("sensor.hello_name")
     assert state is not None
@@ -1145,7 +1157,7 @@ async def test_trigger_entity(hass, start_ha):
         },
     ],
 )
-async def test_trigger_entity_render_error(hass, start_ha):
+async def test_trigger_entity_render_error(hass: HomeAssistant, start_ha) -> None:
     """Test trigger entity handles render error."""
     state = hass.states.get("sensor.hello")
     assert state is not None
@@ -1181,7 +1193,9 @@ async def test_trigger_entity_render_error(hass, start_ha):
         },
     ],
 )
-async def test_trigger_not_allowed_platform_config(hass, start_ha, caplog_setup_text):
+async def test_trigger_not_allowed_platform_config(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test we throw a helpful warning if a trigger is configured in platform config."""
     state = hass.states.get(TEST_NAME)
     assert state is None
@@ -1208,7 +1222,7 @@ async def test_trigger_not_allowed_platform_config(hass, start_ha, caplog_setup_
         },
     ],
 )
-async def test_config_top_level(hass, start_ha):
+async def test_config_top_level(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one sensor per id."""
     assert len(hass.states.async_all()) == 1
     state = hass.states.get("sensor.top_level")
@@ -1458,7 +1472,7 @@ async def test_entity_device_class_errors_works(hass: HomeAssistant) -> None:
     ],
 )
 async def test_trigger_entity_restore_state(
-    hass,
+    hass: HomeAssistant,
     count,
     domain,
     config,
@@ -1466,7 +1480,7 @@ async def test_trigger_entity_restore_state(
     restored_native_value,
     initial_state,
     initial_attributes,
-):
+) -> None:
     """Test restoring trigger template binary sensor."""
 
     restored_attributes = {

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -353,7 +353,7 @@ async def test_missing_off_does_not_create(hass: HomeAssistant) -> None:
     assert hass.states.async_all("switch") == []
 
 
-async def test_on_action(hass, calls):
+async def test_on_action(hass: HomeAssistant, calls) -> None:
     """Test on action."""
     assert await async_setup_component(
         hass,
@@ -393,7 +393,7 @@ async def test_on_action(hass, calls):
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_on_action_optimistic(hass, calls):
+async def test_on_action_optimistic(hass: HomeAssistant, calls) -> None:
     """Test on action in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -434,7 +434,7 @@ async def test_on_action_optimistic(hass, calls):
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_off_action(hass, calls):
+async def test_off_action(hass: HomeAssistant, calls) -> None:
     """Test off action."""
     assert await async_setup_component(
         hass,
@@ -474,7 +474,7 @@ async def test_off_action(hass, calls):
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_off_action_optimistic(hass, calls):
+async def test_off_action_optimistic(hass: HomeAssistant, calls) -> None:
     """Test off action in optimistic mode."""
     assert await async_setup_component(
         hass,

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -8,7 +8,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.template import trigger as template_trigger
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -42,7 +42,7 @@ def setup_comp(hass, calls):
         },
     ],
 )
-async def test_if_fires_on_change_bool(hass, start_ha, calls):
+async def test_if_fires_on_change_bool(hass: HomeAssistant, start_ha, calls) -> None:
     """Test for firing on boolean change."""
     assert len(calls) == 0
 
@@ -263,7 +263,7 @@ async def test_if_fires_on_change_bool(hass, start_ha, calls):
         ),
     ],
 )
-async def test_general(hass, call_setup, start_ha, calls):
+async def test_general(hass: HomeAssistant, call_setup, start_ha, calls) -> None:
     """Test for firing on change."""
     assert len(calls) == 0
 
@@ -298,7 +298,9 @@ async def test_general(hass, call_setup, start_ha, calls):
         ),
     ],
 )
-async def test_if_not_fires_because_fail(hass, call_setup, start_ha, calls):
+async def test_if_not_fires_because_fail(
+    hass: HomeAssistant, call_setup, start_ha, calls
+) -> None:
     """Test for not firing after TemplateError."""
     assert len(calls) == 0
 
@@ -337,7 +339,9 @@ async def test_if_not_fires_because_fail(hass, call_setup, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_template_advanced(hass, start_ha, calls):
+async def test_if_fires_on_change_with_template_advanced(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with template advanced."""
     context = Context()
     await hass.async_block_till_done()
@@ -367,7 +371,7 @@ async def test_if_fires_on_change_with_template_advanced(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_action(hass, start_ha, calls):
+async def test_if_action(hass: HomeAssistant, start_ha, calls) -> None:
     """Test for firing if action."""
     # Condition is not true yet
     hass.bus.async_fire("test_event")
@@ -397,7 +401,9 @@ async def test_if_action(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_bad_template(hass, start_ha, calls):
+async def test_if_fires_on_change_with_bad_template(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with bad template."""
 
 
@@ -434,7 +440,7 @@ async def test_if_fires_on_change_with_bad_template(hass, start_ha, calls):
         },
     ],
 )
-async def test_wait_template_with_trigger(hass, start_ha, calls):
+async def test_wait_template_with_trigger(hass: HomeAssistant, start_ha, calls) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     await hass.async_block_till_done()
 
@@ -450,7 +456,7 @@ async def test_wait_template_with_trigger(hass, start_ha, calls):
     assert calls[0].data["some"] == "template - test.entity - hello - world - None"
 
 
-async def test_if_fires_on_change_with_for(hass, calls):
+async def test_if_fires_on_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for firing on change with for."""
     assert await async_setup_component(
         hass,
@@ -505,7 +511,9 @@ async def test_if_fires_on_change_with_for(hass, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_advanced(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_advanced(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for advanced."""
     context = Context()
     await hass.async_block_till_done()
@@ -550,7 +558,9 @@ async def test_if_fires_on_change_with_for_advanced(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_0_advanced(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_0_advanced(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for: 0 advanced."""
     context = Context()
     await hass.async_block_till_done()
@@ -592,7 +602,9 @@ async def test_if_fires_on_change_with_for_0_advanced(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_2(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_2(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for."""
     context = Context()
     hass.states.async_set("test.entity", "world", context=context)
@@ -621,7 +633,9 @@ async def test_if_fires_on_change_with_for_2(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_not_fires_on_change_with_for(hass, start_ha, calls):
+async def test_if_not_fires_on_change_with_for(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -653,7 +667,9 @@ async def test_if_not_fires_on_change_with_for(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_not_fires_when_turned_off_with_for(hass, start_ha, calls):
+async def test_if_not_fires_when_turned_off_with_for(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -689,7 +705,9 @@ async def test_if_not_fires_when_turned_off_with_for(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_template_1(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_template_1(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -715,7 +733,9 @@ async def test_if_fires_on_change_with_for_template_1(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_template_2(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_template_2(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -741,7 +761,9 @@ async def test_if_fires_on_change_with_for_template_2(hass, start_ha, calls):
         },
     ],
 )
-async def test_if_fires_on_change_with_for_template_3(hass, start_ha, calls):
+async def test_if_fires_on_change_with_for_template_3(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -767,7 +789,7 @@ async def test_if_fires_on_change_with_for_template_3(hass, start_ha, calls):
         },
     ],
 )
-async def test_invalid_for_template_1(hass, start_ha, calls):
+async def test_invalid_for_template_1(hass: HomeAssistant, start_ha, calls) -> None:
     """Test for invalid for template."""
     with mock.patch.object(template_trigger, "_LOGGER") as mock_logger:
         hass.states.async_set("test.entity", "world")
@@ -775,7 +797,7 @@ async def test_invalid_for_template_1(hass, start_ha, calls):
         assert mock_logger.error.called
 
 
-async def test_if_fires_on_time_change(hass, calls):
+async def test_if_fires_on_time_change(hass: HomeAssistant, calls) -> None:
     """Test for firing on time changes."""
     start_time = dt_util.utcnow() + timedelta(hours=24)
     time_that_will_not_match_right_away = start_time.replace(minute=1, second=0)

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -92,7 +92,9 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
         ),
     ],
 )
-async def test_valid_configs(hass, count, parm1, parm2, start_ha):
+async def test_valid_configs(
+    hass: HomeAssistant, count, parm1, parm2, start_ha
+) -> None:
     """Test: configs."""
     assert len(hass.states.async_all("vacuum")) == count
     _verify(hass, parm1, parm2)
@@ -114,7 +116,7 @@ async def test_valid_configs(hass, count, parm1, parm2, start_ha):
         },
     ],
 )
-async def test_invalid_configs(hass, count, start_ha):
+async def test_invalid_configs(hass: HomeAssistant, count, start_ha) -> None:
     """Test: configs."""
     assert len(hass.states.async_all("vacuum")) == count
 
@@ -140,7 +142,7 @@ async def test_invalid_configs(hass, count, start_ha):
         )
     ],
 )
-async def test_templates_with_entities(hass, start_ha):
+async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
     """Test templates with values from other entities."""
     _verify(hass, STATE_UNKNOWN, None)
 
@@ -170,7 +172,7 @@ async def test_templates_with_entities(hass, start_ha):
         )
     ],
 )
-async def test_available_template_with_entities(hass, start_ha):
+async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
     """Test availability templates with values from other entities."""
 
     # When template returns true..
@@ -209,8 +211,8 @@ async def test_available_template_with_entities(hass, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, start_ha, caplog_setup_text
-):
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("vacuum.test_template_vacuum") != STATE_UNAVAILABLE
     assert "UndefinedError: 'x' is undefined" in caplog_setup_text
@@ -239,7 +241,7 @@ async def test_invalid_availability_template_keeps_component_available(
         )
     ],
 )
-async def test_attribute_templates(hass, start_ha):
+async def test_attribute_templates(hass: HomeAssistant, start_ha) -> None:
     """Test attribute_templates template."""
     state = hass.states.get("vacuum.test_template_vacuum")
     assert state.attributes["test_attribute"] == "It ."
@@ -274,7 +276,9 @@ async def test_attribute_templates(hass, start_ha):
         )
     ],
 )
-async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
+async def test_invalid_attribute_template(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
     """Test that errors are logged if rendering template fails."""
     assert len(hass.states.async_all("vacuum")) == 1
     assert "test_attribute" in caplog_setup_text
@@ -307,7 +311,7 @@ async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
         ),
     ],
 )
-async def test_unique_id(hass, start_ha):
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
     """Test unique_id option only creates one vacuum per id."""
     assert len(hass.states.async_all("vacuum")) == 1
 
@@ -343,7 +347,7 @@ async def test_unused_services(hass: HomeAssistant) -> None:
     _verify(hass, STATE_UNKNOWN, None)
 
 
-async def test_state_services(hass, calls):
+async def test_state_services(hass: HomeAssistant, calls) -> None:
     """Test state services."""
     await _register_components(hass)
 
@@ -392,7 +396,7 @@ async def test_state_services(hass, calls):
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_clean_spot_service(hass, calls):
+async def test_clean_spot_service(hass: HomeAssistant, calls) -> None:
     """Test clean spot service."""
     await _register_components(hass)
 
@@ -407,7 +411,7 @@ async def test_clean_spot_service(hass, calls):
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_locate_service(hass, calls):
+async def test_locate_service(hass: HomeAssistant, calls) -> None:
     """Test locate service."""
     await _register_components(hass)
 
@@ -422,7 +426,7 @@ async def test_locate_service(hass, calls):
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_set_fan_speed(hass, calls):
+async def test_set_fan_speed(hass: HomeAssistant, calls) -> None:
     """Test set valid fan speed."""
     await _register_components(hass)
 
@@ -449,7 +453,7 @@ async def test_set_fan_speed(hass, calls):
     assert calls[-1].data["option"] == "medium"
 
 
-async def test_set_invalid_fan_speed(hass, calls):
+async def test_set_invalid_fan_speed(hass: HomeAssistant, calls) -> None:
     """Test set invalid fan speed when fan has valid speed."""
     await _register_components(hass)
 

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -12,6 +12,7 @@ from homeassistant.components.weather import (
     DOMAIN,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
@@ -39,7 +40,7 @@ from homeassistant.const import ATTR_ATTRIBUTION
         },
     ],
 )
-async def test_template_state_text(hass, start_ha):
+async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
     """Test the state text of a template."""
     for attr, v_attr, value in [
         (

--- a/tests/components/tesla_wall_connector/test_config_flow.py
+++ b/tests/components/tesla_wall_connector/test_config_flow.py
@@ -78,8 +78,8 @@ async def test_form_other_error(
 
 
 async def test_form_already_configured(
-    mock_wall_connector_setup, mock_wall_connector_version, hass
-):
+    mock_wall_connector_setup, mock_wall_connector_version, hass: HomeAssistant
+) -> None:
     """Test we get already configured."""
 
     entry = MockConfigEntry(
@@ -105,8 +105,8 @@ async def test_form_already_configured(
 
 
 async def test_dhcp_can_finish(
-    mock_wall_connector_setup, mock_wall_connector_version, hass
-):
+    mock_wall_connector_setup, mock_wall_connector_version, hass: HomeAssistant
+) -> None:
     """Test DHCP discovery flow can finish right away."""
 
     result = await hass.config_entries.flow.async_init(
@@ -132,7 +132,9 @@ async def test_dhcp_can_finish(
     assert result["data"] == {CONF_HOST: "1.2.3.4"}
 
 
-async def test_dhcp_already_exists(mock_wall_connector_version, hass):
+async def test_dhcp_already_exists(
+    mock_wall_connector_version, hass: HomeAssistant
+) -> None:
     """Test DHCP discovery flow when device already exists."""
 
     entry = MockConfigEntry(
@@ -155,7 +157,9 @@ async def test_dhcp_already_exists(mock_wall_connector_version, hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_dhcp_error_from_wall_connector(mock_wall_connector_version, hass):
+async def test_dhcp_error_from_wall_connector(
+    mock_wall_connector_version, hass: HomeAssistant
+) -> None:
     """Test DHCP discovery flow when we cannot communicate with the device."""
 
     with patch(

--- a/tests/components/text/test_device_action.py
+++ b/tests/components/text/test_device_action.py
@@ -7,7 +7,11 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.text import DOMAIN, device_action
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -20,7 +24,11 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions for an entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -57,12 +65,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -95,7 +103,11 @@ async def test_get_actions_hidden_auxiliary(
     assert_lists_same(actions, expected_actions)
 
 
-async def test_get_action_no_state(hass, device_registry, entity_registry):
+async def test_get_action_no_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions for an entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -1,4 +1,6 @@
 """The tests for the text component."""
+from typing import Any
+
 import pytest
 
 from homeassistant.components.text import (
@@ -118,10 +120,10 @@ RESTORE_DATA = {
 
 
 async def test_restore_number_save_state(
-    hass,
-    hass_storage,
-    enable_custom_integrations,
-):
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    enable_custom_integrations: None,
+) -> None:
     """Test RestoreNumber."""
     platform = getattr(hass.components, "test.text")
     platform.init(empty=True)
@@ -160,15 +162,15 @@ async def test_restore_number_save_state(
     ],
 )
 async def test_restore_number_restore_state(
-    hass,
-    enable_custom_integrations,
-    hass_storage,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    hass_storage: dict[str, Any],
     native_max,
     native_min,
     native_value,
     native_value_type,
     extra_data,
-):
+) -> None:
     """Test RestoreNumber."""
     mock_restore_cache_with_extra_data(hass, ((State("text.test", ""), extra_data),))
 

--- a/tests/components/text/test_recorder.py
+++ b/tests/components/text/test_recorder.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components import text
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.text import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_PATTERN
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -16,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test siren registered attributes to be excluded."""
     await async_setup_component(hass, text.DOMAIN, {text.DOMAIN: {"platform": "demo"}})
     await hass.async_block_till_done()

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -1,4 +1,6 @@
 """Test the thread dataset store."""
+from typing import Any
+
 import pytest
 from python_otbr_api.tlv_parser import TLVError
 
@@ -186,7 +188,9 @@ async def test_load_datasets(hass: HomeAssistant) -> None:
     assert dataset_3_store_1 == dataset_3_store_2
 
 
-async def test_loading_datasets_from_storage(hass: HomeAssistant, hass_storage) -> None:
+async def test_loading_datasets_from_storage(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test loading stored datasets on start."""
     hass_storage[dataset_store.STORAGE_KEY] = {
         "version": dataset_store.STORAGE_VERSION_MAJOR,

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -19,7 +19,7 @@ from . import (
 )
 
 
-async def test_discover_routers(hass: HomeAssistant, mock_async_zeroconf) -> None:
+async def test_discover_routers(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test discovering thread routers."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
     mock_async_zeroconf.async_remove_service_listener = AsyncMock()
@@ -130,7 +130,7 @@ async def test_discover_routers(hass: HomeAssistant, mock_async_zeroconf) -> Non
     "data", (ROUTER_DISCOVERY_HASS_BAD_DATA, ROUTER_DISCOVERY_HASS_MISSING_DATA)
 )
 async def test_discover_routers_bad_data(
-    hass: HomeAssistant, mock_async_zeroconf, data
+    hass: HomeAssistant, mock_async_zeroconf: None, data
 ) -> None:
     """Test discovering thread routers with bad or missing vendor mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -168,7 +168,7 @@ async def test_discover_routers_bad_data(
 
 
 async def test_discover_routers_missing_mandatory_data(
-    hass: HomeAssistant, mock_async_zeroconf
+    hass: HomeAssistant, mock_async_zeroconf: None
 ) -> None:
     """Test discovering thread routers with missing mandatory mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -202,7 +202,7 @@ async def test_discover_routers_missing_mandatory_data(
 
 
 async def test_discover_routers_get_service_info_fails(
-    hass: HomeAssistant, mock_async_zeroconf
+    hass: HomeAssistant, mock_async_zeroconf: None
 ) -> None:
     """Test discovering thread routers with invalid mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -232,7 +232,7 @@ async def test_discover_routers_get_service_info_fails(
 
 
 async def test_discover_routers_update_unchanged(
-    hass: HomeAssistant, mock_async_zeroconf
+    hass: HomeAssistant, mock_async_zeroconf: None
 ) -> None:
     """Test discovering thread routers with identical mDNS data in update."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -274,7 +274,7 @@ async def test_discover_routers_update_unchanged(
 
 
 async def test_discover_routers_stop_twice(
-    hass: HomeAssistant, mock_async_zeroconf
+    hass: HomeAssistant, mock_async_zeroconf: None
 ) -> None:
     """Test discovering thread routers stopping discovery twice."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()

--- a/tests/components/thread/test_init.py
+++ b/tests/components/thread/test_init.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_create_entry(hass: HomeAssistant):
+async def test_create_entry(hass: HomeAssistant) -> None:
     """Test an entry is created by async_setup."""
     assert len(hass.config_entries.async_entries(thread.DOMAIN)) == 0
     assert await async_setup_component(hass, thread.DOMAIN, {})
@@ -14,7 +14,7 @@ async def test_create_entry(hass: HomeAssistant):
     assert len(hass.config_entries.async_entries(thread.DOMAIN)) == 1
 
 
-async def test_remove_entry(hass: HomeAssistant, thread_config_entry):
+async def test_remove_entry(hass: HomeAssistant, thread_config_entry) -> None:
     """Test removing the entry."""
 
     config_entry = hass.config_entries.async_entries(thread.DOMAIN)[0]

--- a/tests/components/thread/test_websocket_api.py
+++ b/tests/components/thread/test_websocket_api.py
@@ -20,7 +20,9 @@ from . import (
 from tests.typing import WebSocketGenerator
 
 
-async def test_add_dataset(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_add_dataset(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test we can add a dataset."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
@@ -41,7 +43,9 @@ async def test_add_dataset(hass: HomeAssistant, hass_ws_client) -> None:
     assert dataset.tlv == DATASET_1
 
 
-async def test_add_invalid_dataset(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_add_invalid_dataset(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test adding an invalid dataset."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
@@ -112,7 +116,9 @@ async def test_delete_dataset(
     }
 
 
-async def test_list_get_dataset(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_list_get_dataset(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test list and get datasets."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
@@ -192,7 +198,7 @@ async def test_list_get_dataset(hass: HomeAssistant, hass_ws_client) -> None:
 
 
 async def test_discover_routers(
-    hass: HomeAssistant, hass_ws_client, mock_async_zeroconf
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_async_zeroconf: None
 ) -> None:
     """Test discovering thread routers."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()

--- a/tests/components/tibber/test_config_flow.py
+++ b/tests/components/tibber/test_config_flow.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.tibber.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(name="tibber_setup", autouse=True)
@@ -15,7 +17,7 @@ def tibber_setup_fixture():
         yield
 
 
-async def test_show_config_form(recorder_mock, hass):
+async def test_show_config_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -25,7 +27,7 @@ async def test_show_config_form(recorder_mock, hass):
     assert result["step_id"] == "user"
 
 
-async def test_create_entry(recorder_mock, hass):
+async def test_create_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test create entry from user input."""
     test_data = {
         CONF_ACCESS_TOKEN: "valid",
@@ -49,7 +51,9 @@ async def test_create_entry(recorder_mock, hass):
     assert result["data"] == test_data
 
 
-async def test_flow_entry_already_exists(recorder_mock, hass, config_entry):
+async def test_flow_entry_already_exists(
+    recorder_mock: Recorder, hass: HomeAssistant, config_entry
+) -> None:
     """Test user input for config_entry that already exists."""
     test_data = {
         CONF_ACCESS_TOKEN: "valid",

--- a/tests/components/tibber/test_diagnostics.py
+++ b/tests/components/tibber/test_diagnostics.py
@@ -1,14 +1,22 @@
 """Test the Netatmo diagnostics."""
 from unittest.mock import patch
 
+from homeassistant.components.recorder import Recorder
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .test_common import mock_get_homes
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(recorder_mock, hass, hass_client, config_entry):
+async def test_entry_diagnostics(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry,
+) -> None:
     """Test config entry diagnostics."""
     with patch(
         "tibber.Tibber.update_info",

--- a/tests/components/tibber/test_statistics.py
+++ b/tests/components/tibber/test_statistics.py
@@ -1,8 +1,10 @@
 """Test adding external statistics from Tibber."""
 from unittest.mock import AsyncMock
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.statistics import statistics_during_period
 from homeassistant.components.tibber.sensor import TibberDataCoordinator
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .test_common import CONSUMPTION_DATA_1, PRODUCTION_DATA_1, mock_get_homes
@@ -10,7 +12,7 @@ from .test_common import CONSUMPTION_DATA_1, PRODUCTION_DATA_1, mock_get_homes
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_async_setup_entry(recorder_mock, hass):
+async def test_async_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test setup Tibber."""
     tibber_connection = AsyncMock()
     tibber_connection.name = "tibber"

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.tile import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from .conftest import TEST_PASSWORD, TEST_USERNAME
 
@@ -20,8 +21,8 @@ from .conftest import TEST_PASSWORD, TEST_USERNAME
     ],
 )
 async def test_create_entry(
-    hass, api, config, errors, mock_login_response, mock_pytile
-):
+    hass: HomeAssistant, api, config, errors, mock_login_response, mock_pytile
+) -> None:
     """Test creating an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -52,7 +53,7 @@ async def test_create_entry(
     }
 
 
-async def test_duplicate_error(hass, config, setup_config_entry):
+async def test_duplicate_error(hass: HomeAssistant, config, setup_config_entry) -> None:
     """Test that errors are shown when duplicates are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=config
@@ -61,7 +62,7 @@ async def test_duplicate_error(hass, config, setup_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_import_entry(hass, config, mock_pytile):
+async def test_import_entry(hass: HomeAssistant, config, mock_pytile) -> None:
     """Test importing an entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=config
@@ -74,7 +75,9 @@ async def test_import_entry(hass, config, mock_pytile):
     }
 
 
-async def test_step_reauth(hass, config, config_entry, setup_config_entry):
+async def test_step_reauth(
+    hass: HomeAssistant, config, config_entry, setup_config_entry
+) -> None:
     """Test that the reauth step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_REAUTH}, data=config

--- a/tests/components/tile/test_diagnostics.py
+++ b/tests/components/tile/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test Tile diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_config_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_config_entry,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "tiles": [

--- a/tests/components/tilt_ble/test_sensor.py
+++ b/tests/components/tilt_ble/test_sensor.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass: HomeAssistant):
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -151,7 +151,9 @@ async def test_timezone_intervals(hass: HomeAssistant) -> None:
     "homeassistant.util.dt.utcnow",
     return_value=dt_util.parse_datetime("2017-11-14 02:47:19-00:00"),
 )
-async def test_timezone_intervals_empty_parameter(utcnow_mock, hass):
+async def test_timezone_intervals_empty_parameter(
+    utcnow_mock, hass: HomeAssistant
+) -> None:
     """Test get_interval() without parameters."""
     hass.config.set_time_zone("America/Edmonton")
     device = time_date.TimeDateSensor(hass, "date")

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -53,7 +53,8 @@ from homeassistant.helpers.restore_state import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from tests.common import async_capture_events, async_fire_time_changed
+from tests.common import MockUser, async_capture_events, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -296,7 +297,9 @@ async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> Non
     assert state.state == STATUS_IDLE
 
 
-async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_config_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -500,7 +503,7 @@ async def test_state_changed_when_timer_restarted(hass: HomeAssistant) -> None:
     assert len(results) == 2
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.timer_from_storage")
@@ -509,7 +512,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -523,7 +526,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert state.state == STATUS_IDLE
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
 
@@ -543,7 +548,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "timer from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -569,7 +576,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) is None
 
 
-async def test_update(hass, hass_ws_client, storage_setup):
+async def test_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating timer entity."""
 
     assert await storage_setup()
@@ -611,7 +620,9 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert state.attributes[ATTR_RESTORE]
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 
@@ -642,7 +653,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, timer_id) == timer_entity_id
 
 
-async def test_setup_no_config(hass, hass_admin_user):
+async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
     """Test component setup with no config."""
     count_start = len(hass.states.async_entity_ids())
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -104,8 +104,8 @@ async def test_midnight_turnover_before_midnight_inside_period(
 
 
 async def test_midnight_turnover_after_midnight_inside_period(
-    hass, freezer, hass_tz_info
-):
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test midnight turnover setting before midnight inside period ."""
     test_time = datetime(2019, 1, 10, 21, 0, 0, tzinfo=hass_tz_info)
     config = {
@@ -163,8 +163,8 @@ async def test_after_happens_tomorrow(hass: HomeAssistant) -> None:
 
 
 async def test_midnight_turnover_after_midnight_outside_period(
-    hass, freezer, hass_tz_info
-):
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test midnight turnover setting before midnight inside period ."""
     test_time = datetime(2019, 1, 10, 20, 0, 0, tzinfo=hass_tz_info)
 
@@ -196,7 +196,9 @@ async def test_midnight_turnover_after_midnight_outside_period(
     assert state.state == STATE_OFF
 
 
-async def test_from_sunrise_to_sunset(hass, freezer, hass_tz_info):
+async def test_from_sunrise_to_sunset(
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test period from sunrise to sunset."""
     test_time = datetime(2019, 1, 12, tzinfo=hass_tz_info)
     sunrise = dt_util.as_local(
@@ -253,7 +255,9 @@ async def test_from_sunrise_to_sunset(hass, freezer, hass_tz_info):
     assert state.state == STATE_OFF
 
 
-async def test_from_sunset_to_sunrise(hass, freezer, hass_tz_info):
+async def test_from_sunset_to_sunrise(
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test period from sunset to sunrise."""
     test_time = datetime(2019, 1, 12, tzinfo=hass_tz_info)
     sunset = dt_util.as_local(get_astral_event_date(hass, "sunset", test_time))
@@ -307,7 +311,7 @@ async def test_from_sunset_to_sunrise(hass, freezer, hass_tz_info):
     assert state.state == STATE_OFF
 
 
-async def test_offset(hass, freezer, hass_tz_info):
+async def test_offset(hass: HomeAssistant, freezer, hass_tz_info) -> None:
     """Test offset."""
     after = datetime(2019, 1, 10, 18, 0, 0, tzinfo=hass_tz_info) + timedelta(
         hours=1, minutes=34
@@ -361,7 +365,7 @@ async def test_offset(hass, freezer, hass_tz_info):
     assert state.state == STATE_OFF
 
 
-async def test_offset_overnight(hass, freezer, hass_tz_info):
+async def test_offset_overnight(hass: HomeAssistant, freezer, hass_tz_info) -> None:
     """Test offset overnight."""
     after = datetime(2019, 1, 10, 18, 0, 0, tzinfo=hass_tz_info) + timedelta(
         hours=1, minutes=34
@@ -392,7 +396,9 @@ async def test_offset_overnight(hass, freezer, hass_tz_info):
     assert state.state == STATE_ON
 
 
-async def test_norwegian_case_winter(hass, freezer, hass_tz_info):
+async def test_norwegian_case_winter(
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test location in Norway where the sun doesn't set in summer."""
     hass.config.latitude = 69.6
     hass.config.longitude = 18.8
@@ -458,7 +464,9 @@ async def test_norwegian_case_winter(hass, freezer, hass_tz_info):
     assert state.state == STATE_OFF
 
 
-async def test_norwegian_case_summer(hass, freezer, hass_tz_info):
+async def test_norwegian_case_summer(
+    hass: HomeAssistant, freezer, hass_tz_info
+) -> None:
     """Test location in Norway where the sun doesn't set in summer."""
     hass.config.latitude = 69.6
     hass.config.longitude = 18.8
@@ -526,7 +534,7 @@ async def test_norwegian_case_summer(hass, freezer, hass_tz_info):
     assert state.state == STATE_OFF
 
 
-async def test_sun_offset(hass, freezer, hass_tz_info):
+async def test_sun_offset(hass: HomeAssistant, freezer, hass_tz_info) -> None:
     """Test sun event with offset."""
     test_time = datetime(2019, 1, 12, tzinfo=hass_tz_info)
     sunrise = dt_util.as_local(
@@ -600,7 +608,7 @@ async def test_sun_offset(hass, freezer, hass_tz_info):
     assert state.state == STATE_ON
 
 
-async def test_dst(hass, freezer, hass_tz_info):
+async def test_dst(hass: HomeAssistant, freezer, hass_tz_info) -> None:
     """Test sun event with offset."""
     hass.config.time_zone = "CET"
     dt_util.set_default_time_zone(dt_util.get_time_zone("CET"))

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -7,6 +7,7 @@ from todoist_api_python.models import Due, Label, Project, Task
 from homeassistant import setup
 from homeassistant.components.todoist.calendar import DOMAIN
 from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 
 
@@ -63,7 +64,7 @@ def mock_api() -> AsyncMock:
 
 
 @patch("homeassistant.components.todoist.calendar.TodoistAPIAsync")
-async def test_calendar_entity_unique_id(todoist_api, hass, api):
+async def test_calendar_entity_unique_id(todoist_api, hass: HomeAssistant, api) -> None:
     """Test unique id is set to project id."""
     todoist_api.return_value = api
     assert await setup.async_setup_component(
@@ -84,7 +85,9 @@ async def test_calendar_entity_unique_id(todoist_api, hass, api):
 
 
 @patch("homeassistant.components.todoist.calendar.TodoistAPIAsync")
-async def test_calendar_custom_project_unique_id(todoist_api, hass, api):
+async def test_calendar_custom_project_unique_id(
+    todoist_api, hass: HomeAssistant, api
+) -> None:
     """Test unique id is None for any custom projects."""
     todoist_api.return_value = api
     assert await setup.async_setup_component(

--- a/tests/components/tolo/test_config_flow.py
+++ b/tests/components/tolo/test_config_flow.py
@@ -23,7 +23,7 @@ def toloclient_fixture() -> Mock:
         yield toloclient
 
 
-async def test_user_with_timed_out_host(hass: HomeAssistant, toloclient: Mock):
+async def test_user_with_timed_out_host(hass: HomeAssistant, toloclient: Mock) -> None:
     """Test a user initiated config flow with provided host which times out."""
     toloclient().get_status_info.side_effect = ResponseTimedOutError()
 
@@ -38,7 +38,7 @@ async def test_user_with_timed_out_host(hass: HomeAssistant, toloclient: Mock):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock):
+async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock) -> None:
     """Test complete user flow with first wrong and then correct host."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -70,7 +70,7 @@ async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock):
     assert result3["data"][CONF_HOST] == "127.0.0.1"
 
 
-async def test_dhcp(hass: HomeAssistant, toloclient: Mock):
+async def test_dhcp(hass: HomeAssistant, toloclient: Mock) -> None:
     """Test starting a flow from discovery."""
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: object()
 
@@ -91,7 +91,7 @@ async def test_dhcp(hass: HomeAssistant, toloclient: Mock):
     assert result["result"].unique_id == "00:11:22:33:44:55"
 
 
-async def test_dhcp_invalid_device(hass: HomeAssistant, toloclient: Mock):
+async def test_dhcp_invalid_device(hass: HomeAssistant, toloclient: Mock) -> None:
     """Test starting a flow from discovery."""
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: None
 

--- a/tests/components/tomato/test_device_tracker.py
+++ b/tests/components/tomato/test_device_tracker.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import HomeAssistant
 
 
 def mock_session_response(*args, **kwargs):
@@ -63,7 +64,7 @@ def mock_session_send():
         yield mock_session_send
 
 
-def test_config_missing_optional_params(hass, mock_session_send):
+def test_config_missing_optional_params(hass: HomeAssistant, mock_session_send) -> None:
     """Test the setup without optional parameters."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -89,7 +90,7 @@ def test_config_missing_optional_params(hass, mock_session_send):
 
 @mock.patch("os.access", return_value=True)
 @mock.patch("os.path.isfile", mock.Mock(return_value=True))
-def test_config_default_nonssl_port(hass, mock_session_send):
+def test_config_default_nonssl_port(hass: HomeAssistant, mock_session_send) -> None:
     """Test the setup without a default port set without ssl enabled."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -108,7 +109,7 @@ def test_config_default_nonssl_port(hass, mock_session_send):
 
 @mock.patch("os.access", return_value=True)
 @mock.patch("os.path.isfile", mock.Mock(return_value=True))
-def test_config_default_ssl_port(hass, mock_session_send):
+def test_config_default_ssl_port(hass: HomeAssistant, mock_session_send) -> None:
     """Test the setup without a default port set with ssl enabled."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -128,7 +129,9 @@ def test_config_default_ssl_port(hass, mock_session_send):
 
 @mock.patch("os.access", return_value=True)
 @mock.patch("os.path.isfile", mock.Mock(return_value=True))
-def test_config_verify_ssl_but_no_ssl_enabled(hass, mock_session_send):
+def test_config_verify_ssl_but_no_ssl_enabled(
+    hass: HomeAssistant, mock_session_send
+) -> None:
     """Test the setup with a string with ssl_verify but ssl not enabled."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -159,7 +162,7 @@ def test_config_verify_ssl_but_no_ssl_enabled(hass, mock_session_send):
 
 @mock.patch("os.access", return_value=True)
 @mock.patch("os.path.isfile", mock.Mock(return_value=True))
-def test_config_valid_verify_ssl_path(hass, mock_session_send):
+def test_config_valid_verify_ssl_path(hass: HomeAssistant, mock_session_send) -> None:
     """Test the setup with a string for ssl_verify.
 
     Representing the absolute path to a CA certificate bundle.
@@ -193,7 +196,7 @@ def test_config_valid_verify_ssl_path(hass, mock_session_send):
     )
 
 
-def test_config_valid_verify_ssl_bool(hass, mock_session_send):
+def test_config_valid_verify_ssl_bool(hass: HomeAssistant, mock_session_send) -> None:
     """Test the setup with a bool for ssl_verify."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -294,7 +297,7 @@ def test_config_errors() -> None:
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_config_bad_credentials(hass, mock_exception_logger):
+def test_config_bad_credentials(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test the setup with bad credentials."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -317,7 +320,7 @@ def test_config_bad_credentials(hass, mock_exception_logger):
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_bad_response(hass, mock_exception_logger):
+def test_bad_response(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test the setup with bad response from router."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -340,7 +343,7 @@ def test_bad_response(hass, mock_exception_logger):
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_scan_devices(hass, mock_exception_logger):
+def test_scan_devices(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test scanning for new devices."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -359,7 +362,7 @@ def test_scan_devices(hass, mock_exception_logger):
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_bad_connection(hass, mock_exception_logger):
+def test_bad_connection(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test the router with a connection error."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -387,7 +390,7 @@ def test_bad_connection(hass, mock_exception_logger):
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_router_timeout(hass, mock_exception_logger):
+def test_router_timeout(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test the router with a timeout error."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(
@@ -415,7 +418,7 @@ def test_router_timeout(hass, mock_exception_logger):
 
 
 @mock.patch("requests.Session.send", side_effect=mock_session_response)
-def test_get_device_name(hass, mock_exception_logger):
+def test_get_device_name(hass: HomeAssistant, mock_exception_logger) -> None:
     """Test getting device names."""
     config = {
         DOMAIN: tomato.PLATFORM_SCHEMA(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
