### PR TITLE
Display unit of elevation in met config flow

### DIFF
--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import (
     CONF_TRACK_HOME,
@@ -100,9 +99,7 @@ class MetDataUpdateCoordinator(DataUpdateCoordinator["MetWeatherData"]):
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize global Met data updater."""
         self._unsub_track_home: Callable[[], None] | None = None
-        self.weather = MetWeatherData(
-            hass, config_entry.data, hass.config.units is METRIC_SYSTEM
-        )
+        self.weather = MetWeatherData(hass, config_entry.data)
         self.weather.set_coordinates()
 
         update_interval = timedelta(minutes=randrange(55, 65))
@@ -140,13 +137,10 @@ class MetDataUpdateCoordinator(DataUpdateCoordinator["MetWeatherData"]):
 class MetWeatherData:
     """Keep data for Met.no weather entities."""
 
-    def __init__(
-        self, hass: HomeAssistant, config: MappingProxyType[str, Any], is_metric: bool
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, config: MappingProxyType[str, Any]) -> None:
         """Initialise the weather entity data."""
         self.hass = hass
         self._config = config
-        self._is_metric = is_metric
         self._weather_data: metno.MetWeatherData
         self.current_weather_data: dict = {}
         self.daily_forecast: list[dict] = []

--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -18,14 +18,12 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     EVENT_CORE_CONFIG_UPDATE,
     Platform,
-    UnitOfLength,
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_conversion import DistanceConverter
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import (
@@ -165,14 +163,6 @@ class MetWeatherData:
             latitude = self._config[CONF_LATITUDE]
             longitude = self._config[CONF_LONGITUDE]
             elevation = self._config[CONF_ELEVATION]
-            if not self._is_metric:
-                elevation = int(
-                    round(
-                        DistanceConverter.convert(
-                            elevation, UnitOfLength.FEET, UnitOfLength.METERS
-                        )
-                    )
-                )
 
         coordinates = {
             "lat": str(latitude),

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -10,6 +10,11 @@ from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, C
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     CONF_TRACK_HOME,
@@ -47,7 +52,11 @@ def _get_data_schema(
                 vol.Required(
                     CONF_LONGITUDE, default=hass.config.longitude
                 ): cv.longitude,
-                vol.Required(CONF_ELEVATION, default=hass.config.elevation): int,
+                vol.Required(CONF_ELEVATION, default=hass.config.elevation): TextSelector(
+                    TextSelectorConfig(
+                        type=TextSelectorType.NUMBER, suffix="meters"
+                    )
+                ),
             }
         )
     # Not tracking home, default values come from config entry
@@ -60,9 +69,11 @@ def _get_data_schema(
             vol.Required(
                 CONF_LONGITUDE, default=config_entry.data.get(CONF_LONGITUDE)
             ): cv.longitude,
-            vol.Required(
-                CONF_ELEVATION, default=config_entry.data.get(CONF_ELEVATION)
-            ): int,
+            vol.Required(CONF_ELEVATION, default=config_entry.data.get(CONF_ELEVATION)): TextSelector(
+                TextSelectorConfig(
+                    type=TextSelectorType.NUMBER, suffix="meters"
+                )
+            ),
         }
     )
 

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -6,14 +6,20 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    CONF_ELEVATION,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    UnitOfLength,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
-    TextSelector,
-    TextSelectorConfig,
-    TextSelectorType,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
 )
 
 from .const import (
@@ -52,9 +58,12 @@ def _get_data_schema(
                 vol.Required(
                     CONF_LONGITUDE, default=hass.config.longitude
                 ): cv.longitude,
-                vol.Required(CONF_ELEVATION, default=hass.config.elevation): TextSelector(
-                    TextSelectorConfig(
-                        type=TextSelectorType.NUMBER, suffix="meters"
+                vol.Required(
+                    CONF_ELEVATION, default=hass.config.elevation
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        mode=NumberSelectorMode.BOX,
+                        unit_of_measurement=UnitOfLength.METERS,
                     )
                 ),
             }
@@ -69,9 +78,12 @@ def _get_data_schema(
             vol.Required(
                 CONF_LONGITUDE, default=config_entry.data.get(CONF_LONGITUDE)
             ): cv.longitude,
-            vol.Required(CONF_ELEVATION, default=config_entry.data.get(CONF_ELEVATION)): TextSelector(
-                TextSelectorConfig(
-                    type=TextSelectorType.NUMBER, suffix="meters"
+            vol.Required(
+                CONF_ELEVATION, default=config_entry.data.get(CONF_ELEVATION)
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    mode=NumberSelectorMode.BOX,
+                    unit_of_measurement=UnitOfLength.METERS,
                 )
             ),
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `met` integration now requires elevation to be set in meters, regardless of the unit system set in Home Assistant. This mirrors the behavior of Home Assistant Core, which requires elevation to be in meters regardless of the unit system.

This only affects users who:
- set up the `met` integration manually via Settings (not set up automatically during onboarding), AND
- Home Assistant's unit system is not set to metric

Please double-check that elevation in `met` is set correctly, using the integration's "Configure" dialog.

![Met integration with "Configure" option](https://user-images.githubusercontent.com/30990835/220682154-5cd057e8-d682-45cf-8f4d-e94c61bf9378.png)

## Proposed change

Require elevation in `met` to be in meters.

Display the unit of elevation (always meters) in `met`'s config flow data entry dialog.

![Met's config flow, with unit of elevation shown](https://user-images.githubusercontent.com/30990835/220682926-559df860-e451-44e4-96a6-f47bbce4864f.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84895
- This PR is related to issue: none
- Link to documentation pull request: none

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
