### PR TITLE
Only expose default cloud domains in Assist default agent

### DIFF
--- a/homeassistant/components/conversation/const.py
+++ b/homeassistant/components/conversation/const.py
@@ -1,3 +1,18 @@
 """Const for conversation integration."""
 
 DOMAIN = "conversation"
+
+DEFAULT_EXPOSED_DOMAINS = [
+    "climate",
+    "cover",
+    "fan",
+    "humidifier",
+    "light",
+    "lock",
+    "scene",
+    "script",
+    "sensor",
+    "switch",
+    "vacuum",
+    "water_heater",
+]

--- a/homeassistant/components/conversation/const.py
+++ b/homeassistant/components/conversation/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "conversation"
 
-DEFAULT_EXPOSED_DOMAINS = [
+DEFAULT_EXPOSED_DOMAINS = {
     "climate",
     "cover",
     "fan",
@@ -15,4 +15,4 @@ DEFAULT_EXPOSED_DOMAINS = [
     "switch",
     "vacuum",
     "water_heater",
-]
+}

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 import logging
 from pathlib import Path
@@ -17,6 +17,7 @@ from home_assistant_intents import get_intents
 import yaml
 
 from homeassistant import core, setup
+from homeassistant.components import cloud
 from homeassistant.helpers import (
     area_registry,
     entity_registry,
@@ -33,6 +34,11 @@ _LOGGER = logging.getLogger(__name__)
 _DEFAULT_ERROR_TEXT = "Sorry, I couldn't understand that"
 
 REGEX_TYPE = type(re.compile(""))
+
+
+def is_entity_exposed(state: core.State) -> bool:
+    """Return true if entity belongs to exposed domain list."""
+    return state.domain in cloud.const.DEFAULT_EXPOSED_DOMAINS
 
 
 def json_load(fp: IO[str]) -> JsonObjectType:
@@ -77,8 +83,7 @@ class DefaultAgent(AbstractConversationAgent):
 
         # intent -> [sentences]
         self._config_intents: dict[str, Any] = {}
-        self._areas_list: TextSlotList | None = None
-        self._names_list: TextSlotList | None = None
+        self._slot_lists: dict[str, TextSlotList] | None = None
 
     async def async_initialize(self, config_intents):
         """Initialize the default agent."""
@@ -128,10 +133,7 @@ class DefaultAgent(AbstractConversationAgent):
                 conversation_id,
             )
 
-        slot_lists: dict[str, SlotList] = {
-            "area": self._make_areas_list(),
-            "name": self._make_names_list(),
-        }
+        slot_lists: Mapping[str, SlotList] = self._make_slot_lists()
 
         result = await self.hass.async_add_executor_job(
             self._recognize,
@@ -419,45 +421,37 @@ class DefaultAgent(AbstractConversationAgent):
     @core.callback
     def _async_handle_area_registry_changed(self, event: core.Event) -> None:
         """Clear area area cache when the area registry has changed."""
-        self._areas_list = None
+        self._slot_lists = None
 
     @core.callback
     def _async_handle_entity_registry_changed(self, event: core.Event) -> None:
         """Clear names list cache when an entity changes aliases."""
         if event.data["action"] == "update" and "aliases" not in event.data["changes"]:
             return
-        self._names_list = None
+        self._slot_lists = None
 
     @core.callback
     def _async_handle_state_changed(self, event: core.Event) -> None:
         """Clear names list cache when a state is added or removed from the state machine."""
         if event.data.get("old_state") and event.data.get("new_state"):
             return
-        self._names_list = None
+        self._slot_lists = None
 
-    def _make_areas_list(self) -> TextSlotList:
-        """Create slot list mapping area names/aliases to area ids."""
-        if self._areas_list is not None:
-            return self._areas_list
-        registry = area_registry.async_get(self.hass)
-        areas = []
-        for entry in registry.async_list_areas():
-            areas.append((entry.name, entry.id))
-            if entry.aliases:
-                for alias in entry.aliases:
-                    areas.append((alias, entry.id))
+    def _make_slot_lists(self) -> Mapping[str, SlotList]:
+        """Create slot lists with areas and entity names/aliases."""
+        if self._slot_lists is not None:
+            return self._slot_lists
 
-        self._areas_list = TextSlotList.from_tuples(areas, allow_template=False)
-        return self._areas_list
-
-    def _make_names_list(self) -> TextSlotList:
-        """Create slot list with entity names/aliases."""
-        if self._names_list is not None:
-            return self._names_list
-        states = self.hass.states.async_all()
+        area_ids_with_entities: set[str] = set()
+        states = [
+            state for state in self.hass.states.async_all() if is_entity_exposed(state)
+        ]
         entities = entity_registry.async_get(self.hass)
+
+        # Gather exposed entity names
         names = []
         for state in states:
+            # Checked against "requires_context" and "excludes_context" in hassil
             context = {"domain": state.domain}
 
             entity = entities.async_get(state.entity_id)
@@ -473,12 +467,31 @@ class DefaultAgent(AbstractConversationAgent):
                 # Default name
                 names.append((state.name, state.name, context))
 
+                if entity.area_id:
+                    # Expose area too
+                    area_ids_with_entities.add(entity.area_id)
             else:
                 # Default name
                 names.append((state.name, state.name, context))
 
-        self._names_list = TextSlotList.from_tuples(names, allow_template=False)
-        return self._names_list
+        # Gather areas from exposed entities
+        registry = area_registry.async_get(self.hass)
+        areas = []
+        for entry in registry.async_list_areas():
+            if entry.id not in area_ids_with_entities:
+                continue
+
+            areas.append((entry.name, entry.id))
+            if entry.aliases:
+                for alias in entry.aliases:
+                    areas.append((alias, entry.id))
+
+        self._slot_lists = {
+            "area": TextSlotList.from_tuples(areas, allow_template=False),
+            "name": TextSlotList.from_tuples(names, allow_template=False),
+        }
+
+        return self._slot_lists
 
     def _get_error_text(
         self, response_type: ResponseType, lang_intents: LanguageIntents

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -17,7 +17,6 @@ from home_assistant_intents import get_intents
 import yaml
 
 from homeassistant import core, setup
-from homeassistant.components import cloud
 from homeassistant.helpers import (
     area_registry,
     entity_registry,
@@ -28,7 +27,7 @@ from homeassistant.helpers import (
 from homeassistant.util.json import JsonObjectType, json_loads_object
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
-from .const import DOMAIN
+from .const import DEFAULT_EXPOSED_DOMAINS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 _DEFAULT_ERROR_TEXT = "Sorry, I couldn't understand that"
@@ -38,7 +37,7 @@ REGEX_TYPE = type(re.compile(""))
 
 def is_entity_exposed(state: core.State) -> bool:
     """Return true if entity belongs to exposed domain list."""
-    return state.domain in cloud.const.DEFAULT_EXPOSED_DOMAINS
+    return state.domain in DEFAULT_EXPOSED_DOMAINS
 
 
 def json_load(fp: IO[str]) -> JsonObjectType:

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -1,10 +1,18 @@
 """Test for the default agent."""
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components import conversation
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import DOMAIN as HASS_DOMAIN, Context, HomeAssistant
-from homeassistant.helpers import entity, entity_registry, intent
+from homeassistant.helpers import (
+    area_registry,
+    device_registry,
+    entity,
+    entity_registry,
+    intent,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
@@ -49,8 +57,6 @@ async def test_hidden_entities_skipped(
 
 async def test_exposed_domains(hass: HomeAssistant, init_components) -> None:
     """Test that we can't interact with entities that aren't exposed."""
-    assert await async_setup_component(hass, "media_player", {})
-
     hass.states.async_set(
         "media_player.test", "off", attributes={ATTR_FRIENDLY_NAME: "Test Media Player"}
     )
@@ -63,3 +69,54 @@ async def test_exposed_domains(hass: HomeAssistant, init_components) -> None:
     # media player domain is not exposed.
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+
+
+async def test_exposed_areas(hass: HomeAssistant, init_components) -> None:
+    """Test that only expose areas with an exposed entity/device."""
+    areas = area_registry.async_get(hass)
+    area_kitchen = areas.async_get_or_create("kitchen")
+    area_bedroom = areas.async_get_or_create("bedroom")
+
+    devices = device_registry.async_get(hass)
+    kitchen_device = devices.async_get_or_create(
+        config_entry_id="1234", connections=set(), identifiers={("demo", "id-1234")}
+    )
+    devices.async_update_device(kitchen_device.id, area_id=area_kitchen.id)
+
+    entities = entity_registry.async_get(hass)
+    kitchen_light = entities.async_get_or_create("light", "demo", "1234")
+    entities.async_update_entity(kitchen_light.entity_id, device_id=kitchen_device.id)
+    hass.states.async_set(
+        kitchen_light.entity_id, "on", attributes={ATTR_FRIENDLY_NAME: "kitchen light"}
+    )
+
+    bedroom_light = entities.async_get_or_create("light", "demo", "5678")
+    entities.async_update_entity(bedroom_light.entity_id, area_id=area_bedroom.id)
+    hass.states.async_set(
+        bedroom_light.entity_id, "on", attributes={ATTR_FRIENDLY_NAME: "bedroom light"}
+    )
+
+    def is_entity_exposed(state):
+        return state.entity_id != bedroom_light.entity_id
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.is_entity_exposed",
+        is_entity_exposed,
+    ):
+        result = await conversation.async_converse(
+            hass, "turn on lights in the kitchen", None, Context(), None
+        )
+
+        # All is well for the exposed kitchen light
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+        # Bedroom is not exposed because it has no exposed entities
+        result = await conversation.async_converse(
+            hass, "turn on lights in the bedroom", None, Context(), None
+        )
+
+        # This should be an intent match failure because the area isn't in the slot list
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+        )

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -175,24 +175,3 @@ async def test_cant_turn_on_sensor(hass: HomeAssistant) -> None:
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
-
-
-async def test_exposed_domains(hass: HomeAssistant) -> None:
-    """Test that we can't interact with entities that aren't exposed."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
-    assert await async_setup_component(hass, "intent", {})
-    assert await async_setup_component(hass, "media_player", {})
-
-    hass.states.async_set(
-        "media_player.test", "off", attributes={ATTR_FRIENDLY_NAME: "Test Media Player"}
-    )
-
-    result = await conversation.async_converse(
-        hass, "turn on test media player", None, Context(), None
-    )
-
-    # This is an intent match failure instead of a handle failure because the
-    # media player domain is not exposed.
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously, all entities and areas were exposed to Assist's default agent. This is now restricted to:

- climate
- cover
- fan
- humidifier
- light
- lock
- scene
- script
- sensor
- switch
- vacuum
- water_heater

Only areas with exposed entities will be exposed themselves. In the future, this will be customizable through the frontend.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
