### PR TITLE
Add type hints to integration tests (zha)

### DIFF
--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import async_enable_traffic, find_entity_id
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
@@ -57,7 +58,9 @@ def zigpy_device(zigpy_device_mock):
     "zigpy.zcl.clusters.security.IasAce.client_command",
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
-async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_device):
+async def test_alarm_control_panel(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device
+) -> None:
     """Test ZHA alarm control panel platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -42,7 +42,7 @@ from homeassistant.components.zha.core.const import (
     GROUP_NAME,
 )
 from homeassistant.const import ATTR_NAME, Platform
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 
 from .conftest import (
     FIXTURE_GRP_ID,
@@ -53,6 +53,8 @@ from .conftest import (
     SIG_EP_TYPE,
 )
 from .data import BASE_CUSTOM_CONFIGURATION, CONFIG_WITH_ALARM_OPTIONS
+
+from tests.common import MockUser
 
 IEEE_SWITCH_DEVICE = "01:2d:6f:00:0a:90:69:e7"
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
@@ -145,7 +147,7 @@ async def zha_client(hass, hass_ws_client, device_switch, device_groupable):
     return await hass_ws_client(hass)
 
 
-async def test_device_clusters(hass, zha_client):
+async def test_device_clusters(hass: HomeAssistant, zha_client) -> None:
     """Test getting device cluster info."""
     await zha_client.send_json(
         {ID: 5, TYPE: "zha/devices/clusters", ATTR_IEEE: IEEE_SWITCH_DEVICE}
@@ -168,7 +170,7 @@ async def test_device_clusters(hass, zha_client):
     assert cluster_info[ATTR_NAME] == "OnOff"
 
 
-async def test_device_cluster_attributes(zha_client):
+async def test_device_cluster_attributes(zha_client) -> None:
     """Test getting device cluster attributes."""
     await zha_client.send_json(
         {
@@ -191,7 +193,7 @@ async def test_device_cluster_attributes(zha_client):
         assert attribute[ATTR_NAME] is not None
 
 
-async def test_device_cluster_commands(zha_client):
+async def test_device_cluster_commands(zha_client) -> None:
     """Test getting device cluster commands."""
     await zha_client.send_json(
         {
@@ -215,7 +217,7 @@ async def test_device_cluster_commands(zha_client):
         assert command[TYPE] is not None
 
 
-async def test_list_devices(zha_client):
+async def test_list_devices(zha_client) -> None:
     """Test getting ZHA devices."""
     await zha_client.send_json({ID: 5, TYPE: "zha/devices"})
 
@@ -248,7 +250,7 @@ async def test_list_devices(zha_client):
         assert device == device2
 
 
-async def test_get_zha_config(zha_client):
+async def test_get_zha_config(zha_client) -> None:
     """Test getting ZHA custom configuration."""
     await zha_client.send_json({ID: 5, TYPE: "zha/configuration"})
 
@@ -258,7 +260,9 @@ async def test_get_zha_config(zha_client):
     assert configuration == BASE_CUSTOM_CONFIGURATION
 
 
-async def test_get_zha_config_with_alarm(hass, zha_client, device_ias_ace):
+async def test_get_zha_config_with_alarm(
+    hass: HomeAssistant, zha_client, device_ias_ace
+) -> None:
     """Test getting ZHA custom configuration."""
     await zha_client.send_json({ID: 5, TYPE: "zha/configuration"})
 
@@ -278,7 +282,7 @@ async def test_get_zha_config_with_alarm(hass, zha_client, device_ias_ace):
     assert configuration == BASE_CUSTOM_CONFIGURATION
 
 
-async def test_update_zha_config(zha_client, zigpy_app_controller):
+async def test_update_zha_config(zha_client, zigpy_app_controller) -> None:
     """Test updating ZHA custom configuration."""
 
     configuration = deepcopy(CONFIG_WITH_ALARM_OPTIONS)
@@ -300,7 +304,7 @@ async def test_update_zha_config(zha_client, zigpy_app_controller):
         assert configuration == configuration
 
 
-async def test_device_not_found(zha_client):
+async def test_device_not_found(zha_client) -> None:
     """Test not found response from get device API."""
     await zha_client.send_json(
         {ID: 6, TYPE: "zha/device", ATTR_IEEE: "28:6d:97:00:01:04:11:8c"}
@@ -312,7 +316,7 @@ async def test_device_not_found(zha_client):
     assert msg["error"]["code"] == const.ERR_NOT_FOUND
 
 
-async def test_list_groups(zha_client):
+async def test_list_groups(zha_client) -> None:
     """Test getting ZHA zigbee groups."""
     await zha_client.send_json({ID: 7, TYPE: "zha/groups"})
 
@@ -329,7 +333,7 @@ async def test_list_groups(zha_client):
         assert group["members"] == []
 
 
-async def test_get_group(zha_client):
+async def test_get_group(zha_client) -> None:
     """Test getting a specific ZHA zigbee group."""
     await zha_client.send_json({ID: 8, TYPE: "zha/group", GROUP_ID: FIXTURE_GRP_ID})
 
@@ -344,7 +348,7 @@ async def test_get_group(zha_client):
     assert group["members"] == []
 
 
-async def test_get_group_not_found(zha_client):
+async def test_get_group_not_found(zha_client) -> None:
     """Test not found response from get group API."""
     await zha_client.send_json({ID: 9, TYPE: "zha/group", GROUP_ID: 1_234_567})
 
@@ -356,7 +360,7 @@ async def test_get_group_not_found(zha_client):
     assert msg["error"]["code"] == const.ERR_NOT_FOUND
 
 
-async def test_list_groupable_devices(zha_client, device_groupable):
+async def test_list_groupable_devices(zha_client, device_groupable) -> None:
     """Test getting ZHA devices that have a group cluster."""
 
     await zha_client.send_json({ID: 10, TYPE: "zha/devices/groupable"})
@@ -399,7 +403,7 @@ async def test_list_groupable_devices(zha_client, device_groupable):
     assert len(device_endpoints) == 0
 
 
-async def test_add_group(zha_client):
+async def test_add_group(zha_client) -> None:
     """Test adding and getting a new ZHA zigbee group."""
     await zha_client.send_json({ID: 12, TYPE: "zha/group/add", GROUP_NAME: "new_group"})
 
@@ -425,7 +429,7 @@ async def test_add_group(zha_client):
         assert group["name"] == FIXTURE_GRP_NAME or group["name"] == "new_group"
 
 
-async def test_remove_group(zha_client):
+async def test_remove_group(zha_client) -> None:
     """Test removing a new ZHA zigbee group."""
 
     await zha_client.send_json({ID: 14, TYPE: "zha/groups"})
@@ -487,8 +491,13 @@ async def app_controller(hass, setup_zha):
     ),
 )
 async def test_permit_ha12(
-    hass, app_controller, hass_admin_user, params, duration, node
-):
+    hass: HomeAssistant,
+    app_controller,
+    hass_admin_user: MockUser,
+    params,
+    duration,
+    node,
+) -> None:
     """Test permit service."""
 
     await hass.services.async_call(
@@ -522,8 +531,13 @@ IC_TEST_PARAMS = (
 
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_TEST_PARAMS)
 async def test_permit_with_install_code(
-    hass, app_controller, hass_admin_user, params, src_ieee, code
-):
+    hass: HomeAssistant,
+    app_controller,
+    hass_admin_user: MockUser,
+    params,
+    src_ieee,
+    code,
+) -> None:
     """Test permit service with install code."""
 
     await hass.services.async_call(
@@ -573,8 +587,8 @@ IC_FAIL_PARAMS = (
 
 @pytest.mark.parametrize("params", IC_FAIL_PARAMS)
 async def test_permit_with_install_code_fail(
-    hass, app_controller, hass_admin_user, params
-):
+    hass: HomeAssistant, app_controller, hass_admin_user: MockUser, params
+) -> None:
     """Test permit service with install code."""
 
     with pytest.raises(vol.Invalid):
@@ -611,8 +625,13 @@ IC_QR_CODE_TEST_PARAMS = (
 
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_permit_with_qr_code(
-    hass, app_controller, hass_admin_user, params, src_ieee, code
-):
+    hass: HomeAssistant,
+    app_controller,
+    hass_admin_user: MockUser,
+    params,
+    src_ieee,
+    code,
+) -> None:
     """Test permit service with install code from qr code."""
 
     await hass.services.async_call(
@@ -628,7 +647,7 @@ async def test_permit_with_qr_code(
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_ws_permit_with_qr_code(
     app_controller, zha_client, params, src_ieee, code
-):
+) -> None:
     """Test permit service with install code from qr code."""
 
     await zha_client.send_json(
@@ -648,7 +667,9 @@ async def test_ws_permit_with_qr_code(
 
 
 @pytest.mark.parametrize("params", IC_FAIL_PARAMS)
-async def test_ws_permit_with_install_code_fail(app_controller, zha_client, params):
+async def test_ws_permit_with_install_code_fail(
+    app_controller, zha_client, params
+) -> None:
     """Test permit ws service with install code."""
 
     await zha_client.send_json(
@@ -681,7 +702,9 @@ async def test_ws_permit_with_install_code_fail(app_controller, zha_client, para
         ),
     ),
 )
-async def test_ws_permit_ha12(app_controller, zha_client, params, duration, node):
+async def test_ws_permit_ha12(
+    app_controller, zha_client, params, duration, node
+) -> None:
     """Test permit ws service."""
 
     await zha_client.send_json(
@@ -699,7 +722,7 @@ async def test_ws_permit_ha12(app_controller, zha_client, params, duration, node
     assert app_controller.permit_with_key.call_count == 0
 
 
-async def test_get_network_settings(app_controller, zha_client):
+async def test_get_network_settings(app_controller, zha_client) -> None:
     """Test current network settings are returned."""
 
     await app_controller.backups.create_backup()
@@ -714,7 +737,7 @@ async def test_get_network_settings(app_controller, zha_client):
     assert "network_info" in msg["result"]["settings"]
 
 
-async def test_list_network_backups(app_controller, zha_client):
+async def test_list_network_backups(app_controller, zha_client) -> None:
     """Test backups are serialized."""
 
     await app_controller.backups.create_backup()
@@ -728,7 +751,7 @@ async def test_list_network_backups(app_controller, zha_client):
     assert "network_info" in msg["result"][0]
 
 
-async def test_create_network_backup(app_controller, zha_client):
+async def test_create_network_backup(app_controller, zha_client) -> None:
     """Test creating backup."""
 
     assert not app_controller.backups.backups
@@ -742,7 +765,7 @@ async def test_create_network_backup(app_controller, zha_client):
     assert "backup" in msg["result"] and "is_complete" in msg["result"]
 
 
-async def test_restore_network_backup_success(app_controller, zha_client):
+async def test_restore_network_backup_success(app_controller, zha_client) -> None:
     """Test successfully restoring a backup."""
 
     backup = zigpy.backups.NetworkBackup()
@@ -765,7 +788,9 @@ async def test_restore_network_backup_success(app_controller, zha_client):
     assert msg["success"]
 
 
-async def test_restore_network_backup_force_write_eui64(app_controller, zha_client):
+async def test_restore_network_backup_force_write_eui64(
+    app_controller, zha_client
+) -> None:
     """Test successfully restoring a backup."""
 
     backup = zigpy.backups.NetworkBackup()
@@ -796,7 +821,7 @@ async def test_restore_network_backup_force_write_eui64(app_controller, zha_clie
 
 
 @patch("zigpy.backups.NetworkBackup.from_dict", new=lambda v: v)
-async def test_restore_network_backup_failure(app_controller, zha_client):
+async def test_restore_network_backup_failure(app_controller, zha_client) -> None:
     """Test successfully restoring a backup."""
 
     with patch.object(

--- a/tests/components/zha/test_backup.py
+++ b/tests/components/zha/test_backup.py
@@ -1,11 +1,11 @@
 """Unit tests for ZHA backup platform."""
-
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.zha.backup import async_post_backup, async_pre_backup
+from homeassistant.core import HomeAssistant
 
 
-async def test_pre_backup(hass, setup_zha):
+async def test_pre_backup(hass: HomeAssistant, setup_zha) -> None:
     """Test backup creation when `async_pre_backup` is called."""
     with patch("zigpy.backups.BackupManager.create_backup", AsyncMock()) as backup_mock:
         await setup_zha()
@@ -14,7 +14,7 @@ async def test_pre_backup(hass, setup_zha):
     backup_mock.assert_called_once_with(load_devices=True)
 
 
-async def test_post_backup(hass, setup_zha):
+async def test_post_backup(hass: HomeAssistant, setup_zha) -> None:
     """Test no-op `async_post_backup`."""
     await setup_zha()
     await async_post_backup(hass)

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -7,6 +7,7 @@ import zigpy.zcl.clusters.measurement as measurement
 import zigpy.zcl.clusters.security as security
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 
 from .common import (
     async_enable_traffic,
@@ -83,14 +84,14 @@ async def async_test_iaszone_on_off(hass, cluster, entity_id):
     ],
 )
 async def test_binary_sensor(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined_restored,
     device,
     on_off_test,
     cluster_name,
     reporting,
-):
+) -> None:
     """Test ZHA binary_sensor platform."""
     zigpy_device = zigpy_device_mock(device)
     zha_device = await zha_device_joined_restored(zigpy_device)

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     EntityCategory,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import find_entity_id
@@ -120,7 +121,7 @@ async def tuya_water_valve(hass, zigpy_device_mock, zha_device_joined_restored):
 
 
 @freeze_time("2021-11-04 17:37:00", tz_offset=-1)
-async def test_button(hass, contact_sensor):
+async def test_button(hass: HomeAssistant, contact_sensor) -> None:
     """Test ZHA button platform."""
 
     entity_registry = er.async_get(hass)
@@ -160,7 +161,7 @@ async def test_button(hass, contact_sensor):
     assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.UPDATE
 
 
-async def test_frost_unlock(hass, tuya_water_valve):
+async def test_frost_unlock(hass: HomeAssistant, tuya_water_valve) -> None:
     """Test custom frost unlock ZHA button."""
 
     entity_registry = er.async_get(hass)

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -13,6 +13,7 @@ import homeassistant.components.zha.core.channels as zha_channels
 import homeassistant.components.zha.core.channels.base as base_channels
 import homeassistant.components.zha.core.const as zha_const
 import homeassistant.components.zha.core.registries as registries
+from homeassistant.core import HomeAssistant
 
 from .common import get_zha_gateway, make_zcl_header
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
@@ -234,7 +235,7 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
 )
 async def test_in_channel_config(
     cluster_id, bind_count, attrs, channel_pool, zigpy_device_mock, zha_gateway
-):
+) -> None:
     """Test ZHA core channel configuration for input clusters."""
     zigpy_dev = zigpy_device_mock(
         {1: {SIG_EP_INPUT: [cluster_id], SIG_EP_OUTPUT: [], SIG_EP_TYPE: 0x1234}},
@@ -297,7 +298,7 @@ async def test_in_channel_config(
 )
 async def test_out_channel_config(
     cluster_id, bind_count, channel_pool, zigpy_device_mock, zha_gateway
-):
+) -> None:
     """Test ZHA core channel configuration for output clusters."""
     zigpy_dev = zigpy_device_mock(
         {1: {SIG_EP_OUTPUT: [cluster_id], SIG_EP_INPUT: [], SIG_EP_TYPE: 0x1234}},
@@ -327,7 +328,7 @@ def test_channel_registry() -> None:
         assert issubclass(channel, base_channels.ZigbeeChannel)
 
 
-def test_epch_unclaimed_channels(channel):
+def test_epch_unclaimed_channels(channel) -> None:
     """Test unclaimed channels."""
 
     ch_1 = channel(zha_const.CHANNEL_ON_OFF, 6)
@@ -363,7 +364,7 @@ def test_epch_unclaimed_channels(channel):
         assert ch_3 not in available
 
 
-def test_epch_claim_channels(channel):
+def test_epch_claim_channels(channel) -> None:
     """Test channel claiming."""
 
     ch_1 = channel(zha_const.CHANNEL_ON_OFF, 6)
@@ -402,7 +403,7 @@ def test_epch_claim_channels(channel):
     "homeassistant.components.zha.core.discovery.PROBE.discover_entities",
     mock.MagicMock(),
 )
-def test_ep_channels_all_channels(m1, zha_device_mock):
+def test_ep_channels_all_channels(m1, zha_device_mock) -> None:
     """Test EndpointChannels adding all channels."""
     zha_device = zha_device_mock(
         {
@@ -453,7 +454,7 @@ def test_ep_channels_all_channels(m1, zha_device_mock):
     "homeassistant.components.zha.core.discovery.PROBE.discover_entities",
     mock.MagicMock(),
 )
-def test_channel_power_config(m1, zha_device_mock):
+def test_channel_power_config(m1, zha_device_mock) -> None:
     """Test that channels only get a single power channel."""
     in_clusters = [0, 1, 6, 8]
     zha_device = zha_device_mock(
@@ -498,7 +499,7 @@ def test_channel_power_config(m1, zha_device_mock):
     assert "2:0x0001" in pools[2].all_channels
 
 
-async def test_ep_channels_configure(channel):
+async def test_ep_channels_configure(channel) -> None:
     """Test unclaimed channels."""
 
     ch_1 = channel(zha_const.CHANNEL_ON_OFF, 6)
@@ -535,7 +536,7 @@ async def test_ep_channels_configure(channel):
     assert ch_5.warning.call_count == 2
 
 
-async def test_poll_control_configure(poll_control_ch):
+async def test_poll_control_configure(poll_control_ch) -> None:
     """Test poll control channel configuration."""
     await poll_control_ch.async_configure()
     assert poll_control_ch.cluster.write_attributes.call_count == 1
@@ -544,7 +545,7 @@ async def test_poll_control_configure(poll_control_ch):
     }
 
 
-async def test_poll_control_checkin_response(poll_control_ch):
+async def test_poll_control_checkin_response(poll_control_ch) -> None:
     """Test poll control channel checkin response."""
     rsp_mock = AsyncMock()
     set_interval_mock = AsyncMock()
@@ -569,7 +570,9 @@ async def test_poll_control_checkin_response(poll_control_ch):
     assert cluster.endpoint.request.call_args_list[1][0][0] == 0x0020
 
 
-async def test_poll_control_cluster_command(hass, poll_control_device):
+async def test_poll_control_cluster_command(
+    hass: HomeAssistant, poll_control_device
+) -> None:
     """Test poll control channel response to cluster command."""
     checkin_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
@@ -598,7 +601,9 @@ async def test_poll_control_cluster_command(hass, poll_control_device):
     assert data["device_id"] == poll_control_device.device_id
 
 
-async def test_poll_control_ignore_list(hass, poll_control_device):
+async def test_poll_control_ignore_list(
+    hass: HomeAssistant, poll_control_device
+) -> None:
     """Test poll control channel ignore list."""
     set_long_poll_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
@@ -617,7 +622,7 @@ async def test_poll_control_ignore_list(hass, poll_control_device):
     assert set_long_poll_mock.call_count == 0
 
 
-async def test_poll_control_ikea(hass, poll_control_device):
+async def test_poll_control_ikea(hass: HomeAssistant, poll_control_device) -> None:
     """Test poll control channel ignore list for ikea."""
     set_long_poll_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
@@ -644,7 +649,7 @@ def zigpy_zll_device(zigpy_device_mock):
 
 async def test_zll_device_groups(
     zigpy_zll_device, channel_pool, zigpy_coordinator_device
-):
+) -> None:
     """Test adding coordinator to ZLL groups."""
 
     cluster = zigpy_zll_device.endpoints[1].lightlink
@@ -710,7 +715,7 @@ async def test_zll_device_groups(
     "homeassistant.components.zha.core.discovery.PROBE.discover_entities",
     mock.MagicMock(),
 )
-async def test_cluster_no_ep_attribute(m1, zha_device_mock):
+async def test_cluster_no_ep_attribute(m1, zha_device_mock) -> None:
     """Test channels for clusters without ep_attribute."""
 
     zha_device = zha_device_mock(

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import async_enable_traffic, find_entity_id, send_attributes_report
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
@@ -276,7 +277,7 @@ def test_sequence_mappings() -> None:
             assert Thermostat.SystemMode(HVAC_MODE_2_SYSTEM[hvac_mode]) is not None
 
 
-async def test_climate_local_temperature(hass, device_climate):
+async def test_climate_local_temperature(hass: HomeAssistant, device_climate) -> None:
     """Test local temperature."""
 
     thrm_cluster = device_climate.device.endpoints[1].thermostat
@@ -290,7 +291,9 @@ async def test_climate_local_temperature(hass, device_climate):
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.0
 
 
-async def test_climate_hvac_action_running_state(hass, device_climate_sinope):
+async def test_climate_hvac_action_running_state(
+    hass: HomeAssistant, device_climate_sinope
+) -> None:
     """Test hvac action via running state."""
 
     thrm_cluster = device_climate_sinope.device.endpoints[1].thermostat
@@ -353,7 +356,9 @@ async def test_climate_hvac_action_running_state(hass, device_climate_sinope):
     assert hvac_sensor_state.state == HVACAction.FAN
 
 
-async def test_climate_hvac_action_running_state_zen(hass, device_climate_zen):
+async def test_climate_hvac_action_running_state_zen(
+    hass: HomeAssistant, device_climate_zen
+) -> None:
     """Test Zen hvac action via running state."""
 
     thrm_cluster = device_climate_zen.device.endpoints[1].thermostat
@@ -438,7 +443,9 @@ async def test_climate_hvac_action_running_state_zen(hass, device_climate_zen):
     assert hvac_sensor_state.state == HVACAction.IDLE
 
 
-async def test_climate_hvac_action_pi_demand(hass, device_climate):
+async def test_climate_hvac_action_pi_demand(
+    hass: HomeAssistant, device_climate
+) -> None:
     """Test hvac action based on pi_heating/cooling_demand attrs."""
 
     thrm_cluster = device_climate.device.endpoints[1].thermostat
@@ -485,7 +492,9 @@ async def test_climate_hvac_action_pi_demand(hass, device_climate):
         (Thermostat.SystemMode.Dry, HVACMode.DRY),
     ),
 )
-async def test_hvac_mode(hass, device_climate, sys_mode, hvac_mode):
+async def test_hvac_mode(
+    hass: HomeAssistant, device_climate, sys_mode, hvac_mode
+) -> None:
     """Test HVAC mode."""
 
     thrm_cluster = device_climate.device.endpoints[1].thermostat
@@ -521,7 +530,9 @@ async def test_hvac_mode(hass, device_climate, sys_mode, hvac_mode):
         (0x05, {HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL}),
     ),
 )
-async def test_hvac_modes(hass, device_climate_mock, seq_of_op, modes):
+async def test_hvac_modes(
+    hass: HomeAssistant, device_climate_mock, seq_of_op, modes
+) -> None:
     """Test HVAC modes from sequence of operations."""
 
     device_climate = await device_climate_mock(
@@ -542,8 +553,8 @@ async def test_hvac_modes(hass, device_climate_mock, seq_of_op, modes):
     ),
 )
 async def test_target_temperature(
-    hass, device_climate_mock, sys_mode, preset, target_temp
-):
+    hass: HomeAssistant, device_climate_mock, sys_mode, preset, target_temp
+) -> None:
     """Test target temperature property."""
 
     device_climate = await device_climate_mock(
@@ -580,8 +591,8 @@ async def test_target_temperature(
     ),
 )
 async def test_target_temperature_high(
-    hass, device_climate_mock, preset, unoccupied, target_temp
-):
+    hass: HomeAssistant, device_climate_mock, preset, unoccupied, target_temp
+) -> None:
     """Test target temperature high property."""
 
     device_climate = await device_climate_mock(
@@ -616,8 +627,8 @@ async def test_target_temperature_high(
     ),
 )
 async def test_target_temperature_low(
-    hass, device_climate_mock, preset, unoccupied, target_temp
-):
+    hass: HomeAssistant, device_climate_mock, preset, unoccupied, target_temp
+) -> None:
     """Test target temperature low property."""
 
     device_climate = await device_climate_mock(
@@ -654,7 +665,9 @@ async def test_target_temperature_low(
         (HVACMode.HEAT_COOL, Thermostat.SystemMode.Auto),
     ),
 )
-async def test_set_hvac_mode(hass, device_climate, hvac_mode, sys_mode):
+async def test_set_hvac_mode(
+    hass: HomeAssistant, device_climate, hvac_mode, sys_mode
+) -> None:
     """Test setting hvac mode."""
 
     thrm_cluster = device_climate.device.endpoints[1].thermostat
@@ -696,7 +709,7 @@ async def test_set_hvac_mode(hass, device_climate, hvac_mode, sys_mode):
     }
 
 
-async def test_preset_setting(hass, device_climate_sinope):
+async def test_preset_setting(hass: HomeAssistant, device_climate_sinope) -> None:
     """Test preset setting."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_sinope, hass)
@@ -774,7 +787,9 @@ async def test_preset_setting(hass, device_climate_sinope):
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 1}
 
 
-async def test_preset_setting_invalid(hass, device_climate_sinope):
+async def test_preset_setting_invalid(
+    hass: HomeAssistant, device_climate_sinope
+) -> None:
     """Test invalid preset setting."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_sinope, hass)
@@ -795,7 +810,7 @@ async def test_preset_setting_invalid(hass, device_climate_sinope):
     assert thrm_cluster.write_attributes.call_count == 0
 
 
-async def test_set_temperature_hvac_mode(hass, device_climate):
+async def test_set_temperature_hvac_mode(hass: HomeAssistant, device_climate) -> None:
     """Test setting HVAC mode in temperature service call."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate, hass)
@@ -823,7 +838,9 @@ async def test_set_temperature_hvac_mode(hass, device_climate):
     }
 
 
-async def test_set_temperature_heat_cool(hass, device_climate_mock):
+async def test_set_temperature_heat_cool(
+    hass: HomeAssistant, device_climate_mock
+) -> None:
     """Test setting temperature service call in heating/cooling HVAC mode."""
 
     device_climate = await device_climate_mock(
@@ -909,7 +926,7 @@ async def test_set_temperature_heat_cool(hass, device_climate_mock):
     }
 
 
-async def test_set_temperature_heat(hass, device_climate_mock):
+async def test_set_temperature_heat(hass: HomeAssistant, device_climate_mock) -> None:
     """Test setting temperature service call in heating HVAC mode."""
 
     device_climate = await device_climate_mock(
@@ -988,7 +1005,7 @@ async def test_set_temperature_heat(hass, device_climate_mock):
     }
 
 
-async def test_set_temperature_cool(hass, device_climate_mock):
+async def test_set_temperature_cool(hass: HomeAssistant, device_climate_mock) -> None:
     """Test setting temperature service call in cooling HVAC mode."""
 
     device_climate = await device_climate_mock(
@@ -1067,7 +1084,9 @@ async def test_set_temperature_cool(hass, device_climate_mock):
     }
 
 
-async def test_set_temperature_wrong_mode(hass, device_climate_mock):
+async def test_set_temperature_wrong_mode(
+    hass: HomeAssistant, device_climate_mock
+) -> None:
     """Test setting temperature service call for wrong HVAC mode."""
 
     with patch.object(
@@ -1106,7 +1125,7 @@ async def test_set_temperature_wrong_mode(hass, device_climate_mock):
     assert thrm_cluster.write_attributes.await_count == 0
 
 
-async def test_occupancy_reset(hass, device_climate_sinope):
+async def test_occupancy_reset(hass: HomeAssistant, device_climate_sinope) -> None:
     """Test away preset reset."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_sinope, hass)
@@ -1133,7 +1152,7 @@ async def test_occupancy_reset(hass, device_climate_sinope):
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
 
 
-async def test_fan_mode(hass, device_climate_fan):
+async def test_fan_mode(hass: HomeAssistant, device_climate_fan) -> None:
     """Test fan mode."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_fan, hass)
@@ -1162,7 +1181,9 @@ async def test_fan_mode(hass, device_climate_fan):
     assert state.attributes[ATTR_FAN_MODE] == FAN_ON
 
 
-async def test_set_fan_mode_not_supported(hass, device_climate_fan):
+async def test_set_fan_mode_not_supported(
+    hass: HomeAssistant, device_climate_fan
+) -> None:
     """Test fan setting unsupported mode."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_fan, hass)
@@ -1177,7 +1198,7 @@ async def test_set_fan_mode_not_supported(hass, device_climate_fan):
     assert fan_cluster.write_attributes.await_count == 0
 
 
-async def test_set_fan_mode(hass, device_climate_fan):
+async def test_set_fan_mode(hass: HomeAssistant, device_climate_fan) -> None:
     """Test fan mode setting."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_fan, hass)
@@ -1206,7 +1227,7 @@ async def test_set_fan_mode(hass, device_climate_fan):
     assert fan_cluster.write_attributes.call_args[0][0] == {"fan_mode": 5}
 
 
-async def test_set_moes_preset(hass, device_climate_moes):
+async def test_set_moes_preset(hass: HomeAssistant, device_climate_moes) -> None:
     """Test setting preset for moes trv."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_moes, hass)
@@ -1321,7 +1342,9 @@ async def test_set_moes_preset(hass, device_climate_moes):
     }
 
 
-async def test_set_moes_operation_mode(hass, device_climate_moes):
+async def test_set_moes_operation_mode(
+    hass: HomeAssistant, device_climate_moes
+) -> None:
     """Test setting preset for moes trv."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_moes, hass)
@@ -1363,7 +1386,9 @@ async def test_set_moes_operation_mode(hass, device_climate_moes):
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_COMPLEX
 
 
-async def test_set_zonnsmart_preset(hass, device_climate_zonnsmart):
+async def test_set_zonnsmart_preset(
+    hass: HomeAssistant, device_climate_zonnsmart
+) -> None:
     """Test setting preset from homeassistant for zonnsmart trv."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_zonnsmart, hass)
@@ -1430,7 +1455,9 @@ async def test_set_zonnsmart_preset(hass, device_climate_zonnsmart):
     }
 
 
-async def test_set_zonnsmart_operation_mode(hass, device_climate_zonnsmart):
+async def test_set_zonnsmart_operation_mode(
+    hass: HomeAssistant, device_climate_zonnsmart
+) -> None:
     """Test setting preset from trv for zonnsmart trv."""
 
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate_zonnsmart, hass)

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -168,7 +168,7 @@ async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}")
-async def test_zigate_via_zeroconf(setup_entry_mock, hass):
+async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> None:
     """Test zeroconf flow -- zigate radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         host="192.168.1.200",
@@ -412,7 +412,7 @@ async def test_discovery_via_usb(hass: HomeAssistant) -> None:
 
 
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}", return_value=True)
-async def test_zigate_discovery_via_usb(probe_mock, hass):
+async def test_zigate_discovery_via_usb(probe_mock, hass: HomeAssistant) -> None:
     """Test zigate usb flow -- radio detected."""
     discovery_info = usb.UsbServiceInfo(
         device="/dev/ttyZIGBEE",
@@ -455,7 +455,7 @@ async def test_zigate_discovery_via_usb(probe_mock, hass):
 
 
 @patch(f"bellows.{PROBE_FUNCTION_PATH}", return_value=False)
-async def test_discovery_via_usb_no_radio(probe_mock, hass):
+async def test_discovery_via_usb_no_radio(probe_mock, hass: HomeAssistant) -> None:
     """Test usb flow -- no radio detected."""
     discovery_info = usb.UsbServiceInfo(
         device="/dev/null",
@@ -780,7 +780,7 @@ async def test_user_flow_manual(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("radio_type", RadioType.list())
-async def test_pick_radio_flow(hass, radio_type):
+async def test_pick_radio_flow(hass: HomeAssistant, radio_type) -> None:
     """Test radio picker."""
 
     result = await hass.config_entries.flow.async_init(
@@ -810,8 +810,8 @@ async def test_user_flow_existing_config_entry(hass: HomeAssistant) -> None:
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}", return_value=False)
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", return_value=True)
 async def test_detect_radio_type_success(
-    znp_probe, zigate_probe, deconz_probe, bellows_probe, hass
-):
+    znp_probe, zigate_probe, deconz_probe, bellows_probe, hass: HomeAssistant
+) -> None:
     """Test detect radios successfully."""
 
     handler = config_flow.ZhaConfigFlowHandler()
@@ -838,8 +838,8 @@ async def test_detect_radio_type_success(
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}", return_value=False)
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", return_value=False)
 async def test_detect_radio_type_success_with_settings(
-    znp_probe, zigate_probe, deconz_probe, bellows_probe, hass
-):
+    znp_probe, zigate_probe, deconz_probe, bellows_probe, hass: HomeAssistant
+) -> None:
     """Test detect radios successfully but probing returns new settings."""
 
     handler = config_flow.ZhaConfigFlowHandler()
@@ -859,7 +859,7 @@ async def test_detect_radio_type_success_with_settings(
 
 
 @patch(f"bellows.{PROBE_FUNCTION_PATH}", return_value=False)
-async def test_user_port_config_fail(probe_mock, hass):
+async def test_user_port_config_fail(probe_mock, hass: HomeAssistant) -> None:
     """Test port config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -880,7 +880,7 @@ async def test_user_port_config_fail(probe_mock, hass):
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"bellows.{PROBE_FUNCTION_PATH}", return_value=True)
-async def test_user_port_config(probe_mock, hass):
+async def test_user_port_config(probe_mock, hass: HomeAssistant) -> None:
     """Test port config."""
 
     result = await hass.config_entries.flow.async_init(
@@ -920,7 +920,9 @@ async def test_user_port_config(probe_mock, hass):
         ("deconz", "deconz"),
     ],
 )
-async def test_migration_ti_cc_to_znp(old_type, new_type, hass, config_entry):
+async def test_migration_ti_cc_to_znp(
+    old_type, new_type, hass: HomeAssistant, config_entry
+) -> None:
     """Test zigpy-cc to zigpy-znp config migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -948,7 +950,7 @@ async def test_migration_ti_cc_to_znp(old_type, new_type, hass, config_entry):
 
 @pytest.mark.parametrize("onboarded", [True, False])
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_hardware(onboarded, hass):
+async def test_hardware(onboarded, hass: HomeAssistant) -> None:
     """Test hardware flow."""
     data = {
         "name": "Yellow",
@@ -1026,7 +1028,7 @@ async def test_hardware_already_setup(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "data", (None, {}, {"radio_type": "best_radio"}, {"radio_type": "efr32"})
 )
-async def test_hardware_invalid_data(hass, data):
+async def test_hardware_invalid_data(hass: HomeAssistant, data) -> None:
     """Test onboarding flow -- invalid data."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1090,7 +1092,9 @@ def pick_radio(hass):
         yield wrapper
 
 
-async def test_strategy_no_network_settings(pick_radio, mock_app, hass):
+async def test_strategy_no_network_settings(
+    pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test formation strategy when no network settings are present."""
     mock_app.load_network_info = MagicMock(side_effect=NetworkNotFormed())
 
@@ -1101,7 +1105,9 @@ async def test_strategy_no_network_settings(pick_radio, mock_app, hass):
     )
 
 
-async def test_formation_strategy_form_new_network(pick_radio, mock_app, hass):
+async def test_formation_strategy_form_new_network(
+    pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test forming a new network."""
     result, port = await pick_radio(RadioType.ezsp)
 
@@ -1117,7 +1123,9 @@ async def test_formation_strategy_form_new_network(pick_radio, mock_app, hass):
     assert result2["type"] == FlowResultType.CREATE_ENTRY
 
 
-async def test_formation_strategy_form_initial_network(pick_radio, mock_app, hass):
+async def test_formation_strategy_form_initial_network(
+    pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test forming a new network, with no previous settings on the radio."""
     mock_app.load_network_info = AsyncMock(side_effect=NetworkNotFormed())
 
@@ -1135,7 +1143,9 @@ async def test_formation_strategy_form_initial_network(pick_radio, mock_app, has
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_onboarding_auto_formation_new_hardware(mock_app, hass):
+async def test_onboarding_auto_formation_new_hardware(
+    mock_app, hass: HomeAssistant
+) -> None:
     """Test auto network formation with new hardware during onboarding."""
     mock_app.load_network_info = AsyncMock(side_effect=NetworkNotFormed())
     discovery_info = usb.UsbServiceInfo(
@@ -1167,7 +1177,9 @@ async def test_onboarding_auto_formation_new_hardware(mock_app, hass):
     }
 
 
-async def test_formation_strategy_reuse_settings(pick_radio, mock_app, hass):
+async def test_formation_strategy_reuse_settings(
+    pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test reusing existing network settings."""
     result, port = await pick_radio(RadioType.ezsp)
 
@@ -1184,7 +1196,7 @@ async def test_formation_strategy_reuse_settings(pick_radio, mock_app, hass):
 
 
 @patch("homeassistant.components.zha.config_flow.process_uploaded_file")
-def test_parse_uploaded_backup(process_mock):
+def test_parse_uploaded_backup(process_mock) -> None:
     """Test parsing uploaded backup files."""
     backup = zigpy.backups.NetworkBackup()
 
@@ -1199,8 +1211,8 @@ def test_parse_uploaded_backup(process_mock):
 
 @patch("homeassistant.components.zha.radio_manager._allow_overwrite_ezsp_ieee")
 async def test_formation_strategy_restore_manual_backup_non_ezsp(
-    allow_overwrite_ieee_mock, pick_radio, mock_app, hass
-):
+    allow_overwrite_ieee_mock, pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test restoring a manual backup on non-EZSP coordinators."""
     result, port = await pick_radio(RadioType.znp)
 
@@ -1231,8 +1243,8 @@ async def test_formation_strategy_restore_manual_backup_non_ezsp(
 
 @patch("homeassistant.components.zha.radio_manager._allow_overwrite_ezsp_ieee")
 async def test_formation_strategy_restore_manual_backup_overwrite_ieee_ezsp(
-    allow_overwrite_ieee_mock, pick_radio, mock_app, backup, hass
-):
+    allow_overwrite_ieee_mock, pick_radio, mock_app, backup, hass: HomeAssistant
+) -> None:
     """Test restoring a manual backup on EZSP coordinators (overwrite IEEE)."""
     result, port = await pick_radio(RadioType.ezsp)
 
@@ -1271,8 +1283,8 @@ async def test_formation_strategy_restore_manual_backup_overwrite_ieee_ezsp(
 
 @patch("homeassistant.components.zha.radio_manager._allow_overwrite_ezsp_ieee")
 async def test_formation_strategy_restore_manual_backup_ezsp(
-    allow_overwrite_ieee_mock, pick_radio, mock_app, hass
-):
+    allow_overwrite_ieee_mock, pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test restoring a manual backup on EZSP coordinators (don't overwrite IEEE)."""
     result, port = await pick_radio(RadioType.ezsp)
 
@@ -1312,8 +1324,8 @@ async def test_formation_strategy_restore_manual_backup_ezsp(
 
 
 async def test_formation_strategy_restore_manual_backup_invalid_upload(
-    pick_radio, mock_app, hass
-):
+    pick_radio, mock_app, hass: HomeAssistant
+) -> None:
     """Test restoring a manual backup but an invalid file is uploaded."""
     result, port = await pick_radio(RadioType.ezsp)
 
@@ -1364,8 +1376,8 @@ def test_format_backup_choice() -> None:
 )
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_formation_strategy_restore_automatic_backup_ezsp(
-    pick_radio, mock_app, make_backup, hass
-):
+    pick_radio, mock_app, make_backup, hass: HomeAssistant
+) -> None:
     """Test restoring an automatic backup (EZSP radio)."""
     mock_app.backups.backups = [
         make_backup(),
@@ -1413,8 +1425,8 @@ async def test_formation_strategy_restore_automatic_backup_ezsp(
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @pytest.mark.parametrize("is_advanced", [True, False])
 async def test_formation_strategy_restore_automatic_backup_non_ezsp(
-    is_advanced, pick_radio, mock_app, make_backup, hass
-):
+    is_advanced, pick_radio, mock_app, make_backup, hass: HomeAssistant
+) -> None:
     """Test restoring an automatic backup (non-EZSP radio)."""
     mock_app.backups.backups = [
         make_backup(backup_time_offset=5),
@@ -1466,8 +1478,8 @@ async def test_formation_strategy_restore_automatic_backup_non_ezsp(
 
 @patch("homeassistant.components.zha.radio_manager._allow_overwrite_ezsp_ieee")
 async def test_ezsp_restore_without_settings_change_ieee(
-    allow_overwrite_ieee_mock, pick_radio, mock_app, backup, hass
-):
+    allow_overwrite_ieee_mock, pick_radio, mock_app, backup, hass: HomeAssistant
+) -> None:
     """Test a manual backup on EZSP coordinators without settings (no IEEE write)."""
     # Fail to load settings
     with patch.object(
@@ -1523,7 +1535,9 @@ async def test_ezsp_restore_without_settings_change_ieee(
     ),
 )
 @patch("homeassistant.components.zha.async_setup_entry", return_value=True)
-async def test_options_flow_defaults(async_setup_entry, async_unload_effect, hass):
+async def test_options_flow_defaults(
+    async_setup_entry, async_unload_effect, hass: HomeAssistant
+) -> None:
     """Test options flow defaults match radio defaults."""
 
     entry = MockConfigEntry(
@@ -1710,7 +1724,9 @@ async def test_options_flow_defaults_socket(hass: HomeAssistant) -> None:
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch("homeassistant.components.zha.async_setup_entry", return_value=True)
-async def test_options_flow_restarts_running_zha_if_cancelled(async_setup_entry, hass):
+async def test_options_flow_restarts_running_zha_if_cancelled(
+    async_setup_entry, hass: HomeAssistant
+) -> None:
     """Test options flow restarts a previously-running ZHA if it's cancelled."""
 
     entry = MockConfigEntry(
@@ -1763,7 +1779,9 @@ async def test_options_flow_restarts_running_zha_if_cancelled(async_setup_entry,
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_options_flow_migration_reset_old_adapter(hass, mock_app):
+async def test_options_flow_migration_reset_old_adapter(
+    hass: HomeAssistant, mock_app
+) -> None:
     """Test options flow for migrating from an old radio."""
 
     entry = MockConfigEntry(

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, HomeAssistant, State
 
 from .common import (
     async_enable_traffic,
@@ -120,7 +120,9 @@ def zigpy_keen_vent(zigpy_device_mock):
     )
 
 
-async def test_cover(hass, zha_device_joined_restored, zigpy_cover_device):
+async def test_cover(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_cover_device
+) -> None:
     """Test ZHA cover platform."""
 
     # load up cover domain
@@ -211,7 +213,9 @@ async def test_cover(hass, zha_device_joined_restored, zigpy_cover_device):
     assert hass.states.get(entity_id).state == STATE_OPEN
 
 
-async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
+async def test_shade(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_shade_device
+) -> None:
     """Test ZHA cover platform for shade device type."""
 
     # load up cover domain
@@ -338,7 +342,9 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
         assert cluster_level.request.call_args[0][1] in (0x0003, 0x0007)
 
 
-async def test_restore_state(hass, zha_device_restored, zigpy_shade_device):
+async def test_restore_state(
+    hass: HomeAssistant, zha_device_restored, zigpy_shade_device
+) -> None:
     """Ensure states are restored on startup."""
 
     mock_restore_cache(
@@ -363,7 +369,9 @@ async def test_restore_state(hass, zha_device_restored, zigpy_shade_device):
     assert hass.states.get(entity_id).attributes[ATTR_CURRENT_POSITION] == 50
 
 
-async def test_keen_vent(hass, zha_device_joined_restored, zigpy_keen_vent):
+async def test_keen_vent(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_keen_vent
+) -> None:
     """Test keen vent."""
 
     # load up cover domain
@@ -417,7 +425,9 @@ async def test_keen_vent(hass, zha_device_joined_restored, zigpy_keen_vent):
         assert hass.states.get(entity_id).attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_cover_remote(hass, zha_device_joined_restored, zigpy_cover_remote):
+async def test_cover_remote(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_cover_remote
+) -> None:
     """Test ZHA cover remote."""
 
     # load up cover domain

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -16,6 +16,7 @@ from homeassistant.components.zha.core.const import (
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
 )
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.device_registry as dr
 import homeassistant.util.dt as dt_util
 
@@ -128,8 +129,8 @@ def _send_time_changed(hass, seconds):
     new=mock.AsyncMock(),
 )
 async def test_check_available_success(
-    hass, device_with_basic_channel, zha_device_restored
-):
+    hass: HomeAssistant, device_with_basic_channel, zha_device_restored
+) -> None:
     """Check device availability success on 1st try."""
     zha_device = await zha_device_restored(device_with_basic_channel)
     await async_enable_traffic(hass, [zha_device])
@@ -180,8 +181,8 @@ async def test_check_available_success(
     new=mock.AsyncMock(),
 )
 async def test_check_available_unsuccessful(
-    hass, device_with_basic_channel, zha_device_restored
-):
+    hass: HomeAssistant, device_with_basic_channel, zha_device_restored
+) -> None:
     """Check device availability all tries fail."""
 
     zha_device = await zha_device_restored(device_with_basic_channel)
@@ -222,8 +223,11 @@ async def test_check_available_unsuccessful(
     new=mock.AsyncMock(),
 )
 async def test_check_available_no_basic_channel(
-    hass, device_without_basic_channel, zha_device_restored, caplog
-):
+    hass: HomeAssistant,
+    device_without_basic_channel,
+    zha_device_restored,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Check device availability for a device without basic cluster."""
     caplog.set_level(logging.DEBUG, logger="homeassistant.components.zha")
 
@@ -243,7 +247,7 @@ async def test_check_available_no_basic_channel(
     assert "does not have a mandatory basic cluster" in caplog.text
 
 
-async def test_ota_sw_version(hass, ota_zha_device):
+async def test_ota_sw_version(hass: HomeAssistant, ota_zha_device) -> None:
     """Test device entry gets sw_version updated via OTA channel."""
 
     ota_ch = ota_zha_device.channels.pools[0].client_channels["1:0x0019"]
@@ -303,8 +307,13 @@ async def test_ota_sw_version(hass, ota_zha_device):
     ),
 )
 async def test_device_restore_availability(
-    hass, request, device, last_seen_delta, is_available, zha_device_restored
-):
+    hass: HomeAssistant,
+    request,
+    device,
+    last_seen_delta,
+    is_available,
+    zha_device_restored,
+) -> None:
     """Test initial availability for restored devices."""
 
     zigpy_device = request.getfixturevalue(device)()
@@ -323,7 +332,9 @@ async def test_device_restore_availability(
         assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_device_is_active_coordinator(hass, zha_device_joined, zigpy_device):
+async def test_device_is_active_coordinator(
+    hass: HomeAssistant, zha_device_joined, zigpy_device
+) -> None:
     """Test that the current coordinator is uniquely detected."""
 
     current_coord_dev = zigpy_device(ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000)

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -12,6 +12,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.zha import DOMAIN
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -101,7 +102,7 @@ async def device_inovelli(hass, zigpy_device_mock, zha_device_joined):
     return zigpy_device, zha_device
 
 
-async def test_get_actions(hass, device_ias):
+async def test_get_actions(hass: HomeAssistant, device_ias) -> None:
     """Test we get the expected actions from a ZHA device."""
 
     ieee_address = str(device_ias[0].ieee)
@@ -150,7 +151,7 @@ async def test_get_actions(hass, device_ias):
     assert_lists_same(actions, expected_actions)
 
 
-async def test_get_inovelli_actions(hass, device_inovelli):
+async def test_get_inovelli_actions(hass: HomeAssistant, device_inovelli) -> None:
     """Test we get the expected actions from a ZHA device."""
 
     inovelli_ieee_address = str(device_inovelli[0].ieee)
@@ -230,7 +231,7 @@ async def test_get_inovelli_actions(hass, device_inovelli):
     assert_lists_same(actions, expected_actions)
 
 
-async def test_action(hass, device_ias, device_inovelli):
+async def test_action(hass: HomeAssistant, device_ias, device_inovelli) -> None:
     """Test for executing a ZHA device action."""
     zigpy_device, zha_device = device_ias
     inovelli_zigpy_device, inovelli_zha_device = device_inovelli
@@ -346,7 +347,7 @@ async def test_action(hass, device_ias, device_inovelli):
         )
 
 
-async def test_invalid_zha_event_type(hass, device_ias):
+async def test_invalid_zha_event_type(hass: HomeAssistant, device_ias) -> None:
     """Test that unexpected types are not passed to `zha_send_event`."""
     zigpy_device, zha_device = device_ias
     channel = zha_device.channels.pools[0].client_channels["1:0x0006"]

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -12,6 +12,7 @@ from homeassistant.components.zha.core.registries import (
     SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE,
 )
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .common import (
@@ -62,7 +63,9 @@ def zigpy_device_dt(zigpy_device_mock):
     return zigpy_device_mock(endpoints)
 
 
-async def test_device_tracker(hass, zha_device_joined_restored, zigpy_device_dt):
+async def test_device_tracker(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device_dt
+) -> None:
     """Test ZHA device tracker platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device_dt)

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -10,6 +10,7 @@ import zigpy.zcl.clusters.general as general
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -82,7 +83,7 @@ async def mock_devices(hass, zigpy_device_mock, zha_device_joined_restored):
     return zigpy_device, zha_device
 
 
-async def test_triggers(hass, mock_devices):
+async def test_triggers(hass: HomeAssistant, mock_devices) -> None:
     """Test ZHA device triggers."""
 
     zigpy_device, zha_device = mock_devices
@@ -157,7 +158,7 @@ async def test_triggers(hass, mock_devices):
     assert _same_lists(triggers, expected_triggers)
 
 
-async def test_no_triggers(hass, mock_devices):
+async def test_no_triggers(hass: HomeAssistant, mock_devices) -> None:
     """Test ZHA device with no triggers."""
 
     _, zha_device = mock_devices
@@ -181,7 +182,7 @@ async def test_no_triggers(hass, mock_devices):
     ]
 
 
-async def test_if_fires_on_event(hass, mock_devices, calls):
+async def test_if_fires_on_event(hass: HomeAssistant, mock_devices, calls) -> None:
     """Test for remote triggers firing."""
 
     zigpy_device, zha_device = mock_devices
@@ -231,8 +232,8 @@ async def test_if_fires_on_event(hass, mock_devices, calls):
 
 
 async def test_device_offline_fires(
-    hass, zigpy_device_mock, zha_device_restored, calls
-):
+    hass: HomeAssistant, zigpy_device_mock, zha_device_restored, calls
+) -> None:
     """Test for device offline triggers firing."""
 
     zigpy_device = zigpy_device_mock(
@@ -296,7 +297,9 @@ async def test_device_offline_fires(
     assert calls[0].data["message"] == "service called"
 
 
-async def test_exception_no_triggers(hass, mock_devices, calls, caplog):
+async def test_exception_no_triggers(
+    hass: HomeAssistant, mock_devices, calls, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for exception when validating device triggers."""
 
     _, zha_device = mock_devices
@@ -333,7 +336,9 @@ async def test_exception_no_triggers(hass, mock_devices, calls, caplog):
     )
 
 
-async def test_exception_bad_trigger(hass, mock_devices, calls, caplog):
+async def test_exception_bad_trigger(
+    hass: HomeAssistant, mock_devices, calls, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for exception when validating device triggers."""
 
     zigpy_device, zha_device = mock_devices

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -1,6 +1,4 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
-
-
 from unittest.mock import patch
 
 import pytest
@@ -20,6 +18,7 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 CONFIG_ENTRY_DIAGNOSTICS_KEYS = [
     "config",
@@ -56,11 +55,11 @@ def zigpy_device(zigpy_device_mock):
 
 async def test_diagnostics_for_config_entry(
     hass: HomeAssistant,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     config_entry,
     zha_device_joined,
     zigpy_device,
-):
+) -> None:
     """Test diagnostics for config entry."""
     await zha_device_joined(zigpy_device)
     diagnostics_data = await get_diagnostics_for_config_entry(
@@ -74,11 +73,11 @@ async def test_diagnostics_for_config_entry(
 
 async def test_diagnostics_for_device(
     hass: HomeAssistant,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     config_entry,
     zha_device_joined,
     zigpy_device,
-):
+) -> None:
     """Test diagnostics for device."""
 
     zha_device: ZHADevice = await zha_device_joined(zigpy_device)

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -1,5 +1,4 @@
 """Test ZHA device discovery."""
-
 import re
 from unittest import mock
 from unittest.mock import AsyncMock, Mock, patch
@@ -28,6 +27,7 @@ import homeassistant.components.zha.lock
 import homeassistant.components.zha.sensor
 import homeassistant.components.zha.switch
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry
 
 from .common import get_zha_gateway
@@ -102,7 +102,7 @@ async def test_devices(
     hass_disable_services,
     zigpy_device_mock,
     zha_device_joined_restored,
-):
+) -> None:
     """Test device discovery."""
     entity_registry = homeassistant.helpers.entity_registry.async_get(
         hass_disable_services
@@ -219,7 +219,7 @@ def _get_first_identify_cluster(zigpy_device):
 @mock.patch(
     "homeassistant.components.zha.core.discovery.ProbeEndpoint.discover_by_cluster_id"
 )
-def test_discover_entities(m1, m2):
+def test_discover_entities(m1, m2) -> None:
     """Test discover endpoint class method."""
     ep_channels = mock.MagicMock()
     disc.PROBE.discover_entities(ep_channels)
@@ -238,7 +238,7 @@ def test_discover_entities(m1, m2):
         (0xFFFF, None, False),
     ],
 )
-def test_discover_by_device_type(device_type, component, hit):
+def test_discover_by_device_type(device_type, component, hit) -> None:
     """Test entity discovery by device type."""
 
     ep_channels = mock.MagicMock(spec_set=zha_channels.ChannelPool)
@@ -319,7 +319,9 @@ def test_discover_probe_single_cluster() -> None:
 
 
 @pytest.mark.parametrize("device_info", DEVICES)
-async def test_discover_endpoint(device_info, channels_mock, hass):
+async def test_discover_endpoint(
+    device_info, channels_mock, hass: HomeAssistant
+) -> None:
     """Test device discovery."""
 
     with mock.patch(
@@ -449,7 +451,7 @@ def test_single_input_cluster_device_class_by_cluster_class() -> None:
 )
 async def test_device_override(
     hass_disable_services, zigpy_device_mock, setup_zha, override, entity_id
-):
+) -> None:
     """Test device discovery override."""
 
     zigpy_device = zigpy_device_mock(
@@ -481,7 +483,7 @@ async def test_device_override(
 
 async def test_group_probe_cleanup_called(
     hass_disable_services, setup_zha, config_entry
-):
+) -> None:
     """Test cleanup happens when ZHA is unloaded."""
     await setup_zha()
     disc.GROUP_PROBE.cleanup = mock.Mock(wraps=disc.GROUP_PROBE.cleanup)
@@ -502,7 +504,7 @@ async def test_channel_with_empty_ep_attribute_cluster(
     hass_disable_services,
     zigpy_device_mock,
     zha_device_joined_restored,
-):
+) -> None:
     """Test device discovery for cluster which does not have em_attribute."""
     entity_registry = homeassistant.helpers.entity_registry.async_get(
         hass_disable_services

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -159,7 +160,9 @@ async def device_fan_2(hass, zigpy_device_mock, zha_device_joined):
     return zha_device
 
 
-async def test_fan(hass, zha_device_joined_restored, zigpy_device):
+async def test_fan(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device
+) -> None:
     """Test ZHA fan platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)
@@ -274,7 +277,9 @@ async def async_set_preset_mode(hass, entity_id, preset_mode=None):
     "homeassistant.components.zha.entity.DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY",
     new=0,
 )
-async def test_zha_group_fan_entity(hass, device_fan_1, device_fan_2, coordinator):
+async def test_zha_group_fan_entity(
+    hass: HomeAssistant, device_fan_1, device_fan_2, coordinator
+) -> None:
     """Test the fan entity for a ZHA group."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -387,8 +392,12 @@ async def test_zha_group_fan_entity(hass, device_fan_1, device_fan_2, coordinato
     new=0,
 )
 async def test_zha_group_fan_entity_failure_state(
-    hass, device_fan_1, device_fan_2, coordinator, caplog
-):
+    hass: HomeAssistant,
+    device_fan_1,
+    device_fan_2,
+    coordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test the fan entity for a ZHA group when writing attributes generates an exception."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -453,13 +462,13 @@ async def test_zha_group_fan_entity_failure_state(
     ),
 )
 async def test_fan_init(
-    hass,
+    hass: HomeAssistant,
     zha_device_joined_restored,
     zigpy_device,
     plug_read,
     expected_state,
     expected_percentage,
-):
+) -> None:
     """Test ZHA fan platform."""
 
     cluster = zigpy_device.endpoints.get(1).fan
@@ -474,10 +483,10 @@ async def test_fan_init(
 
 
 async def test_fan_update_entity(
-    hass,
+    hass: HomeAssistant,
     zha_device_joined_restored,
     zigpy_device,
-):
+) -> None:
     """Test ZHA fan platform."""
 
     cluster = zigpy_device.endpoints.get(1).fan
@@ -547,7 +556,9 @@ def zigpy_device_ikea(zigpy_device_mock):
     )
 
 
-async def test_fan_ikea(hass, zha_device_joined_restored, zigpy_device_ikea):
+async def test_fan_ikea(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device_ikea
+) -> None:
     """Test ZHA fan Ikea platform."""
     zha_device = await zha_device_joined_restored(zigpy_device_ikea)
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
@@ -632,14 +643,14 @@ async def test_fan_ikea(hass, zha_device_joined_restored, zigpy_device_ikea):
     ),
 )
 async def test_fan_ikea_init(
-    hass,
+    hass: HomeAssistant,
     zha_device_joined_restored,
     zigpy_device_ikea,
     ikea_plug_read,
     ikea_expected_state,
     ikea_expected_percentage,
     ikea_preset_mode,
-):
+) -> None:
     """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = ikea_plug_read
@@ -656,10 +667,10 @@ async def test_fan_ikea_init(
 
 
 async def test_fan_ikea_update_entity(
-    hass,
+    hass: HomeAssistant,
     zha_device_joined_restored,
     zigpy_device_ikea,
-):
+) -> None:
     """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -10,6 +10,7 @@ import zigpy.zcl.clusters.lighting as lighting
 
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .common import async_find_group_entity_id, get_zha_gateway
@@ -130,7 +131,7 @@ async def device_light_2(hass, zigpy_device_mock, zha_device_joined):
     return zha_device
 
 
-async def test_device_left(hass, zigpy_dev_basic, zha_dev_basic):
+async def test_device_left(hass: HomeAssistant, zigpy_dev_basic, zha_dev_basic) -> None:
     """Device leaving the network should become unavailable."""
 
     assert zha_dev_basic.available is True
@@ -140,7 +141,9 @@ async def test_device_left(hass, zigpy_dev_basic, zha_dev_basic):
     assert zha_dev_basic.available is False
 
 
-async def test_gateway_group_methods(hass, device_light_1, device_light_2, coordinator):
+async def test_gateway_group_methods(
+    hass: HomeAssistant, device_light_1, device_light_2, coordinator
+) -> None:
     """Test creating a group with 2 members."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -197,7 +200,9 @@ async def test_gateway_group_methods(hass, device_light_1, device_light_2, coord
             assert member.device.ieee in [device_light_1.ieee]
 
 
-async def test_gateway_create_group_with_id(hass, device_light_1, coordinator):
+async def test_gateway_create_group_with_id(
+    hass: HomeAssistant, device_light_1, coordinator
+) -> None:
     """Test creating a group with a specific ID."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -232,7 +237,9 @@ async def test_gateway_create_group_with_id(hass, device_light_1, coordinator):
         [MagicMock()],
     ],
 )
-async def test_gateway_initialize_success(startup, hass, device_light_1, coordinator):
+async def test_gateway_initialize_success(
+    startup, hass: HomeAssistant, device_light_1, coordinator
+) -> None:
     """Test ZHA initializing the gateway successfully."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -248,7 +255,9 @@ async def test_gateway_initialize_success(startup, hass, device_light_1, coordin
 
 
 @patch("homeassistant.components.zha.core.gateway.STARTUP_FAILURE_DELAY_S", 0.01)
-async def test_gateway_initialize_failure(hass, device_light_1, coordinator):
+async def test_gateway_initialize_failure(
+    hass: HomeAssistant, device_light_1, coordinator
+) -> None:
     """Test ZHA failing to initialize the gateway."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -263,7 +272,9 @@ async def test_gateway_initialize_failure(hass, device_light_1, coordinator):
 
 
 @patch("homeassistant.components.zha.core.gateway.STARTUP_FAILURE_DELAY_S", 0.01)
-async def test_gateway_initialize_failure_transient(hass, device_light_1, coordinator):
+async def test_gateway_initialize_failure_transient(
+    hass: HomeAssistant, device_light_1, coordinator
+) -> None:
     """Test ZHA failing to initialize the gateway but with a transient error."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -14,6 +14,7 @@ from homeassistant.components.zha.core.helpers import (
     convert_to_zcl_values,
 )
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 
 from .common import async_enable_traffic
@@ -67,7 +68,7 @@ async def device_light(hass, zigpy_device_mock, zha_device_joined):
     return color_cluster, zha_device
 
 
-async def test_zcl_schema_conversions(hass, device_light):
+async def test_zcl_schema_conversions(hass: HomeAssistant, device_light) -> None:
     """Test ZHA ZCL schema conversion helpers."""
     color_cluster, zha_device = device_light
     await async_enable_traffic(hass, [zha_device])

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -1,5 +1,4 @@
 """Tests for ZHA integration init."""
-
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -12,6 +11,7 @@ from homeassistant.components.zha.core.const import (
     DOMAIN,
 )
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -39,7 +39,9 @@ def config_entry_v1(hass):
 
 @pytest.mark.parametrize("config", ({}, {DOMAIN: {}}))
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_migration_from_v1_no_baudrate(hass, config_entry_v1, config):
+async def test_migration_from_v1_no_baudrate(
+    hass: HomeAssistant, config_entry_v1, config
+) -> None:
     """Test migration of config entry from v1."""
     config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, config)
@@ -53,7 +55,9 @@ async def test_migration_from_v1_no_baudrate(hass, config_entry_v1, config):
 
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
+async def test_migration_from_v1_with_baudrate(
+    hass: HomeAssistant, config_entry_v1
+) -> None:
     """Test migration of config entry from v1 with baudrate in config."""
     config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115200}})
@@ -68,7 +72,9 @@ async def test_migration_from_v1_with_baudrate(hass, config_entry_v1):
 
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_migration_from_v1_wrong_baudrate(hass, config_entry_v1):
+async def test_migration_from_v1_wrong_baudrate(
+    hass: HomeAssistant, config_entry_v1
+) -> None:
     """Test migration of config entry from v1 with wrong baudrate."""
     config_entry_v1.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_BAUDRATE: 115222}})
@@ -94,7 +100,7 @@ async def test_migration_from_v1_wrong_baudrate(hass, config_entry_v1):
         {CONF_RADIO_TYPE: "ezsp", CONF_USB_PATH: "str"},
     ),
 )
-async def test_config_depreciation(hass, zha_config):
+async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
     """Test config option depreciation."""
 
     with patch(

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -22,6 +22,7 @@ from homeassistant.components.zha.core.const import (
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.components.zha.light import FLASH_EFFECTS
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .common import (
@@ -253,7 +254,9 @@ async def eWeLink_light(hass, zigpy_device_mock, zha_device_joined):
     return zha_device
 
 
-async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored):
+async def test_light_refresh(
+    hass: HomeAssistant, zigpy_device_mock, zha_device_joined_restored
+) -> None:
     """Test ZHA light platform refresh."""
 
     # create zigpy devices
@@ -312,8 +315,12 @@ async def test_light_refresh(hass, zigpy_device_mock, zha_device_joined_restored
     [(LIGHT_ON_OFF, (1, 0, 0)), (LIGHT_LEVEL, (1, 1, 0)), (LIGHT_COLOR, (1, 1, 6))],
 )
 async def test_light(
-    hass, zigpy_device_mock, zha_device_joined_restored, device, reporting
-):
+    hass: HomeAssistant,
+    zigpy_device_mock,
+    zha_device_joined_restored,
+    device,
+    reporting,
+) -> None:
     """Test ZHA light platform."""
 
     # create zigpy devices
@@ -422,13 +429,13 @@ async def test_light(
     ],
 )
 async def test_light_initialization(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined_restored,
     plugged_attr_reads,
     config_override,
     expected_state,
-):
+) -> None:
     """Test ZHA light initialization with cached attributes and color modes."""
 
     # create zigpy devices
@@ -463,8 +470,8 @@ async def test_light_initialization(
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 async def test_transitions(
-    hass, device_light_1, device_light_2, eWeLink_light, coordinator
-):
+    hass: HomeAssistant, device_light_1, device_light_2, eWeLink_light, coordinator
+) -> None:
     """Test ZHA light transition code."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -1212,7 +1219,7 @@ async def test_transitions(
     "zigpy.zcl.clusters.general.OnOff.request",
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
-async def test_on_with_off_color(hass, device_light_1):
+async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
     """Test turning on the light and sending color commands before on/level commands for supporting lights."""
 
     device_1_entity_id = await find_entity_id(Platform.LIGHT, device_light_1, hass)
@@ -1561,8 +1568,8 @@ async def async_test_flash_from_hass(hass, cluster, entity_id, flash):
     new=0,
 )
 async def test_zha_group_light_entity(
-    hass, device_light_1, device_light_2, device_light_3, coordinator
-):
+    hass: HomeAssistant, device_light_1, device_light_2, device_light_3, coordinator
+) -> None:
     """Test the light entity for a ZHA group."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -1790,13 +1797,13 @@ async def test_zha_group_light_entity(
     new=0,
 )
 async def test_group_member_assume_state(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined,
     coordinator,
     device_light_1,
     device_light_2,
-):
+) -> None:
     """Test the group members assume state function."""
     with patch_zha_config(
         "light", {(ZHA_OPTIONS, CONF_GROUP_MEMBERS_ASSUME_STATE): True}

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_UNLOCKED,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import async_enable_traffic, find_entity_id, send_attributes_report
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
@@ -59,7 +60,7 @@ async def lock(hass, zigpy_device_mock, zha_device_joined_restored):
     return zha_device, zigpy_device.endpoints[1].door_lock
 
 
-async def test_lock(hass, lock):
+async def test_lock(hass: HomeAssistant, lock) -> None:
     """Test ZHA lock platform."""
 
     zha_device, cluster = lock

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -1,5 +1,4 @@
 """ZHA logbook describe events tests."""
-
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +7,7 @@ import zigpy.zcl.clusters.general as general
 
 from homeassistant.components.zha.core.const import ZHA_EVENT
 from homeassistant.const import CONF_DEVICE_ID, CONF_UNIQUE_ID, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -59,7 +59,9 @@ async def mock_devices(hass, zigpy_device_mock, zha_device_joined):
     return zigpy_device, zha_device
 
 
-async def test_zha_logbook_event_device_with_triggers(hass, mock_devices):
+async def test_zha_logbook_event_device_with_triggers(
+    hass: HomeAssistant, mock_devices
+) -> None:
     """Test ZHA logbook events with device and triggers."""
 
     zigpy_device, zha_device = mock_devices
@@ -144,7 +146,9 @@ async def test_zha_logbook_event_device_with_triggers(hass, mock_devices):
     )
 
 
-async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
+async def test_zha_logbook_event_device_no_triggers(
+    hass: HomeAssistant, mock_devices
+) -> None:
     """Test ZHA logbook events with device and without triggers."""
 
     zigpy_device, zha_device = mock_devices
@@ -231,7 +235,9 @@ async def test_zha_logbook_event_device_no_triggers(hass, mock_devices):
     assert events[3]["message"] == "Zha Event was fired"
 
 
-async def test_zha_logbook_event_device_no_device(hass, mock_devices):
+async def test_zha_logbook_event_device_no_device(
+    hass: HomeAssistant, mock_devices
+) -> None:
     """Test ZHA logbook events without device and without triggers."""
 
     hass.config.components.add("recorder")

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -10,6 +10,7 @@ import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -81,7 +82,9 @@ async def light(zigpy_device_mock):
     return zigpy_device
 
 
-async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_device):
+async def test_number(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_analog_output_device
+) -> None:
     """Test ZHA number platform."""
 
     cluster = zigpy_analog_output_device.endpoints.get(1).analog_output
@@ -197,8 +200,8 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     ),
 )
 async def test_level_control_number(
-    hass, light, zha_device_joined, attr, initial_value, new_value
-):
+    hass: HomeAssistant, light, zha_device_joined, attr, initial_value, new_value
+) -> None:
     """Test ZHA level control number entities - new join."""
 
     entity_registry = er.async_get(hass)
@@ -330,8 +333,8 @@ async def test_level_control_number(
     (("start_up_color_temperature", 500, 350),),
 )
 async def test_color_number(
-    hass, light, zha_device_joined, attr, initial_value, new_value
-):
+    hass: HomeAssistant, light, zha_device_joined, attr, initial_value, new_value
+) -> None:
     """Test ZHA color number entities - new join."""
 
     entity_registry = er.async_get(hass)

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 import homeassistant.components.zha.core.registries as registries
+from homeassistant.helpers import entity_registry as er
 
 MANUFACTURER = "mock manufacturer"
 MODEL = "mock model"
@@ -125,7 +126,7 @@ def channels(channel):
         ),
     ],
 )
-def test_registry_matching(rule, matched, channels):
+def test_registry_matching(rule, matched, channels) -> None:
     """Test strict rule matching."""
     assert rule.strict_matched(MANUFACTURER, MODEL, channels) is matched
 
@@ -208,12 +209,12 @@ def test_registry_matching(rule, matched, channels):
         ),
     ],
 )
-def test_registry_loose_matching(rule, matched, channels):
+def test_registry_loose_matching(rule, matched, channels) -> None:
     """Test loose rule matching."""
     assert rule.loose_matched(MANUFACTURER, MODEL, channels) is matched
 
 
-def test_match_rule_claim_channels_color(channel):
+def test_match_rule_claim_channels_color(channel) -> None:
     """Test channel claiming."""
     ch_color = channel("color", 0x300)
     ch_level = channel("level", 8)
@@ -245,7 +246,7 @@ def test_match_rule_claim_channels_color(channel):
         (registries.MatchRule(channel_names={"color"}), set()),
     ],
 )
-def test_match_rule_claim_channels(rule, match, channel, channels):
+def test_match_rule_claim_channels(rule, match, channel, channels) -> None:
     """Test channel claiming."""
     ch_basic = channel("basic", 0)
     channels.append(ch_basic)
@@ -272,7 +273,9 @@ def entity_registry():
         (MANUFACTURER, "some model", "OnOffMultimodel"),
     ),
 )
-def test_weighted_match(channel, entity_registry, manufacturer, model, match_name):
+def test_weighted_match(
+    channel, entity_registry: er.EntityRegistry, manufacturer, model, match_name
+) -> None:
     """Test weightedd match."""
 
     s = mock.sentinel
@@ -316,7 +319,7 @@ def test_weighted_match(channel, entity_registry, manufacturer, model, match_nam
     assert claimed == [ch_on_off]
 
 
-def test_multi_sensor_match(channel, entity_registry):
+def test_multi_sensor_match(channel, entity_registry: er.EntityRegistry) -> None:
     """Test multi-entity match."""
 
     s = mock.sentinel

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -1,5 +1,4 @@
 """Test ZHA select entities."""
-
 from unittest.mock import call, patch
 
 import pytest
@@ -9,6 +8,7 @@ import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.security as security
 
 from homeassistant.const import STATE_UNKNOWN, EntityCategory, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, restore_state
 from homeassistant.util import dt as dt_util
 
@@ -107,7 +107,7 @@ def core_rs(hass_storage):
     return _storage
 
 
-async def test_select(hass, siren):
+async def test_select(hass: HomeAssistant, siren) -> None:
     """Test ZHA select platform."""
 
     entity_registry = er.async_get(hass)
@@ -155,11 +155,11 @@ async def test_select(hass, siren):
 
 
 async def test_select_restore_state(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     core_rs,
     zha_device_restored,
-):
+) -> None:
     """Test ZHA select entity restore state."""
 
     entity_id = "select.fakemanufacturer_fakemodel_default_siren_tone"
@@ -192,7 +192,9 @@ async def test_select_restore_state(
     assert state.state == security.IasWd.Warning.WarningMode.Burglar.name
 
 
-async def test_on_off_select_new_join(hass, light, zha_device_joined):
+async def test_on_off_select_new_join(
+    hass: HomeAssistant, light, zha_device_joined
+) -> None:
     """Test ZHA on off select - new join."""
 
     entity_registry = er.async_get(hass)
@@ -251,7 +253,9 @@ async def test_on_off_select_new_join(hass, light, zha_device_joined):
     assert state.state == general.OnOff.StartUpOnOff.Off.name
 
 
-async def test_on_off_select_restored(hass, light, zha_device_restored):
+async def test_on_off_select_restored(
+    hass: HomeAssistant, light, zha_device_restored
+) -> None:
     """Test ZHA on off select - restored."""
 
     entity_registry = er.async_get(hass)
@@ -303,7 +307,9 @@ async def test_on_off_select_restored(hass, light, zha_device_restored):
     assert entity_entry.entity_category == EntityCategory.CONFIG
 
 
-async def test_on_off_select_unsupported(hass, light, zha_device_joined_restored):
+async def test_on_off_select_unsupported(
+    hass: HomeAssistant, light, zha_device_joined_restored
+) -> None:
     """Test ZHA on off select unsupported."""
 
     on_off_cluster = light.endpoints[1].on_off

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfVolume,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import restore_state
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import dt as dt_util
@@ -409,7 +410,7 @@ async def async_test_device_temperature(hass, cluster, entity_id):
     ),
 )
 async def test_sensor(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined_restored,
     cluster_id,
@@ -418,7 +419,7 @@ async def test_sensor(
     report_count,
     read_plug,
     unsupported_attrs,
-):
+) -> None:
     """Test ZHA sensor platform."""
 
     zigpy_device = zigpy_device_mock(
@@ -537,7 +538,7 @@ async def test_temp_uom(
     core_rs,
     zigpy_device_mock,
     zha_device_restored,
-):
+) -> None:
     """Test ZHA temperature sensor unit of measurement."""
 
     entity_id = "sensor.fake1026_fakemodel1026_004f3202_temperature"
@@ -586,10 +587,10 @@ async def test_temp_uom(
 
 
 async def test_electrical_measurement_init(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined,
-):
+) -> None:
     """Test proper initialization of the electrical measurement cluster."""
 
     cluster_id = homeautomation.ElectricalMeasurement.cluster_id
@@ -716,14 +717,14 @@ async def test_electrical_measurement_init(
     ),
 )
 async def test_unsupported_attributes_sensor(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined_restored,
     cluster_id,
     unsupported_attributes,
     entity_ids,
     missing_entity_ids,
-):
+) -> None:
     """Test ZHA sensor platform."""
 
     entity_ids = {ENTITY_ID_PREFIX.format(e) for e in entity_ids}
@@ -831,14 +832,14 @@ async def test_unsupported_attributes_sensor(
     ),
 )
 async def test_se_summation_uom(
-    hass,
+    hass: HomeAssistant,
     zigpy_device_mock,
     zha_device_joined,
     raw_uom,
     raw_value,
     expected_state,
     expected_uom,
-):
+) -> None:
     """Test ZHA smart energy summation."""
 
     entity_id = ENTITY_ID_PREFIX.format("summation_delivered")
@@ -890,12 +891,12 @@ async def test_se_summation_uom(
     ),
 )
 async def test_elec_measurement_sensor_type(
-    hass,
+    hass: HomeAssistant,
     elec_measurement_zigpy_dev,
     raw_measurement_type,
     expected_type,
     zha_device_joined,
-):
+) -> None:
     """Test ZHA electrical measurement sensor type."""
 
     entity_id = ENTITY_ID_PREFIX.format("active_power")
@@ -941,10 +942,10 @@ async def test_elec_measurement_sensor_type(
     ),
 )
 async def test_elec_measurement_skip_unsupported_attribute(
-    hass,
+    hass: HomeAssistant,
     elec_measurement_zha_dev,
     supported_attributes,
-):
+) -> None:
     """Test ZHA electrical measurement skipping update of unsupported attributes."""
 
     entity_id = ENTITY_ID_PREFIX.format("active_power")

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -20,6 +20,7 @@ from homeassistant.components.zha.core.const import (
     WARNING_DEVICE_SOUND_MEDIUM,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .common import async_enable_traffic, find_entity_id
@@ -63,7 +64,7 @@ async def siren(hass, zigpy_device_mock, zha_device_joined_restored):
     return zha_device, zigpy_device.endpoints[1].ias_wd
 
 
-async def test_siren(hass, siren):
+async def test_siren(hass: HomeAssistant, siren) -> None:
     """Test zha siren platform."""
 
     zha_device, cluster = siren

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -20,6 +20,7 @@ import zigpy.zcl.foundation as zcl_f
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -130,7 +131,9 @@ async def device_switch_2(hass, zigpy_device_mock, zha_device_joined):
     return zha_device
 
 
-async def test_switch(hass, zha_device_joined_restored, zigpy_device):
+async def test_switch(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device
+) -> None:
     """Test ZHA switch platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device)
@@ -261,8 +264,8 @@ async def zigpy_device_tuya(hass, zigpy_device_mock, zha_device_joined):
     new=0,
 )
 async def test_zha_group_switch_entity(
-    hass, device_switch_1, device_switch_2, coordinator
-):
+    hass: HomeAssistant, device_switch_1, device_switch_2, coordinator
+) -> None:
     """Test the switch entity for a ZHA group."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -376,7 +379,9 @@ async def test_zha_group_switch_entity(
     assert hass.states.get(entity_id).state == STATE_ON
 
 
-async def test_switch_configurable(hass, zha_device_joined_restored, zigpy_device_tuya):
+async def test_switch_configurable(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_device_tuya
+) -> None:
     """Test ZHA configurable switch platform."""
 
     zha_device = await zha_device_joined_restored(zigpy_device_tuya)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
