### PR TITLE
Add type hints to integration tests (part 23)

### DIFF
--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -14,6 +14,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def setup_component(hass):
@@ -43,8 +45,11 @@ async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow_implementation(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test registering an integration and finishing flow works."""
     await setup_component(hass)
 
@@ -106,8 +111,11 @@ async def test_full_flow_implementation(
 
 
 async def test_no_agreements(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test abort when there are no displays."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -145,8 +153,11 @@ async def test_no_agreements(
 
 
 async def test_multiple_agreements(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test abort when there are no displays."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -194,8 +205,11 @@ async def test_multiple_agreements(
 
 
 async def test_agreement_already_set_up(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test showing display form again if display already exists."""
     await setup_component(hass)
     MockConfigEntry(domain=DOMAIN, unique_id=123).add_to_hass(hass)
@@ -234,8 +248,11 @@ async def test_agreement_already_set_up(
 
 
 async def test_toon_abort(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test we abort on Toon error."""
     await setup_component(hass)
     result = await hass.config_entries.flow.async_init(
@@ -272,7 +289,7 @@ async def test_toon_abort(
         assert result2["reason"] == "connection_error"
 
 
-async def test_import(hass, current_request_with_host):
+async def test_import(hass: HomeAssistant, current_request_with_host: None) -> None:
     """Test if importing step works."""
     await setup_component(hass)
 
@@ -287,8 +304,11 @@ async def test_import(hass, current_request_with_host):
 
 
 async def test_import_migration(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test if importing step with migration works."""
     old_entry = MockConfigEntry(domain=DOMAIN, unique_id=123, version=1)
     old_entry.add_to_hass(hass)

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -201,7 +201,7 @@ async def test_no_locations(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 1
 
 
-async def test_options_flow(hass: HomeAssistant):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -23,7 +23,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_discovery(hass: HomeAssistant):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     with _patch_discovery(), _patch_single_discovery():
         result = await hass.config_entries.flow.async_init(
@@ -87,7 +87,7 @@ async def test_discovery(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_with_existing_device_present(hass: HomeAssistant):
+async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.2"}, unique_id="dd:dd:dd:dd:dd:dd"
@@ -161,7 +161,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_no_device(hass: HomeAssistant):
+async def test_discovery_no_device(hass: HomeAssistant) -> None:
     """Test discovery without device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -175,7 +175,7 @@ async def test_discovery_no_device(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_manual(hass: HomeAssistant):
+async def test_manual(hass: HomeAssistant) -> None:
     """Test manually setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -223,7 +223,7 @@ async def test_manual(hass: HomeAssistant):
     assert result2["reason"] == "already_configured"
 
 
-async def test_manual_no_capabilities(hass: HomeAssistant):
+async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
     """Test manually setup without successful get_capabilities."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -309,7 +309,9 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery(hass, source, data):
+async def test_discovered_by_dhcp_or_discovery(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we can setup when discovered from dhcp or discovery."""
 
     with _patch_discovery(), _patch_single_discovery():
@@ -350,7 +352,9 @@ async def test_discovered_by_dhcp_or_discovery(hass, source, data):
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(hass, source, data):
+async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort if we cannot get the unique id when discovered from dhcp."""
 
     with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -76,7 +76,7 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
 
 async def test_dimmer_switch_unique_id_fix_original_entity_still_exists(
     hass: HomeAssistant, entity_reg: EntityRegistry
-):
+) -> None:
     """Test no migration happens if the original entity id still exists."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
     config_entry.add_to_hass(hass)

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOM
 from homeassistant.components.traccar import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
@@ -72,7 +73,7 @@ async def webhook_id_fixture(hass, client):
     return result["result"].data["webhook_id"]
 
 
-async def test_missing_data(hass, client, webhook_id):
+async def test_missing_data(hass: HomeAssistant, client, webhook_id) -> None:
     """Test missing data."""
     url = f"/api/webhook/{webhook_id}"
     data = {"lat": "1.0", "lon": "1.1", "id": "123"}
@@ -97,7 +98,7 @@ async def test_missing_data(hass, client, webhook_id):
     assert req.status == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
-async def test_enter_and_exit(hass, client, webhook_id):
+async def test_enter_and_exit(hass: HomeAssistant, client, webhook_id) -> None:
     """Test when there is a known zone."""
     url = f"/api/webhook/{webhook_id}"
     data = {"lat": str(HOME_LATITUDE), "lon": str(HOME_LONGITUDE), "id": "123"}
@@ -139,7 +140,7 @@ async def test_enter_and_exit(hass, client, webhook_id):
     assert len(ent_reg.entities) == 1
 
 
-async def test_enter_with_attrs(hass, client, webhook_id):
+async def test_enter_with_attrs(hass: HomeAssistant, client, webhook_id) -> None:
     """Test when additional attributes are present."""
     url = f"/api/webhook/{webhook_id}"
     data = {
@@ -188,7 +189,7 @@ async def test_enter_with_attrs(hass, client, webhook_id):
     assert state.attributes["altitude"] == 123
 
 
-async def test_two_devices(hass, client, webhook_id):
+async def test_two_devices(hass: HomeAssistant, client, webhook_id) -> None:
     """Test updating two different devices."""
     url = f"/api/webhook/{webhook_id}"
 
@@ -220,7 +221,7 @@ async def test_two_devices(hass, client, webhook_id):
 @pytest.mark.xfail(
     reason="The device_tracker component does not support unloading yet."
 )
-async def test_load_unload_entry(hass, client, webhook_id):
+async def test_load_unload_entry(hass: HomeAssistant, client, webhook_id) -> None:
     """Test that the appropriate dispatch signals are added and removed."""
     url = f"/api/webhook/{webhook_id}"
     data = {"lat": str(HOME_LATITUDE), "lon": str(HOME_LONGITUDE), "id": "123"}

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -20,7 +20,7 @@ def mock_auth_fixture():
         yield auth
 
 
-async def test_already_paired(hass, mock_entry_setup):
+async def test_already_paired(hass: HomeAssistant, mock_entry_setup) -> None:
     """Test Gateway already paired."""
     with patch(
         f"{TRADFRI_PATH}.config_flow.APIFactory",
@@ -40,7 +40,9 @@ async def test_already_paired(hass, mock_entry_setup):
     assert result["errors"] == {"base": "cannot_authenticate"}
 
 
-async def test_user_connection_successful(hass, mock_auth, mock_entry_setup):
+async def test_user_connection_successful(
+    hass: HomeAssistant, mock_auth, mock_entry_setup
+) -> None:
     """Test a successful connection."""
     mock_auth.side_effect = lambda hass, host, code: {"host": host, "gateway_id": "bla"}
 
@@ -61,7 +63,9 @@ async def test_user_connection_successful(hass, mock_auth, mock_entry_setup):
     }
 
 
-async def test_user_connection_timeout(hass, mock_auth, mock_entry_setup):
+async def test_user_connection_timeout(
+    hass: HomeAssistant, mock_auth, mock_entry_setup
+) -> None:
     """Test a connection timeout."""
     mock_auth.side_effect = config_flow.AuthError("timeout")
 
@@ -79,7 +83,9 @@ async def test_user_connection_timeout(hass, mock_auth, mock_entry_setup):
     assert result["errors"] == {"base": "timeout"}
 
 
-async def test_user_connection_bad_key(hass, mock_auth, mock_entry_setup):
+async def test_user_connection_bad_key(
+    hass: HomeAssistant, mock_auth, mock_entry_setup
+) -> None:
     """Test a connection with bad key."""
     mock_auth.side_effect = config_flow.AuthError("invalid_security_code")
 
@@ -97,7 +103,9 @@ async def test_user_connection_bad_key(hass, mock_auth, mock_entry_setup):
     assert result["errors"] == {"security_code": "invalid_security_code"}
 
 
-async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
+async def test_discovery_connection(
+    hass: HomeAssistant, mock_auth, mock_entry_setup
+) -> None:
     """Test a connection via discovery."""
     mock_auth.side_effect = lambda hass, host, code: {"host": host, "gateway_id": "bla"}
 
@@ -170,7 +178,9 @@ async def test_import_duplicate_aborted(hass: HomeAssistant) -> None:
     assert flow["reason"] == "already_configured"
 
 
-async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
+async def test_duplicate_discovery(
+    hass: HomeAssistant, mock_auth, mock_entry_setup
+) -> None:
     """Test a duplicate discovery in progress is ignored."""
     result = await hass.config_entries.flow.async_init(
         "tradfri",

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components import tradfri
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import GATEWAY_ID
@@ -9,7 +10,7 @@ from . import GATEWAY_ID
 from tests.common import MockConfigEntry
 
 
-async def test_entry_setup_unload(hass, mock_api_factory):
+async def test_entry_setup_unload(hass: HomeAssistant, mock_api_factory) -> None:
     """Test config entry setup and unload."""
     entry = MockConfigEntry(
         domain=tradfri.DOMAIN,
@@ -50,7 +51,7 @@ async def test_entry_setup_unload(hass, mock_api_factory):
         assert mock_api_factory.shutdown.call_count == 1
 
 
-async def test_remove_stale_devices(hass, mock_api_factory):
+async def test_remove_stale_devices(hass: HomeAssistant, mock_api_factory) -> None:
     """Test remove stale device registry entries."""
     entry = MockConfigEntry(
         domain=tradfri.DOMAIN,

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -1,5 +1,4 @@
 """Tradfri lights platform tests."""
-
 from copy import deepcopy
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
@@ -7,6 +6,8 @@ import pytest
 from pytradfri.device import Device
 from pytradfri.device.light import Light
 from pytradfri.device.light_control import LightControl
+
+from homeassistant.core import HomeAssistant
 
 from .common import setup_integration
 
@@ -130,7 +131,7 @@ def mock_light(test_features=None, test_state=None, light_number=0):
     return _mock_light
 
 
-async def test_light(hass, mock_gateway, mock_api_factory):
+async def test_light(hass: HomeAssistant, mock_gateway, mock_api_factory) -> None:
     """Test that lights are correctly added."""
     features = {"can_set_dimmer": True, "can_set_color": True, "can_set_temp": True}
 
@@ -153,7 +154,9 @@ async def test_light(hass, mock_gateway, mock_api_factory):
     assert lamp_1.attributes["hs_color"] == (0.549, 0.153)
 
 
-async def test_light_observed(hass, mock_gateway, mock_api_factory):
+async def test_light_observed(
+    hass: HomeAssistant, mock_gateway, mock_api_factory
+) -> None:
     """Test that lights are correctly observed."""
     light = mock_light()
     mock_gateway.mock_devices.append(light)
@@ -161,7 +164,9 @@ async def test_light_observed(hass, mock_gateway, mock_api_factory):
     assert len(light.observe.mock_calls) > 0
 
 
-async def test_light_available(hass, mock_gateway, mock_api_factory):
+async def test_light_available(
+    hass: HomeAssistant, mock_gateway, mock_api_factory
+) -> None:
     """Test light available property."""
     light = mock_light({"state": True}, light_number=1)
     light.reachable = True
@@ -200,14 +205,14 @@ def create_all_turn_on_cases():
 
 @pytest.mark.parametrize(*create_all_turn_on_cases())
 async def test_turn_on(
-    hass,
+    hass: HomeAssistant,
     mock_gateway,
     mock_api_factory,
     test_features,
     test_data,
     expected_result,
     device_id,
-):
+) -> None:
     """Test turning on a light."""
     # Note pytradfri style, not hass. Values not really important.
     initial_state = {
@@ -265,7 +270,7 @@ async def test_turn_on(
             assert states.attributes[result] == pytest.approx(value, abs=0.01)
 
 
-async def test_turn_off(hass, mock_gateway, mock_api_factory):
+async def test_turn_off(hass: HomeAssistant, mock_gateway, mock_api_factory) -> None:
     """Test turning off a light."""
     state = {"state": True, "dimmer": 100}
 

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -13,7 +13,7 @@ from homeassistant.components.tradfri.fan import _from_fan_percentage, _from_fan
         (50, 100),
     ],
 )
-def test_from_fan_speed(fan_speed, expected_result):
+def test_from_fan_speed(fan_speed, expected_result) -> None:
     """Test that we can convert fan speed to percentage value."""
     assert _from_fan_speed(fan_speed) == expected_result
 
@@ -26,6 +26,6 @@ def test_from_fan_speed(fan_speed, expected_result):
         (50, 26),
     ],
 )
-def test_from_percentage(percentage, expected_result):
+def test_from_percentage(percentage, expected_result) -> None:
     """Test that we can convert percentage value to fan speed."""
     assert _from_fan_percentage(percentage) == expected_result

--- a/tests/components/transport_nsw/test_sensor.py
+++ b/tests/components/transport_nsw/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for the Transport NSW (AU) sensor platform."""
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 VALID_CONFIG = {
@@ -29,7 +30,7 @@ def get_departuresMock(_stop_id, route, destination, api_key):
 
 
 @patch("TransportNSW.TransportNSW.get_departures", side_effect=get_departuresMock)
-async def test_transportnsw_config(mocked_get_departures, hass):
+async def test_transportnsw_config(mocked_get_departures, hass: HomeAssistant) -> None:
     """Test minimal TransportNSW configuration."""
     assert await async_setup_component(hass, "sensor", VALID_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -61,14 +61,16 @@ async def setup_tts(hass):
         await hass.async_block_till_done()
 
 
-async def test_setup_component_demo(hass, setup_tts):
+async def test_setup_component_demo(hass: HomeAssistant, setup_tts) -> None:
     """Set up the demo platform with defaults."""
     assert hass.services.has_service(tts.DOMAIN, "demo_say")
     assert hass.services.has_service(tts.DOMAIN, "clear_cache")
     assert f"{tts.DOMAIN}.demo" in hass.config.components
 
 
-async def test_setup_component_demo_no_access_cache_folder(hass, mock_init_cache_dir):
+async def test_setup_component_demo_no_access_cache_folder(
+    hass: HomeAssistant, mock_init_cache_dir
+) -> None:
     """Set up the demo platform with defaults."""
     config = {tts.DOMAIN: {"platform": "demo"}}
 
@@ -79,7 +81,9 @@ async def test_setup_component_demo_no_access_cache_folder(hass, mock_init_cache
     assert not hass.services.has_service(tts.DOMAIN, "clear_cache")
 
 
-async def test_setup_component_and_test_service(hass, empty_cache_dir):
+async def test_setup_component_and_test_service(
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -112,8 +116,8 @@ async def test_setup_component_and_test_service(hass, empty_cache_dir):
 
 
 async def test_setup_component_and_test_service_with_config_language(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -144,8 +148,8 @@ async def test_setup_component_and_test_service_with_config_language(
 
 
 async def test_setup_component_and_test_service_with_config_language_special(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service with extend language."""
     import homeassistant.components.demo.tts as demo_tts
 
@@ -189,8 +193,8 @@ async def test_setup_component_and_test_service_with_wrong_conf_language(
 
 
 async def test_setup_component_and_test_service_with_service_language(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -222,8 +226,8 @@ async def test_setup_component_and_test_service_with_service_language(
 
 
 async def test_setup_component_test_service_with_wrong_service_language(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -250,8 +254,8 @@ async def test_setup_component_test_service_with_wrong_service_language(
 
 
 async def test_setup_component_and_test_service_with_service_options(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service with options."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -286,7 +290,9 @@ async def test_setup_component_and_test_service_with_service_options(
     ).is_file()
 
 
-async def test_setup_component_and_test_with_service_options_def(hass, empty_cache_dir):
+async def test_setup_component_and_test_with_service_options_def(
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service with default options."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -324,8 +330,8 @@ async def test_setup_component_and_test_with_service_options_def(hass, empty_cac
 
 
 async def test_setup_component_and_test_service_with_service_options_wrong(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service with wrong options."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -386,7 +392,9 @@ async def test_setup_component_and_test_service_with_base_url_set(
     )
 
 
-async def test_setup_component_and_test_service_clear_cache(hass, empty_cache_dir):
+async def test_setup_component_and_test_service_clear_cache(
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up the demo platform and call service clear cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -422,8 +430,8 @@ async def test_setup_component_and_test_service_clear_cache(hass, empty_cache_di
 
 
 async def test_setup_component_and_test_service_with_receive_voice(
-    hass, demo_provider, hass_client
-):
+    hass: HomeAssistant, demo_provider, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and call service and receive voice."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -468,8 +476,8 @@ async def test_setup_component_and_test_service_with_receive_voice(
 
 
 async def test_setup_component_and_test_service_with_receive_voice_german(
-    hass, demo_provider, hass_client
-):
+    hass: HomeAssistant, demo_provider, hass_client: ClientSessionGenerator
+) -> None:
     """Set up the demo platform and call service and receive voice."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -538,7 +546,9 @@ async def test_setup_component_and_web_view_wrong_filename(
     assert req.status == HTTPStatus.NOT_FOUND
 
 
-async def test_setup_component_test_without_cache(hass, empty_cache_dir):
+async def test_setup_component_test_without_cache(
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up demo platform without cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -564,8 +574,8 @@ async def test_setup_component_test_without_cache(hass, empty_cache_dir):
 
 
 async def test_setup_component_test_with_cache_call_service_without_cache(
-    hass, empty_cache_dir
-):
+    hass: HomeAssistant, empty_cache_dir
+) -> None:
     """Set up demo platform with cache and call service without cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -592,8 +602,8 @@ async def test_setup_component_test_with_cache_call_service_without_cache(
 
 
 async def test_setup_component_test_with_cache_dir(
-    hass, empty_cache_dir, demo_provider
-):
+    hass: HomeAssistant, empty_cache_dir, demo_provider
+) -> None:
     """Set up demo platform with cache and call service without cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
@@ -642,8 +652,11 @@ async def test_setup_component_test_with_error_on_get_tts(hass: HomeAssistant) -
 
 
 async def test_setup_component_load_cache_retrieve_without_mem_cache(
-    hass, demo_provider, empty_cache_dir, hass_client
-):
+    hass: HomeAssistant,
+    demo_provider,
+    empty_cache_dir,
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Set up component and load cache and get without mem cache."""
     _, demo_data = demo_provider.get_tts_audio("bla", "en")
     cache_file = (
@@ -706,7 +719,7 @@ async def test_setup_component_and_web_get_url_bad_config(
     assert req.status == HTTPStatus.BAD_REQUEST
 
 
-async def test_tags_with_wave(hass, demo_provider):
+async def test_tags_with_wave(hass: HomeAssistant, demo_provider) -> None:
     """Set up the demo platform and call service and receive voice."""
 
     # below data represents an empty wav file
@@ -738,7 +751,7 @@ async def test_tags_with_wave(hass, demo_provider):
         "https://example.com:8123",
     ),
 )
-def test_valid_base_url(value):
+def test_valid_base_url(value) -> None:
     """Test we validate base urls."""
     assert tts.valid_base_url(value) == normalize_url(value)
     # Test we strip trailing `/`
@@ -759,7 +772,7 @@ def test_valid_base_url(value):
         "example.com",
     ),
 )
-def test_invalid_base_url(value):
+def test_invalid_base_url(value) -> None:
     """Test we catch bad base urls."""
     with pytest.raises(vol.Invalid):
         tts.valid_base_url(value)
@@ -775,8 +788,15 @@ def test_invalid_base_url(value):
     ),
 )
 async def test_generate_media_source_id(
-    hass, setup_tts, engine, language, options, cache, result_engine, result_query
-):
+    hass: HomeAssistant,
+    setup_tts,
+    engine,
+    language,
+    options,
+    cache,
+    result_engine,
+    result_query,
+) -> None:
     """Test generating a media source ID."""
     media_source_id = tts.generate_media_source_id(
         hass, "msg", engine, language, options, cache
@@ -799,8 +819,8 @@ async def test_generate_media_source_id(
     ),
 )
 async def test_generate_media_source_id_invalid_options(
-    hass, setup_tts, engine, language, options
-):
+    hass: HomeAssistant, setup_tts, engine, language, options
+) -> None:
     """Test generating a media source ID."""
     with pytest.raises(HomeAssistantError):
         tts.generate_media_source_id(hass, "msg", engine, language, options, None)

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -66,7 +66,7 @@ async def test_browsing(hass: HomeAssistant) -> None:
         await media_source.async_browse_media(hass, "media-source://tts/non-existing")
 
 
-async def test_resolving(hass, mock_get_tts_audio):
+async def test_resolving(hass: HomeAssistant, mock_get_tts_audio) -> None:
     """Test resolving."""
     media = await media_source.async_resolve_media(
         hass, "media-source://tts/demo?message=Hello%20World", None

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_user_flow(
     assert not result["result"].unique_id
 
 
-async def test_error_on_invalid_credentials(hass, tuya):
+async def test_error_on_invalid_credentials(hass: HomeAssistant, tuya) -> None:
     """Test when we have invalid credentials."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/twentemilieu/test_calendar.py
+++ b/tests/components/twentemilieu/test_calendar.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.freeze_time("2022-01-05 00:00:00+00:00")
@@ -47,7 +48,7 @@ async def test_waste_pickup_calendar(
 async def test_api_calendar(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
-    hass_client,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the API returns the calendar."""
     client = await hass_client()
@@ -65,7 +66,7 @@ async def test_api_calendar(
 async def test_api_events(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
-    hass_client,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the Twente Milieu calendar view."""
     client = await hass_client()

--- a/tests/components/twentemilieu/test_diagnostics.py
+++ b/tests/components/twentemilieu/test_diagnostics.py
@@ -11,7 +11,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -18,7 +18,7 @@ from . import TEST_HOST, TEST_MODEL, TEST_NAME_ORIGINAL, ClientMock
 from tests.common import MockConfigEntry
 
 
-async def test_load_unload_entry(hass: HomeAssistant):
+async def test_load_unload_entry(hass: HomeAssistant) -> None:
     """Validate that setup entry also configure the client."""
     client = ClientMock()
 
@@ -46,7 +46,7 @@ async def test_load_unload_entry(hass: HomeAssistant):
     assert config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_config_entry_not_ready(hass: HomeAssistant):
+async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Validate that config entry is retried."""
     client = ClientMock()
     client.is_offline = True

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -21,7 +21,7 @@ from . import TEST_MODEL, TEST_NAME_ORIGINAL, ClientMock
 from tests.common import MockConfigEntry
 
 
-async def test_initial_state(hass: HomeAssistant):
+async def test_initial_state(hass: HomeAssistant) -> None:
     """Validate that entity and device states are updated on startup."""
     entity, device, _, _ = await _create_entries(hass)
 
@@ -42,7 +42,7 @@ async def test_initial_state(hass: HomeAssistant):
     assert device.manufacturer == "LEDWORKS"
 
 
-async def test_turn_on_off(hass: HomeAssistant):
+async def test_turn_on_off(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service."""
     client = ClientMock()
     client.state = False
@@ -61,7 +61,7 @@ async def test_turn_on_off(hass: HomeAssistant):
     assert state.attributes[ATTR_BRIGHTNESS] == 51
 
 
-async def test_turn_on_with_brightness(hass: HomeAssistant):
+async def test_turn_on_with_brightness(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with a brightness parameter."""
     client = ClientMock()
     client.state = False
@@ -94,7 +94,7 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
     assert state.state == "off"
 
 
-async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
+async def test_turn_on_with_color_rgbw(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with a rgbw parameter."""
     client = ClientMock()
     client.state = False
@@ -123,7 +123,7 @@ async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
     assert client.mode == "color"
 
 
-async def test_turn_on_with_color_rgb(hass: HomeAssistant):
+async def test_turn_on_with_color_rgb(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with a rgb parameter."""
     client = ClientMock()
     client.state = False
@@ -152,7 +152,7 @@ async def test_turn_on_with_color_rgb(hass: HomeAssistant):
     assert client.mode == "color"
 
 
-async def test_turn_on_with_effect(hass: HomeAssistant):
+async def test_turn_on_with_effect(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with effects."""
     client = ClientMock()
     client.state = False
@@ -182,7 +182,7 @@ async def test_turn_on_with_effect(hass: HomeAssistant):
     assert client.mode == "movie"
 
 
-async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
+async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with rgbw color and missing effect support."""
     client = ClientMock()
     client.state = False
@@ -212,7 +212,7 @@ async def test_turn_on_with_color_rgbw_and_missing_effect(hass: HomeAssistant):
     assert client.default_mode == "movie"
 
 
-async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
+async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with rgb color and missing effect support."""
     client = ClientMock()
     client.state = False
@@ -242,7 +242,7 @@ async def test_turn_on_with_color_rgb_and_missing_effect(hass: HomeAssistant):
     assert client.default_mode == "movie"
 
 
-async def test_turn_on_with_effect_missing_effects(hass: HomeAssistant):
+async def test_turn_on_with_effect_missing_effects(hass: HomeAssistant) -> None:
     """Test support of the light.turn_on service with effect set even if effects are not supported."""
     client = ClientMock()
     client.state = False
@@ -273,7 +273,7 @@ async def test_turn_on_with_effect_missing_effects(hass: HomeAssistant):
     assert client.mode == "movie"
 
 
-async def test_turn_off(hass: HomeAssistant):
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test support of the light.turn_off service."""
     entity, _, _, _ = await _create_entries(hass)
 
@@ -288,7 +288,7 @@ async def test_turn_off(hass: HomeAssistant):
     assert state.state == "off"
 
 
-async def test_update_name(hass: HomeAssistant):
+async def test_update_name(hass: HomeAssistant) -> None:
     """Validate device's name update behavior.
 
     Validate that if device name is changed from the Twinkly app,
@@ -308,7 +308,7 @@ async def test_update_name(hass: HomeAssistant):
     assert state.attributes["friendly_name"] == "new_device_name"
 
 
-async def test_unload(hass: HomeAssistant):
+async def test_unload(hass: HomeAssistant) -> None:
     """Validate that entities can be unloaded from the UI."""
 
     _, _, client, _ = await _create_entries(hass)

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -87,7 +87,9 @@ DPI_GROUPS = [
 ]
 
 
-async def test_flow_works(hass, aioclient_mock, mock_discovery):
+async def test_flow_works(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_discovery
+) -> None:
     """Test config flow."""
     mock_discovery.return_value = "1"
     result = await hass.config_entries.flow.async_init(
@@ -146,7 +148,9 @@ async def test_flow_works(hass, aioclient_mock, mock_discovery):
     }
 
 
-async def test_flow_works_negative_discovery(hass, aioclient_mock, mock_discovery):
+async def test_flow_works_negative_discovery(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_discovery
+) -> None:
     """Test config flow with a negative outcome of async_discovery_unifi."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -354,8 +354,11 @@ async def test_reset_fails(
 
 
 async def test_connection_state_signalling(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Verify connection statesignalling and connection state are working."""
     client = {
         "hostname": "client",
@@ -383,8 +386,8 @@ async def test_connection_state_signalling(
 
 
 async def test_wireless_client_event_calls_update_wireless_devices(
-    hass, aioclient_mock, mock_unifi_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Call update_wireless_devices method when receiving wireless client event."""
     client_1_dict = {
         "essid": "ssid",
@@ -417,7 +420,9 @@ async def test_wireless_client_event_calls_update_wireless_devices(
         assert wireless_clients_mock.assert_called_once
 
 
-async def test_reconnect_mechanism(hass, aioclient_mock, mock_unifi_websocket):
+async def test_reconnect_mechanism(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Verify reconnect prints only on first reconnection try."""
     await setup_unifi_integration(hass, aioclient_mock)
 
@@ -454,8 +459,11 @@ async def test_reconnect_mechanism(hass, aioclient_mock, mock_unifi_websocket):
     ],
 )
 async def test_reconnect_mechanism_exceptions(
-    hass, aioclient_mock, mock_unifi_websocket, exception
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    exception,
+) -> None:
     """Verify async_reconnect calls expected methods."""
     await setup_unifi_integration(hass, aioclient_mock)
 
@@ -502,8 +510,8 @@ async def test_get_unifi_controller_verify_ssl_false(hass: HomeAssistant) -> Non
     ],
 )
 async def test_get_unifi_controller_fails_to_connect(
-    hass, side_effect, raised_exception
-):
+    hass: HomeAssistant, side_effect, raised_exception
+) -> None:
     """Check that get_unifi_controller can handle controller being unavailable."""
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
         "aiounifi.Controller.login", side_effect=side_effect

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -37,8 +37,11 @@ async def test_no_entities(
 
 
 async def test_tracked_wireless_clients(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Verify tracking of wireless clients."""
     client = {
         "ap_mac": "00:00:00:00:02:01",
@@ -83,8 +86,11 @@ async def test_tracked_wireless_clients(
 
 
 async def test_tracked_clients(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test the update_items function with some clients."""
     client_1 = {
         "ap_mac": "00:00:00:00:02:01",
@@ -158,8 +164,11 @@ async def test_tracked_clients(
 
 
 async def test_tracked_wireless_clients_event_source(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Verify tracking of wireless clients based on event source."""
     client = {
         "ap_mac": "00:00:00:00:02:01",
@@ -270,8 +279,11 @@ async def test_tracked_wireless_clients_event_source(
 
 
 async def test_tracked_devices(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test the update_items function with some devices."""
     device_1 = {
         "board_rev": 3,
@@ -345,8 +357,11 @@ async def test_tracked_devices(
 
 
 async def test_remove_clients(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test the remove_items function with some clients."""
     client_1 = {
         "essid": "ssid",
@@ -381,8 +396,11 @@ async def test_remove_clients(
 
 
 async def test_controller_state_change(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Verify entities state reflect on controller becoming unavailable."""
     client = {
         "essid": "ssid",
@@ -435,7 +453,9 @@ async def test_controller_state_change(
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
 
-async def test_option_track_clients(hass, aioclient_mock, mock_device_registry):
+async def test_option_track_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test the tracking of clients can be turned off."""
     wireless_client = {
         "essid": "ssid",
@@ -501,7 +521,9 @@ async def test_option_track_clients(hass, aioclient_mock, mock_device_registry):
     assert hass.states.get("device_tracker.device")
 
 
-async def test_option_track_wired_clients(hass, aioclient_mock, mock_device_registry):
+async def test_option_track_wired_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test the tracking of wired clients can be turned off."""
     wireless_client = {
         "essid": "ssid",
@@ -567,7 +589,9 @@ async def test_option_track_wired_clients(hass, aioclient_mock, mock_device_regi
     assert hass.states.get("device_tracker.device")
 
 
-async def test_option_track_devices(hass, aioclient_mock, mock_device_registry):
+async def test_option_track_devices(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test the tracking of devices can be turned off."""
     client = {
         "hostname": "client",
@@ -613,8 +637,11 @@ async def test_option_track_devices(hass, aioclient_mock, mock_device_registry):
 
 
 async def test_option_ssid_filter(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test the SSID filter works.
 
     Client will travel from a supported SSID to an unsupported ssid.
@@ -720,8 +747,11 @@ async def test_option_ssid_filter(
 
 
 async def test_wireless_client_go_wired_issue(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test the solution to catch wireless device go wired UniFi issue.
 
     UniFi Network has a known issue that when a wireless device goes away it sometimes gets marked as wired.
@@ -792,8 +822,11 @@ async def test_wireless_client_go_wired_issue(
 
 
 async def test_option_ignore_wired_bug(
-    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    mock_device_registry,
+) -> None:
     """Test option to ignore wired bug."""
     client = {
         "ap_mac": "00:00:00:00:02:01",
@@ -862,7 +895,9 @@ async def test_option_ignore_wired_bug(
     assert client_state.attributes["is_wired"] is False
 
 
-async def test_restoring_client(hass, aioclient_mock, mock_device_registry):
+async def test_restoring_client(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Verify clients are restored from clients_all if they ever was registered to entity registry."""
     client = {
         "hostname": "client",
@@ -916,7 +951,9 @@ async def test_restoring_client(hass, aioclient_mock, mock_device_registry):
     assert not hass.states.get("device_tracker.not_restored")
 
 
-async def test_dont_track_clients(hass, aioclient_mock, mock_device_registry):
+async def test_dont_track_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test don't track clients config works."""
     wireless_client = {
         "essid": "ssid",
@@ -976,7 +1013,9 @@ async def test_dont_track_clients(hass, aioclient_mock, mock_device_registry):
     assert hass.states.get("device_tracker.device")
 
 
-async def test_dont_track_devices(hass, aioclient_mock, mock_device_registry):
+async def test_dont_track_devices(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test don't track devices config works."""
     client = {
         "hostname": "client",
@@ -1015,7 +1054,9 @@ async def test_dont_track_devices(hass, aioclient_mock, mock_device_registry):
     assert not hass.states.get("device_tracker.device")
 
 
-async def test_dont_track_wired_clients(hass, aioclient_mock, mock_device_registry):
+async def test_dont_track_wired_clients(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_device_registry
+) -> None:
     """Test don't track wired clients config works."""
     wireless_client = {
         "essid": "ssid",

--- a/tests/components/unifi/test_diagnostics.py
+++ b/tests/components/unifi/test_diagnostics.py
@@ -1,18 +1,24 @@
 """Test UniFi Network diagnostics."""
-
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
     CONF_BLOCK_CLIENT,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_controller import setup_unifi_integration
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, hass_client, aioclient_mock):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Test config entry diagnostics."""
     client = {
         "blocked": False,

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -1,4 +1,5 @@
 """Test UniFi Network integration setup process."""
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant.components import unifi
@@ -61,7 +62,11 @@ async def test_unload_entry(
     assert not hass.data[UNIFI_DOMAIN]
 
 
-async def test_wireless_clients(hass, hass_storage, aioclient_mock):
+async def test_wireless_clients(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Verify wireless clients class."""
     hass_storage[unifi.STORAGE_KEY] = {
         "version": unifi.STORAGE_VERSION,

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -112,7 +112,9 @@ async def test_no_clients(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
 
 
-async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
+async def test_bandwidth_sensors(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Verify that bandwidth sensors are working as expected."""
     wired_client = {
         "hostname": "Wired client",
@@ -192,14 +194,14 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     ],
 )
 async def test_uptime_sensors(
-    hass,
-    aioclient_mock,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
     entity_registry_enabled_by_default,
     initial_uptime,
     event_uptime,
     new_uptime,
-):
+) -> None:
     """Verify that uptime sensors are working as expected."""
     uptime_client = {
         "mac": "00:00:00:00:00:01",
@@ -267,8 +269,11 @@ async def test_uptime_sensors(
 
 
 async def test_remove_sensors(
-    hass, aioclient_mock, mock_unifi_websocket, entity_registry_enabled_by_default
-):
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    entity_registry_enabled_by_default,
+) -> None:
     """Verify removing of clients work as expected."""
     wired_client = {
         "hostname": "Wired client",
@@ -325,7 +330,9 @@ async def test_remove_sensors(
     assert hass.states.get("sensor.wireless_client_uptime")
 
 
-async def test_poe_port_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_poe_port_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     await setup_unifi_integration(hass, aioclient_mock, devices_response=[DEVICE_1])
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -32,8 +32,11 @@ async def test_service_setup_and_unload(
 @patch("homeassistant.core.ServiceRegistry.async_remove")
 @patch("homeassistant.core.ServiceRegistry.async_register")
 async def test_service_setup_and_unload_not_called_if_multiple_integrations_detected(
-    register_service_mock, remove_service_mock, hass, aioclient_mock
-):
+    register_service_mock,
+    remove_service_mock,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
     """Make sure that services are only setup and removed once."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     register_service_mock.reset_mock()

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -725,7 +725,9 @@ async def test_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 3
 
 
-async def test_remove_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_remove_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     await setup_unifi_integration(
         hass,
@@ -756,7 +758,9 @@ async def test_remove_switches(hass, aioclient_mock, mock_unifi_websocket):
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_block_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -820,7 +824,9 @@ async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
     }
 
 
-async def test_dpi_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_dpi_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     await setup_unifi_integration(
         hass,
@@ -861,7 +867,9 @@ async def test_dpi_switches(hass, aioclient_mock, mock_unifi_websocket):
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_dpi_switches_add_second_app(hass, aioclient_mock, mock_unifi_websocket):
+async def test_dpi_switches_add_second_app(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     await setup_unifi_integration(
         hass,
@@ -917,7 +925,9 @@ async def test_dpi_switches_add_second_app(hass, aioclient_mock, mock_unifi_webs
     assert hass.states.get("switch.block_media_streaming").state == STATE_ON
 
 
-async def test_outlet_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_outlet_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the outlet entities."""
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[OUTLET_UP1]
@@ -1002,8 +1012,8 @@ async def test_outlet_switches(hass, aioclient_mock, mock_unifi_websocket):
 
 
 async def test_new_client_discovered_on_block_control(
-    hass, aioclient_mock, mock_unifi_websocket
-):
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test if 2nd update has a new client."""
     await setup_unifi_integration(
         hass,
@@ -1097,7 +1107,9 @@ async def test_option_remove_switches(
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
 
-async def test_poe_port_switches(hass, aioclient_mock, mock_unifi_websocket):
+async def test_poe_port_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[DEVICE_1]

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -69,7 +69,9 @@ async def test_no_entities(
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 0
 
 
-async def test_device_updates(hass, aioclient_mock, mock_unifi_websocket):
+async def test_device_updates(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Test the update_items function with some devices."""
     device_1 = deepcopy(DEVICE_1)
     await setup_unifi_integration(
@@ -185,7 +187,9 @@ async def test_install(
     )
 
 
-async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocket):
+async def test_controller_state_change(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
     """Verify entities state reflect on controller becoming unavailable."""
     await setup_unifi_integration(
         hass,

--- a/tests/components/unifi_direct/test_device_tracker.py
+++ b/tests/components/unifi_direct/test_device_tracker.py
@@ -40,7 +40,7 @@ def setup_comp(hass):
 
 
 @patch(scanner_path, return_value=MagicMock(spec=UnifiDeviceScanner))
-async def test_get_scanner(unifi_mock, hass):
+async def test_get_scanner(unifi_mock, hass: HomeAssistant) -> None:
     """Test creating an Unifi direct scanner with a password."""
     conf_dict = {
         DOMAIN: {
@@ -62,7 +62,7 @@ async def test_get_scanner(unifi_mock, hass):
 
 
 @patch("pexpect.pxssh.pxssh")
-async def test_get_device_name(mock_ssh, hass):
+async def test_get_device_name(mock_ssh, hass: HomeAssistant) -> None:
     """Testing MAC matching."""
     conf_dict = {
         DOMAIN: {
@@ -85,7 +85,7 @@ async def test_get_device_name(mock_ssh, hass):
 
 @patch("pexpect.pxssh.pxssh.logout")
 @patch("pexpect.pxssh.pxssh.login")
-async def test_failed_to_log_in(mock_login, mock_logout, hass):
+async def test_failed_to_log_in(mock_login, mock_logout, hass: HomeAssistant) -> None:
     """Testing exception at login results in False."""
     from pexpect import exceptions
 
@@ -110,7 +110,9 @@ async def test_failed_to_log_in(mock_login, mock_logout, hass):
 @patch("pexpect.pxssh.pxssh.login", autospec=True)
 @patch("pexpect.pxssh.pxssh.prompt")
 @patch("pexpect.pxssh.pxssh.sendline")
-async def test_to_get_update(mock_sendline, mock_prompt, mock_login, mock_logout, hass):
+async def test_to_get_update(
+    mock_sendline, mock_prompt, mock_login, mock_logout, hass: HomeAssistant
+) -> None:
     """Testing exception in get_update matching."""
     conf_dict = {
         DOMAIN: {

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -45,7 +45,7 @@ SENSE_SENSORS_WRITE = SENSE_SENSORS[:4]
 
 async def test_binary_sensor_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -59,7 +59,7 @@ async def test_binary_sensor_camera_remove(
 
 async def test_binary_sensor_light_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -73,7 +73,7 @@ async def test_binary_sensor_light_remove(
 
 async def test_binary_sensor_sensor_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -87,7 +87,7 @@ async def test_binary_sensor_sensor_remove(
 
 async def test_binary_sensor_setup_light(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test binary_sensor entity setup for light devices."""
 
     await init_entry(hass, ufp, [light])
@@ -115,7 +115,7 @@ async def test_binary_sensor_setup_camera_all(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test binary_sensor entity setup for camera devices (all features)."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -171,7 +171,7 @@ async def test_binary_sensor_setup_camera_all(
 
 async def test_binary_sensor_setup_camera_none(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera
-):
+) -> None:
     """Test binary_sensor entity setup for camera devices (no features)."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -197,7 +197,7 @@ async def test_binary_sensor_setup_camera_none(
 
 async def test_binary_sensor_setup_sensor(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test binary_sensor entity setup for sensor devices."""
 
     await init_entry(hass, ufp, [sensor_all])
@@ -222,7 +222,7 @@ async def test_binary_sensor_setup_sensor(
 
 async def test_binary_sensor_setup_sensor_none(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor: Sensor
-):
+) -> None:
     """Test binary_sensor entity setup for sensor with most sensors disabled."""
 
     sensor.mount_type = MountType.LEAK
@@ -258,7 +258,7 @@ async def test_binary_sensor_update_motion(
     doorbell: Camera,
     unadopted_camera: Camera,
     fixed_now: datetime,
-):
+) -> None:
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -301,7 +301,7 @@ async def test_binary_sensor_update_motion(
 
 async def test_binary_sensor_update_light_motion(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, fixed_now: datetime
-):
+) -> None:
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [light])
@@ -344,7 +344,7 @@ async def test_binary_sensor_update_light_motion(
 
 async def test_binary_sensor_update_mount_type_window(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [sensor_all])
@@ -376,7 +376,7 @@ async def test_binary_sensor_update_mount_type_window(
 
 async def test_binary_sensor_update_mount_type_garage(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test binary_sensor motion entity."""
 
     await init_entry(hass, ufp, [sensor_all])

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -23,7 +23,7 @@ from .utils import (
 
 async def test_button_chime_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, chime: Chime
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     await init_entry(hass, ufp, [chime])
@@ -38,7 +38,7 @@ async def test_reboot_button(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     chime: Chime,
-):
+) -> None:
     """Test button entity."""
 
     await init_entry(hass, ufp, [chime])
@@ -70,7 +70,7 @@ async def test_chime_button(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     chime: Chime,
-):
+) -> None:
     """Test button entity."""
 
     await init_entry(hass, ufp, [chime])
@@ -99,7 +99,7 @@ async def test_chime_button(
 
 async def test_adopt_button(
     hass: HomeAssistant, ufp: MockUFPFixture, doorlock: Doorlock, doorbell: Camera
-):
+) -> None:
     """Test button entity."""
 
     doorlock._api = ufp.api
@@ -140,7 +140,7 @@ async def test_adopt_button(
 
 async def test_adopt_button_removed(
     hass: HomeAssistant, ufp: MockUFPFixture, doorlock: Doorlock, doorbell: Camera
-):
+) -> None:
     """Test button entity."""
 
     entity_id = "button.test_lock_adopt_device"

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -173,7 +173,7 @@ async def test_basic_setup(
     ufp: MockUFPFixture,
     camera_all: ProtectCamera,
     doorbell: ProtectCamera,
-):
+) -> None:
     """Test working setup of unifiprotect entry."""
 
     camera_high_only = camera_all.copy()
@@ -270,7 +270,9 @@ async def test_basic_setup(
     await validate_no_stream_camera_state(hass, doorbell, 3, entity_id, features=0)
 
 
-async def test_adopt(hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera):
+async def test_adopt(
+    hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
+) -> None:
     """Test setting up camera with no camera channels."""
 
     camera1 = camera.copy()
@@ -304,7 +306,7 @@ async def test_adopt(hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCa
 
 async def test_camera_image(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Test retrieving camera image."""
 
     await init_entry(hass, ufp, [camera])
@@ -318,7 +320,7 @@ async def test_camera_image(
 
 async def test_package_camera_image(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: ProtectCamera
-):
+) -> None:
     """Test retrieving package camera image."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -332,7 +334,7 @@ async def test_package_camera_image(
 
 async def test_camera_generic_update(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Tests generic entity update service."""
 
     await init_entry(hass, ufp, [camera])
@@ -358,7 +360,7 @@ async def test_camera_generic_update(
 
 async def test_camera_interval_update(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Interval updates updates camera entity."""
 
     await init_entry(hass, ufp, [camera])
@@ -381,7 +383,7 @@ async def test_camera_interval_update(
 
 async def test_camera_bad_interval_update(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Interval updates marks camera unavailable."""
 
     await init_entry(hass, ufp, [camera])
@@ -408,7 +410,7 @@ async def test_camera_bad_interval_update(
 
 async def test_camera_ws_update(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """WS update updates camera entity."""
 
     await init_entry(hass, ufp, [camera])
@@ -443,7 +445,7 @@ async def test_camera_ws_update(
 
 async def test_camera_ws_update_offline(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """WS updates marks camera unavailable."""
 
     await init_entry(hass, ufp, [camera])
@@ -485,7 +487,7 @@ async def test_camera_ws_update_offline(
 
 async def test_camera_enable_motion(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Tests generic entity update service."""
 
     await init_entry(hass, ufp, [camera])
@@ -507,7 +509,7 @@ async def test_camera_enable_motion(
 
 async def test_camera_disable_motion(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: ProtectCamera
-):
+) -> None:
     """Tests generic entity update service."""
 
     await init_entry(hass, ufp, [camera])

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,5 +1,4 @@
 """Test UniFi Protect diagnostics."""
-
 from pyunifiprotect.data import NVR, Light
 
 from homeassistant.components.unifiprotect.const import CONF_ALLOW_EA
@@ -8,11 +7,15 @@ from homeassistant.core import HomeAssistant
 from .utils import MockUFPFixture, init_entry
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 async def test_diagnostics(
-    hass: HomeAssistant, ufp: MockUFPFixture, light: Light, hass_client
-):
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    light: Light,
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test generating diagnostics for a config entry."""
 
     await init_entry(hass, ufp, [light])

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -41,7 +41,7 @@ async def remove_device(
     return response["success"]
 
 
-async def test_setup(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_setup(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test working setup of unifiprotect entry."""
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
@@ -56,7 +56,7 @@ async def test_setup_multiple(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     bootstrap: Bootstrap,
-):
+) -> None:
     """Test working setup of unifiprotect entry."""
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
@@ -99,7 +99,7 @@ async def test_setup_multiple(
         assert mock_config.unique_id == ufp.api.bootstrap.nvr.mac
 
 
-async def test_reload(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_reload(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test updating entry reload entry."""
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
@@ -115,7 +115,7 @@ async def test_reload(hass: HomeAssistant, ufp: MockUFPFixture):
     assert ufp.api.async_disconnect_ws.called
 
 
-async def test_unload(hass: HomeAssistant, ufp: MockUFPFixture, light: Light):
+async def test_unload(hass: HomeAssistant, ufp: MockUFPFixture, light: Light) -> None:
     """Test unloading of unifiprotect entry."""
 
     await init_entry(hass, ufp, [light])
@@ -126,7 +126,9 @@ async def test_unload(hass: HomeAssistant, ufp: MockUFPFixture, light: Light):
     assert ufp.api.async_disconnect_ws.called
 
 
-async def test_setup_too_old(hass: HomeAssistant, ufp: MockUFPFixture, old_nvr: NVR):
+async def test_setup_too_old(
+    hass: HomeAssistant, ufp: MockUFPFixture, old_nvr: NVR
+) -> None:
     """Test setup of unifiprotect entry with too old of version of UniFi Protect."""
 
     ufp.api.get_nvr.return_value = old_nvr
@@ -137,7 +139,7 @@ async def test_setup_too_old(hass: HomeAssistant, ufp: MockUFPFixture, old_nvr: 
     assert not ufp.api.update.called
 
 
-async def test_setup_failed_update(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_setup_failed_update(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test setup of unifiprotect entry with failed update."""
 
     ufp.api.update = AsyncMock(side_effect=NvrError)
@@ -148,7 +150,9 @@ async def test_setup_failed_update(hass: HomeAssistant, ufp: MockUFPFixture):
     assert ufp.api.update.called
 
 
-async def test_setup_failed_update_reauth(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_setup_failed_update_reauth(
+    hass: HomeAssistant, ufp: MockUFPFixture
+) -> None:
     """Test setup of unifiprotect entry with update that gives unauthroized error."""
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
@@ -170,7 +174,7 @@ async def test_setup_failed_update_reauth(hass: HomeAssistant, ufp: MockUFPFixtu
     assert len(hass.config_entries.flow._progress) == 1
 
 
-async def test_setup_failed_error(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_setup_failed_error(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test setup of unifiprotect entry with generic error."""
 
     ufp.api.get_nvr = AsyncMock(side_effect=NvrError)
@@ -181,7 +185,7 @@ async def test_setup_failed_error(hass: HomeAssistant, ufp: MockUFPFixture):
     assert not ufp.api.update.called
 
 
-async def test_setup_failed_auth(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_setup_failed_auth(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test setup of unifiprotect entry with unauthorized error."""
 
     ufp.api.get_nvr = AsyncMock(side_effect=NotAuthorized)
@@ -193,7 +197,7 @@ async def test_setup_failed_auth(hass: HomeAssistant, ufp: MockUFPFixture):
 
 async def test_setup_starts_discovery(
     hass: HomeAssistant, ufp_config_entry: ConfigEntry, ufp_client: ProtectApiClient
-):
+) -> None:
     """Test setting up will start discovery."""
     with _patch_discovery(), patch(
         "homeassistant.components.unifiprotect.utils.ProtectApiClient"

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -28,7 +28,9 @@ from .utils import (
 )
 
 
-async def test_light_remove(hass: HomeAssistant, ufp: MockUFPFixture, light: Light):
+async def test_light_remove(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
     """Test removing and re-adding a light device."""
 
     await init_entry(hass, ufp, [light])
@@ -41,7 +43,7 @@ async def test_light_remove(hass: HomeAssistant, ufp: MockUFPFixture, light: Lig
 
 async def test_light_setup(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
-):
+) -> None:
     """Test light entity setup."""
 
     await init_entry(hass, ufp, [light, unadopted_light])
@@ -63,7 +65,7 @@ async def test_light_setup(
 
 async def test_light_update(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
-):
+) -> None:
     """Test light entity update."""
 
     await init_entry(hass, ufp, [light, unadopted_light])
@@ -89,7 +91,7 @@ async def test_light_update(
 
 async def test_light_turn_on(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
-):
+) -> None:
     """Test light entity turn off."""
 
     await init_entry(hass, ufp, [light, unadopted_light])
@@ -111,7 +113,7 @@ async def test_light_turn_on(
 
 async def test_light_turn_off(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
-):
+) -> None:
     """Test light entity turn on."""
 
     await init_entry(hass, ufp, [light, unadopted_light])

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -32,7 +32,7 @@ from .utils import (
 
 async def test_lock_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorlock: Doorlock
-):
+) -> None:
     """Test removing and re-adding a lock device."""
 
     await init_entry(hass, ufp, [doorlock])
@@ -48,7 +48,7 @@ async def test_lock_setup(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity setup."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -73,7 +73,7 @@ async def test_lock_locked(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity locked."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -100,7 +100,7 @@ async def test_lock_unlocking(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity unlocking."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -127,7 +127,7 @@ async def test_lock_locking(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity locking."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -154,7 +154,7 @@ async def test_lock_jammed(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity jammed."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -181,7 +181,7 @@ async def test_lock_unavailable(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity unavailable."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -208,7 +208,7 @@ async def test_lock_do_lock(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity lock service."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])
@@ -232,7 +232,7 @@ async def test_lock_do_unlock(
     ufp: MockUFPFixture,
     doorlock: Doorlock,
     unadopted_doorlock: Doorlock,
-):
+) -> None:
     """Test lock entity unlock service."""
 
     await init_entry(hass, ufp, [doorlock, unadopted_doorlock])

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -36,7 +36,7 @@ from .utils import (
 
 async def test_media_player_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -52,7 +52,7 @@ async def test_media_player_setup(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity setup."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -82,7 +82,7 @@ async def test_media_player_update(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity update."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -110,7 +110,7 @@ async def test_media_player_set_volume(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test set_volume_level."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -134,7 +134,7 @@ async def test_media_player_stop(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test media_stop."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -167,7 +167,7 @@ async def test_media_player_play(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test play_media."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -202,7 +202,7 @@ async def test_media_player_play_media_source(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test play_media."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -241,7 +241,7 @@ async def test_media_player_play_invalid(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test play_media, not music."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
@@ -270,7 +270,7 @@ async def test_media_player_play_error(
     ufp: MockUFPFixture,
     doorbell: Camera,
     unadopted_camera: Camera,
-):
+) -> None:
     """Test media_player entity test play_media, not music."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -52,7 +52,7 @@ async def test_get_media_source(hass: HomeAssistant) -> None:
 )
 async def test_resolve_media_bad_identifier(
     hass: HomeAssistant, ufp: MockUFPFixture, identifier: str
-):
+) -> None:
     """Test resolving bad identifiers."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -67,7 +67,7 @@ async def test_resolve_media_bad_identifier(
 
 async def test_resolve_media_thumbnail(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test resolving event thumbnails."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -98,7 +98,7 @@ async def test_resolve_media_thumbnail(
 
 async def test_resolve_media_event(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test resolving event clips."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -152,7 +152,7 @@ async def test_resolve_media_event(
 )
 async def test_browse_media_bad_identifier(
     hass: HomeAssistant, ufp: MockUFPFixture, identifier: str
-):
+) -> None:
     """Test browsing media with bad identifiers."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -167,7 +167,7 @@ async def test_browse_media_bad_identifier(
 
 async def test_browse_media_event_ongoing(
     hass: HomeAssistant, ufp: MockUFPFixture, fixed_now: datetime, doorbell: Camera
-):
+) -> None:
     """Test browsing event that is still ongoing."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -194,7 +194,7 @@ async def test_browse_media_event_ongoing(
 
 async def test_browse_media_root_multiple_consoles(
     hass: HomeAssistant, ufp: MockUFPFixture, bootstrap: Bootstrap
-):
+) -> None:
     """Test browsing root level media with multiple consoles."""
 
     ufp.api.bootstrap._has_media = True
@@ -259,7 +259,7 @@ async def test_browse_media_root_multiple_consoles(
 
 async def test_browse_media_root_multiple_consoles_only_one_media(
     hass: HomeAssistant, ufp: MockUFPFixture, bootstrap: Bootstrap
-):
+) -> None:
     """Test browsing root level media with multiple consoles."""
 
     ufp.api.bootstrap._has_media = True
@@ -323,7 +323,7 @@ async def test_browse_media_root_multiple_consoles_only_one_media(
 
 async def test_browse_media_root_single_console(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test browsing root level media with a single console."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -346,7 +346,7 @@ async def test_browse_media_root_single_console(
 
 async def test_browse_media_camera(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, camera: Camera
-):
+) -> None:
     """Test browsing camera selector level media."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -384,7 +384,7 @@ async def test_browse_media_camera(
 
 async def test_browse_media_camera_offline(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test browsing camera selector level media when camera is offline."""
 
     doorbell.is_connected = False
@@ -409,7 +409,7 @@ async def test_browse_media_camera_offline(
 
 async def test_browse_media_event_type(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test browsing event type selector level media."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -472,7 +472,7 @@ async def test_browse_media_time(
     doorbell: Camera,
     start: datetime,
     months: int,
-):
+) -> None:
     """Test browsing time selector level media."""
 
     end = datetime.fromisoformat("2022-09-15 03:00:00-07:00")
@@ -544,7 +544,7 @@ async def test_browse_media_time_timezone(
     doorbell: Camera,
     start: datetime,
     months: int,
-):
+) -> None:
     """Test browsing time selector level media."""
 
     end = datetime.fromisoformat("2022-08-31 21:00:00-07:00")
@@ -579,7 +579,7 @@ async def test_browse_media_time_timezone(
 
 async def test_browse_media_recent(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test browsing event selector level media for recent days."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -615,7 +615,7 @@ async def test_browse_media_recent(
 
 async def test_browse_media_recent_truncated(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test browsing event selector level media for recent days."""
 
     ufp.entry.options = {"max_media": 1}
@@ -653,7 +653,7 @@ async def test_browse_media_recent_truncated(
 
 async def test_browse_media_event(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test browsing specific event."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -684,7 +684,7 @@ async def test_browse_media_event(
 
 async def test_browse_media_eventthumb(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test browsing specific event."""
 
     ufp.api.get_bootstrap = AsyncMock(return_value=ufp.api.bootstrap)
@@ -716,7 +716,7 @@ async def test_browse_media_eventthumb(
 @freeze_time("2022-09-15 03:00:00-07:00")
 async def test_browse_media_day(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test browsing day selector level media."""
 
     start = datetime.fromisoformat("2022-09-03 03:00:00-07:00")
@@ -744,7 +744,7 @@ async def test_browse_media_day(
 
 async def test_browse_media_browse_day(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test events for a specific day."""
 
     last_month = fixed_now.replace(day=1) - timedelta(days=1)
@@ -784,7 +784,7 @@ async def test_browse_media_browse_day(
 
 async def test_browse_media_browse_whole_month(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test events for a specific day."""
 
     fixed_now = fixed_now.replace(month=10)
@@ -826,7 +826,7 @@ async def test_browse_media_browse_whole_month(
 
 async def test_browse_media_browse_whole_month_december(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test events for a specific day."""
 
     fixed_now = fixed_now.replace(month=12)

--- a/tests/components/unifiprotect/test_migrate.py
+++ b/tests/components/unifiprotect/test_migrate.py
@@ -23,7 +23,7 @@ from .utils import (
 
 async def test_migrate_reboot_button(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test migrating unique ID of reboot button."""
 
     light1 = light.copy()
@@ -73,7 +73,9 @@ async def test_migrate_reboot_button(
     assert light.unique_id == f"{light2.mac}_reboot"
 
 
-async def test_migrate_nvr_mac(hass: HomeAssistant, ufp: MockUFPFixture, light: Light):
+async def test_migrate_nvr_mac(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
     """Test migrating unique ID of NVR to use MAC address."""
 
     light1 = light.copy()
@@ -114,7 +116,7 @@ async def test_migrate_nvr_mac(hass: HomeAssistant, ufp: MockUFPFixture, light: 
 
 async def test_migrate_reboot_button_no_device(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test migrating unique ID of reboot button if UniFi Protect device ID changed."""
 
     light2_id, _ = generate_random_ids()
@@ -144,7 +146,7 @@ async def test_migrate_reboot_button_no_device(
 
 async def test_migrate_reboot_button_fail(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test migrating unique ID of reboot button."""
 
     registry = er.async_get(hass)
@@ -177,7 +179,7 @@ async def test_migrate_reboot_button_fail(
 
 async def test_migrate_device_mac_button_fail(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test migrating unique ID to MAC format."""
 
     registry = er.async_get(hass)
@@ -210,7 +212,7 @@ async def test_migrate_device_mac_button_fail(
 
 async def test_migrate_device_mac_bootstrap_fail(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test migrating with a network error."""
 
     registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -31,7 +31,7 @@ from .utils import (
 
 async def test_number_sensor_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     await init_entry(hass, ufp, [camera, unadopted_camera])
@@ -44,7 +44,7 @@ async def test_number_sensor_camera_remove(
 
 async def test_number_sensor_light_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     await init_entry(hass, ufp, [light])
@@ -57,7 +57,7 @@ async def test_number_sensor_light_remove(
 
 async def test_number_lock_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorlock: Doorlock
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     await init_entry(hass, ufp, [doorlock])
@@ -70,7 +70,7 @@ async def test_number_lock_remove(
 
 async def test_number_setup_light(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test number entity setup for light devices."""
 
     await init_entry(hass, ufp, [light])
@@ -94,7 +94,7 @@ async def test_number_setup_light(
 
 async def test_number_setup_camera_all(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera
-):
+) -> None:
     """Test number entity setup for camera devices (all features)."""
 
     camera.feature_flags.has_chime = True
@@ -121,7 +121,7 @@ async def test_number_setup_camera_all(
 
 async def test_number_setup_camera_none(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera
-):
+) -> None:
     """Test number entity setup for camera devices (no features)."""
 
     camera.feature_flags.can_optical_zoom = False
@@ -135,7 +135,7 @@ async def test_number_setup_camera_none(
 
 async def test_number_setup_camera_missing_attr(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera
-):
+) -> None:
     """Test number entity setup for camera devices (no features, bad attrs)."""
 
     camera.feature_flags = None
@@ -146,7 +146,7 @@ async def test_number_setup_camera_missing_attr(
 
 async def test_number_light_sensitivity(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test sensitivity number entity for lights."""
 
     await init_entry(hass, ufp, [light])
@@ -169,7 +169,7 @@ async def test_number_light_sensitivity(
 
 async def test_number_light_duration(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test auto-shutoff duration number entity for lights."""
 
     await init_entry(hass, ufp, [light])
@@ -195,7 +195,7 @@ async def test_number_camera_simple(
     ufp: MockUFPFixture,
     camera: Camera,
     description: ProtectNumberEntityDescription,
-):
+) -> None:
     """Tests all simple numbers for cameras."""
 
     await init_entry(hass, ufp, [camera])
@@ -215,7 +215,7 @@ async def test_number_camera_simple(
 
 async def test_number_lock_auto_close(
     hass: HomeAssistant, ufp: MockUFPFixture, doorlock: Doorlock
-):
+) -> None:
     """Test auto-lock timeout for locks."""
 
     await init_entry(hass, ufp, [doorlock])

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -1,5 +1,4 @@
 """Test repairs for unifiprotect."""
-
 from __future__ import annotations
 
 from copy import copy
@@ -25,13 +24,15 @@ from homeassistant.setup import async_setup_component
 
 from .utils import MockUFPFixture, init_entry
 
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
 
 async def test_ea_warning_ignore(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
-    hass_client,
-    hass_ws_client,
-):
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test EA warning is created if using prerelease version of Protect."""
 
     version = ufp.api.bootstrap.nvr.version
@@ -81,9 +82,9 @@ async def test_ea_warning_ignore(
 async def test_ea_warning_fix(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
-    hass_client,
-    hass_ws_client,
-):
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test EA warning is created if using prerelease version of Protect."""
 
     version = ufp.api.bootstrap.nvr.version
@@ -132,8 +133,11 @@ async def test_ea_warning_fix(
 
 
 async def test_deprecate_smart_default(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    hass_ws_client: WebSocketGenerator,
+    doorbell: Camera,
+) -> None:
     """Test Deprecate Sensor repair does not exist by default (new installs)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -153,8 +157,11 @@ async def test_deprecate_smart_default(
 
 
 async def test_deprecate_smart_no_automations(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    hass_ws_client: WebSocketGenerator,
+    doorbell: Camera,
+) -> None:
     """Test Deprecate Sensor repair exists for existing installs."""
 
     registry = er.async_get(hass)
@@ -215,8 +222,11 @@ async def _load_automation(hass: HomeAssistant, entity_id: str):
 
 
 async def test_deprecate_smart_automation(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    hass_ws_client: WebSocketGenerator,
+    doorbell: Camera,
+) -> None:
     """Test Deprecate Sensor repair exists for existing installs."""
 
     registry = er.async_get(hass)
@@ -279,8 +289,11 @@ async def _load_script(hass: HomeAssistant, entity_id: str):
 
 
 async def test_deprecate_smart_script(
-    hass: HomeAssistant, ufp: MockUFPFixture, hass_ws_client, doorbell: Camera
-):
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    hass_ws_client: WebSocketGenerator,
+    doorbell: Camera,
+) -> None:
     """Test Deprecate Sensor repair exists for existing installs."""
 
     registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -51,7 +51,7 @@ from .utils import (
 
 async def test_select_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -65,7 +65,7 @@ async def test_select_camera_remove(
 
 async def test_select_light_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -79,7 +79,7 @@ async def test_select_light_remove(
 
 async def test_select_viewer_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, viewer: Viewer
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -93,7 +93,7 @@ async def test_select_viewer_remove(
 
 async def test_select_setup_light(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test select entity setup for light devices."""
 
     light.light_mode_settings.enable_at = LightModeEnableType.DARK
@@ -120,7 +120,7 @@ async def test_select_setup_light(
 
 async def test_select_setup_viewer(
     hass: HomeAssistant, ufp: MockUFPFixture, viewer: Viewer, liveview: Liveview
-):
+) -> None:
     """Test select entity setup for light devices."""
 
     ufp.api.bootstrap.liveviews = {liveview.id: liveview}
@@ -146,7 +146,7 @@ async def test_select_setup_viewer(
 
 async def test_select_setup_camera_all(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test select entity setup for camera devices (all features)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -172,7 +172,7 @@ async def test_select_setup_camera_all(
 
 async def test_select_setup_camera_none(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera
-):
+) -> None:
     """Test select entity setup for camera devices (no features)."""
 
     await init_entry(hass, ufp, [camera])
@@ -201,7 +201,7 @@ async def test_select_setup_camera_none(
 
 async def test_select_update_liveview(
     hass: HomeAssistant, ufp: MockUFPFixture, viewer: Viewer, liveview: Liveview
-):
+) -> None:
     """Test select entity update (new Liveview)."""
 
     ufp.api.bootstrap.liveviews = {liveview.id: liveview}
@@ -237,7 +237,7 @@ async def test_select_update_liveview(
 
 async def test_select_update_doorbell_settings(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test select entity update (new Doorbell Message)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -283,7 +283,7 @@ async def test_select_update_doorbell_settings(
 
 async def test_select_update_doorbell_message(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test select entity update (change doorbell message)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -317,7 +317,7 @@ async def test_select_update_doorbell_message(
 
 async def test_select_set_option_light_motion(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test Light Mode select."""
 
     await init_entry(hass, ufp, [light])
@@ -342,7 +342,7 @@ async def test_select_set_option_light_motion(
 
 async def test_select_set_option_light_camera(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, camera: Camera
-):
+) -> None:
     """Test Paired Camera select."""
 
     await init_entry(hass, ufp, [light, camera])
@@ -376,7 +376,7 @@ async def test_select_set_option_light_camera(
 
 async def test_select_set_option_camera_recording(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Recording Mode select."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -401,7 +401,7 @@ async def test_select_set_option_camera_recording(
 
 async def test_select_set_option_camera_ir(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Infrared Mode select."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -426,7 +426,7 @@ async def test_select_set_option_camera_ir(
 
 async def test_select_set_option_camera_doorbell_custom(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Doorbell Text select (user defined message)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -453,7 +453,7 @@ async def test_select_set_option_camera_doorbell_custom(
 
 async def test_select_set_option_camera_doorbell_unifi(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Doorbell Text select (unifi message)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -495,7 +495,7 @@ async def test_select_set_option_camera_doorbell_unifi(
 
 async def test_select_set_option_camera_doorbell_default(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Doorbell Text select (default message)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -523,7 +523,7 @@ async def test_select_set_option_camera_doorbell_default(
 
 async def test_select_set_option_viewer(
     hass: HomeAssistant, ufp: MockUFPFixture, viewer: Viewer, liveview: Liveview
-):
+) -> None:
     """Test Liveview select."""
 
     ufp.api.bootstrap.liveviews = {liveview.id: liveview}
@@ -551,7 +551,7 @@ async def test_select_set_option_viewer(
 
 async def test_select_service_doorbell_invalid(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Doorbell Text service (invalid)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -577,7 +577,7 @@ async def test_select_service_doorbell_invalid(
 
 async def test_select_service_doorbell_success(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test Doorbell Text service (success)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -612,7 +612,7 @@ async def test_select_service_doorbell_with_reset(
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
-):
+) -> None:
     """Test Doorbell Text service (success with reset time)."""
 
     mock_now.return_value = fixed_now

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -57,7 +57,7 @@ SENSE_SENSORS_WRITE = SENSE_SENSORS[:8]
 
 async def test_sensor_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -71,7 +71,7 @@ async def test_sensor_camera_remove(
 
 async def test_sensor_sensor_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -85,7 +85,7 @@ async def test_sensor_sensor_remove(
 
 async def test_sensor_setup_sensor(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
-):
+) -> None:
     """Test sensor entity setup for sensor devices."""
 
     await init_entry(hass, ufp, [sensor_all])
@@ -136,7 +136,7 @@ async def test_sensor_setup_sensor(
 
 async def test_sensor_setup_sensor_none(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor: Sensor
-):
+) -> None:
     """Test sensor entity setup for sensor devices with no sensors enabled."""
 
     await init_entry(hass, ufp, [sensor])
@@ -170,7 +170,7 @@ async def test_sensor_setup_sensor_none(
 
 async def test_sensor_setup_nvr(
     hass: HomeAssistant, ufp: MockUFPFixture, fixed_now: datetime
-):
+) -> None:
     """Test sensor entity setup for NVR device."""
 
     reset_objects(ufp.api.bootstrap)
@@ -244,7 +244,9 @@ async def test_sensor_setup_nvr(
         assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
 
-async def test_sensor_nvr_missing_values(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_sensor_nvr_missing_values(
+    hass: HomeAssistant, ufp: MockUFPFixture
+) -> None:
     """Test NVR sensor sensors if no data available."""
 
     reset_objects(ufp.api.bootstrap)
@@ -314,7 +316,7 @@ async def test_sensor_nvr_missing_values(hass: HomeAssistant, ufp: MockUFPFixtur
 
 async def test_sensor_setup_camera(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test sensor entity setup for camera devices."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -420,7 +422,7 @@ async def test_sensor_setup_camera_with_last_trip_time(
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
-):
+) -> None:
     """Test sensor entity setup for camera devices with last trip time."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -448,7 +450,7 @@ async def test_sensor_setup_camera_with_last_trip_time(
 
 async def test_sensor_update_motion(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, fixed_now: datetime
-):
+) -> None:
     """Test sensor motion entity."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -494,7 +496,7 @@ async def test_sensor_update_motion(
 
 async def test_sensor_update_alarm(
     hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor, fixed_now: datetime
-):
+) -> None:
     """Test sensor motion entity."""
 
     await init_entry(hass, ufp, [sensor_all])
@@ -542,7 +544,7 @@ async def test_sensor_update_alarm_with_last_trip_time(
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     fixed_now: datetime,
-):
+) -> None:
     """Test sensor motion entity with last trip time."""
 
     await init_entry(hass, ufp, [sensor_all])
@@ -569,7 +571,7 @@ async def test_sensor_update_alarm_with_last_trip_time(
 
 async def test_camera_update_licenseplate(
     hass: HomeAssistant, ufp: MockUFPFixture, camera: Camera, fixed_now: datetime
-):
+) -> None:
     """Test sensor motion entity."""
 
     camera.feature_flags.smart_detect_types.append(SmartDetectObjectType.LICENSE_PLATE)

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -45,7 +45,9 @@ async def subdevice_fixture(hass: HomeAssistant, ufp: MockUFPFixture, light: Lig
     return [d for d in device_registry.devices.values() if d.name != "UnifiProtect"][0]
 
 
-async def test_global_service_bad_device(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_global_service_bad_device(
+    hass: HomeAssistant, ufp: MockUFPFixture
+) -> None:
     """Test global service, invalid device ID."""
 
     nvr = ufp.api.bootstrap.nvr
@@ -64,7 +66,7 @@ async def test_global_service_bad_device(hass: HomeAssistant, ufp: MockUFPFixtur
 
 async def test_global_service_exception(
     hass: HomeAssistant, device: dr.DeviceEntry, ufp: MockUFPFixture
-):
+) -> None:
     """Test global service, unexpected error."""
 
     nvr = ufp.api.bootstrap.nvr
@@ -83,7 +85,7 @@ async def test_global_service_exception(
 
 async def test_add_doorbell_text(
     hass: HomeAssistant, device: dr.DeviceEntry, ufp: MockUFPFixture
-):
+) -> None:
     """Test add_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
@@ -101,7 +103,7 @@ async def test_add_doorbell_text(
 
 async def test_remove_doorbell_text(
     hass: HomeAssistant, subdevice: dr.DeviceEntry, ufp: MockUFPFixture
-):
+) -> None:
     """Test remove_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
@@ -119,7 +121,7 @@ async def test_remove_doorbell_text(
 
 async def test_set_default_doorbell_text(
     hass: HomeAssistant, device: dr.DeviceEntry, ufp: MockUFPFixture
-):
+) -> None:
     """Test set_default_doorbell_text service."""
 
     nvr = ufp.api.bootstrap.nvr
@@ -140,7 +142,7 @@ async def test_set_chime_paired_doorbells(
     ufp: MockUFPFixture,
     chime: Chime,
     doorbell: Camera,
-):
+) -> None:
     """Test set_chime_paired_doorbells."""
 
     ufp.api.update_device = AsyncMock()

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -46,7 +46,7 @@ CAMERA_SWITCHES_NO_EXTRA = [
 
 async def test_switch_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -60,7 +60,7 @@ async def test_switch_camera_remove(
 
 async def test_switch_light_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Test removing and re-adding a light device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -72,7 +72,7 @@ async def test_switch_light_remove(
     assert_entity_counts(hass, Platform.SWITCH, 4, 3)
 
 
-async def test_switch_nvr(hass: HomeAssistant, ufp: MockUFPFixture):
+async def test_switch_nvr(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test switch entity setup for light devices."""
 
     await init_entry(hass, ufp, [])
@@ -102,7 +102,7 @@ async def test_switch_setup_no_perm(
     ufp: MockUFPFixture,
     light: Light,
     doorbell: Camera,
-):
+) -> None:
     """Test switch entity setup for light devices."""
 
     ufp.api.bootstrap.auth_user.all_permissions = [
@@ -118,7 +118,7 @@ async def test_switch_setup_light(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     light: Light,
-):
+) -> None:
     """Test switch entity setup for light devices."""
 
     await init_entry(hass, ufp, [light])
@@ -163,7 +163,7 @@ async def test_switch_setup_camera_all(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     doorbell: Camera,
-):
+) -> None:
     """Test switch entity setup for camera devices (all enabled feature flags)."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -210,7 +210,7 @@ async def test_switch_setup_camera_none(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     camera: Camera,
-):
+) -> None:
     """Test switch entity setup for camera devices (no enabled feature flags)."""
 
     await init_entry(hass, ufp, [camera])
@@ -258,7 +258,7 @@ async def test_switch_setup_camera_none(
 
 async def test_switch_light_status(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
-):
+) -> None:
     """Tests status light switch for lights."""
 
     await init_entry(hass, ufp, [light])
@@ -286,7 +286,7 @@ async def test_switch_light_status(
 
 async def test_switch_camera_ssh(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Tests SSH switch for cameras."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -319,7 +319,7 @@ async def test_switch_camera_simple(
     ufp: MockUFPFixture,
     doorbell: Camera,
     description: ProtectSwitchEntityDescription,
-):
+) -> None:
     """Tests all simple switches for cameras."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -348,7 +348,7 @@ async def test_switch_camera_simple(
 
 async def test_switch_camera_highfps(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Tests High FPS switch for cameras."""
 
     await init_entry(hass, ufp, [doorbell])
@@ -376,7 +376,7 @@ async def test_switch_camera_highfps(
 
 async def test_switch_camera_privacy(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Tests Privacy Mode switch for cameras with privacy mode defaulted on."""
 
     previous_mic = doorbell.mic_volume = 53
@@ -430,7 +430,7 @@ async def test_switch_camera_privacy(
 
 async def test_switch_camera_privacy_already_on(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Tests Privacy Mode switch for cameras with privacy mode defaulted on."""
 
     doorbell.add_privacy_zone()

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -24,7 +24,7 @@ from .utils import (
 
 async def test_text_camera_remove(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera, unadopted_camera: Camera
-):
+) -> None:
     """Test removing and re-adding a camera device."""
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
@@ -38,7 +38,7 @@ async def test_text_camera_remove(
 
 async def test_text_camera_setup(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test text entity setup for camera devices."""
 
     doorbell.lcd_message = LCDMessage(
@@ -66,7 +66,7 @@ async def test_text_camera_setup(
 
 async def test_text_camera_set(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-):
+) -> None:
     """Test text entity setting value camera devices."""
 
     await init_entry(hass, ufp, [doorbell])

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -288,7 +288,9 @@ async def test_config_children_only(hass: HomeAssistant) -> None:
     assert config_start == config
 
 
-async def test_config_children_and_attr(hass, config_children_and_attr):
+async def test_config_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr
+) -> None:
     """Check config with children and attributes."""
     config_start = copy(config_children_and_attr)
     del config_start["platform"]
@@ -379,7 +381,9 @@ async def test_master_state(hass: HomeAssistant) -> None:
     assert ump.master_state is None
 
 
-async def test_master_state_with_attrs(hass, config_children_and_attr, mock_states):
+async def test_master_state_with_attrs(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test master state property."""
     config = validate_config(config_children_and_attr)
 
@@ -390,7 +394,9 @@ async def test_master_state_with_attrs(hass, config_children_and_attr, mock_stat
     assert ump.master_state == STATE_ON
 
 
-async def test_master_state_with_bad_attrs(hass, config_children_and_attr):
+async def test_master_state_with_bad_attrs(
+    hass: HomeAssistant, config_children_and_attr
+) -> None:
     """Test master state property."""
     config = copy(config_children_and_attr)
     config["attributes"]["state"] = "bad.entity_id"
@@ -401,7 +407,7 @@ async def test_master_state_with_bad_attrs(hass, config_children_and_attr):
     assert ump.master_state == STATE_OFF
 
 
-async def test_active_child_state(hass, mock_states):
+async def test_active_child_state(hass: HomeAssistant, mock_states) -> None:
     """Test active child state property."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -460,7 +466,7 @@ async def test_polling(hass: HomeAssistant) -> None:
     assert ump.should_poll is False
 
 
-async def test_state_children_only(hass, mock_states):
+async def test_state_children_only(hass: HomeAssistant, mock_states) -> None:
     """Test media player state with only children."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -478,8 +484,8 @@ async def test_state_children_only(hass, mock_states):
 
 
 async def test_state_with_children_and_attrs(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test media player with children and master state."""
     config = validate_config(config_children_and_attr)
 
@@ -504,7 +510,7 @@ async def test_state_with_children_and_attrs(
     assert ump.state == STATE_OFF
 
 
-async def test_volume_level(hass, mock_states):
+async def test_volume_level(hass: HomeAssistant, mock_states) -> None:
     """Test volume level property."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -527,7 +533,7 @@ async def test_volume_level(hass, mock_states):
     assert ump.volume_level == 1
 
 
-async def test_media_image_url(hass, mock_states):
+async def test_media_image_url(hass: HomeAssistant, mock_states) -> None:
     """Test media_image_url property."""
     test_url = "test_url"
     config = validate_config(CONFIG_CHILDREN_ONLY)
@@ -548,7 +554,7 @@ async def test_media_image_url(hass, mock_states):
     assert mock_states.mock_mp_1.entity_picture == ump.entity_picture
 
 
-async def test_is_volume_muted_children_only(hass, mock_states):
+async def test_is_volume_muted_children_only(hass: HomeAssistant, mock_states) -> None:
     """Test is volume muted property w/ children only."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -572,8 +578,8 @@ async def test_is_volume_muted_children_only(hass, mock_states):
 
 
 async def test_sound_mode_list_children_and_attr(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test sound mode list property w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -588,8 +594,8 @@ async def test_sound_mode_list_children_and_attr(
 
 
 async def test_source_list_children_and_attr(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test source list property w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -602,8 +608,8 @@ async def test_source_list_children_and_attr(
 
 
 async def test_sound_mode_children_and_attr(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test sound modeproperty w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -615,7 +621,9 @@ async def test_sound_mode_children_and_attr(
     assert ump.sound_mode == "movie"
 
 
-async def test_source_children_and_attr(hass, config_children_and_attr, mock_states):
+async def test_source_children_and_attr(
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test source property w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -628,8 +636,8 @@ async def test_source_children_and_attr(hass, config_children_and_attr, mock_sta
 
 
 async def test_volume_level_children_and_attr(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test volume level property w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -642,8 +650,8 @@ async def test_volume_level_children_and_attr(
 
 
 async def test_is_volume_muted_children_and_attr(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test is volume muted property w/ children and attrs."""
     config = validate_config(config_children_and_attr)
 
@@ -655,7 +663,9 @@ async def test_is_volume_muted_children_and_attr(
     assert ump.is_volume_muted
 
 
-async def test_supported_features_children_only(hass, mock_states):
+async def test_supported_features_children_only(
+    hass: HomeAssistant, mock_states
+) -> None:
     """Test supported media commands with only children."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -674,8 +684,8 @@ async def test_supported_features_children_only(hass, mock_states):
 
 
 async def test_supported_features_children_and_cmds(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test supported media commands with children and attrs."""
     config = copy(config_children_and_attr)
     excmd = {"service": "media_player.test", "data": {}}
@@ -732,7 +742,7 @@ async def test_supported_features_children_and_cmds(
     assert check_flags == ump.supported_features
 
 
-async def test_overrides(hass, config_children_and_attr):
+async def test_overrides(hass: HomeAssistant, config_children_and_attr) -> None:
     """Test overrides."""
     config = copy(config_children_and_attr)
     excmd = {"service": "test.override", "data": {}}
@@ -908,8 +918,8 @@ async def test_overrides(hass, config_children_and_attr):
 
 
 async def test_supported_features_play_pause(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test supported media commands with play_pause function."""
     config = copy(config_children_and_attr)
     excmd = {"service": "media_player.test", "data": {"entity_id": "test"}}
@@ -931,8 +941,8 @@ async def test_supported_features_play_pause(
 
 
 async def test_service_call_no_active_child(
-    hass, config_children_and_attr, mock_states
-):
+    hass: HomeAssistant, config_children_and_attr, mock_states
+) -> None:
     """Test a service call to children with no active child."""
     config = validate_config(config_children_and_attr)
 
@@ -952,7 +962,7 @@ async def test_service_call_no_active_child(
     assert len(mock_states.mock_mp_2.service_calls["turn_off"]) == 0
 
 
-async def test_service_call_to_child(hass, mock_states):
+async def test_service_call_to_child(hass: HomeAssistant, mock_states) -> None:
     """Test service calls that should be routed to a child."""
     config = validate_config(CONFIG_CHILDREN_ONLY)
 
@@ -1027,7 +1037,7 @@ async def test_service_call_to_child(hass, mock_states):
     assert len(mock_states.mock_mp_2.service_calls["turn_off"]) == 2
 
 
-async def test_service_call_to_command(hass, mock_states):
+async def test_service_call_to_command(hass: HomeAssistant, mock_states) -> None:
     """Test service call to command."""
     config = copy(CONFIG_CHILDREN_ONLY)
     config["commands"] = {"turn_off": {"service": "test.turn_off", "data": {}}}

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 import requests.exceptions
+import requests_mock
 from requests_mock import ANY
 from upcloud_api import UpCloudAPIError
 
@@ -32,7 +33,9 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_connection_error(hass, requests_mock):
+async def test_connection_error(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we show user form on connection error."""
     requests_mock.request(ANY, ANY, exc=requests.exceptions.ConnectionError())
     result = await hass.config_entries.flow.async_init(
@@ -44,7 +47,9 @@ async def test_connection_error(hass, requests_mock):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_login_error(hass, requests_mock):
+async def test_login_error(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test we show user form with appropriate error on response failure."""
     requests_mock.request(
         ANY,
@@ -63,7 +68,9 @@ async def test_login_error(hass, requests_mock):
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_success(hass, requests_mock):
+async def test_success(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Test successful flow provides entry creation data."""
     requests_mock.request(ANY, ANY, text='{"account":{"username":"user"}}')
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -8,9 +8,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.update import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import DeviceRegistry
-from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryHider
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -33,8 +31,8 @@ def calls(hass: HomeAssistant) -> list[ServiceCall]:
 
 async def test_get_triggers(
     hass: HomeAssistant,
-    device_registry: DeviceRegistry,
-    entity_registry: EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get the expected triggers from a update entity."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -66,19 +64,19 @@ async def test_get_triggers(
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
     (
-        (RegistryEntryHider.INTEGRATION, None),
-        (RegistryEntryHider.USER, None),
+        (er.RegistryEntryHider.INTEGRATION, None),
+        (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -113,8 +111,8 @@ async def test_get_triggers_hidden_auxiliary(
 
 async def test_get_trigger_capabilities(
     hass: HomeAssistant,
-    device_registry: DeviceRegistry,
-    entity_registry: EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get the expected capabilities from a update trigger."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.update.const import (
@@ -21,8 +22,8 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock, hass: HomeAssistant, enable_custom_integrations: None
-):
+    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test update attributes to be excluded."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
