### PR TITLE
Refactor json tests to align with new code

### DIFF
--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -1,25 +1,56 @@
 """Test Home Assistant remote methods and classes."""
 import datetime
+from functools import partial
 import json
+import math
+import os
+from tempfile import mkdtemp
 import time
 from typing import NamedTuple
+from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import Event, HomeAssistant, State
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
-    JSONEncoder,
+    JSONEncoder as DefaultHASSJSONEncoder,
+    find_paths_unserializable_data,
     json_bytes_strip_null,
     json_dumps,
     json_dumps_sorted,
+    save_json,
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.util.color import RGBColor
+from homeassistant.util.json import SerializationError, load_json
+
+# Test data that can be saved as JSON
+TEST_JSON_A = {"a": 1, "B": "two"}
+TEST_JSON_B = {"a": "one", "B": 2}
+
+TMP_DIR = None
 
 
-@pytest.mark.parametrize("encoder", (JSONEncoder, ExtendedJSONEncoder))
-def test_json_encoder(hass, encoder):
+@pytest.fixture(autouse=True)
+def setup_and_teardown():
+    """Clean up after tests."""
+    global TMP_DIR
+    TMP_DIR = mkdtemp()
+
+    yield
+
+    for fname in os.listdir(TMP_DIR):
+        os.remove(os.path.join(TMP_DIR, fname))
+    os.rmdir(TMP_DIR)
+
+
+def _path_for(leaf_name):
+    return os.path.join(TMP_DIR, f"{leaf_name}.json")
+
+
+@pytest.mark.parametrize("encoder", (DefaultHASSJSONEncoder, ExtendedJSONEncoder))
+def test_json_encoder(hass: HomeAssistant, encoder: type[json.JSONEncoder]) -> None:
     """Test the JSON encoders."""
     ha_json_enc = encoder()
     state = State("test.test", "hello")
@@ -38,7 +69,7 @@ def test_json_encoder(hass, encoder):
 
 def test_json_encoder_raises(hass: HomeAssistant) -> None:
     """Test the JSON encoder raises on unsupported types."""
-    ha_json_enc = JSONEncoder()
+    ha_json_enc = DefaultHASSJSONEncoder()
 
     # Default method raises TypeError if non HA object
     with pytest.raises(TypeError):
@@ -135,3 +166,143 @@ def test_json_bytes_strip_null() -> None:
         json_bytes_strip_null([[{"k1": {"k2": ["silly\0stuff"]}}]])
         == b'[[{"k1":{"k2":["silly"]}}]]'
     )
+
+
+def test_save_and_load() -> None:
+    """Test saving and loading back."""
+    fname = _path_for("test1")
+    save_json(fname, TEST_JSON_A)
+    data = load_json(fname)
+    assert data == TEST_JSON_A
+
+
+def test_save_and_load_int_keys() -> None:
+    """Test saving and loading back stringifies the keys."""
+    fname = _path_for("test1")
+    save_json(fname, {1: "a", 2: "b"})
+    data = load_json(fname)
+    assert data == {"1": "a", "2": "b"}
+
+
+def test_save_and_load_private() -> None:
+    """Test we can load private files and that they are protected."""
+    fname = _path_for("test2")
+    save_json(fname, TEST_JSON_A, private=True)
+    data = load_json(fname)
+    assert data == TEST_JSON_A
+    stats = os.stat(fname)
+    assert stats.st_mode & 0o77 == 0
+
+
+@pytest.mark.parametrize("atomic_writes", [True, False])
+def test_overwrite_and_reload(atomic_writes: bool) -> None:
+    """Test that we can overwrite an existing file and read back."""
+    fname = _path_for("test3")
+    save_json(fname, TEST_JSON_A, atomic_writes=atomic_writes)
+    save_json(fname, TEST_JSON_B, atomic_writes=atomic_writes)
+    data = load_json(fname)
+    assert data == TEST_JSON_B
+
+
+def test_save_bad_data() -> None:
+    """Test error from trying to save unserializable data."""
+
+    class CannotSerializeMe:
+        """Cannot serialize this."""
+
+    with pytest.raises(SerializationError) as excinfo:
+        save_json("test4", {"hello": CannotSerializeMe()})
+
+    assert "Failed to serialize to JSON: test4. Bad data at $.hello=" in str(
+        excinfo.value
+    )
+
+
+def test_custom_encoder() -> None:
+    """Test serializing with a custom encoder."""
+
+    class MockJSONEncoder(json.JSONEncoder):
+        """Mock JSON encoder."""
+
+        def default(self, o):
+            """Mock JSON encode method."""
+            return "9"
+
+    fname = _path_for("test6")
+    save_json(fname, Mock(), encoder=MockJSONEncoder)
+    data = load_json(fname)
+    assert data == "9"
+
+
+def test_default_encoder_is_passed() -> None:
+    """Test we use orjson if they pass in the default encoder."""
+    fname = _path_for("test6")
+    with patch(
+        "homeassistant.helpers.json.orjson.dumps", return_value=b"{}"
+    ) as mock_orjson_dumps:
+        save_json(fname, {"any": 1}, encoder=DefaultHASSJSONEncoder)
+    assert len(mock_orjson_dumps.mock_calls) == 1
+    # Patch json.dumps to make sure we are using the orjson path
+    with patch("homeassistant.helpers.json.json.dumps", side_effect=Exception):
+        save_json(fname, {"any": {1}}, encoder=DefaultHASSJSONEncoder)
+    data = load_json(fname)
+    assert data == {"any": [1]}
+
+
+def test_find_unserializable_data() -> None:
+    """Find unserializeable data."""
+    assert find_paths_unserializable_data(1) == {}
+    assert find_paths_unserializable_data([1, 2]) == {}
+    assert find_paths_unserializable_data({"something": "yo"}) == {}
+
+    assert find_paths_unserializable_data({"something": set()}) == {
+        "$.something": set()
+    }
+    assert find_paths_unserializable_data({"something": [1, set()]}) == {
+        "$.something[1]": set()
+    }
+    assert find_paths_unserializable_data([1, {"bla": set(), "blub": set()}]) == {
+        "$[1].bla": set(),
+        "$[1].blub": set(),
+    }
+    assert find_paths_unserializable_data({("A",): 1}) == {"$<key: ('A',)>": ("A",)}
+    assert math.isnan(
+        find_paths_unserializable_data(
+            float("nan"), dump=partial(json.dumps, allow_nan=False)
+        )["$"]
+    )
+
+    # Test custom encoder + State support.
+
+    class MockJSONEncoder(json.JSONEncoder):
+        """Mock JSON encoder."""
+
+        def default(self, o):
+            """Mock JSON encode method."""
+            if isinstance(o, datetime.datetime):
+                return o.isoformat()
+            return super().default(o)
+
+    bad_data = object()
+
+    assert find_paths_unserializable_data(
+        [State("mock_domain.mock_entity", "on", {"bad": bad_data})],
+        dump=partial(json.dumps, cls=MockJSONEncoder),
+    ) == {"$[0](State: mock_domain.mock_entity).attributes.bad": bad_data}
+
+    assert find_paths_unserializable_data(
+        [Event("bad_event", {"bad_attribute": bad_data})],
+        dump=partial(json.dumps, cls=MockJSONEncoder),
+    ) == {"$[0](Event: bad_event).data.bad_attribute": bad_data}
+
+    class BadData:
+        def __init__(self):
+            self.bla = bad_data
+
+        def as_dict(self):
+            return {"bla": self.bla}
+
+    assert find_paths_unserializable_data(
+        BadData(),
+        dump=partial(json.dumps, cls=MockJSONEncoder),
+    ) == {"$(BadData).bla": bad_data}

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,31 +1,17 @@
 """Test Home Assistant json utility functions."""
-from datetime import datetime
-from functools import partial
-from json import JSONEncoder, dumps
-import math
 import os
 from tempfile import mkdtemp
-from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.json import JSONEncoder as DefaultHASSJSONEncoder
-from homeassistant.util.json import (
-    SerializationError,
-    find_paths_unserializable_data,
-    json_loads_array,
-    json_loads_object,
-    load_json,
-    save_json,
-)
+from homeassistant.util.json import json_loads_array, json_loads_object, load_json
 
 # Test data that can be saved as JSON
 TEST_JSON_A = {"a": 1, "B": "two"}
-TEST_JSON_B = {"a": "one", "B": 2}
 # Test data that cannot be loaded as JSON
 TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
+
 TMP_DIR = None
 
 
@@ -46,56 +32,6 @@ def _path_for(leaf_name):
     return os.path.join(TMP_DIR, f"{leaf_name}.json")
 
 
-def test_save_and_load() -> None:
-    """Test saving and loading back."""
-    fname = _path_for("test1")
-    save_json(fname, TEST_JSON_A)
-    data = load_json(fname)
-    assert data == TEST_JSON_A
-
-
-def test_save_and_load_int_keys() -> None:
-    """Test saving and loading back stringifies the keys."""
-    fname = _path_for("test1")
-    save_json(fname, {1: "a", 2: "b"})
-    data = load_json(fname)
-    assert data == {"1": "a", "2": "b"}
-
-
-def test_save_and_load_private() -> None:
-    """Test we can load private files and that they are protected."""
-    fname = _path_for("test2")
-    save_json(fname, TEST_JSON_A, private=True)
-    data = load_json(fname)
-    assert data == TEST_JSON_A
-    stats = os.stat(fname)
-    assert stats.st_mode & 0o77 == 0
-
-
-@pytest.mark.parametrize("atomic_writes", [True, False])
-def test_overwrite_and_reload(atomic_writes):
-    """Test that we can overwrite an existing file and read back."""
-    fname = _path_for("test3")
-    save_json(fname, TEST_JSON_A, atomic_writes=atomic_writes)
-    save_json(fname, TEST_JSON_B, atomic_writes=atomic_writes)
-    data = load_json(fname)
-    assert data == TEST_JSON_B
-
-
-def test_save_bad_data() -> None:
-    """Test error from trying to save unserializable data."""
-
-    class CannotSerializeMe:
-        """Cannot serialize this."""
-
-    with pytest.raises(SerializationError) as excinfo:
-        save_json("test4", {"hello": CannotSerializeMe()})
-
-    assert "Failed to serialize to JSON: test4. Bad data at $.hello=" in str(
-        excinfo.value
-    )
-
-
 def test_load_bad_data() -> None:
     """Test error from trying to load unserialisable data."""
     fname = _path_for("test5")
@@ -103,96 +39,6 @@ def test_load_bad_data() -> None:
         fh.write(TEST_BAD_SERIALIED)
     with pytest.raises(HomeAssistantError):
         load_json(fname)
-
-
-def test_custom_encoder() -> None:
-    """Test serializing with a custom encoder."""
-
-    class MockJSONEncoder(JSONEncoder):
-        """Mock JSON encoder."""
-
-        def default(self, o):
-            """Mock JSON encode method."""
-            return "9"
-
-    fname = _path_for("test6")
-    save_json(fname, Mock(), encoder=MockJSONEncoder)
-    data = load_json(fname)
-    assert data == "9"
-
-
-def test_default_encoder_is_passed() -> None:
-    """Test we use orjson if they pass in the default encoder."""
-    fname = _path_for("test6")
-    with patch(
-        "homeassistant.util.json.orjson.dumps", return_value=b"{}"
-    ) as mock_orjson_dumps:
-        save_json(fname, {"any": 1}, encoder=DefaultHASSJSONEncoder)
-    assert len(mock_orjson_dumps.mock_calls) == 1
-    # Patch json.dumps to make sure we are using the orjson path
-    with patch("homeassistant.util.json.json.dumps", side_effect=Exception):
-        save_json(fname, {"any": {1}}, encoder=DefaultHASSJSONEncoder)
-    data = load_json(fname)
-    assert data == {"any": [1]}
-
-
-def test_find_unserializable_data() -> None:
-    """Find unserializeable data."""
-    assert find_paths_unserializable_data(1) == {}
-    assert find_paths_unserializable_data([1, 2]) == {}
-    assert find_paths_unserializable_data({"something": "yo"}) == {}
-
-    assert find_paths_unserializable_data({"something": set()}) == {
-        "$.something": set()
-    }
-    assert find_paths_unserializable_data({"something": [1, set()]}) == {
-        "$.something[1]": set()
-    }
-    assert find_paths_unserializable_data([1, {"bla": set(), "blub": set()}]) == {
-        "$[1].bla": set(),
-        "$[1].blub": set(),
-    }
-    assert find_paths_unserializable_data({("A",): 1}) == {"$<key: ('A',)>": ("A",)}
-    assert math.isnan(
-        find_paths_unserializable_data(
-            float("nan"), dump=partial(dumps, allow_nan=False)
-        )["$"]
-    )
-
-    # Test custom encoder + State support.
-
-    class MockJSONEncoder(JSONEncoder):
-        """Mock JSON encoder."""
-
-        def default(self, o):
-            """Mock JSON encode method."""
-            if isinstance(o, datetime):
-                return o.isoformat()
-            return super().default(o)
-
-    bad_data = object()
-
-    assert find_paths_unserializable_data(
-        [State("mock_domain.mock_entity", "on", {"bad": bad_data})],
-        dump=partial(dumps, cls=MockJSONEncoder),
-    ) == {"$[0](State: mock_domain.mock_entity).attributes.bad": bad_data}
-
-    assert find_paths_unserializable_data(
-        [Event("bad_event", {"bad_attribute": bad_data})],
-        dump=partial(dumps, cls=MockJSONEncoder),
-    ) == {"$[0](Event: bad_event).data.bad_attribute": bad_data}
-
-    class BadData:
-        def __init__(self):
-            self.bla = bad_data
-
-        def as_dict(self):
-            return {"bla": self.bla}
-
-    assert find_paths_unserializable_data(
-        BadData(),
-        dump=partial(dumps, cls=MockJSONEncoder),
-    ) == {"$(BadData).bla": bad_data}
 
 
 def test_json_loads_array() -> None:
@@ -233,6 +79,9 @@ async def test_deprecated_test_find_unserializable_data(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test deprecated test_find_unserializable_data logs a warning."""
+    # pylint: disable-next=hass-deprecated-import,import-outside-toplevel
+    from homeassistant.util.json import find_paths_unserializable_data
+
     find_paths_unserializable_data(1)
     assert (
         "uses find_paths_unserializable_data from homeassistant.util.json"
@@ -243,6 +92,9 @@ async def test_deprecated_test_find_unserializable_data(
 
 async def test_deprecated_save_json(caplog: pytest.LogCaptureFixture) -> None:
     """Test deprecated save_json logs a warning."""
+    # pylint: disable-next=hass-deprecated-import,import-outside-toplevel
+    from homeassistant.util.json import save_json
+
     fname = _path_for("test1")
     save_json(fname, TEST_JSON_A)
     assert "uses save_json from homeassistant.util.json" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to https://github.com/home-assistant/core/pull/88099, this ensures that `util/test_json.py` does not refer to methods moved to `helper`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
