### PR TITLE
Add type hints to integration tests (part 25)

### DIFF
--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
@@ -85,8 +86,8 @@ async def _async_multiple_call_helper(hass, pywemo_device, call1, call2):
 
 
 async def test_async_update_locked_callback_and_update(
-    hass, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Test that a callback and a state update request can't both happen at the same time.
 
     When a state update is received via a callback from the device at the same time
@@ -99,7 +100,9 @@ async def test_async_update_locked_callback_and_update(
     await _async_multiple_call_helper(hass, pywemo_device, callback, update)
 
 
-async def test_async_update_locked_multiple_updates(hass, pywemo_device, wemo_entity):
+async def test_async_update_locked_multiple_updates(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Test that two hass async_update state updates do not proceed at the same time."""
     coordinator = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     await async_setup_component(hass, HA_DOMAIN, {})
@@ -107,7 +110,9 @@ async def test_async_update_locked_multiple_updates(hass, pywemo_device, wemo_en
     await _async_multiple_call_helper(hass, pywemo_device, update, update)
 
 
-async def test_async_update_locked_multiple_callbacks(hass, pywemo_device, wemo_entity):
+async def test_async_update_locked_multiple_callbacks(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Test that two device callback state updates do not proceed at the same time."""
     coordinator = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     await async_setup_component(hass, HA_DOMAIN, {})
@@ -116,8 +121,8 @@ async def test_async_update_locked_multiple_callbacks(hass, pywemo_device, wemo_
 
 
 async def test_avaliable_after_update(
-    hass, pywemo_registry, pywemo_device, wemo_entity, domain
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity, domain
+) -> None:
     """Test the avaliability when an On call fails and after an update.
 
     This test expects that the pywemo_device Mock has been setup to raise an
@@ -137,7 +142,7 @@ async def test_avaliable_after_update(
     assert hass.states.get(wemo_entity.entity_id).state == STATE_ON
 
 
-async def test_turn_off_state(hass, wemo_entity, domain):
+async def test_turn_off_state(hass: HomeAssistant, wemo_entity, domain) -> None:
     """Test that the device state is updated after turning off."""
     await hass.services.async_call(
         domain,

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -56,7 +56,7 @@ async def setup_automation(hass, device_id, trigger_type):
     )
 
 
-async def test_get_triggers(hass, wemo_entity):
+async def test_get_triggers(hass: HomeAssistant, wemo_entity) -> None:
     """Test that the triggers appear for a supported device."""
     assert wemo_entity.device_id is not None
 

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -1,5 +1,4 @@
 """Tests for the Wemo fan entity."""
-
 import pytest
 from pywemo.exceptions import ActionException
 from pywemo.ouimeaux_device.humidifier import DesiredHumidity, FanMode
@@ -16,6 +15,7 @@ from homeassistant.components.homeassistant import (
 from homeassistant.components.wemo import fan
 from homeassistant.components.wemo.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -43,8 +43,8 @@ test_async_update_locked_callback_and_update = (
 
 
 async def test_fan_registry_state_callback(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the fan receives state updates from the registry."""
     # On state.
     pywemo_device.get_state.return_value = 1
@@ -59,7 +59,9 @@ async def test_fan_registry_state_callback(
     assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
 
 
-async def test_fan_update_entity(hass, pywemo_registry, pywemo_device, wemo_entity):
+async def test_fan_update_entity(
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the fan performs state updates."""
     await async_setup_component(hass, HA_DOMAIN, {})
 
@@ -85,8 +87,8 @@ async def test_fan_update_entity(hass, pywemo_registry, pywemo_device, wemo_enti
 
 
 async def test_available_after_update(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Test the avaliability when an On call fails and after an update."""
     pywemo_device.set_state.side_effect = ActionException
     pywemo_device.get_state.return_value = 1
@@ -95,12 +97,14 @@ async def test_available_after_update(
     )
 
 
-async def test_turn_off_state(hass, wemo_entity):
+async def test_turn_off_state(hass: HomeAssistant, wemo_entity) -> None:
     """Test that the device state is updated after turning off."""
     await entity_test_helpers.test_turn_off_state(hass, wemo_entity, FAN_DOMAIN)
 
 
-async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):
+async def test_fan_reset_filter_service(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Verify that SERVICE_RESET_FILTER_LIFE is registered and works."""
     assert await hass.services.async_call(
         DOMAIN,
@@ -123,8 +127,8 @@ async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):
     ],
 )
 async def test_fan_set_humidity_service(
-    hass, pywemo_device, wemo_entity, test_input, expected
-):
+    hass: HomeAssistant, pywemo_device, wemo_entity, test_input, expected
+) -> None:
     """Verify that SERVICE_SET_HUMIDITY is registered and works."""
     assert await hass.services.async_call(
         DOMAIN,
@@ -150,8 +154,8 @@ async def test_fan_set_humidity_service(
     ],
 )
 async def test_fan_set_percentage(
-    hass, pywemo_device, wemo_entity, percentage, expected_fan_mode
-):
+    hass: HomeAssistant, pywemo_device, wemo_entity, percentage, expected_fan_mode
+) -> None:
     """Verify set_percentage works properly through the entire range of FanModes."""
     assert await hass.services.async_call(
         FAN_DOMAIN,
@@ -162,7 +166,7 @@ async def test_fan_set_percentage(
     pywemo_device.set_state.assert_called_with(expected_fan_mode)
 
 
-async def test_fan_mode_high_initially(hass, pywemo_device):
+async def test_fan_mode_high_initially(hass: HomeAssistant, pywemo_device) -> None:
     """Verify the FanMode is set to High when turned on."""
     pywemo_device.fan_mode = FanMode.Off
     wemo_entity = await async_create_wemo_entity(hass, pywemo_device, "")

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -32,7 +32,9 @@ async def test_config_no_static(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_DISCOVERY: False}})
 
 
-async def test_static_duplicate_static_entry(hass, pywemo_device):
+async def test_static_duplicate_static_entry(
+    hass: HomeAssistant, pywemo_device
+) -> None:
     """Duplicate static entries are merged into a single entity."""
     static_config_entry = f"{MOCK_HOST}:{MOCK_PORT}"
     assert await async_setup_component(
@@ -54,7 +56,7 @@ async def test_static_duplicate_static_entry(hass, pywemo_device):
     assert len(entity_entries) == 1
 
 
-async def test_static_config_with_port(hass, pywemo_device):
+async def test_static_config_with_port(hass: HomeAssistant, pywemo_device) -> None:
     """Static device with host and port is added and removed."""
     assert await async_setup_component(
         hass,
@@ -72,7 +74,7 @@ async def test_static_config_with_port(hass, pywemo_device):
     assert len(entity_entries) == 1
 
 
-async def test_static_config_without_port(hass, pywemo_device):
+async def test_static_config_without_port(hass: HomeAssistant, pywemo_device) -> None:
     """Static device with host and no port is added and removed."""
     assert await async_setup_component(
         hass,
@@ -105,7 +107,7 @@ async def test_static_config_with_invalid_host(hass: HomeAssistant) -> None:
     assert not setup_success
 
 
-async def test_discovery(hass, pywemo_registry):
+async def test_discovery(hass: HomeAssistant, pywemo_registry) -> None:
     """Verify that discovery dispatches devices to the platform for setup."""
 
     def create_device(counter):

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -16,6 +16,7 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -44,8 +45,8 @@ def pywemo_bridge_light_fixture(pywemo_device):
 
 
 async def test_async_update_locked_callback_and_update(
-    hass, pywemo_bridge_light, wemo_entity, pywemo_device
-):
+    hass: HomeAssistant, pywemo_bridge_light, wemo_entity, pywemo_device
+) -> None:
     """Test that a callback and a state update request can't both happen at the same time."""
     await entity_test_helpers.test_async_update_locked_callback_and_update(
         hass,
@@ -55,8 +56,8 @@ async def test_async_update_locked_callback_and_update(
 
 
 async def test_async_update_locked_multiple_updates(
-    hass, pywemo_bridge_light, wemo_entity, pywemo_device
-):
+    hass: HomeAssistant, pywemo_bridge_light, wemo_entity, pywemo_device
+) -> None:
     """Test that two state updates do not proceed at the same time."""
     await entity_test_helpers.test_async_update_locked_multiple_updates(
         hass,
@@ -66,8 +67,8 @@ async def test_async_update_locked_multiple_updates(
 
 
 async def test_async_update_locked_multiple_callbacks(
-    hass, pywemo_bridge_light, wemo_entity, pywemo_device
-):
+    hass: HomeAssistant, pywemo_bridge_light, wemo_entity, pywemo_device
+) -> None:
     """Test that two device callback state updates do not proceed at the same time."""
     await entity_test_helpers.test_async_update_locked_multiple_callbacks(
         hass,
@@ -77,8 +78,12 @@ async def test_async_update_locked_multiple_callbacks(
 
 
 async def test_available_after_update(
-    hass, pywemo_registry, pywemo_device, pywemo_bridge_light, wemo_entity
-):
+    hass: HomeAssistant,
+    pywemo_registry,
+    pywemo_device,
+    pywemo_bridge_light,
+    wemo_entity,
+) -> None:
     """Test the avaliability when an On call fails and after an update."""
     pywemo_bridge_light.turn_on.side_effect = pywemo.exceptions.ActionException
     pywemo_bridge_light.state["onoff"] = 1
@@ -87,14 +92,16 @@ async def test_available_after_update(
     )
 
 
-async def test_turn_off_state(hass, pywemo_bridge_light, wemo_entity):
+async def test_turn_off_state(
+    hass: HomeAssistant, pywemo_bridge_light, wemo_entity
+) -> None:
     """Test that the device state is updated after turning off."""
     await entity_test_helpers.test_turn_off_state(hass, wemo_entity, LIGHT_DOMAIN)
 
 
 async def test_light_update_entity(
-    hass, pywemo_registry, pywemo_bridge_light, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_bridge_light, wemo_entity
+) -> None:
     """Verify that the light performs state updates."""
     await async_setup_component(hass, HA_DOMAIN, {})
 

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -1,5 +1,4 @@
 """Tests for the Wemo standalone/non-bridge light entity."""
-
 import pytest
 from pywemo.exceptions import ActionException
 
@@ -9,6 +8,7 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -35,8 +35,8 @@ test_async_update_locked_callback_and_update = (
 
 
 async def test_available_after_update(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Test the avaliability when an On call fails and after an update."""
     pywemo_device.on.side_effect = ActionException
     pywemo_device.get_state.return_value = 1
@@ -45,12 +45,14 @@ async def test_available_after_update(
     )
 
 
-async def test_turn_off_state(hass, wemo_entity):
+async def test_turn_off_state(hass: HomeAssistant, wemo_entity) -> None:
     """Test that the device state is updated after turning off."""
     await entity_test_helpers.test_turn_off_state(hass, wemo_entity, LIGHT_DOMAIN)
 
 
-async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
+async def test_turn_on_brightness(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Test setting the brightness value of the light."""
     brightness = 0
     state = 0
@@ -78,8 +80,8 @@ async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
 
 
 async def test_light_registry_state_callback(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the light receives state updates from the registry."""
     # On state.
     pywemo_device.get_state.return_value = 1
@@ -94,7 +96,9 @@ async def test_light_registry_state_callback(
     assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
 
 
-async def test_light_update_entity(hass, pywemo_registry, pywemo_device, wemo_entity):
+async def test_light_update_entity(
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the light performs state updates."""
     await async_setup_component(hass, HA_DOMAIN, {})
 

--- a/tests/components/wemo/test_switch.py
+++ b/tests/components/wemo/test_switch.py
@@ -1,5 +1,4 @@
 """Tests for the Wemo switch entity."""
-
 import pytest
 import pywemo
 
@@ -25,6 +24,7 @@ from homeassistant.const import (
     STATE_STANDBY,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -56,8 +56,8 @@ test_async_update_locked_callback_and_update = (
 
 
 async def test_switch_registry_state_callback(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the switch receives state updates from the registry."""
     # On state.
     pywemo_device.get_state.return_value = 1
@@ -72,7 +72,9 @@ async def test_switch_registry_state_callback(
     assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
 
 
-async def test_switch_update_entity(hass, pywemo_registry, pywemo_device, wemo_entity):
+async def test_switch_update_entity(
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Verify that the switch performs state updates."""
     await async_setup_component(hass, HA_DOMAIN, {})
 
@@ -98,8 +100,8 @@ async def test_switch_update_entity(hass, pywemo_registry, pywemo_device, wemo_e
 
 
 async def test_available_after_update(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Test the avaliability when an On call fails and after an update."""
     pywemo_device.on.side_effect = pywemo.exceptions.ActionException
     pywemo_device.get_state.return_value = 1
@@ -108,12 +110,12 @@ async def test_available_after_update(
     )
 
 
-async def test_turn_off_state(hass, wemo_entity):
+async def test_turn_off_state(hass: HomeAssistant, wemo_entity) -> None:
     """Test that the device state is updated after turning off."""
     await entity_test_helpers.test_turn_off_state(hass, wemo_entity, SWITCH_DOMAIN)
 
 
-async def test_insight_state_attributes(hass, pywemo_registry):
+async def test_insight_state_attributes(hass: HomeAssistant, pywemo_registry) -> None:
     """Verify the switch attributes are set for the Insight device."""
     await async_setup_component(hass, HA_DOMAIN, {})
     with create_pywemo_device(pywemo_registry, "Insight") as insight:
@@ -152,7 +154,7 @@ async def test_insight_state_attributes(hass, pywemo_registry):
         assert attributes[ATTR_CURRENT_STATE_DETAIL] == STATE_UNKNOWN
 
 
-async def test_maker_state_attributes(hass, pywemo_registry):
+async def test_maker_state_attributes(hass: HomeAssistant, pywemo_registry) -> None:
     """Verify the switch attributes are set for the Insight device."""
     await async_setup_component(hass, HA_DOMAIN, {})
     with create_pywemo_device(pywemo_registry, "Maker") as maker:

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -11,7 +11,7 @@ from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 from homeassistant import runner
 from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, wemo_device
 from homeassistant.components.wemo.const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,9 @@ def pywemo_model():
     return "LightSwitchLongPress"
 
 
-async def test_async_register_device_longpress_fails(hass, pywemo_device):
+async def test_async_register_device_longpress_fails(
+    hass: HomeAssistant, pywemo_device
+) -> None:
     """Device is still registered if ensure_long_press_virtual_device fails."""
     with patch.object(pywemo_device, "ensure_long_press_virtual_device") as elp:
         elp.side_effect = PyWeMoException
@@ -52,7 +54,9 @@ async def test_async_register_device_longpress_fails(hass, pywemo_device):
     assert device.supports_long_press is False
 
 
-async def test_long_press_event(hass, pywemo_registry, wemo_entity):
+async def test_long_press_event(
+    hass: HomeAssistant, pywemo_registry, wemo_entity
+) -> None:
     """Device fires a long press event."""
     device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     got_event = asyncio.Event()
@@ -85,7 +89,9 @@ async def test_long_press_event(hass, pywemo_registry, wemo_entity):
     }
 
 
-async def test_subscription_callback(hass, pywemo_registry, wemo_entity):
+async def test_subscription_callback(
+    hass: HomeAssistant, pywemo_registry, wemo_entity
+) -> None:
     """Device processes a registry subscription callback."""
     device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = False
@@ -107,7 +113,9 @@ async def test_subscription_callback(hass, pywemo_registry, wemo_entity):
     assert device.last_update_success
 
 
-async def test_subscription_update_action_exception(hass, pywemo_device, wemo_entity):
+async def test_subscription_update_action_exception(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Device handles ActionException on get_state properly."""
     device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = True
@@ -125,7 +133,9 @@ async def test_subscription_update_action_exception(hass, pywemo_device, wemo_en
     assert isinstance(device.last_exception, UpdateFailed)
 
 
-async def test_subscription_update_exception(hass, pywemo_device, wemo_entity):
+async def test_subscription_update_exception(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Device handles Exception on get_state properly."""
     device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = True
@@ -144,8 +154,8 @@ async def test_subscription_update_exception(hass, pywemo_device, wemo_entity):
 
 
 async def test_async_update_data_subscribed(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """No update happens when the device is subscribed."""
     device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
     pywemo_registry.is_subscribed.return_value = True
@@ -154,7 +164,7 @@ async def test_async_update_data_subscribed(
     pywemo_device.get_state.assert_not_called()
 
 
-async def test_device_info(hass, wemo_entity):
+async def test_device_info(hass: HomeAssistant, wemo_entity) -> None:
     """Verify the DeviceInfo data is set properly."""
     dr = device_registry.async_get(hass)
     device_entries = list(dr.devices.values())
@@ -168,7 +178,7 @@ async def test_device_info(hass, wemo_entity):
     assert device_entries[0].sw_version == MOCK_FIRMWARE_VERSION
 
 
-async def test_dli_device_info(hass, wemo_dli_entity):
+async def test_dli_device_info(hass: HomeAssistant, wemo_dli_entity) -> None:
     """Verify the DeviceInfo data for Digital Loggers emulated wemo device."""
     dr = device_registry.async_get(hass)
     device_entries = list(dr.devices.values())

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -63,7 +63,7 @@ async def update_ac_state(
 
 async def test_no_appliances(
     hass: HomeAssistant, mock_appliances_manager_api: MagicMock
-):
+) -> None:
     """Test the setup of the climate entities when there are no appliances available."""
     mock_appliances_manager_api.return_value.aircons = []
     await init_integration(hass)
@@ -74,7 +74,7 @@ async def test_static_attributes(
     hass: HomeAssistant,
     mock_aircon1_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test static climate attributes."""
     await init_integration(hass)
 
@@ -121,7 +121,7 @@ async def test_dynamic_attributes(
     mock_aircon_api_instances: MagicMock,
     mock_aircon1_api: MagicMock,
     mock_aircon2_api: MagicMock,
-):
+) -> None:
     """Test dynamic attributes."""
     await init_integration(hass)
 
@@ -210,7 +210,7 @@ async def test_service_calls(
     mock_aircon_api_instances: MagicMock,
     mock_aircon1_api: MagicMock,
     mock_aircon2_api: MagicMock,
-):
+) -> None:
     """Test controlling the entity through service calls."""
     await init_integration(hass)
 

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -19,7 +19,7 @@ async def test_setup(
     mock_backend_selector_api: MagicMock,
     region,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test setup."""
     entry = await init_integration(hass, region[0])
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
@@ -31,7 +31,7 @@ async def test_setup_region_fallback(
     hass: HomeAssistant,
     mock_backend_selector_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test setup when no region is available on the ConfigEntry.
 
     This can happen after a version update, since there was no region in the first versions.
@@ -54,7 +54,7 @@ async def test_setup_http_exception(
     hass: HomeAssistant,
     mock_auth_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test setup with an http exception."""
     mock_auth_api.return_value.do_auth = AsyncMock(
         side_effect=aiohttp.ClientConnectionError()
@@ -68,7 +68,7 @@ async def test_setup_auth_failed(
     hass: HomeAssistant,
     mock_auth_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test setup with failed auth."""
     mock_auth_api.return_value.do_auth = AsyncMock()
     mock_auth_api.return_value.is_access_token_valid.return_value = False
@@ -81,7 +81,7 @@ async def test_setup_fetch_appliances_failed(
     hass: HomeAssistant,
     mock_appliances_manager_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
-):
+) -> None:
     """Test setup with failed fetch_appliances."""
     mock_appliances_manager_api.return_value.fetch_appliances.return_value = False
     entry = await init_integration(hass)
@@ -93,7 +93,7 @@ async def test_unload_entry(
     hass: HomeAssistant,
     mock_aircon_api_instances: MagicMock,
     mock_sensor_api_instances: MagicMock,
-):
+) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/whois/test_diagnostics.py
+++ b/tests/components/whois/test_diagnostics.py
@@ -10,7 +10,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/wiffi/test_config_flow.py
+++ b/tests/components/wiffi/test_config_flow.py
@@ -69,7 +69,7 @@ def mock_start_server_failed():
         yield server
 
 
-async def test_form(hass, dummy_tcp_server):
+async def test_form(hass: HomeAssistant, dummy_tcp_server) -> None:
     """Test how we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -85,7 +85,7 @@ async def test_form(hass, dummy_tcp_server):
     assert result2["type"] == FlowResultType.CREATE_ENTRY
 
 
-async def test_form_addr_in_use(hass, addr_in_use):
+async def test_form_addr_in_use(hass: HomeAssistant, addr_in_use) -> None:
     """Test how we handle addr_in_use error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -99,7 +99,9 @@ async def test_form_addr_in_use(hass, addr_in_use):
     assert result2["reason"] == "addr_in_use"
 
 
-async def test_form_start_server_failed(hass, start_server_failed):
+async def test_form_start_server_failed(
+    hass: HomeAssistant, start_server_failed
+) -> None:
     """Test how we handle start_server_failed error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/withings/test_binary_sensor.py
+++ b/tests/components/withings/test_binary_sensor.py
@@ -18,7 +18,9 @@ WITHINGS_MEASUREMENTS_MAP: dict[Measurement, WithingsEntityDescription] = {
 
 
 async def test_binary_sensor(
-    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
+    hass: HomeAssistant,
+    component_factory: ComponentFactory,
+    current_request_with_host: None,
 ) -> None:
     """Test binary sensor."""
     in_bed_attribute = WITHINGS_MEASUREMENTS_MAP[Measurement.IN_BED]

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -23,6 +23,7 @@ from .common import ComponentFactory, get_data_manager_by_user_id, new_profile_c
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def test_config_entry_withings_api(hass: HomeAssistant) -> None:
@@ -67,12 +68,12 @@ async def test_config_entry_withings_api(hass: HomeAssistant) -> None:
 async def test_webhook_post(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
-    aiohttp_client,
+    aiohttp_client: ClientSessionGenerator,
     user_id: int,
     arg_user_id: Any,
     arg_appli: Any,
     expected_code: int,
-    current_request_with_host,
+    current_request_with_host: None,
 ) -> None:
     """Test webhook callback."""
     person0 = new_profile_config("person0", user_id)
@@ -105,8 +106,8 @@ async def test_webhook_post(
 async def test_webhook_head(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
-    aiohttp_client,
-    current_request_with_host,
+    aiohttp_client: ClientSessionGenerator,
+    current_request_with_host: None,
 ) -> None:
     """Test head method on webhook view."""
     person0 = new_profile_config("person0", 0)
@@ -123,8 +124,8 @@ async def test_webhook_head(
 async def test_webhook_put(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
-    aiohttp_client,
-    current_request_with_host,
+    aiohttp_client: ClientSessionGenerator,
+    current_request_with_host: None,
 ) -> None:
     """Test webhook callback."""
     person0 = new_profile_config("person0", 0)

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.helpers.config_entry_oauth2_flow import AUTH_CALLBACK_PATH
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 async def test_config_non_unique_profile(hass: HomeAssistant) -> None:
@@ -37,7 +39,10 @@ async def test_config_non_unique_profile(hass: HomeAssistant) -> None:
 
 
 async def test_config_reauth_profile(
-    hass: HomeAssistant, hass_client_no_auth, aioclient_mock, current_request_with_host
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
 ) -> None:
     """Test reauth an existing profile re-creates the config entry."""
     hass_config = {

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -119,7 +119,7 @@ async def test_auth_failure(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
     exception: Exception,
-    current_request_with_host,
+    current_request_with_host: None,
 ) -> None:
     """Test auth failure."""
     person0 = new_profile_config(

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -305,7 +305,9 @@ def async_assert_state_equals(
 
 
 async def test_sensor_default_enabled_entities(
-    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
+    hass: HomeAssistant,
+    component_factory: ComponentFactory,
+    current_request_with_host: None,
 ) -> None:
     """Test entities enabled by default."""
     entity_registry: EntityRegistry = er.async_get(hass)
@@ -352,7 +354,9 @@ async def test_sensor_default_enabled_entities(
 
 
 async def test_all_entities(
-    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
+    hass: HomeAssistant,
+    component_factory: ComponentFactory,
+    current_request_with_host: None,
 ) -> None:
     """Test all entities."""
     entity_registry: EntityRegistry = er.async_get(hass)

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -119,7 +119,9 @@ async def test_user_flow_enters_dns_name(hass: HomeAssistant) -> None:
         (ConnectionRefusedError, "cannot_connect"),
     ],
 )
-async def test_user_form_exceptions(hass, side_effect, error_base):
+async def test_user_form_exceptions(
+    hass: HomeAssistant, side_effect, error_base
+) -> None:
     """Test all user exceptions in the flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -169,7 +171,9 @@ async def test_form_updates_unique_id(hass: HomeAssistant) -> None:
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),
     ],
 )
-async def test_discovered_by_dhcp_connection_fails(hass, source, data):
+async def test_discovered_by_dhcp_connection_fails(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort on connection failure."""
     with patch(
         "homeassistant.components.wiz.wizlight.getBulbConfig",
@@ -246,8 +250,8 @@ async def test_discovered_by_dhcp_connection_fails(hass, source, data):
     ],
 )
 async def test_discovered_by_dhcp_or_integration_discovery(
-    hass, source, data, bulb_type, extended_white_range, name
-):
+    hass: HomeAssistant, source, data, bulb_type, extended_white_range, name
+) -> None:
     """Test we can configure when discovered from dhcp or discovery."""
     with _patch_wizlight(
         device=None, extended_white_range=extended_white_range, bulb_type=bulb_type
@@ -291,8 +295,8 @@ async def test_discovered_by_dhcp_or_integration_discovery(
     ],
 )
 async def test_discovered_by_dhcp_or_integration_discovery_updates_host(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test dhcp or discovery updates existing host."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -320,8 +324,8 @@ async def test_discovered_by_dhcp_or_integration_discovery_updates_host(
     ],
 )
 async def test_discovered_by_dhcp_or_integration_discovery_avoid_waiting_for_retry(
-    hass, source, data
-):
+    hass: HomeAssistant, source, data
+) -> None:
     """Test dhcp or discovery kicks off setup when in retry."""
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     bulb.getMac = AsyncMock(side_effect=OSError)
@@ -516,7 +520,7 @@ async def test_discovery_with_firmware_update(hass: HomeAssistant) -> None:
         (config_entries.SOURCE_INTEGRATION_DISCOVERY, INTEGRATION_DISCOVERY),
     ],
 )
-async def test_discovered_during_onboarding(hass, source, data):
+async def test_discovered_during_onboarding(hass: HomeAssistant, source, data) -> None:
     """Test dhcp or discovery during onboarding creates the config entry."""
     with _patch_wizlight(), patch(
         "homeassistant.components.wiz.async_setup_entry",

--- a/tests/components/wled/test_diagnostics.py
+++ b/tests/components/wled/test_diagnostics.py
@@ -10,7 +10,7 @@ async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-):
+) -> None:
     """Test diagnostics."""
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, init_integration

--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -1,6 +1,7 @@
 """The test for the World clock sensor platform."""
 import pytest
 
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -11,7 +12,7 @@ def time_zone():
     return dt_util.get_time_zone("America/New_York")
 
 
-async def test_time(hass, time_zone):
+async def test_time(hass: HomeAssistant, time_zone) -> None:
     """Test the time at a different location."""
     config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
 
@@ -28,7 +29,7 @@ async def test_time(hass, time_zone):
     assert state.state == dt_util.now(time_zone=time_zone).strftime("%H:%M")
 
 
-async def test_time_format(hass, time_zone):
+async def test_time_format(hass: HomeAssistant, time_zone) -> None:
     """Test time_format setting."""
     time_format = "%a, %b %d, %Y %I:%M %p"
     config = {

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -2,6 +2,8 @@
 from datetime import datetime, timedelta, timezone
 import re
 
+import requests_mock
+
 import homeassistant.components.wsdot.sensor as wsdot
 from homeassistant.components.wsdot.sensor import (
     ATTR_DESCRIPTION,
@@ -30,7 +32,7 @@ async def test_setup_with_config(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "sensor", {"wsdot": config})
 
 
-async def test_setup(hass, requests_mock):
+async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
     """Test for operational WSDOT sensor with proper attributes."""
     entities = []
 

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -8,6 +8,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -25,8 +27,11 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,

--- a/tests/components/xiaomi/test_device_tracker.py
+++ b/tests/components/xiaomi/test_device_tracker.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_tracker import DOMAIN
 import homeassistant.components.xiaomi.device_tracker as xiaomi
 from homeassistant.components.xiaomi.device_tracker import get_scanner
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ def mocked_requests(*args, **kwargs):
     "homeassistant.components.xiaomi.device_tracker.XiaomiDeviceScanner",
     return_value=MagicMock(),
 )
-async def test_config(xiaomi_mock, hass):
+async def test_config(xiaomi_mock, hass: HomeAssistant) -> None:
     """Testing minimal configuration."""
     config = {
         DOMAIN: xiaomi.PLATFORM_SCHEMA(
@@ -172,7 +173,7 @@ async def test_config(xiaomi_mock, hass):
     "homeassistant.components.xiaomi.device_tracker.XiaomiDeviceScanner",
     return_value=MagicMock(),
 )
-async def test_config_full(xiaomi_mock, hass):
+async def test_config_full(xiaomi_mock, hass: HomeAssistant) -> None:
     """Testing full configuration."""
     config = {
         DOMAIN: xiaomi.PLATFORM_SCHEMA(
@@ -196,7 +197,7 @@ async def test_config_full(xiaomi_mock, hass):
 
 @patch("requests.get", side_effect=mocked_requests)
 @patch("requests.post", side_effect=mocked_requests)
-async def test_invalid_credential(mock_get, mock_post, hass):
+async def test_invalid_credential(mock_get, mock_post, hass: HomeAssistant) -> None:
     """Testing invalid credential handling."""
     config = {
         DOMAIN: xiaomi.PLATFORM_SCHEMA(
@@ -213,7 +214,7 @@ async def test_invalid_credential(mock_get, mock_post, hass):
 
 @patch("requests.get", side_effect=mocked_requests)
 @patch("requests.post", side_effect=mocked_requests)
-async def test_valid_credential(mock_get, mock_post, hass):
+async def test_valid_credential(mock_get, mock_post, hass: HomeAssistant) -> None:
     """Testing valid refresh."""
     config = {
         DOMAIN: xiaomi.PLATFORM_SCHEMA(
@@ -234,7 +235,7 @@ async def test_valid_credential(mock_get, mock_post, hass):
 
 @patch("requests.get", side_effect=mocked_requests)
 @patch("requests.post", side_effect=mocked_requests)
-async def test_token_timed_out(mock_get, mock_post, hass):
+async def test_token_timed_out(mock_get, mock_post, hass: HomeAssistant) -> None:
     """Testing refresh with a timed out token.
 
     New token is requested and list is downloaded a second time.

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -262,7 +262,7 @@ async def test_smoke(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_unavailable(hass):
+async def test_unavailable(hass: HomeAssistant) -> None:
     """Test normal device goes to unavailable after 60 minutes."""
     start_monotonic = time.monotonic()
 
@@ -314,7 +314,7 @@ async def test_unavailable(hass):
     await hass.async_block_till_done()
 
 
-async def test_sleepy_device(hass):
+async def test_sleepy_device(hass: HomeAssistant) -> None:
     """Test sleepy device does not go to unavailable after 60 minutes."""
     start_monotonic = time.monotonic()
 

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -194,8 +194,8 @@ async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key(
 
 
 async def test_async_step_bluetooth_valid_device_legacy_encryption_wrong_key_length(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test discovery via bluetooth with a valid device, with legacy encryption and wrong key length."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -640,8 +640,8 @@ async def test_async_step_user_with_found_devices_legacy_encryption(
 
 
 async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with legacy encryption and wrong key."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",
@@ -685,8 +685,8 @@ async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key(
 
 
 async def test_async_step_user_with_found_devices_legacy_encryption_wrong_key_length(
-    hass,
-):
+    hass: HomeAssistant,
+) -> None:
     """Test setup from service info cache with devices found, with legacy encryption and wrong key length."""
     with patch(
         "homeassistant.components.xiaomi_ble.config_flow.async_discovered_service_info",

--- a/tests/components/xiaomi_ble/test_device_trigger.py
+++ b/tests/components/xiaomi_ble/test_device_trigger.py
@@ -179,7 +179,7 @@ async def test_get_triggers_for_invalid_device_id(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_if_fires_on_motion_detected(hass, calls):
+async def test_if_fires_on_motion_detected(hass: HomeAssistant, calls) -> None:
     """Test for motion event trigger firing."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -332,7 +332,7 @@ async def test_automation_with_invalid_trigger_event_property(
     await hass.async_block_till_done()
 
 
-async def test_triggers_for_invalid__model(hass, calls):
+async def test_triggers_for_invalid__model(hass: HomeAssistant, calls) -> None:
     """Test invalid model doesn't return triggers."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -48,6 +48,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import TEST_MAC
@@ -220,7 +221,7 @@ def mirobo_is_on_fixture():
         yield mock_vacuum
 
 
-async def test_xiaomi_exceptions(hass, mock_mirobo_is_on):
+async def test_xiaomi_exceptions(hass: HomeAssistant, mock_mirobo_is_on) -> None:
     """Test error logging on exceptions."""
     entity_name = "test_vacuum_cleaner_error"
     entity_id = await setup_component(hass, entity_name)
@@ -251,7 +252,9 @@ async def test_xiaomi_exceptions(hass, mock_mirobo_is_on):
     assert mock_mirobo_is_on.status.call_count == 1
 
 
-async def test_xiaomi_vacuum_services(hass, mock_mirobo_is_got_error):
+async def test_xiaomi_vacuum_services(
+    hass: HomeAssistant, mock_mirobo_is_got_error
+) -> None:
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_1"
     entity_id = await setup_component(hass, entity_name)
@@ -442,7 +445,7 @@ async def test_xiaomi_vacuum_services(hass, mock_mirobo_is_got_error):
     ],
 )
 async def test_xiaomi_specific_services(
-    hass,
+    hass: HomeAssistant,
     mock_mirobo_is_on,
     service,
     service_data,
@@ -450,7 +453,7 @@ async def test_xiaomi_specific_services(
     device_method_call,
     error,
     status_calls,
-):
+) -> None:
     """Test vacuum supported features."""
     entity_name = "test_vacuum_cleaner_2"
     entity_id = await setup_component(hass, entity_name)
@@ -490,7 +493,9 @@ async def test_xiaomi_specific_services(
     mock_mirobo_is_on.reset_mock()
 
 
-async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
+async def test_xiaomi_vacuum_fanspeeds(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_mirobo_fanspeeds
+) -> None:
     """Test Xiaomi vacuum fanspeeds."""
     entity_name = "test_vacuum_cleaner_2"
     entity_id = await setup_component(hass, entity_name)

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -6,6 +6,7 @@ import pytest
 import homeassistant.components.media_player as mp
 from homeassistant.components.yamaha import media_player as yamaha
 from homeassistant.components.yamaha.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 
@@ -47,7 +48,7 @@ def device_fixture(main_zone):
         yield device
 
 
-async def test_setup_host(hass, device, main_zone):
+async def test_setup_host(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration with host."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
     await hass.async_block_till_done()
@@ -58,7 +59,7 @@ async def test_setup_host(hass, device, main_zone):
     assert state.state == "off"
 
 
-async def test_setup_no_host(hass, device, main_zone):
+async def test_setup_no_host(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration without host."""
     with patch("rxv.find", return_value=[device]):
         assert await async_setup_component(
@@ -72,7 +73,7 @@ async def test_setup_no_host(hass, device, main_zone):
     assert state.state == "off"
 
 
-async def test_setup_discovery(hass, device, main_zone):
+async def test_setup_discovery(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration via discovery."""
     discovery_info = {
         "name": "Yamaha Receiver",
@@ -91,7 +92,7 @@ async def test_setup_discovery(hass, device, main_zone):
     assert state.state == "off"
 
 
-async def test_setup_zone_ignore(hass, device, main_zone):
+async def test_setup_zone_ignore(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration without host."""
     assert await async_setup_component(
         hass,
@@ -111,7 +112,7 @@ async def test_setup_zone_ignore(hass, device, main_zone):
     assert state is None
 
 
-async def test_enable_output(hass, device, main_zone):
+async def test_enable_output(hass: HomeAssistant, device, main_zone) -> None:
     """Test enable output service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
     await hass.async_block_till_done()
@@ -142,7 +143,7 @@ async def test_enable_output(hass, device, main_zone):
     ],
 )
 @pytest.mark.usefixtures("device")
-async def test_menu_cursor(hass, main_zone, cursor, method):
+async def test_menu_cursor(hass: HomeAssistant, main_zone, cursor, method) -> None:
     """Verify that the correct menu method is called for the menu_cursor service."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
     await hass.async_block_till_done()
@@ -156,7 +157,9 @@ async def test_menu_cursor(hass, main_zone, cursor, method):
     getattr(main_zone, method).assert_called_once_with()
 
 
-async def test_select_scene(hass, device, main_zone, caplog):
+async def test_select_scene(
+    hass: HomeAssistant, device, main_zone, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test select scene service."""
     scene_prop = PropertyMock(return_value=None)
     type(main_zone).scene = scene_prop

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test config flow."""
-
 from unittest.mock import patch
 
 from aiomusiccast import MusicCastConnectionException
@@ -10,6 +9,7 @@ from homeassistant.components import ssdp
 from homeassistant.components.yamaha_musiccast.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -125,8 +125,8 @@ def mock_empty_discovery_information():
 
 
 async def test_user_input_device_not_found(
-    hass, mock_get_device_info_mc_exception, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_device_info_mc_exception, mock_get_source_ip
+) -> None:
     """Test when user specifies a non-existing device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -143,8 +143,8 @@ async def test_user_input_device_not_found(
 
 
 async def test_user_input_non_yamaha_device_found(
-    hass, mock_get_device_info_invalid, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_device_info_invalid, mock_get_source_ip
+) -> None:
     """Test when user specifies an existing device, which does not provide the musiccast API."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -161,8 +161,8 @@ async def test_user_input_non_yamaha_device_found(
 
 
 async def test_user_input_device_already_existing(
-    hass, mock_get_device_info_valid, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_device_info_valid, mock_get_source_ip
+) -> None:
     """Test when user specifies an existing device."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -185,8 +185,8 @@ async def test_user_input_device_already_existing(
 
 
 async def test_user_input_unknown_error(
-    hass, mock_get_device_info_exception, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_get_device_info_exception, mock_get_source_ip
+) -> None:
     """Test when user specifies an existing device, which does not provide the musiccast API."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -203,11 +203,11 @@ async def test_user_input_unknown_error(
 
 
 async def test_user_input_device_found(
-    hass,
+    hass: HomeAssistant,
     mock_get_device_info_valid,
     mock_valid_discovery_information,
     mock_get_source_ip,
-):
+) -> None:
     """Test when user specifies an existing device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -229,11 +229,11 @@ async def test_user_input_device_found(
 
 
 async def test_user_input_device_found_no_ssdp(
-    hass,
+    hass: HomeAssistant,
     mock_get_device_info_valid,
     mock_empty_discovery_information,
     mock_get_source_ip,
-):
+) -> None:
     """Test when user specifies an existing device, which no discovery data are present for."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -257,7 +257,9 @@ async def test_user_input_device_found_no_ssdp(
 # SSDP Flows
 
 
-async def test_ssdp_discovery_failed(hass, mock_ssdp_no_yamaha, mock_get_source_ip):
+async def test_ssdp_discovery_failed(
+    hass: HomeAssistant, mock_ssdp_no_yamaha, mock_get_source_ip
+) -> None:
     """Test when an SSDP discovered device is not a musiccast device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -278,8 +280,8 @@ async def test_ssdp_discovery_failed(hass, mock_ssdp_no_yamaha, mock_get_source_
 
 
 async def test_ssdp_discovery_successful_add_device(
-    hass, mock_ssdp_yamaha, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_ssdp_yamaha, mock_get_source_ip
+) -> None:
     """Test when the SSDP discovered device is a musiccast device and the user confirms it."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -314,8 +316,8 @@ async def test_ssdp_discovery_successful_add_device(
 
 
 async def test_ssdp_discovery_existing_device_update(
-    hass, mock_ssdp_yamaha, mock_get_source_ip
-):
+    hass: HomeAssistant, mock_ssdp_yamaha, mock_get_source_ip
+) -> None:
     """Test when the SSDP discovered device is a musiccast device, but it already exists with another IP."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/yandex_transport/test_yandex_transport_sensor.py
+++ b/tests/components/yandex_transport/test_yandex_transport_sensor.py
@@ -1,5 +1,4 @@
 """Tests for the yandex transport platform."""
-
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -7,6 +6,7 @@ import pytest
 
 import homeassistant.components.sensor as sensor
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -80,33 +80,37 @@ async def assert_setup_sensor(hass, config, count=1):
         await hass.async_block_till_done()
 
 
-async def test_setup_platform_valid_config(hass, mock_requester_bus):
+async def test_setup_platform_valid_config(
+    hass: HomeAssistant, mock_requester_bus
+) -> None:
     """Test that sensor is set up properly with valid config."""
     await assert_setup_sensor(hass, TEST_BUS_CONFIG)
 
 
-async def test_setup_platform_invalid_config(hass, mock_requester_bus):
+async def test_setup_platform_invalid_config(
+    hass: HomeAssistant, mock_requester_bus
+) -> None:
     """Check an invalid configuration."""
     await assert_setup_sensor(
         hass, {"sensor": {"platform": "yandex_transport", "stopid": 1234}}, count=0
     )
 
 
-async def test_name(hass, mock_requester_bus):
+async def test_name(hass: HomeAssistant, mock_requester_bus) -> None:
     """Return the name if set in the configuration."""
     await assert_setup_sensor(hass, TEST_BUS_CONFIG)
     state = hass.states.get("sensor.test_name")
     assert state.name == TEST_BUS_CONFIG["sensor"][CONF_NAME]
 
 
-async def test_state(hass, mock_requester_bus):
+async def test_state(hass: HomeAssistant, mock_requester_bus) -> None:
     """Return the contents of _state."""
     await assert_setup_sensor(hass, TEST_BUS_CONFIG)
     state = hass.states.get("sensor.test_name")
     assert state.state == BUS_RESULT_STATE
 
 
-async def test_filtered_attributes(hass, mock_requester_bus):
+async def test_filtered_attributes(hass: HomeAssistant, mock_requester_bus) -> None:
     """Return the contents of attributes."""
     await assert_setup_sensor(hass, TEST_BUS_CONFIG)
     state = hass.states.get("sensor.test_name")
@@ -114,7 +118,9 @@ async def test_filtered_attributes(hass, mock_requester_bus):
     assert state_attrs == FILTERED_ATTRS
 
 
-async def test_suburban_trains(hass, mock_requester_suburban_train):
+async def test_suburban_trains(
+    hass: HomeAssistant, mock_requester_suburban_train
+) -> None:
     """Return the contents of _state for suburban."""
     await assert_setup_sensor(hass, TEST_SUBURBAN_CONFIG)
     state = hass.states.get("sensor.test_name")

--- a/tests/components/yeelight/test_binary_sensor.py
+++ b/tests/components/yeelight/test_binary_sensor.py
@@ -18,7 +18,7 @@ from . import (
 ENTITY_BINARY_SENSOR = f"binary_sensor.{NAME}_nightlight"
 
 
-async def test_nightlight(hass: HomeAssistant):
+async def test_nightlight(hass: HomeAssistant) -> None:
     """Test nightlight sensor."""
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), patch(f"{MODULE}.AsyncBulb", return_value=mocked_bulb):

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -59,7 +59,7 @@ SSDP_INFO = ssdp.SsdpServiceInfo(
 )
 
 
-async def test_discovery(hass: HomeAssistant):
+async def test_discovery(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     with _patch_discovery(), _patch_discovery_interval():
         result = await hass.config_entries.flow.async_init(
@@ -116,7 +116,7 @@ async def test_discovery(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_with_existing_device_present(hass: HomeAssistant):
+async def test_discovery_with_existing_device_present(hass: HomeAssistant) -> None:
     """Test setting up discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_ID: "0x000000000099999", CONF_HOST: "4.4.4.4"}
@@ -194,7 +194,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_discovery_no_device(hass: HomeAssistant):
+async def test_discovery_no_device(hass: HomeAssistant) -> None:
     """Test discovery without device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -209,7 +209,7 @@ async def test_discovery_no_device(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
-async def test_import(hass: HomeAssistant):
+async def test_import(hass: HomeAssistant) -> None:
     """Test import from yaml."""
     config = {
         CONF_NAME: DEFAULT_NAME,
@@ -269,7 +269,7 @@ async def test_import(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_manual(hass: HomeAssistant):
+async def test_manual(hass: HomeAssistant) -> None:
     """Test manually setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -339,7 +339,7 @@ async def test_manual(hass: HomeAssistant):
     assert result2["reason"] == "already_configured"
 
 
-async def test_options(hass: HomeAssistant):
+async def test_options(hass: HomeAssistant) -> None:
     """Test options flow."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -382,7 +382,7 @@ async def test_options(hass: HomeAssistant):
     assert hass.states.get(f"light.{NAME}_nightlight") is not None
 
 
-async def test_options_unknown_model(hass: HomeAssistant):
+async def test_options_unknown_model(hass: HomeAssistant) -> None:
     """Test options flow with an unknown model."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -424,7 +424,7 @@ async def test_options_unknown_model(hass: HomeAssistant):
     assert hass.states.get(f"light.{NAME}_nightlight") is not None
 
 
-async def test_manual_no_capabilities(hass: HomeAssistant):
+async def test_manual_no_capabilities(hass: HomeAssistant) -> None:
     """Test manually setup without successful get_capabilities."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -546,7 +546,7 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_homekit(hass, source, data):
+async def test_discovered_by_dhcp_or_homekit(hass: HomeAssistant, source, data) -> None:
     """Test we can setup when discovered from dhcp or homekit."""
 
     mocked_bulb = _mocked_bulb()
@@ -614,7 +614,9 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
         ),
     ],
 )
-async def test_discovered_by_dhcp_or_homekit_failed_to_get_id(hass, source, data):
+async def test_discovered_by_dhcp_or_homekit_failed_to_get_id(
+    hass: HomeAssistant, source, data
+) -> None:
     """Test we abort if we cannot get the unique id when discovered from dhcp or homekit."""
 
     mocked_bulb = _mocked_bulb()
@@ -738,7 +740,7 @@ async def test_discovered_zeroconf(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_discovery_updates_ip(hass: HomeAssistant):
+async def test_discovery_updates_ip(hass: HomeAssistant) -> None:
     """Test discovery updates ip."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "1.2.2.3"}, unique_id=ID
@@ -761,7 +763,9 @@ async def test_discovery_updates_ip(hass: HomeAssistant):
     assert config_entry.data[CONF_HOST] == IP_ADDRESS
 
 
-async def test_discovery_updates_ip_no_reload_setup_in_progress(hass: HomeAssistant):
+async def test_discovery_updates_ip_no_reload_setup_in_progress(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery updates ip does not reload if setup is an an error state."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -790,7 +794,7 @@ async def test_discovery_updates_ip_no_reload_setup_in_progress(hass: HomeAssist
     assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_discovery_adds_missing_ip_id_only(hass: HomeAssistant):
+async def test_discovery_adds_missing_ip_id_only(hass: HomeAssistant) -> None:
     """Test discovery adds missing ip."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_ID: ID})
     config_entry.add_to_hass(hass)
@@ -834,7 +838,7 @@ async def test_discovery_adds_missing_ip_id_only(hass: HomeAssistant):
         ),
     ],
 )
-async def test_discovered_during_onboarding(hass, source, data):
+async def test_discovered_during_onboarding(hass: HomeAssistant, source, data) -> None:
     """Test we create a config entry when discovered during onboarding."""
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), _patch_discovery_interval(), patch(

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -51,7 +51,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_ip_changes_fallback_discovery(hass: HomeAssistant):
+async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
     """Test Yeelight ip changes and we fallback to discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_ID: ID, CONF_HOST: "5.5.5.5"}, unique_id=ID
@@ -96,7 +96,7 @@ async def test_ip_changes_fallback_discovery(hass: HomeAssistant):
     assert entity_registry.async_get(binary_sensor_entity_id) is not None
 
 
-async def test_ip_changes_id_missing_cannot_fallback(hass: HomeAssistant):
+async def test_ip_changes_id_missing_cannot_fallback(hass: HomeAssistant) -> None:
     """Test Yeelight ip changes and we fallback to discovery."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "5.5.5.5"})
     config_entry.add_to_hass(hass)
@@ -112,7 +112,7 @@ async def test_ip_changes_id_missing_cannot_fallback(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_discovery(hass: HomeAssistant):
+async def test_setup_discovery(hass: HomeAssistant) -> None:
     """Test setting up Yeelight by discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, **CONFIG_ENTRY_DATA}
@@ -154,7 +154,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 
 async def test_setup_discovery_with_manually_configured_network_adapter(
     hass: HomeAssistant,
-):
+) -> None:
     """Test setting up Yeelight by discovery with a manually configured network adapter."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, **CONFIG_ENTRY_DATA}
@@ -209,8 +209,8 @@ _ADAPTERS_WITH_MANUAL_CONFIG_ONE_FAILING = [
 
 
 async def test_setup_discovery_with_manually_configured_network_adapter_one_fails(
-    hass: HomeAssistant, caplog
-):
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test setting up Yeelight by discovery with a manually configured network adapter with one that fails to bind."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, **CONFIG_ENTRY_DATA}
@@ -244,7 +244,7 @@ async def test_setup_discovery_with_manually_configured_network_adapter_one_fail
     assert f"Failed to setup listener for ('{FAIL_TO_BIND_IP}', 0)" in caplog.text
 
 
-async def test_setup_import(hass: HomeAssistant):
+async def test_setup_import(hass: HomeAssistant) -> None:
     """Test import from yaml."""
     mocked_bulb = _mocked_bulb()
     name = "yeelight"
@@ -273,7 +273,7 @@ async def test_setup_import(hass: HomeAssistant):
     assert entry.data[CONF_ID] == "0x000000000015243f"
 
 
-async def test_unique_ids_device(hass: HomeAssistant):
+async def test_unique_ids_device(hass: HomeAssistant) -> None:
     """Test Yeelight unique IDs from yeelight device IDs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -298,7 +298,7 @@ async def test_unique_ids_device(hass: HomeAssistant):
     assert entity_registry.async_get(ENTITY_AMBILIGHT).unique_id == f"{ID}-ambilight"
 
 
-async def test_unique_ids_entry(hass: HomeAssistant):
+async def test_unique_ids_entry(hass: HomeAssistant) -> None:
     """Test Yeelight unique IDs from entry IDs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -329,7 +329,7 @@ async def test_unique_ids_entry(hass: HomeAssistant):
     )
 
 
-async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant):
+async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant) -> None:
     """Test Yeelight off while adding to ha, for example on HA start."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={**CONFIG_ENTRY_DATA, CONF_HOST: IP_ADDRESS}, unique_id=ID
@@ -435,7 +435,7 @@ async def test_unload_before_discovery(
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_async_listen_error_has_host_with_id(hass: HomeAssistant):
+async def test_async_listen_error_has_host_with_id(hass: HomeAssistant) -> None:
     """Test the async listen error."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_ID: ID, CONF_HOST: "127.0.0.1"}
@@ -452,7 +452,7 @@ async def test_async_listen_error_has_host_with_id(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_async_listen_error_has_host_without_id(hass: HomeAssistant):
+async def test_async_listen_error_has_host_without_id(hass: HomeAssistant) -> None:
     """Test the async listen error but no id."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "127.0.0.1"})
     config_entry.add_to_hass(hass)
@@ -467,7 +467,7 @@ async def test_async_listen_error_has_host_without_id(hass: HomeAssistant):
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_async_setup_with_missing_id(hass: HomeAssistant):
+async def test_async_setup_with_missing_id(hass: HomeAssistant) -> None:
     """Test that setting adds the missing CONF_ID from unique_id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -493,7 +493,7 @@ async def test_async_setup_with_missing_id(hass: HomeAssistant):
         assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_async_setup_with_missing_unique_id(hass: HomeAssistant):
+async def test_async_setup_with_missing_unique_id(hass: HomeAssistant) -> None:
     """Test that setting adds the missing unique_id from CONF_ID."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -518,7 +518,7 @@ async def test_async_setup_with_missing_unique_id(hass: HomeAssistant):
         assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_connection_dropped_resyncs_properties(hass: HomeAssistant):
+async def test_connection_dropped_resyncs_properties(hass: HomeAssistant) -> None:
     """Test handling a connection drop results in a property resync."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -548,7 +548,9 @@ async def test_connection_dropped_resyncs_properties(hass: HomeAssistant):
         assert len(mocked_bulb.async_get_properties.mock_calls) == 2
 
 
-async def test_oserror_on_first_update_results_in_unavailable(hass: HomeAssistant):
+async def test_oserror_on_first_update_results_in_unavailable(
+    hass: HomeAssistant,
+) -> None:
     """Test that an OSError on first update results in unavailable."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -572,7 +574,7 @@ async def test_oserror_on_first_update_results_in_unavailable(hass: HomeAssistan
 @pytest.mark.parametrize("exception", [BulbException, asyncio.TimeoutError])
 async def test_non_oserror_exception_on_first_update(
     hass: HomeAssistant, exception: Exception
-):
+) -> None:
     """Test that an exceptions other than OSError on first update do not result in unavailable.
 
     The unavailable state will come as a push update in this case
@@ -596,7 +598,7 @@ async def test_non_oserror_exception_on_first_update(
     assert hass.states.get("light.test_name").state != STATE_UNAVAILABLE
 
 
-async def test_async_setup_with_discovery_not_working(hass: HomeAssistant):
+async def test_async_setup_with_discovery_not_working(hass: HomeAssistant) -> None:
     """Test we can setup even if discovery is broken."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -138,7 +138,7 @@ SUPPORT_YEELIGHT = (
 )
 
 
-async def test_services(hass: HomeAssistant, caplog):
+async def test_services(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test Yeelight services."""
     assert await async_setup_component(hass, "homeassistant", {})
     config_entry = MockConfigEntry(
@@ -525,7 +525,9 @@ async def test_services(hass: HomeAssistant, caplog):
     assert hass.states.get(ENTITY_LIGHT).state == STATE_UNAVAILABLE
 
 
-async def test_update_errors(hass: HomeAssistant, caplog):
+async def test_update_errors(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test update errors."""
     assert await async_setup_component(hass, "homeassistant", {})
     config_entry = MockConfigEntry(
@@ -575,7 +577,7 @@ async def test_update_errors(hass: HomeAssistant, caplog):
     assert hass.states.get(ENTITY_LIGHT).state == STATE_UNAVAILABLE
 
 
-async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
+async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant) -> None:
     """Ensure we suppress state changes that will increase the rate limit when there is no change."""
     mocked_bulb = _mocked_bulb()
     properties = {**PROPERTIES}
@@ -767,7 +769,9 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
     mocked_bulb.last_properties["flowing"] = "0"
 
 
-async def test_device_types(hass: HomeAssistant, caplog):
+async def test_device_types(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test different device types."""
     mocked_bulb = _mocked_bulb()
     properties = {**PROPERTIES}
@@ -1337,7 +1341,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
     )
 
 
-async def test_effects(hass: HomeAssistant):
+async def test_effects(hass: HomeAssistant) -> None:
     """Test effects."""
     assert await async_setup_component(
         hass,
@@ -1508,7 +1512,7 @@ async def test_effects(hass: HomeAssistant):
     await _async_test_effect("not_existed", called=False)
 
 
-async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant):
+async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant) -> None:
     """Test that main light on ambilights with the nightlight disabled shows the correct brightness."""
     mocked_bulb = _mocked_bulb()
     properties = {**PROPERTIES}
@@ -1542,7 +1546,7 @@ async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant):
     assert state.attributes[ATTR_BRIGHTNESS] == 128
 
 
-async def test_state_fails_to_update_triggers_update(hass: HomeAssistant):
+async def test_state_fails_to_update_triggers_update(hass: HomeAssistant) -> None:
     """Ensure we call async_get_properties if the turn on/off fails to update the state."""
     mocked_bulb = _mocked_bulb()
     properties = {**PROPERTIES}

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -11,6 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
@@ -26,7 +28,7 @@ async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     assert result["reason"] == "missing_credentials"
 
 
-async def test_abort_if_existing_entry(hass: HomeAssistant):
+async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     """Check flow abort when an entry already exist."""
     MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
@@ -37,8 +39,11 @@ async def test_abort_if_existing_entry(hass: HomeAssistant):
 
 
 async def test_full_flow(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Check full flow."""
     assert await setup.async_setup_component(
         hass,
@@ -105,7 +110,9 @@ async def test_full_flow(
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_abort_if_authorization_timeout(hass, current_request_with_host):
+async def test_abort_if_authorization_timeout(
+    hass: HomeAssistant, current_request_with_host: None
+) -> None:
     """Check yolink authorization timeout."""
     assert await setup.async_setup_component(
         hass,
@@ -131,8 +138,11 @@ async def test_abort_if_authorization_timeout(hass, current_request_with_host):
 
 
 async def test_reauthentication(
-    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
-):
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> None:
     """Test yolink reauthentication."""
     await setup.async_setup_component(
         hass,

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -3,6 +3,7 @@ from ipaddress import ip_address
 from typing import Any
 from unittest.mock import call, patch
 
+import pytest
 from zeroconf import (
     BadTypeInNameException,
     InterfaceChoice,
@@ -151,7 +152,7 @@ def get_zeroconf_info_mock_model(model):
     return mock_zc_info
 
 
-async def test_setup(hass, mock_async_zeroconf):
+async def test_setup(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test configured options for a device are loaded via config entry."""
     mock_zc = {
         "_http._tcp.local.": [
@@ -196,7 +197,9 @@ async def test_setup(hass, mock_async_zeroconf):
     )
 
 
-async def test_setup_with_overly_long_url_and_name(hass, mock_async_zeroconf, caplog):
+async def test_setup_with_overly_long_url_and_name(
+    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we still setup with long urls and names."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -233,7 +236,9 @@ async def test_setup_with_overly_long_url_and_name(hass, mock_async_zeroconf, ca
     assert "German Umlaut" in caplog.text
 
 
-async def test_setup_with_default_interface(hass, mock_async_zeroconf):
+async def test_setup_with_default_interface(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -250,7 +255,9 @@ async def test_setup_with_default_interface(hass, mock_async_zeroconf):
     assert mock_async_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
 
 
-async def test_setup_without_default_interface(hass, mock_async_zeroconf):
+async def test_setup_without_default_interface(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -265,7 +272,9 @@ async def test_setup_without_default_interface(hass, mock_async_zeroconf):
     assert mock_async_zeroconf.called_with()
 
 
-async def test_setup_without_ipv6(hass, mock_async_zeroconf):
+async def test_setup_without_ipv6(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -282,7 +291,7 @@ async def test_setup_without_ipv6(hass, mock_async_zeroconf):
     assert mock_async_zeroconf.called_with(ip_version=IPVersion.V4Only)
 
 
-async def test_setup_with_ipv6(hass, mock_async_zeroconf):
+async def test_setup_with_ipv6(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -299,7 +308,9 @@ async def test_setup_with_ipv6(hass, mock_async_zeroconf):
     assert mock_async_zeroconf.called_with()
 
 
-async def test_setup_with_ipv6_default(hass, mock_async_zeroconf):
+async def test_setup_with_ipv6_default(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without ipv6 as default."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -314,7 +325,9 @@ async def test_setup_with_ipv6_default(hass, mock_async_zeroconf):
     assert mock_async_zeroconf.called_with()
 
 
-async def test_zeroconf_match_macaddress(hass, mock_async_zeroconf):
+async def test_zeroconf_match_macaddress(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -356,7 +369,9 @@ async def test_zeroconf_match_macaddress(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][2]["context"] == {"source": "zeroconf"}
 
 
-async def test_zeroconf_match_manufacturer(hass, mock_async_zeroconf):
+async def test_zeroconf_match_manufacturer(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -393,7 +408,9 @@ async def test_zeroconf_match_manufacturer(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "samsungtv"
 
 
-async def test_zeroconf_match_model(hass, mock_async_zeroconf):
+async def test_zeroconf_match_model(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test matching a specific model in zeroconf."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -430,7 +447,9 @@ async def test_zeroconf_match_model(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "appletv"
 
 
-async def test_zeroconf_match_manufacturer_not_present(hass, mock_async_zeroconf):
+async def test_zeroconf_match_manufacturer_not_present(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test matchers reject when a property is missing."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -466,7 +485,9 @@ async def test_zeroconf_match_manufacturer_not_present(hass, mock_async_zeroconf
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match(hass, mock_async_zeroconf):
+async def test_zeroconf_no_match(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -498,7 +519,9 @@ async def test_zeroconf_no_match(hass, mock_async_zeroconf):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match_manufacturer(hass, mock_async_zeroconf):
+async def test_zeroconf_no_match_manufacturer(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -534,7 +557,9 @@ async def test_zeroconf_no_match_manufacturer(hass, mock_async_zeroconf):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_homekit_match_partial_space(hass, mock_async_zeroconf):
+async def test_homekit_match_partial_space(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -570,7 +595,9 @@ async def test_homekit_match_partial_space(hass, mock_async_zeroconf):
     }
 
 
-async def test_device_with_invalid_name(hass, mock_async_zeroconf, caplog):
+async def test_device_with_invalid_name(
+    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we ignore devices with an invalid name."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -601,7 +628,9 @@ async def test_device_with_invalid_name(hass, mock_async_zeroconf, caplog):
     assert "Bad name in zeroconf record" in caplog.text
 
 
-async def test_homekit_match_partial_dash(hass, mock_async_zeroconf):
+async def test_homekit_match_partial_dash(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -632,7 +661,9 @@ async def test_homekit_match_partial_dash(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "lutron_caseta"
 
 
-async def test_homekit_match_partial_fnmatch(hass, mock_async_zeroconf):
+async def test_homekit_match_partial_fnmatch(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test matching homekit devices with fnmatch."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -663,7 +694,9 @@ async def test_homekit_match_partial_fnmatch(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "yeelight"
 
 
-async def test_homekit_match_full(hass, mock_async_zeroconf):
+async def test_homekit_match_full(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -694,7 +727,9 @@ async def test_homekit_match_full(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 
-async def test_homekit_already_paired(hass, mock_async_zeroconf):
+async def test_homekit_already_paired(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test that an already paired device is sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -729,7 +764,9 @@ async def test_homekit_already_paired(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
 
 
-async def test_homekit_invalid_paring_status(hass, mock_async_zeroconf):
+async def test_homekit_invalid_paring_status(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test that missing paring data is not sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -760,7 +797,9 @@ async def test_homekit_invalid_paring_status(hass, mock_async_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "lutron_caseta"
 
 
-async def test_homekit_not_paired(hass, mock_async_zeroconf):
+async def test_homekit_not_paired(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test that an not paired device is sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -786,8 +825,8 @@ async def test_homekit_not_paired(hass, mock_async_zeroconf):
 
 
 async def test_homekit_controller_still_discovered_unpaired_for_cloud(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test discovery is still passed to homekit controller when unpaired.
 
     When unpaired and discovered by cloud integration.
@@ -826,8 +865,8 @@ async def test_homekit_controller_still_discovered_unpaired_for_cloud(
 
 
 async def test_homekit_controller_still_discovered_unpaired_for_polling(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test discovery is still passed to homekit controller when unpaired.
 
     When unpaired and discovered by polling integration.
@@ -962,7 +1001,7 @@ async def test_info_from_service_can_return_ipv6(hass: HomeAssistant) -> None:
     assert info.host == "fd11:1111:1111:0:1234:1234:1234:1234"
 
 
-async def test_get_instance(hass, mock_async_zeroconf):
+async def test_get_instance(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test we get an instance."""
     assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
     assert (
@@ -973,7 +1012,7 @@ async def test_get_instance(hass, mock_async_zeroconf):
     assert len(mock_async_zeroconf.ha_async_close.mock_calls) == 1
 
 
-async def test_removed_ignored(hass, mock_async_zeroconf):
+async def test_removed_ignored(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test we remove it when a zeroconf entry is removed."""
 
     def service_update_mock(ipv6, zeroconf, services, handlers):
@@ -1025,8 +1064,8 @@ _ADAPTER_WITH_DEFAULT_ENABLED = [
 
 
 async def test_async_detect_interfaces_setting_non_loopback_route(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without default interface and the route returns a non-loopback address."""
     with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc, patch.object(
         hass.config_entries.flow, "async_init"
@@ -1109,8 +1148,8 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 
 
 async def test_async_detect_interfaces_setting_empty_route_linux(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without default interface config and the route returns nothing on linux."""
     with patch("homeassistant.components.zeroconf.sys.platform", "linux"), patch(
         "homeassistant.components.zeroconf.HaZeroconf"
@@ -1139,8 +1178,8 @@ async def test_async_detect_interfaces_setting_empty_route_linux(
 
 
 async def test_async_detect_interfaces_setting_empty_route_freebsd(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test without default interface and the route returns nothing on freebsd."""
     with patch("homeassistant.components.zeroconf.sys.platform", "freebsd"), patch(
         "homeassistant.components.zeroconf.HaZeroconf"
@@ -1165,7 +1204,9 @@ async def test_async_detect_interfaces_setting_empty_route_freebsd(
     )
 
 
-async def test_get_announced_addresses(hass, mock_async_zeroconf):
+async def test_get_announced_addresses(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test addresses for mDNS announcement."""
     expected = {
         ip_address(ip).packed
@@ -1207,8 +1248,8 @@ _ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6 = [
 
 
 async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test interfaces are explicitly set when IPv6 is present on linux."""
     with patch("homeassistant.components.zeroconf.sys.platform", "linux"), patch(
         "homeassistant.components.zeroconf.HaZeroconf"
@@ -1232,8 +1273,8 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
 
 
 async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
-    hass, mock_async_zeroconf
-):
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test interfaces are explicitly set when IPv6 is present on freebsd."""
     with patch("homeassistant.components.zeroconf.sys.platform", "freebsd"), patch(
         "homeassistant.components.zeroconf.HaZeroconf"
@@ -1256,7 +1297,7 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
     )
 
 
-async def test_no_name(hass, mock_async_zeroconf):
+async def test_no_name(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     """Test fallback to Home for mDNS announcement if the name is missing."""
     hass.config.location_name = ""
     with patch("homeassistant.components.zeroconf.HaZeroconf"):
@@ -1270,8 +1311,8 @@ async def test_no_name(hass, mock_async_zeroconf):
 
 
 async def test_setup_with_disallowed_characters_in_local_name(
-    hass, mock_async_zeroconf, caplog
-):
+    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test we still setup with disallowed characters in the location name."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -1288,7 +1329,9 @@ async def test_setup_with_disallowed_characters_in_local_name(
     assert calls[0][1][0].name == "My House._home-assistant._tcp.local."
 
 
-async def test_start_with_frontend(hass, mock_async_zeroconf):
+async def test_start_with_frontend(
+    hass: HomeAssistant, mock_async_zeroconf: None
+) -> None:
     """Test we start with the frontend."""
     with patch("homeassistant.components.zeroconf.HaZeroconf"):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -1,18 +1,23 @@
 """Test Zeroconf multiple instance protection."""
 from unittest.mock import Mock, patch
 
+import pytest
 import zeroconf
 
 from homeassistant.components.zeroconf import async_get_instance
 from homeassistant.components.zeroconf.usage import install_multiple_zeroconf_catcher
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 DOMAIN = "zeroconf"
 
 
 async def test_multiple_zeroconf_instances(
-    hass, mock_async_zeroconf, mock_zeroconf, caplog
-):
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_zeroconf: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test creating multiple zeroconf throws without an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -27,8 +32,11 @@ async def test_multiple_zeroconf_instances(
 
 
 async def test_multiple_zeroconf_instances_gives_shared(
-    hass, mock_async_zeroconf, mock_zeroconf, caplog
-):
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_zeroconf: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test creating multiple zeroconf gives the shared instance to an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -66,7 +67,7 @@ async def mock_light(hass, mock_entry):
     return light
 
 
-async def test_init(hass, mock_entry):
+async def test_init(hass: HomeAssistant, mock_entry) -> None:
     """Test platform setup."""
 
     mock_entry.add_to_hass(hass)
@@ -126,7 +127,7 @@ async def test_init(hass, mock_entry):
     assert hass.data[DOMAIN]["addresses"] == {"AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"}
 
 
-async def test_discovery_exception(hass, mock_entry):
+async def test_discovery_exception(hass: HomeAssistant, mock_entry) -> None:
     """Test platform setup."""
 
     mock_entry.add_to_hass(hass)
@@ -142,7 +143,7 @@ async def test_discovery_exception(hass, mock_entry):
     assert len(hass.data[DOMAIN]["addresses"]) == 0
 
 
-async def test_remove_entry(hass, mock_light, mock_entry):
+async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None:
     """Test platform setup."""
     assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:DD:EE:FF"}
     assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
@@ -154,7 +155,9 @@ async def test_remove_entry(hass, mock_light, mock_entry):
     assert DOMAIN not in hass.data
 
 
-async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
+async def test_remove_entry_exceptions_caught(
+    hass: HomeAssistant, mock_light, mock_entry
+) -> None:
     """Assert that disconnect exceptions are caught."""
     with patch.object(
         mock_light, "disconnect", side_effect=pyzerproc.ZerprocException("Mock error")
@@ -164,7 +167,7 @@ async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
     assert mock_disconnect.called
 
 
-async def test_light_turn_on(hass, mock_light):
+async def test_light_turn_on(hass: HomeAssistant, mock_light) -> None:
     """Test ZerprocLight turn_on."""
     utcnow = dt_util.utcnow()
     with patch.object(mock_light, "turn_on") as mock_turn_on:
@@ -256,7 +259,7 @@ async def test_light_turn_on(hass, mock_light):
         mock_set_color.assert_called_with(162, 200, 50)
 
 
-async def test_light_turn_off(hass, mock_light):
+async def test_light_turn_off(hass: HomeAssistant, mock_light) -> None:
     """Test ZerprocLight turn_on."""
     with patch.object(mock_light, "turn_off") as mock_turn_off:
         await hass.services.async_call(
@@ -269,7 +272,7 @@ async def test_light_turn_off(hass, mock_light):
     mock_turn_off.assert_called()
 
 
-async def test_light_update(hass, mock_light):
+async def test_light_update(hass: HomeAssistant, mock_light) -> None:
     """Test ZerprocLight update."""
     utcnow = dt_util.utcnow()
 

--- a/tests/components/zodiac/test_sensor.py
+++ b/tests/components/zodiac/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.zodiac.const import (
     SIGN_TAURUS,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -36,7 +37,7 @@ DAY3 = datetime(2020, 4, 21, tzinfo=dt_util.UTC)
         (DAY3, SIGN_TAURUS, ELEMENT_EARTH, MODALITY_FIXED),
     ],
 )
-async def test_zodiac_day(hass, now, sign, element, modality):
+async def test_zodiac_day(hass: HomeAssistant, now, sign, element, modality) -> None:
     """Test the zodiac sensor."""
     hass.config.set_time_zone("UTC")
     config = {DOMAIN: {}}

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -18,7 +18,8 @@ from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -246,7 +247,9 @@ async def test_core_config_update(hass: HomeAssistant) -> None:
     assert home_updated.attributes["longitude"] == 20
 
 
-async def test_reload(hass, hass_admin_user, hass_read_only_user):
+async def test_reload(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_read_only_user: MockUser
+) -> None:
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
     ent_reg = er.async_get(hass)
@@ -317,7 +320,7 @@ async def test_reload(hass, hass_admin_user, hass_read_only_user):
     assert state_3.attributes["longitude"] == 6
 
 
-async def test_load_from_storage(hass, storage_setup):
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
@@ -326,7 +329,7 @@ async def test_load_from_storage(hass, storage_setup):
     assert state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_editable_state_attribute(hass, storage_setup):
+async def test_editable_state_attribute(hass: HomeAssistant, storage_setup) -> None:
     """Test editable attribute."""
     assert await storage_setup(
         config={DOMAIN: [{"name": "yaml option", "latitude": 3, "longitude": 4}]}
@@ -342,7 +345,9 @@ async def test_editable_state_attribute(hass, storage_setup):
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
-async def test_ws_list(hass, hass_ws_client, storage_setup):
+async def test_ws_list(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test listing via WS."""
     assert await storage_setup(
         config={DOMAIN: [{"name": "yaml option", "latitude": 3, "longitude": 4}]}
@@ -364,7 +369,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
-async def test_ws_delete(hass, hass_ws_client, storage_setup):
+async def test_ws_delete(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()
 
@@ -389,7 +396,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
 
 
-async def test_update(hass, hass_ws_client, storage_setup):
+async def test_update(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test updating min/max updates the state."""
 
     items = [
@@ -434,7 +443,9 @@ async def test_update(hass, hass_ws_client, storage_setup):
     assert state.attributes["passive"] is True
 
 
-async def test_ws_create(hass, hass_ws_client, storage_setup):
+async def test_ws_create(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
     """Test create WS."""
     assert await storage_setup(items=[])
 

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -3,7 +3,7 @@ import pytest
 
 from homeassistant.components import automation, zone
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -37,7 +37,7 @@ def setup_comp(hass):
     )
 
 
-async def test_if_fires_on_zone_enter(hass, calls):
+async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone enter."""
     context = Context()
     hass.states.async_set(
@@ -109,7 +109,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_zone_enter_uuid(hass, calls):
+async def test_if_fires_on_zone_enter_uuid(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone enter when device is specified by entity registry id."""
     context = Context()
 
@@ -188,7 +188,7 @@ async def test_if_fires_on_zone_enter_uuid(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_enter_on_zone_leave(hass, calls):
+async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) -> None:
     """Test for not firing on zone leave."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -219,7 +219,7 @@ async def test_if_not_fires_for_enter_on_zone_leave(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_leave(hass, calls):
+async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
     """Test for firing on zone leave."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -250,7 +250,7 @@ async def test_if_fires_on_zone_leave(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_leave_on_zone_enter(hass, calls):
+async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) -> None:
     """Test for not firing on zone enter."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.881011, "longitude": -117.234758}
@@ -281,7 +281,7 @@ async def test_if_not_fires_for_leave_on_zone_enter(hass, calls):
     assert len(calls) == 0
 
 
-async def test_zone_condition(hass, calls):
+async def test_zone_condition(hass: HomeAssistant, calls) -> None:
     """Test for zone condition."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -309,7 +309,9 @@ async def test_zone_condition(hass, calls):
     assert len(calls) == 1
 
 
-async def test_unknown_zone(hass, calls, caplog):
+async def test_unknown_zone(
+    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for firing on zone enter."""
     context = Context()
     hass.states.async_set(

--- a/tests/components/zwave_me/test_config_flow.py
+++ b/tests/components/zwave_me/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf(hass: HomeAssistant):
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf."""
     with patch(
         "homeassistant.components.zwave_me.async_setup_entry",
@@ -91,7 +91,7 @@ async def test_zeroconf(hass: HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_error_handling_zeroconf(hass: HomeAssistant):
+async def test_error_handling_zeroconf(hass: HomeAssistant) -> None:
     """Test getting proper errors from no uuid."""
     with patch("homeassistant.components.zwave_me.helpers.get_uuid", return_value=None):
         result: FlowResult = await hass.config_entries.flow.async_init(
@@ -103,7 +103,7 @@ async def test_error_handling_zeroconf(hass: HomeAssistant):
         assert result["reason"] == "no_valid_uuid_set"
 
 
-async def test_handle_error_user(hass: HomeAssistant):
+async def test_handle_error_user(hass: HomeAssistant) -> None:
     """Test getting proper errors from no uuid."""
     with patch("homeassistant.components.zwave_me.helpers.get_uuid", return_value=None):
         result = await hass.config_entries.flow.async_init(
@@ -121,7 +121,7 @@ async def test_handle_error_user(hass: HomeAssistant):
         assert result2["errors"] == {"base": "no_valid_uuid_set"}
 
 
-async def test_duplicate_user(hass: HomeAssistant):
+async def test_duplicate_user(hass: HomeAssistant) -> None:
     """Test getting proper errors from duplicate uuid."""
     entry: MockConfigEntry = MockConfigEntry(
         domain=DOMAIN,
@@ -153,7 +153,7 @@ async def test_duplicate_user(hass: HomeAssistant):
         assert result2["reason"] == "already_configured"
 
 
-async def test_duplicate_zeroconf(hass: HomeAssistant):
+async def test_duplicate_zeroconf(hass: HomeAssistant) -> None:
     """Test getting proper errors from duplicate uuid."""
     entry: MockConfigEntry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/zwave_me/test_remove_stale_devices.py
+++ b/tests/components/zwave_me/test_remove_stale_devices.py
@@ -8,6 +8,7 @@ from zwave_me_ws import ZWaveMeData
 from homeassistant.components.zwave_me import ZWaveMePlatform
 from homeassistant.const import CONF_TOKEN, CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -34,8 +35,8 @@ async def mock_connection(controller):
     ],
 )
 async def test_remove_stale_devices(
-    hass: HomeAssistant, device_registry, identifier, should_exist
-):
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, identifier, should_exist
+) -> None:
     """Test removing devices with old-format ids."""
 
     config_entry = MockConfigEntry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
