### PR TITLE
Add type hints to integration tests (part 24)

### DIFF
--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_upnp_binary_sensors(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
-):
+) -> None:
     """Test normal sensors."""
     # First poll.
     wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -39,7 +39,7 @@ from tests.common import MockConfigEntry
     "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
-async def test_flow_ssdp(hass: HomeAssistant):
+async def test_flow_ssdp(hass: HomeAssistant) -> None:
     """Test config flow: discovered + configured through ssdp."""
     # Discovered via step ssdp.
     result = await hass.config_entries.flow.async_init(
@@ -73,7 +73,7 @@ async def test_flow_ssdp(hass: HomeAssistant):
     "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
-async def test_flow_ssdp_ignore(hass: HomeAssistant):
+async def test_flow_ssdp_ignore(hass: HomeAssistant) -> None:
     """Test config flow: discovered + ignore through ssdp."""
     # Discovered via step ssdp.
     result = await hass.config_entries.flow.async_init(
@@ -103,7 +103,7 @@ async def test_flow_ssdp_ignore(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_get_source_ip")
-async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant):
+async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant) -> None:
     """Test config flow: incomplete discovery through ssdp."""
     # Discovered via step ssdp.
     result = await hass.config_entries.flow.async_init(
@@ -124,7 +124,7 @@ async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_get_source_ip")
-async def test_flow_ssdp_non_igd_device(hass: HomeAssistant):
+async def test_flow_ssdp_non_igd_device(hass: HomeAssistant) -> None:
     """Test config flow: incomplete discovery through ssdp."""
     # Discovered via step ssdp.
     result = await hass.config_entries.flow.async_init(
@@ -150,7 +150,7 @@ async def test_flow_ssdp_non_igd_device(hass: HomeAssistant):
     "mock_get_source_ip",
     "mock_no_mac_address_from_host",
 )
-async def test_flow_ssdp_no_mac_address(hass: HomeAssistant):
+async def test_flow_ssdp_no_mac_address(hass: HomeAssistant) -> None:
     """Test config flow: discovered + configured through ssdp."""
     # Discovered via step ssdp.
     result = await hass.config_entries.flow.async_init(
@@ -179,7 +179,7 @@ async def test_flow_ssdp_no_mac_address(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_mac_address_from_host")
-async def test_flow_ssdp_discovery_changed_udn_match_mac(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_changed_udn_match_mac(hass: HomeAssistant) -> None:
     """Test config flow: discovery through ssdp, same device, but new UDN, matched on mac address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -211,7 +211,7 @@ async def test_flow_ssdp_discovery_changed_udn_match_mac(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_mac_address_from_host")
-async def test_flow_ssdp_discovery_changed_udn_match_host(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_changed_udn_match_host(hass: HomeAssistant) -> None:
     """Test config flow: discovery through ssdp, same device, but new UDN, matched on mac address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -247,7 +247,9 @@ async def test_flow_ssdp_discovery_changed_udn_match_host(hass: HomeAssistant):
     "mock_setup_entry",
     "mock_get_source_ip",
 )
-async def test_flow_ssdp_discovery_changed_udn_but_st_differs(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_changed_udn_but_st_differs(
+    hass: HomeAssistant,
+) -> None:
     """Test config flow: discovery through ssdp, same device, but new UDN, and different ST, so not matched --> new discovery."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -301,7 +303,7 @@ async def test_flow_ssdp_discovery_changed_udn_but_st_differs(hass: HomeAssistan
 
 
 @pytest.mark.usefixtures("mock_mac_address_from_host")
-async def test_flow_ssdp_discovery_changed_location(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_changed_location(hass: HomeAssistant) -> None:
     """Test config flow: discovery through ssdp, same device, but new location."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -335,7 +337,7 @@ async def test_flow_ssdp_discovery_changed_location(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_mac_address_from_host")
-async def test_flow_ssdp_discovery_ignored_entry(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_ignored_entry(hass: HomeAssistant) -> None:
     """Test config flow: discovery through ssdp, same device, but new UDN, matched on mac address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -361,7 +363,9 @@ async def test_flow_ssdp_discovery_ignored_entry(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("mock_mac_address_from_host")
-async def test_flow_ssdp_discovery_changed_udn_ignored_entry(hass: HomeAssistant):
+async def test_flow_ssdp_discovery_changed_udn_ignored_entry(
+    hass: HomeAssistant,
+) -> None:
     """Test config flow: discovery through ssdp, same device, but new UDN, matched on mac address, entry ignored."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -397,7 +401,7 @@ async def test_flow_ssdp_discovery_changed_udn_ignored_entry(hass: HomeAssistant
     "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
-async def test_flow_user(hass: HomeAssistant):
+async def test_flow_user(hass: HomeAssistant) -> None:
     """Test config flow: discovered + configured through user."""
     # Discovered via step user.
     result = await hass.config_entries.flow.async_init(
@@ -429,7 +433,7 @@ async def test_flow_user(hass: HomeAssistant):
     "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
-async def test_flow_user_no_discovery(hass: HomeAssistant):
+async def test_flow_user_no_discovery(hass: HomeAssistant) -> None:
     """Test config flow: user, but no discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery", "mock_get_source_ip", "mock_mac_address_from_host"
 )
-async def test_async_setup_entry_default(hass: HomeAssistant):
+async def test_async_setup_entry_default(hass: HomeAssistant) -> None:
     """Test async_setup_entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -43,7 +43,7 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery", "mock_get_source_ip", "mock_no_mac_address_from_host"
 )
-async def test_async_setup_entry_default_no_mac_address(hass: HomeAssistant):
+async def test_async_setup_entry_default_no_mac_address(hass: HomeAssistant) -> None:
     """Test async_setup_entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -11,7 +11,9 @@ import homeassistant.util.dt as dt_util
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_upnp_sensors(hass: HomeAssistant, mock_config_entry: MockConfigEntry):
+async def test_upnp_sensors(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Test sensors."""
     # First poll.
     assert hass.states.get("sensor.mock_name_b_received").state == "0"

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -29,7 +29,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_reauthentication_trigger_in_setup(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     """Test reauthentication trigger."""
     mock_config_entry = MockConfigEntry(**MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA)
     mock_config_entry.add_to_hass(hass)
@@ -61,7 +61,7 @@ async def test_reauthentication_trigger_in_setup(
 
 async def test_reauthentication_trigger_key_read_only(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     """Test reauthentication trigger."""
     mock_config_entry = MockConfigEntry(
         **MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA_KEY_READ_ONLY
@@ -94,7 +94,7 @@ async def test_reauthentication_trigger_key_read_only(
 
 async def test_reauthentication_trigger_after_setup(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     """Test reauthentication trigger."""
     mock_config_entry = await setup_uptimerobot_integration(hass)
 
@@ -125,7 +125,7 @@ async def test_reauthentication_trigger_after_setup(
     assert flow["context"]["entry_id"] == mock_config_entry.entry_id
 
 
-async def test_integration_reload(hass: HomeAssistant):
+async def test_integration_reload(hass: HomeAssistant) -> None:
     """Test integration reload."""
     mock_entry = await setup_uptimerobot_integration(hass)
 
@@ -142,7 +142,9 @@ async def test_integration_reload(hass: HomeAssistant):
     assert hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state == STATE_ON
 
 
-async def test_update_errors(hass: HomeAssistant, caplog: pytest.LogCaptureFixture):
+async def test_update_errors(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test errors during updates."""
     await setup_uptimerobot_integration(hass)
 
@@ -179,7 +181,7 @@ async def test_update_errors(hass: HomeAssistant, caplog: pytest.LogCaptureFixtu
     assert "Error fetching uptimerobot data: test error from API" in caplog.text
 
 
-async def test_device_management(hass: HomeAssistant):
+async def test_device_management(hass: HomeAssistant) -> None:
     """Test that we are adding and removing devices for monitors returned from the API."""
     mock_entry = await setup_uptimerobot_integration(hass)
     dev_reg = dr.async_get(hass)

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -1,7 +1,7 @@
 """Test UptimeRobot switch."""
-
 from unittest.mock import patch
 
+import pytest
 from pyuptimerobot import UptimeRobotAuthenticationException
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -94,7 +94,9 @@ async def test_switch_on(hass: HomeAssistant) -> None:
         assert entity.state == STATE_ON
 
 
-async def test_authentication_error(hass: HomeAssistant, caplog) -> None:
+async def test_authentication_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test authentication error turning switch on/off."""
     await setup_uptimerobot_integration(hass)
 
@@ -117,7 +119,9 @@ async def test_authentication_error(hass: HomeAssistant, caplog) -> None:
         assert config_entry_reauth.assert_called
 
 
-async def test_refresh_data(hass: HomeAssistant, caplog) -> None:
+async def test_refresh_data(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test authentication error turning switch on/off."""
     await setup_uptimerobot_integration(hass)
 
@@ -137,7 +141,9 @@ async def test_refresh_data(hass: HomeAssistant, caplog) -> None:
         assert coordinator_refresh.assert_called
 
 
-async def test_switch_api_failure(hass: HomeAssistant, caplog) -> None:
+async def test_switch_api_failure(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test general exception turning switch on/off."""
     await setup_uptimerobot_integration(hass)
 

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -59,7 +59,9 @@ def mock_venv():
     not sys.platform.startswith("linux"),
     reason="Only works on linux",
 )
-async def test_observer_discovery(hass, hass_ws_client, venv):
+async def test_observer_discovery(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
+) -> None:
     """Test that observer can discover a device without raising an exception."""
     new_usb = [{"domain": "test1", "vid": "3039"}]
 
@@ -113,7 +115,9 @@ async def test_observer_discovery(hass, hass_ws_client, venv):
     not sys.platform.startswith("linux"),
     reason="Only works on linux",
 )
-async def test_removal_by_observer_before_started(hass, operating_system):
+async def test_removal_by_observer_before_started(
+    hass: HomeAssistant, operating_system
+) -> None:
     """Test a device is removed by the observer before started."""
 
     async def _mock_monitor_observer_callback(callback):
@@ -198,8 +202,8 @@ async def test_discovered_by_websocket_scan(
 
 
 async def test_discovered_by_websocket_scan_limited_by_description_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan is limited by the description matcher."""
     new_usb = [
         {"domain": "test1", "vid": "3039", "pid": "3039", "description": "*2652*"}
@@ -279,8 +283,8 @@ async def test_most_targeted_matcher_wins(
 
 
 async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan rejected by the description matcher."""
     new_usb = [
         {"domain": "test1", "vid": "3039", "pid": "3039", "description": "*not_it*"}
@@ -318,8 +322,8 @@ async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
 
 
 async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan is limited by the serial_number matcher."""
     new_usb = [
         {
@@ -363,8 +367,8 @@ async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
 
 
 async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan is rejected by the serial_number matcher."""
     new_usb = [
         {"domain": "test1", "vid": "3039", "pid": "3039", "serial_number": "123*"}
@@ -402,8 +406,8 @@ async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
 
 
 async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan is limited by the manufacturer matcher."""
     new_usb = [
         {
@@ -447,8 +451,8 @@ async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
 
 
 async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket scan is rejected by the manufacturer matcher."""
     new_usb = [
         {
@@ -491,8 +495,8 @@ async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
 
 
 async def test_discovered_by_websocket_rejected_with_empty_serial_number_only(
-    hass, hass_ws_client
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a device is discovered from websocket is rejected with empty serial number."""
     new_usb = [
         {"domain": "test1", "vid": "3039", "pid": "3039", "serial_number": "123*"}
@@ -643,8 +647,8 @@ async def test_discovered_by_websocket_no_vid_pid(
 
 @pytest.mark.parametrize("exception_type", [ImportError, OSError])
 async def test_non_matching_discovered_by_scanner_after_started(
-    hass, exception_type, hass_ws_client
-):
+    hass: HomeAssistant, exception_type, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test a websocket scan that does not match."""
     new_usb = [{"domain": "test1", "vid": "4444", "pid": "4444"}]
 
@@ -684,8 +688,8 @@ async def test_non_matching_discovered_by_scanner_after_started(
     reason="Only works on linux",
 )
 async def test_observer_on_wsl_fallback_without_throwing_exception(
-    hass, hass_ws_client, venv
-):
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
+) -> None:
     """Test that observer on WSL failure results in fallback to scanning without raising an exception."""
     new_usb = [{"domain": "test1", "vid": "3039"}]
 
@@ -725,7 +729,9 @@ async def test_observer_on_wsl_fallback_without_throwing_exception(
     not sys.platform.startswith("linux"),
     reason="Only works on linux",
 )
-async def test_not_discovered_by_observer_before_started_on_docker(hass, docker):
+async def test_not_discovered_by_observer_before_started_on_docker(
+    hass: HomeAssistant, docker
+) -> None:
     """Test a device is not discovered since observer is not running on bare docker."""
 
     async def _mock_monitor_observer_callback(callback):
@@ -902,7 +908,9 @@ async def test_async_is_plugged_in(
         {"description": "A description"},
     ],
 )
-async def test_async_is_plugged_in_case_enforcement(hass, matcher):
+async def test_async_is_plugged_in_case_enforcement(
+    hass: HomeAssistant, matcher
+) -> None:
     """Test `async_is_plugged_in` throws an error when incorrect cases are used."""
 
     new_usb = [{"domain": "test1", "vid": "ABCD"}]

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -66,7 +66,7 @@ async def test_restore_state(hass: HomeAssistant) -> None:
         "select.energy_bill",
     ),
 )
-async def test_services(hass, meter):
+async def test_services(hass: HomeAssistant, meter) -> None:
     """Test energy sensor reset service."""
     config = {
         "utility_meter": {

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -83,7 +83,7 @@ def set_utc(hass):
         ),
     ),
 )
-async def test_state(hass, yaml_config, config_entry_config):
+async def test_state(hass: HomeAssistant, yaml_config, config_entry_config) -> None:
     """Test utility sensor state."""
     if yaml_config:
         assert await async_setup_component(hass, DOMAIN, yaml_config)
@@ -245,7 +245,7 @@ async def test_state(hass, yaml_config, config_entry_config):
         ),
     ),
 )
-async def test_not_unique_tariffs(hass, yaml_config):
+async def test_not_unique_tariffs(hass: HomeAssistant, yaml_config) -> None:
     """Test utility sensor state initializtion."""
     assert not await async_setup_component(hass, DOMAIN, yaml_config)
 
@@ -278,7 +278,7 @@ async def test_not_unique_tariffs(hass, yaml_config):
         ),
     ),
 )
-async def test_init(hass, yaml_config, config_entry_config):
+async def test_init(hass: HomeAssistant, yaml_config, config_entry_config) -> None:
     """Test utility sensor state initializtion."""
     if yaml_config:
         assert await async_setup_component(hass, DOMAIN, yaml_config)
@@ -389,7 +389,7 @@ async def test_unique_id(hass: HomeAssistant) -> None:
         ),
     ),
 )
-async def test_entity_name(hass, yaml_config, entity_id, name):
+async def test_entity_name(hass: HomeAssistant, yaml_config, entity_id, name) -> None:
     """Test utility sensor state initializtion."""
     assert await async_setup_component(hass, DOMAIN, yaml_config)
     await hass.async_block_till_done()
@@ -445,7 +445,9 @@ async def test_entity_name(hass, yaml_config, entity_id, name):
         ),
     ),
 )
-async def test_device_class(hass, yaml_config, config_entry_configs):
+async def test_device_class(
+    hass: HomeAssistant, yaml_config, config_entry_configs
+) -> None:
     """Test utility device_class."""
     if yaml_config:
         assert await async_setup_component(hass, DOMAIN, yaml_config)
@@ -519,7 +521,9 @@ async def test_device_class(hass, yaml_config, config_entry_configs):
         ),
     ),
 )
-async def test_restore_state(hass, yaml_config, config_entry_config):
+async def test_restore_state(
+    hass: HomeAssistant, yaml_config, config_entry_config
+) -> None:
     """Test utility sensor restore state."""
     # Home assistant is not runnit yet
     hass.state = CoreState.not_running
@@ -676,7 +680,9 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
         ),
     ),
 )
-async def test_net_consumption(hass, yaml_config, config_entry_config):
+async def test_net_consumption(
+    hass: HomeAssistant, yaml_config, config_entry_config
+) -> None:
     """Test utility sensor state."""
     if yaml_config:
         assert await async_setup_component(hass, DOMAIN, yaml_config)
@@ -744,7 +750,12 @@ async def test_net_consumption(hass, yaml_config, config_entry_config):
         ),
     ),
 )
-async def test_non_net_consumption(hass, yaml_config, config_entry_config, caplog):
+async def test_non_net_consumption(
+    hass: HomeAssistant,
+    yaml_config,
+    config_entry_config,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test utility sensor state."""
     if yaml_config:
         assert await async_setup_component(hass, DOMAIN, yaml_config)
@@ -823,7 +834,12 @@ async def test_non_net_consumption(hass, yaml_config, config_entry_config, caplo
         ),
     ),
 )
-async def test_delta_values(hass, yaml_config, config_entry_config, caplog):
+async def test_delta_values(
+    hass: HomeAssistant,
+    yaml_config,
+    config_entry_config,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test utility meter "delta_values" mode."""
     # Home assistant is not runnit yet
     hass.state = CoreState.not_running

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -15,6 +15,7 @@ from homeassistant.components.camera import (
     async_get_image,
     async_get_stream_source,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
@@ -109,7 +110,7 @@ def camera_v313_fixture():
         yield camera
 
 
-async def test_setup_full_config(hass, mock_remote, camera_info):
+async def test_setup_full_config(hass: HomeAssistant, mock_remote, camera_info) -> None:
     """Test the setup with full configuration."""
     config = {
         "platform": "uvc",
@@ -161,7 +162,7 @@ async def test_setup_full_config(hass, mock_remote, camera_info):
     assert entity_entry.unique_id == "id2"
 
 
-async def test_setup_partial_config(hass, mock_remote):
+async def test_setup_partial_config(hass: HomeAssistant, mock_remote) -> None:
     """Test the setup with partial configuration."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
 
@@ -195,7 +196,7 @@ async def test_setup_partial_config(hass, mock_remote):
     assert entity_entry.unique_id == "id2"
 
 
-async def test_setup_partial_config_v31x(hass, mock_remote):
+async def test_setup_partial_config_v31x(hass: HomeAssistant, mock_remote) -> None:
     """Test the setup with a v3.1.x server."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     mock_remote.return_value.server_version = (3, 1, 3)
@@ -238,7 +239,9 @@ async def test_setup_partial_config_v31x(hass, mock_remote):
         {"platform": "uvc", "nvr": "foo", "key": "secret", "port": "invalid"},
     ],
 )
-async def test_setup_incomplete_config(hass, mock_remote, config):
+async def test_setup_incomplete_config(
+    hass: HomeAssistant, mock_remote, config
+) -> None:
     """Test the setup with incomplete or invalid configuration."""
     assert await async_setup_component(hass, "camera", config)
     await hass.async_block_till_done()
@@ -256,7 +259,9 @@ async def test_setup_incomplete_config(hass, mock_remote, config):
         (requests.exceptions.ConnectionError, 2),
     ],
 )
-async def test_setup_nvr_errors_during_indexing(hass, mock_remote, error, ready_states):
+async def test_setup_nvr_errors_during_indexing(
+    hass: HomeAssistant, mock_remote, error, ready_states
+) -> None:
     """Set up test for NVR errors during indexing."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     now = utcnow()
@@ -288,8 +293,8 @@ async def test_setup_nvr_errors_during_indexing(hass, mock_remote, error, ready_
     ],
 )
 async def test_setup_nvr_errors_during_initialization(
-    hass, mock_remote, error, ready_states
-):
+    hass: HomeAssistant, mock_remote, error, ready_states
+) -> None:
     """Set up test for NVR errors during initialization."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     now = utcnow()
@@ -314,7 +319,7 @@ async def test_setup_nvr_errors_during_initialization(
     assert len(camera_states) == ready_states
 
 
-async def test_properties(hass, mock_remote):
+async def test_properties(hass: HomeAssistant, mock_remote) -> None:
     """Test the properties."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     assert await async_setup_component(hass, "camera", {"camera": config})
@@ -334,7 +339,9 @@ async def test_properties(hass, mock_remote):
     assert state.attributes["supported_features"] == CameraEntityFeature.STREAM
 
 
-async def test_motion_recording_mode_properties(hass, mock_remote):
+async def test_motion_recording_mode_properties(
+    hass: HomeAssistant, mock_remote
+) -> None:
     """Test the properties."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     now = utcnow()
@@ -399,7 +406,7 @@ async def test_motion_recording_mode_properties(hass, mock_remote):
     assert state.state == STATE_RECORDING
 
 
-async def test_stream(hass, mock_remote):
+async def test_stream(hass: HomeAssistant, mock_remote) -> None:
     """Test the RTSP stream URI."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     assert await async_setup_component(hass, "camera", {"camera": config})
@@ -410,7 +417,7 @@ async def test_stream(hass, mock_remote):
     assert stream_source == "rtsp://foo:7447/uuid_rtspchannel_0"
 
 
-async def test_login(hass, mock_remote, camera_v320):
+async def test_login(hass: HomeAssistant, mock_remote, camera_v320) -> None:
     """Test the login."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
     assert await async_setup_component(hass, "camera", {"camera": config})
@@ -425,7 +432,7 @@ async def test_login(hass, mock_remote, camera_v320):
     assert image.content == "test_image"
 
 
-async def test_login_v31x(hass, mock_remote, camera_v313):
+async def test_login_v31x(hass: HomeAssistant, mock_remote, camera_v313) -> None:
     """Test login with v3.1.x server."""
     mock_remote.return_value.server_version = (3, 1, 3)
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
@@ -444,7 +451,9 @@ async def test_login_v31x(hass, mock_remote, camera_v313):
 @pytest.mark.parametrize(
     "error", [OSError, camera.CameraConnectError, camera.CameraAuthError]
 )
-async def test_login_tries_both_addrs_and_caches(hass, mock_remote, camera_v320, error):
+async def test_login_tries_both_addrs_and_caches(
+    hass: HomeAssistant, mock_remote, camera_v320, error
+) -> None:
     """Test the login tries."""
     responses = [0]
 
@@ -492,7 +501,9 @@ async def test_login_tries_both_addrs_and_caches(hass, mock_remote, camera_v320,
     assert image.content == "test_image"
 
 
-async def test_login_fails_both_properly(hass, mock_remote, camera_v320):
+async def test_login_fails_both_properly(
+    hass: HomeAssistant, mock_remote, camera_v320
+) -> None:
     """Test if login fails properly."""
     camera_v320.return_value.login.side_effect = OSError
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
@@ -513,8 +524,13 @@ async def test_login_fails_both_properly(hass, mock_remote, camera_v320):
     ],
 )
 async def test_camera_image_error(
-    hass, mock_remote, camera_v320, source_error, raised_error, snapshot_calls
-):
+    hass: HomeAssistant,
+    mock_remote,
+    camera_v320,
+    source_error,
+    raised_error,
+    snapshot_calls,
+) -> None:
     """Test the camera image error."""
     camera_v320.return_value.get_snapshot.side_effect = source_error
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
@@ -527,7 +543,9 @@ async def test_camera_image_error(
     assert camera_v320.return_value.get_snapshot.call_count == snapshot_calls
 
 
-async def test_enable_disable_motion_detection(hass, mock_remote, camera_info):
+async def test_enable_disable_motion_detection(
+    hass: HomeAssistant, mock_remote, camera_info
+) -> None:
     """Test enable and disable motion detection."""
 
     def set_recordmode(uuid, mode):

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -6,7 +6,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -19,7 +19,11 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a vacuum."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -57,12 +61,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -10,7 +10,8 @@ from homeassistant.components.vacuum import (
     STATE_RETURNING,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, device_registry, entity_registry):
+async def test_get_conditions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected conditions from a vacuum."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_conditions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_conditions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected conditions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,7 @@ async def test_get_conditions_hidden_auxiliary(
     assert_lists_same(conditions, expected_conditions)
 
 
-async def test_if_state(hass, calls):
+async def test_if_state(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off conditions."""
     hass.states.async_set("vacuum.entity", STATE_DOCKED)
 

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
 from homeassistant.const import EntityCategory
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -29,7 +30,11 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_triggers(hass, device_registry, entity_registry):
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected triggers from a vacuum."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -67,12 +72,12 @@ async def test_get_triggers(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -105,7 +110,11 @@ async def test_get_triggers_hidden_auxiliary(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected capabilities from a vacuum device."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -132,7 +141,7 @@ async def test_get_trigger_capabilities(hass, device_registry, entity_registry):
         }
 
 
-async def test_if_fires_on_state_change(hass, calls):
+async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     """Test for turn_on and turn_off triggers firing."""
     hass.states.async_set("vacuum.entity", STATE_DOCKED)
 
@@ -200,7 +209,7 @@ async def test_if_fires_on_state_change(hass, calls):
     )
 
 
-async def test_if_fires_on_state_change_with_for(hass, calls):
+async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for triggers firing with delay."""
     entity_id = f"{DOMAIN}.entity"
     hass.states.async_set(entity_id, STATE_DOCKED)

--- a/tests/components/vacuum/test_recorder.py
+++ b/tests/components/vacuum/test_recorder.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components import vacuum
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.vacuum import ATTR_FAN_SPEED_LIST
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -16,7 +17,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test vacuum registered attributes to be excluded."""
     await async_setup_component(
         hass, vacuum.DOMAIN, {vacuum.DOMAIN: {"platform": "demo"}}

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -47,7 +47,7 @@ def _now_at_13():
 
 async def test_remaining_filter_returns_timestamp(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test that the remaining time for filter sensor returns a timestamp."""
     # Act
     with patch(
@@ -64,7 +64,7 @@ async def test_remaining_filter_returns_timestamp(
 
 async def test_remaining_time_for_filter_none_returned_from_vallox(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test that the remaining time for filter sensor returns 'unknown' when Vallox returns None."""
     # Act
     with patch(
@@ -90,7 +90,7 @@ async def test_remaining_time_for_filter_none_returned_from_vallox(
 )
 async def test_remaining_time_for_filter_in_the_future(
     mock_entry: MockConfigEntry, set_tz: tzinfo, hass: HomeAssistant
-):
+) -> None:
     """Test remaining time for filter when Vallox returns a date in the future."""
     # Arrange
     remaining_days = 112
@@ -114,7 +114,7 @@ async def test_remaining_time_for_filter_in_the_future(
 
 async def test_remaining_time_for_filter_today(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test remaining time for filter when Vallox returns today."""
     # Arrange
     remaining_days = 0
@@ -138,7 +138,7 @@ async def test_remaining_time_for_filter_today(
 
 async def test_remaining_time_for_filter_in_the_past(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test remaining time for filter when Vallox returns a date in the past."""
     # Arrange
     remaining_days = -3
@@ -162,7 +162,7 @@ async def test_remaining_time_for_filter_in_the_past(
 
 async def test_cell_state_sensor_heat_recovery(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test cell state sensor in heat recovery state."""
     # Arrange
     metrics = {"A_CYC_CELL_STATE": 0}
@@ -179,7 +179,7 @@ async def test_cell_state_sensor_heat_recovery(
 
 async def test_cell_state_sensor_cool_recovery(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test cell state sensor in cool recovery state."""
     # Arrange
     metrics = {"A_CYC_CELL_STATE": 1}
@@ -196,7 +196,7 @@ async def test_cell_state_sensor_cool_recovery(
 
 async def test_cell_state_sensor_bypass(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test cell state sensor in bypass state."""
     # Arrange
     metrics = {"A_CYC_CELL_STATE": 2}
@@ -213,7 +213,7 @@ async def test_cell_state_sensor_bypass(
 
 async def test_cell_state_sensor_defrosting(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test cell state sensor in defrosting state."""
     # Arrange
     metrics = {"A_CYC_CELL_STATE": 3}
@@ -230,7 +230,7 @@ async def test_cell_state_sensor_defrosting(
 
 async def test_cell_state_sensor_unknown_state(
     mock_entry: MockConfigEntry, hass: HomeAssistant
-):
+) -> None:
     """Test cell state sensor in unknown state."""
     # Arrange
     metrics = {"A_CYC_CELL_STATE": 4}

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -64,7 +64,7 @@ def mock_controller_connection_failed():
 
 
 @pytest.mark.usefixtures("controller")
-async def test_user(hass: HomeAssistant):
+async def test_user(hass: HomeAssistant) -> None:
     """Test user config."""
     # simple user form
     result = await hass.config_entries.flow.async_init(
@@ -103,7 +103,7 @@ async def test_user(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("controller_connection_failed")
-async def test_user_fail(hass: HomeAssistant):
+async def test_user_fail(hass: HomeAssistant) -> None:
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -125,7 +125,7 @@ async def test_user_fail(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("config_entry")
-async def test_abort_if_already_setup(hass: HomeAssistant):
+async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if Velbus is already setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -139,7 +139,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant):
 
 @pytest.mark.usefixtures("controller")
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_flow_usb(hass: HomeAssistant):
+async def test_flow_usb(hass: HomeAssistant) -> None:
     """Test usb discovery flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -175,7 +175,7 @@ async def test_flow_usb(hass: HomeAssistant):
 
 @pytest.mark.usefixtures("controller_connection_failed")
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_flow_usb_failed(hass: HomeAssistant):
+async def test_flow_usb_failed(hass: HomeAssistant) -> None:
     """Test usb discovery flow with a failed velbus test."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("controller")
-async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Test being able to unload an entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -31,7 +31,7 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 @pytest.mark.usefixtures("controller")
 async def test_device_identifier_migration(
     hass: HomeAssistant, config_entry: ConfigEntry, device_registry: dr.DeviceRegistry
-):
+) -> None:
     """Test being able to unload an entry."""
     original_identifiers = {(DOMAIN, "module_address", "module_serial")}
     target_identifiers = {(DOMAIN, "module_address")}

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 TEST_HOST = "venstartest.localdomain"
 
 
-async def test_setup_entry(hass: HomeAssistant):
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Validate that setup entry also configure the client."""
     config_entry = MockConfigEntry(
         domain=VENSTAR_DOMAIN,
@@ -53,7 +53,7 @@ async def test_setup_entry(hass: HomeAssistant):
     assert config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_entry_exception(hass: HomeAssistant):
+async def test_setup_entry_exception(hass: HomeAssistant) -> None:
     """Validate that setup entry also configure the client."""
     config_entry = MockConfigEntry(
         domain=VENSTAR_DOMAIN,

--- a/tests/components/version/test_binary_sensor.py
+++ b/tests/components/version/test_binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from .common import setup_version_integration
 
 
-async def test_version_binary_sensor_local_source(hass: HomeAssistant):
+async def test_version_binary_sensor_local_source(hass: HomeAssistant) -> None:
     """Test the Version binary sensor with local source."""
     await setup_version_integration(hass)
 
@@ -15,7 +15,7 @@ async def test_version_binary_sensor_local_source(hass: HomeAssistant):
     assert not state
 
 
-async def test_version_binary_sensor(hass: HomeAssistant):
+async def test_version_binary_sensor(hass: HomeAssistant) -> None:
     """Test the Version binary sensor."""
     await setup_version_integration(hass, {**DEFAULT_CONFIGURATION, "source": "pypi"})
 

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -27,7 +27,7 @@ from .common import MOCK_VERSION, MOCK_VERSION_DATA, setup_version_integration
 from tests.common import async_fire_time_changed
 
 
-async def test_reload_config_entry(hass: HomeAssistant):
+async def test_reload_config_entry(hass: HomeAssistant) -> None:
     """Test reloading the config entry."""
     config_entry = await setup_version_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED

--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from .common import MOCK_VERSION, mock_get_version_update, setup_version_integration
 
 
-async def test_version_sensor(hass: HomeAssistant):
+async def test_version_sensor(hass: HomeAssistant) -> None:
     """Test the Version sensor with different sources."""
     await setup_version_integration(hass)
 
@@ -19,7 +19,7 @@ async def test_version_sensor(hass: HomeAssistant):
     assert "channel" not in state.attributes
 
 
-async def test_update(hass: HomeAssistant, caplog: pytest.LogCaptureFixture):
+async def test_update(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test updates."""
     await setup_version_integration(hass)
     assert hass.states.get("sensor.local_installation").state == MOCK_VERSION

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -669,7 +669,7 @@ async def test_import_error(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_bypass_setup: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that error is logged when import config has an error."""
     entry = MockConfigEntry(

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -508,7 +508,7 @@ async def test_update_unavailable_to_available(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device becomes available after being unavailable."""
     await _test_update_availability_switch(hass, None, True, caplog)
@@ -518,7 +518,7 @@ async def test_update_available_to_unavailable(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device becomes unavailable after being available."""
     await _test_update_availability_switch(hass, True, None, caplog)
@@ -528,7 +528,7 @@ async def test_setup_with_apps(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -556,7 +556,7 @@ async def test_setup_with_apps_include(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["include"] in config."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -574,7 +574,7 @@ async def test_setup_with_apps_exclude(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["exclude"] in config."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -592,7 +592,7 @@ async def test_setup_with_apps_additional_apps_config(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["additional_configs"] in config."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -655,7 +655,7 @@ async def test_setup_with_apps_additional_apps_config(
         assert not service_call2.called
 
 
-def test_invalid_apps_config(hass: HomeAssistant):
+def test_invalid_apps_config(hass: HomeAssistant) -> None:
     """Test that schema validation fails on certain conditions."""
     with pytest.raises(vol.Invalid):
         vol.Schema(vol.All(VIZIO_SCHEMA, validate_apps))(MOCK_TV_APPS_FAILURE)
@@ -668,7 +668,7 @@ async def test_setup_with_unknown_app_config(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where app config returned is unknown."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -685,7 +685,7 @@ async def test_setup_with_no_running_app(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where no app is running."""
     async with _cm_for_test_setup_tv_with_apps(
@@ -726,7 +726,7 @@ async def test_apps_update(
     hass: HomeAssistant,
     vizio_connect: pytest.fixture,
     vizio_update_with_apps: pytest.fixture,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where no app is running."""
     with patch(

--- a/tests/components/vulcan/test_config_flow.py
+++ b/tests/components/vulcan/test_config_flow.py
@@ -45,8 +45,8 @@ async def test_show_form(hass: HomeAssistant) -> None:
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 async def test_config_flow_auth_success(
-    mock_keystore, mock_account, mock_student, hass
-):
+    mock_keystore, mock_account, mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow initialized by the user."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -80,8 +80,8 @@ async def test_config_flow_auth_success(
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 async def test_config_flow_auth_success_with_multiple_students(
-    mock_keystore, mock_account, mock_student, hass
-):
+    mock_keystore, mock_account, mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow with multiple students."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -125,8 +125,8 @@ async def test_config_flow_auth_success_with_multiple_students(
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
 async def test_config_flow_reauth_success(
-    mock_account, mock_keystore, mock_student, hass
-):
+    mock_account, mock_keystore, mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow reauth."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -164,8 +164,8 @@ async def test_config_flow_reauth_success(
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
 async def test_config_flow_reauth_without_matching_entries(
-    mock_account, mock_keystore, mock_student, hass
-):
+    mock_account, mock_keystore, mock_student, hass: HomeAssistant
+) -> None:
     """Test a aborted config flow reauth caused by leak of matching entries."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -196,7 +196,9 @@ async def test_config_flow_reauth_without_matching_entries(
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
-async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass):
+async def test_config_flow_reauth_with_errors(
+    mock_account, mock_keystore, hass: HomeAssistant
+) -> None:
     """Test reauth config flow with errors."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -288,7 +290,9 @@ async def test_config_flow_reauth_with_errors(mock_account, mock_keystore, hass)
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
-async def test_multiple_config_entries(mock_account, mock_keystore, mock_student, hass):
+async def test_multiple_config_entries(
+    mock_account, mock_keystore, mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow for multiple config entries."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -333,7 +337,9 @@ async def test_multiple_config_entries(mock_account, mock_keystore, mock_student
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
-async def test_multiple_config_entries_using_saved_credentials(mock_student, hass):
+async def test_multiple_config_entries_using_saved_credentials(
+    mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow for multiple config entries using saved credentials."""
     mock_student.return_value = [
         Student.load(load_fixture("fake_student_1.json", "vulcan"))
@@ -367,7 +373,9 @@ async def test_multiple_config_entries_using_saved_credentials(mock_student, has
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
-async def test_multiple_config_entries_using_saved_credentials_2(mock_student, hass):
+async def test_multiple_config_entries_using_saved_credentials_2(
+    mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow for multiple config entries using saved credentials (different situation)."""
     mock_student.return_value = [
         Student.load(load_fixture("fake_student_1.json", "vulcan"))
@@ -410,7 +418,9 @@ async def test_multiple_config_entries_using_saved_credentials_2(mock_student, h
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
-async def test_multiple_config_entries_using_saved_credentials_3(mock_student, hass):
+async def test_multiple_config_entries_using_saved_credentials_3(
+    mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow for multiple config entries using saved credentials."""
     mock_student.return_value = [
         Student.load(load_fixture("fake_student_1.json", "vulcan"))
@@ -461,7 +471,9 @@ async def test_multiple_config_entries_using_saved_credentials_3(mock_student, h
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
-async def test_multiple_config_entries_using_saved_credentials_4(mock_student, hass):
+async def test_multiple_config_entries_using_saved_credentials_4(
+    mock_student, hass: HomeAssistant
+) -> None:
     """Test a successful config flow for multiple config entries using saved credentials (different situation)."""
     mock_student.return_value = [
         Student.load(load_fixture("fake_student_1.json", "vulcan"))
@@ -569,8 +581,8 @@ async def test_multiple_config_entries_without_valid_saved_credentials(
 
 
 async def test_multiple_config_entries_using_saved_credentials_with_connections_issues(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test a unsuccessful config flow for multiple config entries without valid saved credentials."""
     MockConfigEntry(
         entry_id="456",
@@ -667,7 +679,9 @@ async def test_multiple_config_entries_using_saved_credentials_with_unknown_erro
 @mock.patch("homeassistant.components.vulcan.config_flow.Vulcan.get_students")
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
 @mock.patch("homeassistant.components.vulcan.config_flow.Account.register")
-async def test_student_already_exists(mock_account, mock_keystore, mock_student, hass):
+async def test_student_already_exists(
+    mock_account, mock_keystore, mock_student, hass: HomeAssistant
+) -> None:
     """Test config entry when student's entry already exists."""
     mock_keystore.return_value = fake_keystore
     mock_account.return_value = fake_account
@@ -701,7 +715,9 @@ async def test_student_already_exists(mock_account, mock_keystore, mock_student,
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_invalid_token(mock_keystore, hass):
+async def test_config_flow_auth_invalid_token(
+    mock_keystore, hass: HomeAssistant
+) -> None:
     """Test a config flow initialized by the user using invalid token."""
     mock_keystore.return_value = fake_keystore
     with patch(
@@ -727,7 +743,9 @@ async def test_config_flow_auth_invalid_token(mock_keystore, hass):
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_invalid_region(mock_keystore, hass):
+async def test_config_flow_auth_invalid_region(
+    mock_keystore, hass: HomeAssistant
+) -> None:
     """Test a config flow initialized by the user using invalid region."""
     mock_keystore.return_value = fake_keystore
     with patch(
@@ -753,7 +771,7 @@ async def test_config_flow_auth_invalid_region(mock_keystore, hass):
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_invalid_pin(mock_keystore, hass):
+async def test_config_flow_auth_invalid_pin(mock_keystore, hass: HomeAssistant) -> None:
     """Test a config flow initialized by the with invalid pin."""
     mock_keystore.return_value = fake_keystore
     with patch(
@@ -779,7 +797,9 @@ async def test_config_flow_auth_invalid_pin(mock_keystore, hass):
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_expired_token(mock_keystore, hass):
+async def test_config_flow_auth_expired_token(
+    mock_keystore, hass: HomeAssistant
+) -> None:
     """Test a config flow initialized by the with expired token."""
     mock_keystore.return_value = fake_keystore
     with patch(
@@ -805,7 +825,9 @@ async def test_config_flow_auth_expired_token(mock_keystore, hass):
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_connection_error(mock_keystore, hass):
+async def test_config_flow_auth_connection_error(
+    mock_keystore, hass: HomeAssistant
+) -> None:
     """Test a config flow with connection error."""
     mock_keystore.return_value = fake_keystore
     with patch(
@@ -831,7 +853,9 @@ async def test_config_flow_auth_connection_error(mock_keystore, hass):
 
 
 @mock.patch("homeassistant.components.vulcan.config_flow.Keystore.create")
-async def test_config_flow_auth_unknown_error(mock_keystore, hass):
+async def test_config_flow_auth_unknown_error(
+    mock_keystore, hass: HomeAssistant
+) -> None:
     """Test a config flow with unknown error."""
     mock_keystore.return_value = fake_keystore
     with patch(

--- a/tests/components/vultr/test_binary_sensor.py
+++ b/tests/components/vultr/test_binary_sensor.py
@@ -24,7 +24,7 @@ CONFIGS = [
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_binary_sensor(hass: HomeAssistant):
+def test_binary_sensor(hass: HomeAssistant) -> None:
     """Test successful instance."""
     hass_devices = []
 
@@ -81,7 +81,7 @@ def test_invalid_sensor_config() -> None:
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_invalid_sensors(hass: HomeAssistant):
+def test_invalid_sensors(hass: HomeAssistant) -> None:
     """Test the VultrBinarySensor fails."""
     hass_devices = []
 

--- a/tests/components/vultr/test_init.py
+++ b/tests/components/vultr/test_init.py
@@ -12,7 +12,7 @@ from .const import VALID_CONFIG
 from tests.common import load_fixture
 
 
-def test_setup(hass: HomeAssistant):
+def test_setup(hass: HomeAssistant) -> None:
     """Test successful setup."""
     with patch(
         "vultr.Vultr.server_list",
@@ -22,7 +22,7 @@ def test_setup(hass: HomeAssistant):
     assert response
 
 
-async def test_setup_no_api_key(hass: HomeAssistant):
+async def test_setup_no_api_key(hass: HomeAssistant) -> None:
     """Test failed setup with missing API Key."""
     conf = deepcopy(VALID_CONFIG)
     del conf["vultr"]["api_key"]

--- a/tests/components/vultr/test_sensor.py
+++ b/tests/components/vultr/test_sensor.py
@@ -33,7 +33,7 @@ CONFIGS = [
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_sensor(hass: HomeAssistant):
+def test_sensor(hass: HomeAssistant) -> None:
     """Test the Vultr sensor class and methods."""
     hass_devices = []
 
@@ -113,7 +113,7 @@ def test_invalid_sensor_config() -> None:
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_invalid_sensors(hass: HomeAssistant):
+def test_invalid_sensors(hass: HomeAssistant) -> None:
     """Test the VultrSensor fails."""
     hass_devices = []
 

--- a/tests/components/vultr/test_switch.py
+++ b/tests/components/vultr/test_switch.py
@@ -134,7 +134,7 @@ def test_invalid_switch_config() -> None:
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_invalid_switches(hass: HomeAssistant):
+def test_invalid_switches(hass: HomeAssistant) -> None:
     """Test the VultrSwitch fails."""
     hass_devices = []
 

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -6,7 +6,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.water_heater import DOMAIN
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
@@ -19,7 +19,11 @@ from tests.common import (
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
-async def test_get_actions(hass, device_registry, entity_registry):
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test we get the expected actions from a water_heater."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -57,12 +61,12 @@ async def test_get_actions(hass, device_registry, entity_registry):
     ),
 )
 async def test_get_actions_hidden_auxiliary(
-    hass,
-    device_registry,
-    entity_registry,
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     hidden_by,
     entity_category,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/water_heater/test_recorder.py
+++ b/tests/components/water_heater/test_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components import water_heater
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.water_heater import (
@@ -12,7 +13,7 @@ from homeassistant.components.water_heater import (
     ATTR_OPERATION_LIST,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,7 +21,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass):
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test water_heater registered attributes to be excluded."""
     await async_setup_component(
         hass, water_heater.DOMAIN, {water_heater.DOMAIN: {"platform": "demo"}}

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -84,7 +84,7 @@ async def test_coordinate_errors(
 )
 async def test_duplicate_error(
     hass: HomeAssistant, config_auth, config_entry, config_location_type, setup_watttime
-):
+) -> None:
     """Test that errors are shown when duplicate entries are added."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=config_auth
@@ -96,7 +96,7 @@ async def test_duplicate_error(
     assert result["reason"] == "already_configured"
 
 
-async def test_options_flow(hass: HomeAssistant, config_entry):
+async def test_options_flow(hass: HomeAssistant, config_entry) -> None:
     """Test config flow options."""
     with patch(
         "homeassistant.components.watttime.async_setup_entry", return_value=True

--- a/tests/components/watttime/test_diagnostics.py
+++ b/tests/components/watttime/test_diagnostics.py
@@ -1,10 +1,17 @@
 """Test WattTime diagnostics."""
 from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
-async def test_entry_diagnostics(hass, config_entry, hass_client, setup_watttime):
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry,
+    hass_client: ClientSessionGenerator,
+    setup_watttime,
+) -> None:
     """Test config entry diagnostics."""
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "entry": {

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -145,11 +145,11 @@ async def create_entity(hass: HomeAssistant, **kwargs):
 )
 async def test_temperature(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test temperature."""
     hass.config.units = unit_system
     native_value = 38
@@ -181,11 +181,11 @@ async def test_temperature(
 )
 async def test_temperature_no_unit(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test temperature when the entity does not declare a native unit."""
     hass.config.units = unit_system
     native_value = 38
@@ -214,11 +214,11 @@ async def test_temperature_no_unit(
 )
 async def test_pressure(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test pressure."""
     hass.config.units = unit_system
     native_value = 30
@@ -244,11 +244,11 @@ async def test_pressure(
 )
 async def test_pressure_no_unit(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test pressure when the entity does not declare a native unit."""
     hass.config.units = unit_system
     native_value = 30
@@ -284,11 +284,11 @@ async def test_pressure_no_unit(
 )
 async def test_wind_speed(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test wind speed."""
     hass.config.units = unit_system
     native_value = 10
@@ -320,11 +320,11 @@ async def test_wind_speed(
 )
 async def test_wind_speed_no_unit(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test wind speed when the entity does not declare a native unit."""
     hass.config.units = unit_system
     native_value = 10
@@ -356,11 +356,11 @@ async def test_wind_speed_no_unit(
 )
 async def test_visibility(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test visibility."""
     hass.config.units = unit_system
     native_value = 10
@@ -387,11 +387,11 @@ async def test_visibility(
 )
 async def test_visibility_no_unit(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test visibility when the entity does not declare a native unit."""
     hass.config.units = unit_system
     native_value = 10
@@ -418,11 +418,11 @@ async def test_visibility_no_unit(
 )
 async def test_precipitation(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test precipitation."""
     hass.config.units = unit_system
     native_value = 30
@@ -451,11 +451,11 @@ async def test_precipitation(
 )
 async def test_precipitation_no_unit(
     hass: HomeAssistant,
-    enable_custom_integrations,
+    enable_custom_integrations: None,
     native_unit: str,
     state_unit: str,
     unit_system,
-):
+) -> None:
     """Test precipitation when the entity does not declare a native unit."""
     hass.config.units = unit_system
     native_value = 30
@@ -476,8 +476,8 @@ async def test_precipitation_no_unit(
 
 async def test_wind_bearing_and_ozone(
     hass: HomeAssistant,
-    enable_custom_integrations,
-):
+    enable_custom_integrations: None,
+) -> None:
     """Test wind bearing."""
     wind_bearing_value = 180
     ozone_value = 10
@@ -493,8 +493,8 @@ async def test_wind_bearing_and_ozone(
 
 async def test_none_forecast(
     hass: HomeAssistant,
-    enable_custom_integrations,
-):
+    enable_custom_integrations: None,
+) -> None:
     """Test that conversion with None values succeeds."""
     entity0 = await create_entity(
         hass,
@@ -514,7 +514,9 @@ async def test_none_forecast(
     assert forecast.get(ATTR_FORECAST_PRECIPITATION) is None
 
 
-async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> None:
+async def test_custom_units(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test custom unit."""
     wind_speed_value = 5
     wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
@@ -630,7 +632,7 @@ async def test_custom_units(hass: HomeAssistant, enable_custom_integrations) -> 
 
 
 async def test_backwards_compatibility(
-    hass: HomeAssistant, enable_custom_integrations
+    hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test backwards compatibility."""
     wind_speed_value = 5
@@ -746,7 +748,7 @@ async def test_backwards_compatibility(
 
 
 async def test_backwards_compatibility_convert_values(
-    hass: HomeAssistant, enable_custom_integrations
+    hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test backward compatibility for converting values."""
     wind_speed_value = 5

--- a/tests/components/weather/test_recorder.py
+++ b/tests/components/weather/test_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.db_schema import StateAttributes, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.components.weather import ATTR_FORECAST, DOMAIN
@@ -15,7 +16,7 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test weather attributes to be excluded."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"platform": "demo"}})
     hass.config.units = METRIC_SYSTEM

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -11,6 +11,8 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.typing import WebSocketGenerator
+
 
 @pytest.fixture
 def mock_client(hass, hass_client):
@@ -19,7 +21,7 @@ def mock_client(hass, hass_client):
     return hass.loop.run_until_complete(hass_client())
 
 
-async def test_unregistering_webhook(hass, mock_client):
+async def test_unregistering_webhook(hass: HomeAssistant, mock_client) -> None:
     """Test unregistering a webhook."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -58,20 +60,20 @@ async def test_async_generate_path(hass: HomeAssistant) -> None:
     assert path == "/api/webhook/some_id"
 
 
-async def test_posting_webhook_nonexisting(hass, mock_client):
+async def test_posting_webhook_nonexisting(hass: HomeAssistant, mock_client) -> None:
     """Test posting to a nonexisting webhook."""
     resp = await mock_client.post("/api/webhook/non-existing")
     assert resp.status == HTTPStatus.OK
 
 
-async def test_posting_webhook_invalid_json(hass, mock_client):
+async def test_posting_webhook_invalid_json(hass: HomeAssistant, mock_client) -> None:
     """Test posting to a nonexisting webhook."""
     webhook.async_register(hass, "test", "Test hook", "hello", None)
     resp = await mock_client.post("/api/webhook/hello", data="not-json")
     assert resp.status == HTTPStatus.OK
 
 
-async def test_posting_webhook_json(hass, mock_client):
+async def test_posting_webhook_json(hass: HomeAssistant, mock_client) -> None:
     """Test posting a webhook with JSON data."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -90,7 +92,7 @@ async def test_posting_webhook_json(hass, mock_client):
     assert hooks[0][2] == '{"data": true}'
 
 
-async def test_posting_webhook_no_data(hass, mock_client):
+async def test_posting_webhook_no_data(hass: HomeAssistant, mock_client) -> None:
     """Test posting a webhook with no data."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -110,7 +112,7 @@ async def test_posting_webhook_no_data(hass, mock_client):
     assert await hooks[0][2].text() == ""
 
 
-async def test_webhook_put(hass, mock_client):
+async def test_webhook_put(hass: HomeAssistant, mock_client) -> None:
     """Test sending a put request to a webhook."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -129,7 +131,7 @@ async def test_webhook_put(hass, mock_client):
     assert hooks[0][2].method == "PUT"
 
 
-async def test_webhook_head(hass, mock_client):
+async def test_webhook_head(hass: HomeAssistant, mock_client) -> None:
     """Test sending a head request to a webhook."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -148,7 +150,7 @@ async def test_webhook_head(hass, mock_client):
     assert hooks[0][2].method == "HEAD"
 
 
-async def test_webhook_local_only(hass, mock_client):
+async def test_webhook_local_only(hass: HomeAssistant, mock_client) -> None:
     """Test posting a webhook with local only."""
     hooks = []
     webhook_id = webhook.async_generate_id()
@@ -180,8 +182,11 @@ async def test_webhook_local_only(hass, mock_client):
 
 
 async def test_listing_webhook(
-    hass, hass_ws_client, hass_access_token, enable_custom_integrations
-):
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_access_token: str,
+    enable_custom_integrations: None,
+) -> None:
     """Test unregistering a webhook."""
     assert await async_setup_component(hass, "webhook", {})
     client = await hass_ws_client(hass, hass_access_token)
@@ -210,7 +215,11 @@ async def test_listing_webhook(
     ]
 
 
-async def test_ws_webhook(hass, caplog, hass_ws_client):
+async def test_ws_webhook(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test sending webhook msg via WS API."""
     assert await async_setup_component(hass, "webhook", {})
 

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components import ssdp
 from homeassistant.components.webostv.const import CONF_SOURCES, DOMAIN, LIVE_TV_APP_ID
 from homeassistant.config_entries import SOURCE_SSDP
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_NAME, CONF_SOURCE
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import setup_webostv
@@ -31,7 +32,7 @@ MOCK_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
 )
 
 
-async def test_form(hass, client):
+async def test_form(hass: HomeAssistant, client) -> None:
     """Test we get the form."""
     assert client
 
@@ -92,7 +93,9 @@ async def test_form(hass, client):
         ({}, MOCK_INPUTS),
     ],
 )
-async def test_options_flow_live_tv_in_apps(hass, client, apps, inputs):
+async def test_options_flow_live_tv_in_apps(
+    hass: HomeAssistant, client, apps, inputs
+) -> None:
     """Test options config flow Live TV found in apps."""
     client.apps = apps
     client.inputs = inputs
@@ -114,7 +117,7 @@ async def test_options_flow_live_tv_in_apps(hass, client, apps, inputs):
     assert result2["data"][CONF_SOURCES] == ["Live TV", "Input01", "Input02"]
 
 
-async def test_options_flow_cannot_retrieve(hass, client):
+async def test_options_flow_cannot_retrieve(hass: HomeAssistant, client) -> None:
     """Test options config flow cannot retrieve sources."""
     entry = await setup_webostv(hass)
 
@@ -126,7 +129,7 @@ async def test_options_flow_cannot_retrieve(hass, client):
     assert result["errors"] == {"base": "cannot_retrieve"}
 
 
-async def test_form_cannot_connect(hass, client):
+async def test_form_cannot_connect(hass: HomeAssistant, client) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -144,7 +147,7 @@ async def test_form_cannot_connect(hass, client):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_pairexception(hass, client):
+async def test_form_pairexception(hass: HomeAssistant, client) -> None:
     """Test pairing exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -162,7 +165,7 @@ async def test_form_pairexception(hass, client):
     assert result2["reason"] == "error_pairing"
 
 
-async def test_entry_already_configured(hass, client):
+async def test_entry_already_configured(hass: HomeAssistant, client) -> None:
     """Test entry already configured."""
     await setup_webostv(hass)
     assert client
@@ -177,7 +180,7 @@ async def test_entry_already_configured(hass, client):
     assert result["reason"] == "already_configured"
 
 
-async def test_form_ssdp(hass, client):
+async def test_form_ssdp(hass: HomeAssistant, client) -> None:
     """Test that the ssdp confirmation form is served."""
     assert client
 
@@ -191,7 +194,7 @@ async def test_form_ssdp(hass, client):
     assert result["step_id"] == "pairing"
 
 
-async def test_ssdp_in_progress(hass, client):
+async def test_ssdp_in_progress(hass: HomeAssistant, client) -> None:
     """Test abort if ssdp paring is already in progress."""
     assert client
 
@@ -214,7 +217,7 @@ async def test_ssdp_in_progress(hass, client):
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_ssdp_update_uuid(hass, client):
+async def test_ssdp_update_uuid(hass: HomeAssistant, client) -> None:
     """Test that ssdp updates existing host entry uuid."""
     entry = await setup_webostv(hass, None)
     assert client
@@ -230,7 +233,7 @@ async def test_ssdp_update_uuid(hass, client):
     assert entry.unique_id == MOCK_DISCOVERY_INFO.upnp[ssdp.ATTR_UPNP_UDN][5:]
 
 
-async def test_ssdp_not_update_uuid(hass, client):
+async def test_ssdp_not_update_uuid(hass: HomeAssistant, client) -> None:
     """Test that ssdp not updates different host."""
     entry = await setup_webostv(hass, None)
     assert client
@@ -249,7 +252,7 @@ async def test_ssdp_not_update_uuid(hass, client):
     assert entry.unique_id is None
 
 
-async def test_form_abort_uuid_configured(hass, client):
+async def test_form_abort_uuid_configured(hass: HomeAssistant, client) -> None:
     """Test abort if uuid is already configured, verify host update."""
     entry = await setup_webostv(hass, MOCK_DISCOVERY_INFO.upnp[ssdp.ATTR_UPNP_UDN][5:])
     assert client
@@ -291,7 +294,7 @@ async def test_form_abort_uuid_configured(hass, client):
     assert entry.data[CONF_HOST] == "new_host"
 
 
-async def test_reauth_successful(hass, client, monkeypatch):
+async def test_reauth_successful(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test that the reauthorization is successful."""
     entry = await setup_webostv(hass)
     assert client
@@ -326,7 +329,9 @@ async def test_reauth_successful(hass, client, monkeypatch):
         (ConnectionRefusedError, "reauth_unsuccessful"),
     ],
 )
-async def test_reauth_errors(hass, client, monkeypatch, side_effect, reason):
+async def test_reauth_errors(
+    hass: HomeAssistant, client, monkeypatch, side_effect, reason
+) -> None:
     """Test reauthorization errors."""
     entry = await setup_webostv(hass)
     assert client

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -8,6 +8,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.webostv import DOMAIN, device_trigger
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -18,7 +19,7 @@ from .const import ENTITY_ID, FAKE_UUID
 from tests.common import MockConfigEntry, async_get_device_automations
 
 
-async def test_get_triggers(hass, client):
+async def test_get_triggers(hass: HomeAssistant, client) -> None:
     """Test we get the expected triggers."""
     await setup_webostv(hass)
 
@@ -39,7 +40,7 @@ async def test_get_triggers(hass, client):
     assert turn_on_trigger in triggers
 
 
-async def test_if_fires_on_turn_on_request(hass, calls, client):
+async def test_if_fires_on_turn_on_request(hass: HomeAssistant, calls, client) -> None:
     """Test for turn_on and turn_off triggers firing."""
     await setup_webostv(hass)
 
@@ -98,7 +99,7 @@ async def test_if_fires_on_turn_on_request(hass, calls, client):
     assert calls[1].data["id"] == 0
 
 
-async def test_failure_scenarios(hass, client):
+async def test_failure_scenarios(hass: HomeAssistant, client) -> None:
     """Test failure scenarios."""
     await setup_webostv(hass)
 

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -6,11 +6,12 @@ from aiowebostv import WebOsTvPairError
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 
 from . import setup_webostv
 
 
-async def test_reauth_setup_entry(hass, client, monkeypatch):
+async def test_reauth_setup_entry(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test reauth flow triggered by setup entry."""
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
     monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
@@ -30,7 +31,7 @@ async def test_reauth_setup_entry(hass, client, monkeypatch):
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_key_update_setup_entry(hass, client, monkeypatch):
+async def test_key_update_setup_entry(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test key update from setup entry."""
     monkeypatch.setattr(client, "client_key", "new_key")
     entry = await setup_webostv(hass)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -59,7 +59,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -69,6 +69,8 @@ from . import setup_webostv
 from .const import CHANNEL_2, ENTITY_ID, TV_NAME
 
 from tests.common import async_fire_time_changed, mock_restore_cache
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.parametrize(
@@ -81,7 +83,9 @@ from tests.common import async_fire_time_changed, mock_restore_cache
         (SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0.0}, ("set_volume", 0)),
     ],
 )
-async def test_services_with_parameters(hass, client, service, attr_data, client_call):
+async def test_services_with_parameters(
+    hass: HomeAssistant, client, service, attr_data, client_call
+) -> None:
     """Test services that has parameters in calls."""
     await setup_webostv(hass)
 
@@ -102,7 +106,7 @@ async def test_services_with_parameters(hass, client, service, attr_data, client
         (SERVICE_MEDIA_STOP, "stop"),
     ],
 )
-async def test_services(hass, client, service, client_call):
+async def test_services(hass: HomeAssistant, client, service, client_call) -> None:
     """Test simple services without parameters."""
     await setup_webostv(hass)
 
@@ -112,7 +116,7 @@ async def test_services(hass, client, service, client_call):
     getattr(client, client_call).assert_called_once()
 
 
-async def test_media_play_pause(hass, client):
+async def test_media_play_pause(hass: HomeAssistant, client) -> None:
     """Test media play pause service."""
     await setup_webostv(hass)
 
@@ -143,8 +147,8 @@ async def test_media_play_pause(hass, client):
     ],
 )
 async def test_media_next_previous_track(
-    hass, client, service, client_call, monkeypatch
-):
+    hass: HomeAssistant, client, service, client_call, monkeypatch
+) -> None:
     """Test media next/previous track services."""
     await setup_webostv(hass)
 
@@ -164,7 +168,9 @@ async def test_media_next_previous_track(
     getattr(client, client_call[1]).assert_called_once()
 
 
-async def test_select_source_with_empty_source_list(hass, client, caplog):
+async def test_select_source_with_empty_source_list(
+    hass: HomeAssistant, client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Ensure we don't call client methods when we don't have sources."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -180,7 +186,7 @@ async def test_select_source_with_empty_source_list(hass, client, caplog):
     assert f"Source nonexistent not found for {TV_NAME}" in caplog.text
 
 
-async def test_select_app_source(hass, client):
+async def test_select_app_source(hass: HomeAssistant, client) -> None:
     """Test select app source."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -195,7 +201,7 @@ async def test_select_app_source(hass, client):
     client.set_input.assert_not_called()
 
 
-async def test_select_input_source(hass, client):
+async def test_select_input_source(hass: HomeAssistant, client) -> None:
     """Test select input source."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -210,7 +216,7 @@ async def test_select_input_source(hass, client):
     client.set_input.assert_called_once_with("in1")
 
 
-async def test_button(hass, client):
+async def test_button(hass: HomeAssistant, client) -> None:
     """Test generic button functionality."""
     await setup_webostv(hass)
 
@@ -224,7 +230,7 @@ async def test_button(hass, client):
     client.button.assert_called_with("test")
 
 
-async def test_command(hass, client):
+async def test_command(hass: HomeAssistant, client) -> None:
     """Test generic command functionality."""
     await setup_webostv(hass)
 
@@ -237,7 +243,7 @@ async def test_command(hass, client):
     client.request.assert_called_with("test", payload=None)
 
 
-async def test_command_with_optional_arg(hass, client):
+async def test_command_with_optional_arg(hass: HomeAssistant, client) -> None:
     """Test generic command functionality."""
     await setup_webostv(hass)
 
@@ -253,7 +259,7 @@ async def test_command_with_optional_arg(hass, client):
     )
 
 
-async def test_select_sound_output(hass, client):
+async def test_select_sound_output(hass: HomeAssistant, client) -> None:
     """Test select sound output service."""
     await setup_webostv(hass)
 
@@ -268,7 +274,9 @@ async def test_select_sound_output(hass, client):
     client.change_sound_output.assert_called_once_with("external_speaker")
 
 
-async def test_device_info_startup_off(hass, client, monkeypatch):
+async def test_device_info_startup_off(
+    hass: HomeAssistant, client, monkeypatch
+) -> None:
     """Test device info when device is off at startup."""
     monkeypatch.setattr(client, "system_info", None)
     monkeypatch.setattr(client, "is_on", False)
@@ -288,7 +296,7 @@ async def test_device_info_startup_off(hass, client, monkeypatch):
     assert device.model is None
 
 
-async def test_entity_attributes(hass, client, monkeypatch):
+async def test_entity_attributes(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test entity attributes."""
     entry = await setup_webostv(hass)
     await client.mock_state_update()
@@ -343,7 +351,7 @@ async def test_entity_attributes(hass, client, monkeypatch):
     assert state.attributes.get(ATTR_SOUND_OUTPUT) is None
 
 
-async def test_service_entity_id_none(hass, client):
+async def test_service_entity_id_none(hass: HomeAssistant, client) -> None:
     """Test service call with none as entity id."""
     await setup_webostv(hass)
 
@@ -366,7 +374,7 @@ async def test_service_entity_id_none(hass, client):
         ("20", "ch2id"),  # Perfect Match by channel number
     ],
 )
-async def test_play_media(hass, client, media_id, ch_id):
+async def test_play_media(hass: HomeAssistant, client, media_id, ch_id) -> None:
     """Test play media service."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -381,7 +389,9 @@ async def test_play_media(hass, client, media_id, ch_id):
     client.set_channel.assert_called_once_with(ch_id)
 
 
-async def test_update_sources_live_tv_find(hass, client, monkeypatch):
+async def test_update_sources_live_tv_find(
+    hass: HomeAssistant, client, monkeypatch
+) -> None:
     """Test finding live TV app id in update sources."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -463,7 +473,7 @@ async def test_update_sources_live_tv_find(hass, client, monkeypatch):
     assert len(sources) == 1
 
 
-async def test_client_disconnected(hass, client, monkeypatch):
+async def test_client_disconnected(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test error not raised when client is disconnected."""
     await setup_webostv(hass)
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
@@ -473,7 +483,9 @@ async def test_client_disconnected(hass, client, monkeypatch):
     await hass.async_block_till_done()
 
 
-async def test_control_error_handling(hass, client, caplog, monkeypatch):
+async def test_control_error_handling(
+    hass: HomeAssistant, client, caplog: pytest.LogCaptureFixture, monkeypatch
+) -> None:
     """Test control errors handling."""
     await setup_webostv(hass)
     monkeypatch.setattr(client, "play", Mock(side_effect=WebOsTvCommandError))
@@ -502,7 +514,7 @@ async def test_control_error_handling(hass, client, caplog, monkeypatch):
     )
 
 
-async def test_supported_features(hass, client, monkeypatch):
+async def test_supported_features(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test test supported features."""
     monkeypatch.setattr(client, "sound_output", "lineout")
     await setup_webostv(hass)
@@ -559,7 +571,9 @@ async def test_supported_features(hass, client, monkeypatch):
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
 
-async def test_cached_supported_features(hass, client, monkeypatch):
+async def test_cached_supported_features(
+    hass: HomeAssistant, client, monkeypatch
+) -> None:
     """Test test supported features."""
     monkeypatch.setattr(client, "is_on", False)
     monkeypatch.setattr(client, "sound_output", None)
@@ -664,7 +678,9 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     )
 
 
-async def test_supported_features_no_cache(hass, client, monkeypatch):
+async def test_supported_features_no_cache(
+    hass: HomeAssistant, client, monkeypatch
+) -> None:
     """Test supported features if device is off and no cache."""
     monkeypatch.setattr(client, "is_on", False)
     monkeypatch.setattr(client, "sound_output", None)
@@ -678,7 +694,7 @@ async def test_supported_features_no_cache(hass, client, monkeypatch):
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
 
-async def test_supported_features_ignore_cache(hass, client):
+async def test_supported_features_ignore_cache(hass: HomeAssistant, client) -> None:
     """Test ignore cached supported features if device is on at startup."""
     mock_restore_cache(
         hass,
@@ -703,8 +719,12 @@ async def test_supported_features_ignore_cache(hass, client):
 
 
 async def test_get_image_http(
-    hass, client, hass_client_no_auth, aioclient_mock, monkeypatch
-):
+    hass: HomeAssistant,
+    client,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    monkeypatch,
+) -> None:
     """Test get image via http."""
     url = "http://something/valid_icon"
     monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
@@ -724,8 +744,13 @@ async def test_get_image_http(
 
 
 async def test_get_image_http_error(
-    hass, client, hass_client_no_auth, aioclient_mock, caplog, monkeypatch
-):
+    hass: HomeAssistant,
+    client,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch,
+) -> None:
     """Test get image via http error."""
     url = "http://something/icon_error"
     monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
@@ -747,8 +772,12 @@ async def test_get_image_http_error(
 
 
 async def test_get_image_https(
-    hass, client, hass_client_no_auth, aioclient_mock, monkeypatch
-):
+    hass: HomeAssistant,
+    client,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    monkeypatch,
+) -> None:
     """Test get image via http."""
     url = "https://something/valid_icon_https"
     monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
@@ -767,7 +796,7 @@ async def test_get_image_https(
     assert content == b"https_image"
 
 
-async def test_reauth_reconnect(hass, client, monkeypatch):
+async def test_reauth_reconnect(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test reauth flow triggered by reconnect."""
     entry = await setup_webostv(hass)
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -21,7 +21,7 @@ ICON_PATH = "/some/path"
 MESSAGE = "one, two, testing, testing"
 
 
-async def test_notify(hass, client):
+async def test_notify(hass: HomeAssistant, client) -> None:
     """Test sending a message."""
     await setup_webostv(hass)
     assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
@@ -71,7 +71,7 @@ async def test_notify(hass, client):
     )
 
 
-async def test_notify_not_connected(hass, client, monkeypatch):
+async def test_notify_not_connected(hass: HomeAssistant, client, monkeypatch) -> None:
     """Test sending a message when client is not connected."""
     await setup_webostv(hass)
     assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
@@ -93,7 +93,9 @@ async def test_notify_not_connected(hass, client, monkeypatch):
     client.send_message.assert_called_with(MESSAGE, icon_path=ICON_PATH)
 
 
-async def test_icon_not_found(hass, caplog, client, monkeypatch):
+async def test_icon_not_found(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client, monkeypatch
+) -> None:
     """Test notify icon not found error."""
     await setup_webostv(hass)
     assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
@@ -123,7 +125,14 @@ async def test_icon_not_found(hass, caplog, client, monkeypatch):
         (ConnectionRefusedError, "TV unreachable"),
     ],
 )
-async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect, error):
+async def test_connection_errors(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    client,
+    monkeypatch,
+    side_effect,
+    error,
+) -> None:
     """Test connection errors scenarios."""
     await setup_webostv(hass)
     assert hass.services.has_service("notify", TV_NAME)

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components import automation
 from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -16,7 +17,9 @@ from .const import ENTITY_ID, FAKE_UUID
 from tests.common import MockEntity, MockEntityPlatform
 
 
-async def test_webostv_turn_on_trigger_device_id(hass, calls, client):
+async def test_webostv_turn_on_trigger_device_id(
+    hass: HomeAssistant, calls, client
+) -> None:
     """Test for turn_on triggers by device_id firing."""
     await setup_webostv(hass)
 
@@ -74,7 +77,9 @@ async def test_webostv_turn_on_trigger_device_id(hass, calls, client):
     assert len(calls) == 0
 
 
-async def test_webostv_turn_on_trigger_entity_id(hass, calls, client):
+async def test_webostv_turn_on_trigger_entity_id(
+    hass: HomeAssistant, calls, client
+) -> None:
     """Test for turn_on triggers by entity_id firing."""
     await setup_webostv(hass)
 
@@ -113,7 +118,9 @@ async def test_webostv_turn_on_trigger_entity_id(hass, calls, client):
     assert calls[0].data["id"] == 0
 
 
-async def test_wrong_trigger_platform_type(hass, caplog, client):
+async def test_wrong_trigger_platform_type(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client
+) -> None:
     """Test wrong trigger platform type."""
     await setup_webostv(hass)
 
@@ -145,7 +152,9 @@ async def test_wrong_trigger_platform_type(hass, caplog, client):
     )
 
 
-async def test_trigger_invalid_entity_id(hass, caplog, client):
+async def test_trigger_invalid_entity_id(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client
+) -> None:
     """Test turn on trigger using invalid entity_id."""
     await setup_webostv(hass)
 

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -4,6 +4,9 @@ from unittest.mock import patch
 import aiohttp
 import pytest
 
+from homeassistant.auth.providers.legacy_api_password import (
+    LegacyApiPasswordAuthProvider,
+)
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_INVALID,
@@ -45,8 +48,12 @@ def track_connected(hass):
 
 
 async def test_auth_events(
-    hass, no_auth_websocket_client, legacy_auth, hass_access_token, track_connected
-):
+    hass: HomeAssistant,
+    no_auth_websocket_client,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+    hass_access_token: str,
+    track_connected,
+) -> None:
     """Test authenticating."""
 
     await test_auth_active_with_token(hass, no_auth_websocket_client, hass_access_token)
@@ -60,7 +67,7 @@ async def test_auth_events(
     assert len(track_connected["disconnected"]) == 1
 
 
-async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
+async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client) -> None:
     """Test authenticating."""
     with patch(
         "homeassistant.components.websocket_api.auth.process_wrong_login",
@@ -77,7 +84,9 @@ async def test_auth_via_msg_incorrect_pass(no_auth_websocket_client):
     assert msg["message"] == "Invalid access token or password"
 
 
-async def test_auth_events_incorrect_pass(no_auth_websocket_client, track_connected):
+async def test_auth_events_incorrect_pass(
+    no_auth_websocket_client, track_connected
+) -> None:
     """Test authenticating."""
 
     await test_auth_via_msg_incorrect_pass(no_auth_websocket_client)
@@ -91,7 +100,7 @@ async def test_auth_events_incorrect_pass(no_auth_websocket_client, track_connec
     assert not track_connected["disconnected"]
 
 
-async def test_pre_auth_only_auth_allowed(no_auth_websocket_client):
+async def test_pre_auth_only_auth_allowed(no_auth_websocket_client) -> None:
     """Verify that before authentication, only auth messages are allowed."""
     await no_auth_websocket_client.send_json(
         {
@@ -109,8 +118,8 @@ async def test_pre_auth_only_auth_allowed(no_auth_websocket_client):
 
 
 async def test_auth_active_with_token(
-    hass, no_auth_websocket_client, hass_access_token
-):
+    hass: HomeAssistant, no_auth_websocket_client, hass_access_token: str
+) -> None:
     """Test authenticating with a token."""
     await no_auth_websocket_client.send_json(
         {"type": TYPE_AUTH, "access_token": hass_access_token}
@@ -120,7 +129,11 @@ async def test_auth_active_with_token(
     assert auth_msg["type"] == TYPE_AUTH_OK
 
 
-async def test_auth_active_user_inactive(hass, hass_client_no_auth, hass_access_token):
+async def test_auth_active_user_inactive(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test authenticating with a token."""
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
     refresh_token.user.is_active = False
@@ -159,8 +172,10 @@ async def test_auth_active_with_password_not_allow(
 
 
 async def test_auth_legacy_support_with_password(
-    hass, hass_client_no_auth, legacy_auth
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+) -> None:
     """Test authenticating with a token."""
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()
@@ -196,7 +211,9 @@ async def test_auth_with_invalid_token(
         assert auth_msg["type"] == TYPE_AUTH_INVALID
 
 
-async def test_auth_close_after_revoke(hass, websocket_client, hass_access_token):
+async def test_auth_close_after_revoke(
+    hass: HomeAssistant, websocket_client, hass_access_token: str
+) -> None:
     """Test that a websocket is closed after the refresh token is revoked."""
     assert not websocket_client.closed
 

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -23,8 +23,8 @@ from homeassistant.helpers.json import json_loads
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import DATA_SETUP_TIME, async_setup_component
 
-from tests.common import MockEntity, MockEntityPlatform, async_mock_service
-from tests.typing import WebSocketGenerator
+from tests.common import MockEntity, MockEntityPlatform, MockUser, async_mock_service
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 STATE_KEY_SHORT_NAMES = {
     "entity_id": "e",
@@ -59,7 +59,7 @@ def _apply_entities_changes(state_dict: dict, change_dict: dict) -> None:
             del state_dict[STATE_KEY_LONG_NAMES[key]][item]
 
 
-async def test_fire_event(hass, websocket_client):
+async def test_fire_event(hass: HomeAssistant, websocket_client) -> None:
     """Test fire event command."""
     runs = []
 
@@ -88,7 +88,7 @@ async def test_fire_event(hass, websocket_client):
     assert runs[0].data == {"hello": "world"}
 
 
-async def test_fire_event_without_data(hass, websocket_client):
+async def test_fire_event_without_data(hass: HomeAssistant, websocket_client) -> None:
     """Test fire event command."""
     runs = []
 
@@ -116,7 +116,7 @@ async def test_fire_event_without_data(hass, websocket_client):
     assert runs[0].data == {}
 
 
-async def test_call_service(hass, websocket_client):
+async def test_call_service(hass: HomeAssistant, websocket_client) -> None:
     """Test call service command."""
     calls = async_mock_service(hass, "domain_test", "test_service")
 
@@ -145,7 +145,9 @@ async def test_call_service(hass, websocket_client):
 
 
 @pytest.mark.parametrize("command", ("call_service", "call_service_action"))
-async def test_call_service_blocking(hass, websocket_client, command):
+async def test_call_service_blocking(
+    hass: HomeAssistant, websocket_client, command
+) -> None:
     """Test call service commands block, except for homeassistant restart / stop."""
     with patch(
         "homeassistant.core.ServiceRegistry.async_call", autospec=True
@@ -221,7 +223,7 @@ async def test_call_service_blocking(hass, websocket_client, command):
     )
 
 
-async def test_call_service_target(hass, websocket_client):
+async def test_call_service_target(hass: HomeAssistant, websocket_client) -> None:
     """Test call service command with target."""
     calls = async_mock_service(hass, "domain_test", "test_service")
 
@@ -257,7 +259,9 @@ async def test_call_service_target(hass, websocket_client):
     assert call.context.as_dict() == msg["result"]["context"]
 
 
-async def test_call_service_target_template(hass, websocket_client):
+async def test_call_service_target_template(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test call service command with target does not allow template."""
     await websocket_client.send_json(
         {
@@ -279,7 +283,7 @@ async def test_call_service_target_template(hass, websocket_client):
     assert msg["error"]["code"] == const.ERR_INVALID_FORMAT
 
 
-async def test_call_service_not_found(hass, websocket_client):
+async def test_call_service_not_found(hass: HomeAssistant, websocket_client) -> None:
     """Test call service command."""
     await websocket_client.send_json(
         {
@@ -298,7 +302,9 @@ async def test_call_service_not_found(hass, websocket_client):
     assert msg["error"]["code"] == const.ERR_NOT_FOUND
 
 
-async def test_call_service_child_not_found(hass, websocket_client):
+async def test_call_service_child_not_found(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test not reporting not found errors if it's not the called service."""
 
     async def serv_handler(call):
@@ -325,7 +331,7 @@ async def test_call_service_child_not_found(hass, websocket_client):
 
 async def test_call_service_schema_validation_error(
     hass: HomeAssistant, websocket_client
-):
+) -> None:
     """Test call service command with invalid service data."""
 
     calls = []
@@ -394,7 +400,7 @@ async def test_call_service_schema_validation_error(
     assert len(calls) == 0
 
 
-async def test_call_service_error(hass, websocket_client):
+async def test_call_service_error(hass: HomeAssistant, websocket_client) -> None:
     """Test call service command with error."""
 
     @callback
@@ -441,7 +447,9 @@ async def test_call_service_error(hass, websocket_client):
     assert msg["error"]["message"] == "value_error"
 
 
-async def test_subscribe_unsubscribe_events(hass, websocket_client):
+async def test_subscribe_unsubscribe_events(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test subscribe/unsubscribe events command."""
     init_count = sum(hass.bus.async_listeners().values())
 
@@ -485,7 +493,7 @@ async def test_subscribe_unsubscribe_events(hass, websocket_client):
     assert sum(hass.bus.async_listeners().values()) == init_count
 
 
-async def test_get_states(hass, websocket_client):
+async def test_get_states(hass: HomeAssistant, websocket_client) -> None:
     """Test get_states command."""
     hass.states.async_set("greeting.hello", "world")
     hass.states.async_set("greeting.bye", "universe")
@@ -504,7 +512,7 @@ async def test_get_states(hass, websocket_client):
     assert msg["result"] == states
 
 
-async def test_get_services(hass, websocket_client):
+async def test_get_services(hass: HomeAssistant, websocket_client) -> None:
     """Test get_services command."""
     await websocket_client.send_json({"id": 5, "type": "get_services"})
 
@@ -515,7 +523,7 @@ async def test_get_services(hass, websocket_client):
     assert msg["result"] == hass.services.async_services()
 
 
-async def test_get_config(hass, websocket_client):
+async def test_get_config(hass: HomeAssistant, websocket_client) -> None:
     """Test get_config command."""
     await websocket_client.send_json({"id": 5, "type": "get_config"})
 
@@ -542,7 +550,7 @@ async def test_get_config(hass, websocket_client):
     assert msg["result"] == hass.config.as_dict()
 
 
-async def test_ping(websocket_client):
+async def test_ping(websocket_client) -> None:
     """Test get_panels command."""
     await websocket_client.send_json({"id": 5, "type": "ping"})
 
@@ -552,8 +560,10 @@ async def test_ping(websocket_client):
 
 
 async def test_call_service_context_with_user(
-    hass, hass_client_no_auth, hass_access_token
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_access_token: str,
+) -> None:
     """Test that the user is set in the service call context."""
     assert await async_setup_component(hass, "websocket_api", {})
 
@@ -592,7 +602,9 @@ async def test_call_service_context_with_user(
         assert call.context.user_id == refresh_token.user.id
 
 
-async def test_subscribe_requires_admin(websocket_client, hass_admin_user):
+async def test_subscribe_requires_admin(
+    websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribing events without being admin."""
     hass_admin_user.groups = []
     await websocket_client.send_json(
@@ -604,7 +616,9 @@ async def test_subscribe_requires_admin(websocket_client, hass_admin_user):
     assert msg["error"]["code"] == const.ERR_UNAUTHORIZED
 
 
-async def test_states_filters_visible(hass, hass_admin_user, websocket_client):
+async def test_states_filters_visible(
+    hass: HomeAssistant, hass_admin_user: MockUser, websocket_client
+) -> None:
     """Test we only get entities that we're allowed to see."""
     hass_admin_user.mock_policy({"entities": {"entity_ids": {"test.entity": True}}})
     hass.states.async_set("test.entity", "hello")
@@ -620,7 +634,7 @@ async def test_states_filters_visible(hass, hass_admin_user, websocket_client):
     assert msg["result"][0]["entity_id"] == "test.entity"
 
 
-async def test_get_states_not_allows_nan(hass, websocket_client):
+async def test_get_states_not_allows_nan(hass: HomeAssistant, websocket_client) -> None:
     """Test get_states command converts NaN to None."""
     hass.states.async_set("greeting.hello", "world")
     hass.states.async_set("greeting.bad", "data", {"hello": float("NaN")})
@@ -643,8 +657,8 @@ async def test_get_states_not_allows_nan(hass, websocket_client):
 
 
 async def test_subscribe_unsubscribe_events_whitelist(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe events on whitelist."""
     hass_admin_user.groups = []
 
@@ -680,8 +694,8 @@ async def test_subscribe_unsubscribe_events_whitelist(
 
 
 async def test_subscribe_unsubscribe_events_state_changed(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe state_changed events."""
     hass_admin_user.groups = []
     hass_admin_user.mock_policy({"entities": {"entity_ids": {"light.permitted": True}}})
@@ -706,8 +720,8 @@ async def test_subscribe_unsubscribe_events_state_changed(
 
 
 async def test_subscribe_entities_with_unserializable_state(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe entities with an unserializeable state."""
 
     class CannotSerializeMe:
@@ -822,7 +836,9 @@ async def test_subscribe_entities_with_unserializable_state(
     }
 
 
-async def test_subscribe_unsubscribe_entities(hass, websocket_client, hass_admin_user):
+async def test_subscribe_unsubscribe_entities(
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe entities."""
 
     hass.states.async_set("light.permitted", "off", {"color": "red"})
@@ -987,8 +1003,8 @@ async def test_subscribe_unsubscribe_entities(hass, websocket_client, hass_admin
 
 
 async def test_subscribe_unsubscribe_entities_specific_entities(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe entities with a list of entity ids."""
 
     hass.states.async_set("light.permitted", "off", {"color": "red"})
@@ -1048,7 +1064,9 @@ async def test_subscribe_unsubscribe_entities_specific_entities(
     }
 
 
-async def test_render_template_renders_template(hass, websocket_client):
+async def test_render_template_renders_template(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test simple template is rendered and updated."""
     hass.states.async_set("light.test", "on")
 
@@ -1095,7 +1113,9 @@ async def test_render_template_renders_template(hass, websocket_client):
     }
 
 
-async def test_render_template_with_timeout_and_variables(hass, websocket_client):
+async def test_render_template_with_timeout_and_variables(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test a template with a timeout and variables renders without error."""
     await websocket_client.send_json(
         {
@@ -1128,8 +1148,8 @@ async def test_render_template_with_timeout_and_variables(hass, websocket_client
 
 
 async def test_render_template_manual_entity_ids_no_longer_needed(
-    hass, websocket_client
-):
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test that updates to specified entity ids cause a template rerender."""
     hass.states.async_set("light.test", "on")
 
@@ -1185,7 +1205,9 @@ async def test_render_template_manual_entity_ids_no_longer_needed(
         "{{ now() | unknown_filter }}",
     ],
 )
-async def test_render_template_with_error(hass, websocket_client, caplog, template):
+async def test_render_template_with_error(
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture, template
+) -> None:
     """Test a template with an error."""
     await websocket_client.send_json(
         {"id": 5, "type": "render_template", "template": template, "strict": True}
@@ -1211,8 +1233,8 @@ async def test_render_template_with_error(hass, websocket_client, caplog, templa
     ],
 )
 async def test_render_template_with_timeout_and_error(
-    hass, websocket_client, caplog, template
-):
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture, template
+) -> None:
     """Test a template with an error with a timeout."""
     await websocket_client.send_json(
         {
@@ -1234,7 +1256,9 @@ async def test_render_template_with_timeout_and_error(
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_error_in_template_code(hass, websocket_client, caplog):
+async def test_render_template_error_in_template_code(
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a template that will throw in template.py."""
     await websocket_client.send_json(
         {"id": 5, "type": "render_template", "template": "{{ now() | random }}"}
@@ -1249,7 +1273,9 @@ async def test_render_template_error_in_template_code(hass, websocket_client, ca
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_with_delayed_error(hass, websocket_client, caplog):
+async def test_render_template_with_delayed_error(
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a template with an error that only happens after a state change."""
     hass.states.async_set("sensor.test", "on")
     await hass.async_block_till_done()
@@ -1299,7 +1325,9 @@ async def test_render_template_with_delayed_error(hass, websocket_client, caplog
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_with_timeout(hass, websocket_client, caplog):
+async def test_render_template_with_timeout(
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test a template that will timeout."""
 
     slow_template_str = """
@@ -1328,7 +1356,9 @@ async def test_render_template_with_timeout(hass, websocket_client, caplog):
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_returns_with_match_all(hass, websocket_client):
+async def test_render_template_returns_with_match_all(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test that a template that would match with all entities still return success."""
     await websocket_client.send_json(
         {"id": 5, "type": "render_template", "template": "State is: {{ 42 }}"}
@@ -1340,7 +1370,7 @@ async def test_render_template_returns_with_match_all(hass, websocket_client):
     assert msg["success"]
 
 
-async def test_manifest_list(hass, websocket_client):
+async def test_manifest_list(hass: HomeAssistant, websocket_client) -> None:
     """Test loading manifests."""
     http = await async_get_integration(hass, "http")
     websocket_api = await async_get_integration(hass, "websocket_api")
@@ -1357,7 +1387,9 @@ async def test_manifest_list(hass, websocket_client):
     ]
 
 
-async def test_manifest_list_specific_integrations(hass, websocket_client):
+async def test_manifest_list_specific_integrations(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test loading manifests for specific integrations."""
     websocket_api = await async_get_integration(hass, "websocket_api")
 
@@ -1376,7 +1408,7 @@ async def test_manifest_list_specific_integrations(hass, websocket_client):
     ]
 
 
-async def test_manifest_get(hass, websocket_client):
+async def test_manifest_get(hass: HomeAssistant, websocket_client) -> None:
     """Test getting a manifest."""
     hue = await async_get_integration(hass, "hue")
 
@@ -1402,7 +1434,9 @@ async def test_manifest_get(hass, websocket_client):
     assert msg["error"]["code"] == "not_found"
 
 
-async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
+async def test_entity_source_admin(
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Check that we fetch sources correctly."""
     platform = MockEntityPlatform(hass)
 
@@ -1521,7 +1555,7 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["error"]["code"] == const.ERR_UNAUTHORIZED
 
 
-async def test_subscribe_trigger(hass, websocket_client):
+async def test_subscribe_trigger(hass: HomeAssistant, websocket_client) -> None:
     """Test subscribing to a trigger."""
     init_count = sum(hass.bus.async_listeners().values())
 
@@ -1575,7 +1609,7 @@ async def test_subscribe_trigger(hass, websocket_client):
     assert sum(hass.bus.async_listeners().values()) == init_count
 
 
-async def test_test_condition(hass, websocket_client):
+async def test_test_condition(hass: HomeAssistant, websocket_client) -> None:
     """Test testing a condition."""
     hass.states.async_set("hello.world", "paulus")
 
@@ -1635,7 +1669,7 @@ async def test_test_condition(hass, websocket_client):
     assert msg["result"]["result"] is False
 
 
-async def test_execute_script(hass, websocket_client):
+async def test_execute_script(hass: HomeAssistant, websocket_client) -> None:
     """Test testing a condition."""
     calls = async_mock_service(hass, "domain_test", "test_service")
 
@@ -1693,8 +1727,8 @@ async def test_execute_script(hass, websocket_client):
 
 
 async def test_subscribe_unsubscribe_bootstrap_integrations(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe bootstrap_integrations."""
     await websocket_client.send_json(
         {"id": 7, "type": "subscribe_bootstrap_integrations"}
@@ -1714,7 +1748,9 @@ async def test_subscribe_unsubscribe_bootstrap_integrations(
     assert msg["event"] == message
 
 
-async def test_integration_setup_info(hass, websocket_client, hass_admin_user):
+async def test_integration_setup_info(
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test subscribe/unsubscribe bootstrap_integrations."""
     hass.data[DATA_SETUP_TIME] = {
         "august": datetime.timedelta(seconds=12.5),
@@ -1743,7 +1779,7 @@ async def test_integration_setup_info(hass, websocket_client, hass_admin_user):
         ("action", {"service": "domain_test.test_service"}),
     ),
 )
-async def test_validate_config_works(websocket_client, key, config):
+async def test_validate_config_works(websocket_client, key, config) -> None:
     """Test config validation."""
     await websocket_client.send_json({"id": 7, "type": "validate_config", key: config})
 
@@ -1781,7 +1817,7 @@ async def test_validate_config_works(websocket_client, key, config):
         ),
     ),
 )
-async def test_validate_config_invalid(websocket_client, key, config, error):
+async def test_validate_config_invalid(websocket_client, key, config, error) -> None:
     """Test config validation."""
     await websocket_client.send_json({"id": 7, "type": "validate_config", key: config})
 
@@ -1792,7 +1828,9 @@ async def test_validate_config_invalid(websocket_client, key, config, error):
     assert msg["result"] == {key: {"valid": False, "error": error}}
 
 
-async def test_message_coalescing(hass, websocket_client, hass_admin_user):
+async def test_message_coalescing(
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test enabling message coalescing."""
     await websocket_client.send_json(
         {
@@ -1863,8 +1901,8 @@ async def test_message_coalescing(hass, websocket_client, hass_admin_user):
 
 
 async def test_message_coalescing_not_supported_by_websocket_client(
-    hass, websocket_client, hass_admin_user
-):
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test enabling message coalescing not supported by websocket client."""
     await websocket_client.send_json({"id": 7, "type": "subscribe_entities"})
 
@@ -1904,7 +1942,9 @@ async def test_message_coalescing_not_supported_by_websocket_client(
     await hass.async_block_till_done()
 
 
-async def test_client_message_coalescing(hass, websocket_client, hass_admin_user):
+async def test_client_message_coalescing(
+    hass: HomeAssistant, websocket_client, hass_admin_user: MockUser
+) -> None:
     """Test client message coalescing."""
     await websocket_client.send_json(
         [

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -61,7 +61,7 @@ async def test_exception_handling(
     code: str,
     err: str,
     log: str,
-):
+) -> None:
     """Test handling of exceptions."""
     send_messages = []
     user = MockUser()

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -1,8 +1,11 @@
 """Test decorators."""
 from homeassistant.components import http, websocket_api
+from homeassistant.core import HomeAssistant
 
 
-async def test_async_response_request_context(hass, websocket_client):
+async def test_async_response_request_context(
+    hass: HomeAssistant, websocket_client
+) -> None:
     """Test we can access current request."""
 
     def handle_request(request, connection, msg):
@@ -68,7 +71,7 @@ async def test_async_response_request_context(hass, websocket_client):
     assert msg["error"]["code"] == "not_found"
 
 
-async def test_supervisor_only(hass, websocket_client):
+async def test_supervisor_only(hass: HomeAssistant, websocket_client) -> None:
     """Test that only the Supervisor can make requests."""
 
     @websocket_api.ws_require_user(only_supervisor=True)

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -7,9 +7,11 @@ from aiohttp import ServerDisconnectedError, WSMsgType, web
 import pytest
 
 from homeassistant.components.websocket_api import const, http
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -26,7 +28,9 @@ def mock_low_peak():
         yield
 
 
-async def test_pending_msg_overflow(hass, mock_low_queue, websocket_client):
+async def test_pending_msg_overflow(
+    hass: HomeAssistant, mock_low_queue, websocket_client
+) -> None:
     """Test get_panels command."""
     for idx in range(10):
         await websocket_client.send_json({"id": idx + 1, "type": "ping"})
@@ -34,7 +38,12 @@ async def test_pending_msg_overflow(hass, mock_low_queue, websocket_client):
     assert msg.type == WSMsgType.close
 
 
-async def test_pending_msg_peak(hass, mock_low_peak, hass_ws_client, caplog):
+async def test_pending_msg_peak(
+    hass: HomeAssistant,
+    mock_low_peak,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test pending msg overflow command."""
     orig_handler = http.WebSocketHandler
     instance = None
@@ -68,8 +77,11 @@ async def test_pending_msg_peak(hass, mock_low_peak, hass_ws_client, caplog):
 
 
 async def test_pending_msg_peak_but_does_not_overflow(
-    hass, mock_low_peak, hass_ws_client, caplog
-):
+    hass: HomeAssistant,
+    mock_low_peak,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test pending msg hits the low peak but recovers and does not overflow."""
     orig_handler = http.WebSocketHandler
     instance: http.WebSocketHandler | None = None
@@ -111,7 +123,9 @@ async def test_pending_msg_peak_but_does_not_overflow(
     assert "Client unable to keep up with pending messages" not in caplog.text
 
 
-async def test_non_json_message(hass, websocket_client, caplog):
+async def test_non_json_message(
+    hass: HomeAssistant, websocket_client, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test trying to serialize non JSON objects."""
     bad_data = object()
     hass.states.async_set("test_domain.entity", "testing", {"bad": bad_data})
@@ -128,7 +142,11 @@ async def test_non_json_message(hass, websocket_client, caplog):
     )
 
 
-async def test_prepare_fail(hass, hass_ws_client, caplog):
+async def test_prepare_fail(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test failing to prepare."""
     with patch(
         "homeassistant.components.websocket_api.http.web.WebSocketResponse.prepare",

--- a/tests/components/websocket_api/test_init.py
+++ b/tests/components/websocket_api/test_init.py
@@ -9,9 +9,10 @@ from homeassistant.components.websocket_api import (
     const,
     messages,
 )
+from homeassistant.core import HomeAssistant
 
 
-async def test_invalid_message_format(websocket_client):
+async def test_invalid_message_format(websocket_client) -> None:
     """Test sending invalid JSON."""
     await websocket_client.send_json({"type": 5})
 
@@ -23,7 +24,7 @@ async def test_invalid_message_format(websocket_client):
     assert error["message"].startswith("Message incorrectly formatted")
 
 
-async def test_invalid_json(websocket_client):
+async def test_invalid_json(websocket_client) -> None:
     """Test sending invalid JSON."""
     await websocket_client.send_str("this is not JSON")
 
@@ -32,7 +33,7 @@ async def test_invalid_json(websocket_client):
     assert msg.type == WSMsgType.close
 
 
-async def test_quiting_hass(hass, websocket_client):
+async def test_quiting_hass(hass: HomeAssistant, websocket_client) -> None:
     """Test sending invalid JSON."""
     with patch.object(hass.loop, "stop"):
         await hass.async_stop()
@@ -42,7 +43,7 @@ async def test_quiting_hass(hass, websocket_client):
     assert msg.type == WSMsgType.CLOSE
 
 
-async def test_unknown_command(websocket_client):
+async def test_unknown_command(websocket_client) -> None:
     """Test get_panels command."""
     await websocket_client.send_json({"id": 5, "type": "unknown_command"})
 
@@ -51,7 +52,7 @@ async def test_unknown_command(websocket_client):
     assert msg["error"]["code"] == const.ERR_UNKNOWN_COMMAND
 
 
-async def test_handler_failing(hass, websocket_client):
+async def test_handler_failing(hass: HomeAssistant, websocket_client) -> None:
     """Test a command that raises."""
     async_register_command(
         hass,
@@ -68,7 +69,7 @@ async def test_handler_failing(hass, websocket_client):
     assert msg["error"]["code"] == const.ERR_UNKNOWN_ERROR
 
 
-async def test_invalid_vol(hass, websocket_client):
+async def test_invalid_vol(hass: HomeAssistant, websocket_client) -> None:
     """Test a command that raises invalid vol error."""
     async_register_command(
         hass,

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -1,4 +1,6 @@
 """Test Websocket API messages module."""
+import pytest
+
 from homeassistant.components.websocket_api.messages import (
     _cached_event_message as lru_event_cache,
     cached_event_message,
@@ -77,7 +79,7 @@ async def test_cached_event_message_with_different_idens(hass: HomeAssistant) ->
     assert cache_info.currsize == 1
 
 
-async def test_message_to_json(caplog):
+async def test_message_to_json(caplog: pytest.LogCaptureFixture) -> None:
     """Test we can serialize websocket messages."""
 
     json_str = message_to_json({"id": 1, "message": "xyz"})

--- a/tests/components/websocket_api/test_sensor.py
+++ b/tests/components/websocket_api/test_sensor.py
@@ -1,13 +1,23 @@
 """Test cases for the API stream sensor."""
-
+from homeassistant.auth.providers.legacy_api_password import (
+    LegacyApiPasswordAuthProvider,
+)
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.websocket_api.auth import TYPE_AUTH_REQUIRED
 from homeassistant.components.websocket_api.http import URL
+from homeassistant.core import HomeAssistant
 
 from .test_auth import test_auth_active_with_token
 
+from tests.typing import ClientSessionGenerator
 
-async def test_websocket_api(hass, hass_client_no_auth, hass_access_token, legacy_auth):
+
+async def test_websocket_api(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    hass_access_token: str,
+    legacy_auth: LegacyApiPasswordAuthProvider,
+) -> None:
     """Test API streams."""
     await async_setup_component(
         hass, "sensor", {"sensor": {"platform": "websocket_api"}}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
