### PR TITLE
Add type hints to integration tests (zwave_js)

### DIFF
--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -77,7 +77,11 @@ from homeassistant.components.zwave_js.const import (
     DOMAIN,
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockUser
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 def get_device(hass, node):
@@ -88,8 +92,13 @@ def get_device(hass, node):
 
 
 async def test_no_driver(
-    hass, client, multisensor_6, controller_state, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    controller_state,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test driver missing results in error."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -108,8 +117,12 @@ async def test_no_driver(
 
 
 async def test_network_status(
-    hass, multisensor_6, controller_state, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    controller_state,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the network status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -226,12 +239,12 @@ async def test_network_status(
 
 
 async def test_subscribe_node_status(
-    hass,
+    hass: HomeAssistant,
     multisensor_6_state,
     client,
     integration,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the subscribe node status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -294,7 +307,9 @@ async def test_subscribe_node_status(
     assert msg["event"]["ready"]
 
 
-async def test_node_status(hass, multisensor_6, integration, hass_ws_client):
+async def test_node_status(
+    hass: HomeAssistant, multisensor_6, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the node status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -350,7 +365,12 @@ async def test_node_status(hass, multisensor_6, integration, hass_ws_client):
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_node_metadata(hass, wallmote_central_scene, integration, hass_ws_client):
+async def test_node_metadata(
+    hass: HomeAssistant,
+    wallmote_central_scene,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the node metadata websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -425,7 +445,12 @@ async def test_node_metadata(hass, wallmote_central_scene, integration, hass_ws_
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_node_comments(hass, wallmote_central_scene, integration, hass_ws_client):
+async def test_node_comments(
+    hass: HomeAssistant,
+    wallmote_central_scene,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the node comments websocket command."""
     ws_client = await hass_ws_client(hass)
 
@@ -446,8 +471,12 @@ async def test_node_comments(hass, wallmote_central_scene, integration, hass_ws_
 
 
 async def test_add_node(
-    hass, nortek_thermostat_added_event, integration, client, hass_ws_client
-):
+    hass: HomeAssistant,
+    nortek_thermostat_added_event,
+    integration,
+    client,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the add_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -857,7 +886,9 @@ async def test_add_node(
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_grant_security_classes(hass, integration, client, hass_ws_client):
+async def test_grant_security_classes(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the grant_security_classes websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -902,7 +933,9 @@ async def test_grant_security_classes(hass, integration, client, hass_ws_client)
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_validate_dsk_and_enter_pin(hass, integration, client, hass_ws_client):
+async def test_validate_dsk_and_enter_pin(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the validate_dsk_and_enter_pin websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -945,7 +978,9 @@ async def test_validate_dsk_and_enter_pin(hass, integration, client, hass_ws_cli
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_provision_smart_start_node(hass, integration, client, hass_ws_client):
+async def test_provision_smart_start_node(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test provision_smart_start_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1127,7 +1162,9 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_unprovision_smart_start_node(hass, integration, client, hass_ws_client):
+async def test_unprovision_smart_start_node(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test unprovision_smart_start_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1229,7 +1266,9 @@ async def test_unprovision_smart_start_node(hass, integration, client, hass_ws_c
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_get_provisioning_entries(hass, integration, client, hass_ws_client):
+async def test_get_provisioning_entries(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test get_provisioning_entries websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1294,7 +1333,9 @@ async def test_get_provisioning_entries(hass, integration, client, hass_ws_clien
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
+async def test_parse_qr_code_string(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test parse_qr_code_string websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1390,7 +1431,9 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_supports_feature(hass, integration, client, hass_ws_client):
+async def test_supports_feature(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test supports_feature websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1411,7 +1454,9 @@ async def test_supports_feature(hass, integration, client, hass_ws_client):
     assert msg["result"] == {"supported": True}
 
 
-async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_client):
+async def test_cancel_inclusion_exclusion(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test cancelling the inclusion and exclusion process."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1490,13 +1535,13 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
 
 
 async def test_remove_node(
-    hass,
+    hass: HomeAssistant,
     integration,
     client,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     nortek_thermostat,
     nortek_thermostat_removed_event,
-):
+) -> None:
     """Test the remove_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1601,14 +1646,14 @@ async def test_remove_node(
 
 
 async def test_replace_failed_node(
-    hass,
+    hass: HomeAssistant,
     nortek_thermostat,
     integration,
     client,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     nortek_thermostat_added_event,
     nortek_thermostat_removed_event,
-):
+) -> None:
     """Test the replace_failed_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -1950,14 +1995,14 @@ async def test_replace_failed_node(
 
 
 async def test_remove_failed_node(
-    hass,
+    hass: HomeAssistant,
     nortek_thermostat,
     integration,
     client,
-    hass_ws_client,
+    hass_ws_client: WebSocketGenerator,
     nortek_thermostat_removed_event,
     nortek_thermostat_added_event,
-):
+) -> None:
     """Test the remove_failed_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2037,11 +2082,11 @@ async def test_remove_failed_node(
 
 
 async def test_begin_healing_network(
-    hass,
+    hass: HomeAssistant,
     integration,
     client,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the begin_healing_network websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2096,8 +2141,8 @@ async def test_begin_healing_network(
 
 
 async def test_subscribe_heal_network_progress(
-    hass, integration, client, hass_ws_client
-):
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the subscribe_heal_network_progress command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2146,8 +2191,8 @@ async def test_subscribe_heal_network_progress(
 
 
 async def test_subscribe_heal_network_progress_initial_value(
-    hass, integration, client, hass_ws_client
-):
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test subscribe_heal_network_progress command when heal network in progress."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2179,11 +2224,11 @@ async def test_subscribe_heal_network_progress_initial_value(
 
 
 async def test_stop_healing_network(
-    hass,
+    hass: HomeAssistant,
     integration,
     client,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the stop_healing_network websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2238,12 +2283,12 @@ async def test_stop_healing_network(
 
 
 async def test_heal_node(
-    hass,
+    hass: HomeAssistant,
     multisensor_6,
     integration,
     client,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the heal_node websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2299,8 +2344,12 @@ async def test_heal_node(
 
 
 async def test_refresh_node_info(
-    hass, client, multisensor_6, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the refresh_node_info WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2423,8 +2472,12 @@ async def test_refresh_node_info(
 
 
 async def test_refresh_node_values(
-    hass, client, multisensor_6, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the refresh_node_values WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2496,8 +2549,12 @@ async def test_refresh_node_values(
 
 
 async def test_refresh_node_cc_values(
-    hass, multisensor_6, client, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    client,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the refresh_node_cc_values WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2587,8 +2644,12 @@ async def test_refresh_node_cc_values(
 
 
 async def test_set_config_parameter(
-    hass, multisensor_6, client, hass_ws_client, integration
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    client,
+    hass_ws_client: WebSocketGenerator,
+    integration,
+) -> None:
     """Test the set_config_parameter service."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2772,7 +2833,9 @@ async def test_set_config_parameter(
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_get_config_parameters(hass, multisensor_6, integration, hass_ws_client):
+async def test_get_config_parameters(
+    hass: HomeAssistant, multisensor_6, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the get config parameters websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -2831,8 +2894,12 @@ async def test_get_config_parameters(hass, multisensor_6, integration, hass_ws_c
 
 
 async def test_firmware_upload_view(
-    hass, multisensor_6, integration, hass_client, firmware_file
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    hass_client: ClientSessionGenerator,
+    firmware_file,
+) -> None:
     """Test the HTTP firmware upload view."""
     client = await hass_client()
     device = get_device(hass, multisensor_6)
@@ -2857,8 +2924,12 @@ async def test_firmware_upload_view(
 
 
 async def test_firmware_upload_view_failed_command(
-    hass, multisensor_6, integration, hass_client, firmware_file
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    hass_client: ClientSessionGenerator,
+    firmware_file,
+) -> None:
     """Test failed command for the HTTP firmware upload view."""
     client = await hass_client()
     device = get_device(hass, multisensor_6)
@@ -2874,8 +2945,8 @@ async def test_firmware_upload_view_failed_command(
 
 
 async def test_firmware_upload_view_invalid_payload(
-    hass, multisensor_6, integration, hass_client
-):
+    hass: HomeAssistant, multisensor_6, integration, hass_client: ClientSessionGenerator
+) -> None:
     """Test an invalid payload for the HTTP firmware upload view."""
     device = get_device(hass, multisensor_6)
     client = await hass_client()
@@ -2891,8 +2962,14 @@ async def test_firmware_upload_view_invalid_payload(
     [("post", "/api/zwave_js/firmware/upload/{}")],
 )
 async def test_node_view_non_admin_user(
-    hass, multisensor_6, integration, hass_client, hass_admin_user, method, url
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    method,
+    url,
+) -> None:
     """Test node level views for non-admin users."""
     client = await hass_client()
     device = get_device(hass, multisensor_6)
@@ -2909,8 +2986,13 @@ async def test_node_view_non_admin_user(
     ],
 )
 async def test_view_unloaded_config_entry(
-    hass, multisensor_6, integration, hass_client, method, url
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    hass_client: ClientSessionGenerator,
+    method,
+    url,
+) -> None:
     """Test an unloaded config entry raises Bad Request."""
     client = await hass_client()
     device = get_device(hass, multisensor_6)
@@ -2923,14 +3005,18 @@ async def test_view_unloaded_config_entry(
     ("method", "url"),
     [("post", "/api/zwave_js/firmware/upload/INVALID")],
 )
-async def test_view_invalid_device_id(integration, hass_client, method, url):
+async def test_view_invalid_device_id(
+    integration, hass_client: ClientSessionGenerator, method, url
+) -> None:
     """Test an invalid device id parameter."""
     client = await hass_client()
     resp = await client.request(method, url.format(integration.entry_id))
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
+async def test_subscribe_log_updates(
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the subscribe_log_updates websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3033,7 +3119,9 @@ async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_update_log_config(hass, client, integration, hass_ws_client):
+async def test_update_log_config(
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the update_log_config WS API call works and that schema validation works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3189,7 +3277,9 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_get_log_config(hass, client, integration, hass_ws_client):
+async def test_get_log_config(
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the get_log_config WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3230,7 +3320,9 @@ async def test_get_log_config(hass, client, integration, hass_ws_client):
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
-async def test_data_collection(hass, client, integration, hass_ws_client):
+async def test_data_collection(
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the data collection WS API commands work."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3368,8 +3460,12 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
 
 
 async def test_abort_firmware_update(
-    hass, client, multisensor_6, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the abort_firmware_update WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3440,8 +3536,12 @@ async def test_abort_firmware_update(
 
 
 async def test_is_node_firmware_update_in_progress(
-    hass, client, multisensor_6, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the is_firmware_update_in_progress WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3500,8 +3600,12 @@ async def test_is_node_firmware_update_in_progress(
 
 
 async def test_subscribe_firmware_update_status(
-    hass, multisensor_6, integration, client, hass_ws_client
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    integration,
+    client,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the subscribe_firmware_update_status websocket command."""
     ws_client = await hass_ws_client(hass)
     device = get_device(hass, multisensor_6)
@@ -3574,8 +3678,12 @@ async def test_subscribe_firmware_update_status(
 
 
 async def test_subscribe_firmware_update_status_initial_value(
-    hass, multisensor_6, client, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    client,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test subscribe_firmware_update_status websocket command with in progress update."""
     ws_client = await hass_ws_client(hass)
     device = get_device(hass, multisensor_6)
@@ -3626,8 +3734,12 @@ async def test_subscribe_firmware_update_status_initial_value(
 
 
 async def test_subscribe_firmware_update_status_failures(
-    hass, multisensor_6, client, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    multisensor_6,
+    client,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test failures for the subscribe_firmware_update_status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3663,8 +3775,12 @@ async def test_subscribe_firmware_update_status_failures(
 
 
 async def test_get_node_firmware_update_capabilities(
-    hass, client, multisensor_6, integration, hass_ws_client
-):
+    hass: HomeAssistant,
+    client,
+    multisensor_6,
+    integration,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test that the get_node_firmware_update_capabilities WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3748,8 +3864,8 @@ async def test_get_node_firmware_update_capabilities(
 
 
 async def test_is_any_ota_firmware_update_in_progress(
-    hass, client, integration, hass_ws_client
-):
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the is_any_ota_firmware_update_in_progress WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3818,7 +3934,9 @@ async def test_is_any_ota_firmware_update_in_progress(
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
 
-async def test_check_for_config_updates(hass, client, integration, hass_ws_client):
+async def test_check_for_config_updates(
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the check_for_config_updates WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3891,7 +4009,9 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
 
-async def test_install_config_update(hass, client, integration, hass_ws_client):
+async def test_install_config_update(
+    hass: HomeAssistant, client, integration, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that the install_config_update WS API call works."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -3957,8 +4077,8 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
 
 
 async def test_subscribe_controller_statistics(
-    hass, integration, client, hass_ws_client
-):
+    hass: HomeAssistant, integration, client, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test the subscribe_controller_statistics command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -4056,14 +4176,14 @@ async def test_subscribe_controller_statistics(
 
 
 async def test_subscribe_node_statistics(
-    hass,
+    hass: HomeAssistant,
     multisensor_6,
     wallmote_central_scene,
     zen_31,
     integration,
     client,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test the subscribe_node_statistics command."""
     entry = integration
     ws_client = await hass_ws_client(hass)

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -25,7 +25,9 @@ from .common import (
 from tests.common import MockConfigEntry
 
 
-async def test_low_battery_sensor(hass, multisensor_6, integration):
+async def test_low_battery_sensor(
+    hass: HomeAssistant, multisensor_6, integration
+) -> None:
     """Test boolean binary sensor of type low battery."""
     state = hass.states.get(LOW_BATTERY_BINARY_SENSOR)
 
@@ -40,7 +42,9 @@ async def test_low_battery_sensor(hass, multisensor_6, integration):
     assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
-async def test_enabled_legacy_sensor(hass, ecolink_door_sensor, integration):
+async def test_enabled_legacy_sensor(
+    hass: HomeAssistant, ecolink_door_sensor, integration
+) -> None:
     """Test enabled legacy boolean binary sensor."""
     node = ecolink_door_sensor
     # this node has Notification CC not (fully) implemented
@@ -98,7 +102,9 @@ async def test_enabled_legacy_sensor(hass, ecolink_door_sensor, integration):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_disabled_legacy_sensor(hass, multisensor_6, integration):
+async def test_disabled_legacy_sensor(
+    hass: HomeAssistant, multisensor_6, integration
+) -> None:
     """Test disabled legacy boolean binary sensor."""
     # this node has Notification CC implemented so legacy binary sensor should be disabled
 
@@ -119,7 +125,9 @@ async def test_disabled_legacy_sensor(hass, multisensor_6, integration):
     assert updated_entry.disabled is False
 
 
-async def test_notification_sensor(hass, multisensor_6, integration):
+async def test_notification_sensor(
+    hass: HomeAssistant, multisensor_6, integration
+) -> None:
     """Test binary sensor created from Notification CC."""
     state = hass.states.get(NOTIFICATION_MOTION_BINARY_SENSOR)
 
@@ -143,7 +151,7 @@ async def test_notification_sensor(hass, multisensor_6, integration):
 async def test_notification_off_state(
     hass: HomeAssistant,
     lock_popp_electric_strike_lock_control: Node,
-):
+) -> None:
     """Test the description off_state attribute of certain notification sensors."""
     node = lock_popp_electric_strike_lock_control
     # Remove all other values except the door state value.
@@ -172,7 +180,9 @@ async def test_notification_off_state(
     assert state.entity_id == "binary_sensor.node_62_window_door_is_open"
 
 
-async def test_property_sensor_door_status(hass, lock_august_pro, integration):
+async def test_property_sensor_door_status(
+    hass: HomeAssistant, lock_august_pro, integration
+) -> None:
     """Test property binary sensor with sensor mapping (doorStatus)."""
     node = lock_august_pro
 

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -1,18 +1,21 @@
 """Test the Z-Wave JS button entities."""
+import pytest
+
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.zwave_js.const import DOMAIN, SERVICE_REFRESH_VALUE
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 
 
 async def test_ping_entity(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-    caplog,
-):
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test ping entity."""
     client.async_send_command.return_value = {"responded": True}
 

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import (
     CLIMATE_DANFOSS_LC13_ENTITY,
@@ -48,8 +49,8 @@ from .common import (
 
 
 async def test_thermostat_v2(
-    hass, client, climate_radio_thermostat_ct100_plus, integration
-):
+    hass: HomeAssistant, client, climate_radio_thermostat_ct100_plus, integration
+) -> None:
     """Test a thermostat v2 command class entity."""
     node = climate_radio_thermostat_ct100_plus
     state = hass.states.get(CLIMATE_RADIO_THERMOSTAT_ENTITY)
@@ -281,8 +282,11 @@ async def test_thermostat_v2(
 
 
 async def test_thermostat_different_endpoints(
-    hass, client, climate_radio_thermostat_ct100_plus_different_endpoints, integration
-):
+    hass: HomeAssistant,
+    client,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+) -> None:
     """Test an entity with values on a different endpoint from the primary value."""
     state = hass.states.get(CLIMATE_RADIO_THERMOSTAT_ENTITY)
 
@@ -292,7 +296,9 @@ async def test_thermostat_different_endpoints(
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
 
 
-async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integration):
+async def test_setpoint_thermostat(
+    hass: HomeAssistant, client, climate_danfoss_lc_13, integration
+) -> None:
     """Test a setpoint thermostat command class entity."""
     node = climate_danfoss_lc_13
     state = hass.states.get(CLIMATE_DANFOSS_LC13_ENTITY)
@@ -387,8 +393,8 @@ async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integrat
 
 
 async def test_thermostat_heatit_z_trm3_no_value(
-    hass, client, climate_heatit_z_trm3_no_value, integration
-):
+    hass: HomeAssistant, client, climate_heatit_z_trm3_no_value, integration
+) -> None:
     """Test a heatit Z-TRM3 entity that is missing a value."""
     # When the config parameter that specifies what sensor to use has no value, we fall
     # back to the first temperature sensor found on the device
@@ -397,8 +403,8 @@ async def test_thermostat_heatit_z_trm3_no_value(
 
 
 async def test_thermostat_heatit_z_trm3(
-    hass, client, climate_heatit_z_trm3, integration
-):
+    hass: HomeAssistant, client, climate_heatit_z_trm3, integration
+) -> None:
     """Test a heatit Z-TRM3 entity."""
     node = climate_heatit_z_trm3
     state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
@@ -467,8 +473,8 @@ async def test_thermostat_heatit_z_trm3(
 
 
 async def test_thermostat_heatit_z_trm2fx(
-    hass, client, climate_heatit_z_trm2fx, integration
-):
+    hass: HomeAssistant, client, climate_heatit_z_trm2fx, integration
+) -> None:
     """Test a heatit Z-TRM2fx entity."""
     node = climate_heatit_z_trm2fx
     state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
@@ -513,7 +519,9 @@ async def test_thermostat_heatit_z_trm2fx(
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 0
 
 
-async def test_thermostat_srt321_hrt4_zw(hass, client, srt321_hrt4_zw, integration):
+async def test_thermostat_srt321_hrt4_zw(
+    hass: HomeAssistant, client, srt321_hrt4_zw, integration
+) -> None:
     """Test a climate entity from a HRT4-ZW / SRT321 thermostat device.
 
     This device currently has no setpoint values.
@@ -531,8 +539,8 @@ async def test_thermostat_srt321_hrt4_zw(hass, client, srt321_hrt4_zw, integrati
 
 
 async def test_preset_and_no_setpoint(
-    hass, client, climate_eurotronic_spirit_z, integration
-):
+    hass: HomeAssistant, client, climate_eurotronic_spirit_z, integration
+) -> None:
     """Test preset without setpoint value."""
     node = climate_eurotronic_spirit_z
 
@@ -630,12 +638,12 @@ async def test_preset_and_no_setpoint(
 
 
 async def test_temp_unit_fix(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct101_multiple_temp_units,
     climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints,
     integration,
-):
+) -> None:
     """Test temperaturee unit fix."""
     state = hass.states.get("climate.thermostat")
     assert state
@@ -647,8 +655,8 @@ async def test_temp_unit_fix(
 
 
 async def test_thermostat_unknown_values(
-    hass, client, climate_radio_thermostat_ct100_plus_state, integration
-):
+    hass: HomeAssistant, client, climate_radio_thermostat_ct100_plus_state, integration
+) -> None:
     """Test a thermostat v2 with unknown values."""
     node_state = replace_value_of_zwave_value(
         climate_radio_thermostat_ct100_plus_state,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -262,7 +262,9 @@ async def slow_server_version(*args):
         ),
     ],
 )
-async def test_manual_errors(hass, integration, url, error, flow, flow_params):
+async def test_manual_errors(
+    hass: HomeAssistant, integration, url, error, flow, flow_params
+) -> None:
     """Test all errors with a manual set up."""
     entry = integration
     result = await getattr(hass.config_entries, flow).async_init(**flow_params(entry))
@@ -319,8 +321,12 @@ async def test_manual_already_configured(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_supervisor_discovery(
-    hass, supervisor, addon_running, addon_options, get_addon_discovery_info
-):
+    hass: HomeAssistant,
+    supervisor,
+    addon_running,
+    addon_options,
+    get_addon_discovery_info,
+) -> None:
     """Test flow started from Supervisor discovery."""
 
     addon_options["device"] = "/test"
@@ -369,8 +375,8 @@ async def test_supervisor_discovery(
     [({"config": ADDON_DISCOVERY_INFO}, asyncio.TimeoutError())],
 )
 async def test_supervisor_discovery_cannot_connect(
-    hass, supervisor, get_addon_discovery_info
-):
+    hass: HomeAssistant, supervisor, get_addon_discovery_info
+) -> None:
     """Test Supervisor discovery and cannot connect."""
 
     result = await hass.config_entries.flow.async_init(
@@ -389,8 +395,12 @@ async def test_supervisor_discovery_cannot_connect(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_clean_discovery_on_user_create(
-    hass, supervisor, addon_running, addon_options, get_addon_discovery_info
-):
+    hass: HomeAssistant,
+    supervisor,
+    addon_running,
+    addon_options,
+    get_addon_discovery_info,
+) -> None:
     """Test discovery flow is cleaned up when a user flow is finished."""
 
     addon_options["device"] = "/test"
@@ -457,8 +467,8 @@ async def test_clean_discovery_on_user_create(
 
 
 async def test_abort_discovery_with_existing_entry(
-    hass, supervisor, addon_running, addon_options
-):
+    hass: HomeAssistant, supervisor, addon_running, addon_options
+) -> None:
     """Test discovery flow is aborted if an entry already exists."""
 
     entry = MockConfigEntry(
@@ -486,8 +496,8 @@ async def test_abort_discovery_with_existing_entry(
 
 
 async def test_abort_hassio_discovery_with_existing_flow(
-    hass, supervisor, addon_installed, addon_options
-):
+    hass: HomeAssistant, supervisor, addon_installed, addon_options
+) -> None:
     """Test hassio discovery flow is aborted when another discovery has happened."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -512,8 +522,8 @@ async def test_abort_hassio_discovery_with_existing_flow(
 
 
 async def test_abort_hassio_discovery_for_other_addon(
-    hass, supervisor, addon_installed, addon_options
-):
+    hass: HomeAssistant, supervisor, addon_installed, addon_options
+) -> None:
     """Test hassio discovery flow is aborted for a non official add-on discovery."""
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -535,7 +545,7 @@ async def test_abort_hassio_discovery_for_other_addon(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_usb_discovery(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_not_installed,
     install_addon,
@@ -543,7 +553,7 @@ async def test_usb_discovery(
     get_addon_discovery_info,
     set_addon_options,
     start_addon,
-):
+) -> None:
     """Test usb discovery success path."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -625,14 +635,14 @@ async def test_usb_discovery(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_usb_discovery_addon_not_running(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test usb discovery when add-on is installed but not running."""
     addon_options["device"] = "/dev/incorrect_device"
 
@@ -714,8 +724,13 @@ async def test_usb_discovery_addon_not_running(
 
 
 async def test_discovery_addon_not_running(
-    hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
-):
+    hass: HomeAssistant,
+    supervisor,
+    addon_installed,
+    addon_options,
+    set_addon_options,
+    start_addon,
+) -> None:
     """Test discovery with add-on already installed but not running."""
     addon_options["device"] = None
 
@@ -794,14 +809,14 @@ async def test_discovery_addon_not_running(
 
 
 async def test_discovery_addon_not_installed(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_not_installed,
     install_addon,
     addon_options,
     set_addon_options,
     start_addon,
-):
+) -> None:
     """Test discovery with add-on not installed."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -886,7 +901,9 @@ async def test_discovery_addon_not_installed(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_options):
+async def test_abort_usb_discovery_with_existing_flow(
+    hass: HomeAssistant, supervisor, addon_options
+) -> None:
     """Test usb discovery flow is aborted when another discovery has happened."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -910,7 +927,9 @@ async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_op
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_options):
+async def test_abort_usb_discovery_already_configured(
+    hass: HomeAssistant, supervisor, addon_options
+) -> None:
     """Test usb discovery flow is aborted when there is an existing entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -940,7 +959,9 @@ async def test_usb_discovery_requires_supervisor(hass: HomeAssistant) -> None:
     assert result["reason"] == "discovery_requires_supervisor"
 
 
-async def test_usb_discovery_already_running(hass, supervisor, addon_running):
+async def test_usb_discovery_already_running(
+    hass: HomeAssistant, supervisor, addon_running
+) -> None:
     """Test usb discovery flow is aborted when the addon is running."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -956,8 +977,8 @@ async def test_usb_discovery_already_running(hass, supervisor, addon_running):
     [CP2652_ZIGBEE_DISCOVERY_INFO],
 )
 async def test_abort_usb_discovery_aborts_specific_devices(
-    hass, supervisor, addon_options, discovery_info
-):
+    hass: HomeAssistant, supervisor, addon_options, discovery_info
+) -> None:
     """Test usb discovery flow is aborted on specific devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -968,7 +989,7 @@ async def test_abort_usb_discovery_aborts_specific_devices(
     assert result["reason"] == "not_zwave_device"
 
 
-async def test_not_addon(hass, supervisor):
+async def test_not_addon(hass: HomeAssistant, supervisor) -> None:
     """Test opting out of add-on on Supervisor."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1017,12 +1038,12 @@ async def test_not_addon(hass, supervisor):
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_addon_running(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_running,
     addon_options,
     get_addon_discovery_info,
-):
+) -> None:
     """Test add-on already running on Supervisor."""
     addon_options["device"] = "/test"
     addon_options["s0_legacy_key"] = "new123"
@@ -1104,13 +1125,13 @@ async def test_addon_running(
     ],
 )
 async def test_addon_running_failures(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_running,
     addon_options,
     get_addon_discovery_info,
     abort_reason,
-):
+) -> None:
     """Test all failures when add-on is running."""
     addon_options["device"] = "/test"
     addon_options["network_key"] = "abc123"
@@ -1132,8 +1153,12 @@ async def test_addon_running_failures(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_addon_running_already_configured(
-    hass, supervisor, addon_running, addon_options, get_addon_discovery_info
-):
+    hass: HomeAssistant,
+    supervisor,
+    addon_running,
+    addon_options,
+    get_addon_discovery_info,
+) -> None:
     """Test that only one unique instance is allowed when add-on is running."""
     addon_options["device"] = "/test_new"
     addon_options["s0_legacy_key"] = "new123"
@@ -1180,14 +1205,14 @@ async def test_addon_running_already_configured(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_addon_installed(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test add-on already installed but not running on Supervisor."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1265,14 +1290,14 @@ async def test_addon_installed(
     [({"config": ADDON_DISCOVERY_INFO}, HassioAPIError())],
 )
 async def test_addon_installed_start_failure(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test add-on start failure when add-on is installed."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1340,14 +1365,14 @@ async def test_addon_installed_start_failure(
     ],
 )
 async def test_addon_installed_failures(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test all failures when add-on is installed."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1406,14 +1431,14 @@ async def test_addon_installed_failures(
     [(HassioAPIError(), {"config": ADDON_DISCOVERY_INFO})],
 )
 async def test_addon_installed_set_options_failure(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test all failures when add-on is installed."""
 
     result = await hass.config_entries.flow.async_init(
@@ -1463,14 +1488,14 @@ async def test_addon_installed_set_options_failure(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_addon_installed_already_configured(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test that only one unique instance is allowed when add-on is installed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1547,7 +1572,7 @@ async def test_addon_installed_already_configured(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_addon_not_installed(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_not_installed,
     install_addon,
@@ -1555,7 +1580,7 @@ async def test_addon_not_installed(
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-):
+) -> None:
     """Test add-on not installed."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1638,8 +1663,8 @@ async def test_addon_not_installed(
 
 
 async def test_install_addon_failure(
-    hass, supervisor, addon_not_installed, install_addon
-):
+    hass: HomeAssistant, supervisor, addon_not_installed, install_addon
+) -> None:
     """Test add-on install failure."""
     install_addon.side_effect = HassioAPIError()
 
@@ -1667,7 +1692,7 @@ async def test_install_addon_failure(
     assert result["reason"] == "addon_install_failed"
 
 
-async def test_options_manual(hass, client, integration):
+async def test_options_manual(hass: HomeAssistant, client, integration) -> None:
     """Test manual settings in options flow."""
     entry = integration
     entry.unique_id = "1234"
@@ -1693,7 +1718,9 @@ async def test_options_manual(hass, client, integration):
     assert client.disconnect.call_count == 1
 
 
-async def test_options_manual_different_device(hass, integration):
+async def test_options_manual_different_device(
+    hass: HomeAssistant, integration
+) -> None:
     """Test options flow manual step connecting to different device."""
     entry = integration
     entry.unique_id = 5678
@@ -1712,7 +1739,9 @@ async def test_options_manual_different_device(hass, integration):
     assert result["reason"] == "different_device"
 
 
-async def test_options_not_addon(hass, client, supervisor, integration):
+async def test_options_not_addon(
+    hass: HomeAssistant, client, supervisor, integration
+) -> None:
     """Test options flow and opting out of add-on on Supervisor."""
     entry = integration
     entry.unique_id = "1234"
@@ -1804,7 +1833,7 @@ async def test_options_not_addon(hass, client, supervisor, integration):
     ],
 )
 async def test_options_addon_running(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     integration,
@@ -1818,7 +1847,7 @@ async def test_options_addon_running(
     old_addon_options,
     new_addon_options,
     disconnect_calls,
-):
+) -> None:
     """Test options flow and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -1915,7 +1944,7 @@ async def test_options_addon_running(
     ],
 )
 async def test_options_addon_running_no_changes(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     integration,
@@ -1928,7 +1957,7 @@ async def test_options_addon_running_no_changes(
     entry_data,
     old_addon_options,
     new_addon_options,
-):
+) -> None:
     """Test options flow without changes, and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -2057,7 +2086,7 @@ async def different_device_server_version(*args):
     ],
 )
 async def test_options_different_device(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     integration,
@@ -2072,7 +2101,7 @@ async def test_options_different_device(
     new_addon_options,
     disconnect_calls,
     server_version_side_effect,
-):
+) -> None:
     """Test options flow and configuring a different device."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -2216,7 +2245,7 @@ async def test_options_different_device(
     ],
 )
 async def test_options_addon_restart_failed(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     integration,
@@ -2231,7 +2260,7 @@ async def test_options_addon_restart_failed(
     new_addon_options,
     disconnect_calls,
     restart_addon_side_effect,
-):
+) -> None:
     """Test options flow and add-on restart failure."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -2344,7 +2373,7 @@ async def test_options_addon_restart_failed(
     ],
 )
 async def test_options_addon_running_server_info_failure(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     integration,
@@ -2359,7 +2388,7 @@ async def test_options_addon_running_server_info_failure(
     new_addon_options,
     disconnect_calls,
     server_version_side_effect,
-):
+) -> None:
     """Test options flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -2453,7 +2482,7 @@ async def test_options_addon_running_server_info_failure(
     ],
 )
 async def test_options_addon_not_installed(
-    hass,
+    hass: HomeAssistant,
     client,
     supervisor,
     addon_not_installed,
@@ -2468,7 +2497,7 @@ async def test_options_addon_not_installed(
     old_addon_options,
     new_addon_options,
     disconnect_calls,
-):
+) -> None:
     """Test options flow and add-on not installed on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
@@ -2540,7 +2569,7 @@ async def test_options_addon_not_installed(
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_import_addon_installed(
-    hass,
+    hass: HomeAssistant,
     supervisor,
     addon_installed,
     addon_options,
@@ -2548,7 +2577,7 @@ async def test_import_addon_installed(
     start_addon,
     get_addon_discovery_info,
     serial_port,
-):
+) -> None:
     """Test import step while add-on already installed on Supervisor."""
     serial_port.device = "/test/imported"
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import replace_value_of_zwave_value
 
@@ -35,7 +36,9 @@ AEOTEC_SHUTTER_COVER_ENTITY = "cover.nano_shutter_v_3"
 FIBARO_SHUTTER_COVER_ENTITY = "cover.fgr_222_test_cover"
 
 
-async def test_window_cover(hass, client, chain_actuator_zws12, integration):
+async def test_window_cover(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
     """Test the cover entity."""
     node = chain_actuator_zws12
     state = hass.states.get(WINDOW_COVER_ENTITY)
@@ -216,8 +219,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
 
 
 async def test_fibaro_FGR222_shutter_cover(
-    hass, client, fibaro_fgr222_shutter, integration
-):
+    hass: HomeAssistant, client, fibaro_fgr222_shutter, integration
+) -> None:
     """Test tilt function of the Fibaro Shutter devices."""
     state = hass.states.get(FIBARO_SHUTTER_COVER_ENTITY)
     assert state
@@ -294,8 +297,8 @@ async def test_fibaro_FGR222_shutter_cover(
 
 
 async def test_aeotec_nano_shutter_cover(
-    hass, client, aeotec_nano_shutter, integration
-):
+    hass: HomeAssistant, client, aeotec_nano_shutter, integration
+) -> None:
     """Test movement of an Aeotec Nano Shutter cover entity. Useful to make sure the stop command logic is handled properly."""
     node = aeotec_nano_shutter
     state = hass.states.get(AEOTEC_SHUTTER_COVER_ENTITY)
@@ -410,7 +413,9 @@ async def test_aeotec_nano_shutter_cover(
     assert not open_args["value"]
 
 
-async def test_blind_cover(hass, client, iblinds_v2, integration):
+async def test_blind_cover(
+    hass: HomeAssistant, client, iblinds_v2, integration
+) -> None:
     """Test a blind cover entity."""
     state = hass.states.get(BLIND_COVER_ENTITY)
 
@@ -418,7 +423,9 @@ async def test_blind_cover(hass, client, iblinds_v2, integration):
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.BLIND
 
 
-async def test_shutter_cover(hass, client, qubino_shutter, integration):
+async def test_shutter_cover(
+    hass: HomeAssistant, client, qubino_shutter, integration
+) -> None:
     """Test a shutter cover entity."""
     state = hass.states.get(SHUTTER_COVER_ENTITY)
 
@@ -426,7 +433,9 @@ async def test_shutter_cover(hass, client, qubino_shutter, integration):
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.SHUTTER
 
 
-async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
+async def test_motor_barrier_cover(
+    hass: HomeAssistant, client, gdc_zw062, integration
+) -> None:
     """Test the cover entity."""
     node = gdc_zw062
 
@@ -597,8 +606,8 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
 
 
 async def test_motor_barrier_cover_no_primary_value(
-    hass, client, gdc_zw062_state, integration
-):
+    hass: HomeAssistant, client, gdc_zw062_state, integration
+) -> None:
     """Test the cover entity where primary value value is None."""
     node_state = replace_value_of_zwave_value(
         gdc_zw062_state,
@@ -623,8 +632,8 @@ async def test_motor_barrier_cover_no_primary_value(
 
 
 async def test_fibaro_FGR222_shutter_cover_no_tilt(
-    hass, client, fibaro_fgr222_shutter_state, integration
-):
+    hass: HomeAssistant, client, fibaro_fgr222_shutter_state, integration
+) -> None:
     """Test tilt function of the Fibaro Shutter devices with tilt value is None."""
     node_state = replace_value_of_zwave_value(
         fibaro_fgr222_shutter_state,

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -415,7 +415,7 @@ async def test_get_action_capabilities(
     client: Client,
     climate_radio_thermostat_ct100_plus: Node,
     integration: ConfigEntry,
-):
+) -> None:
     """Test we get the expected action capabilities."""
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device(
@@ -582,7 +582,7 @@ async def test_get_action_capabilities_lock_triggers(
     client: Client,
     lock_schlage_be469: Node,
     integration: ConfigEntry,
-):
+) -> None:
     """Test we get the expected action capabilities for lock triggers."""
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(
@@ -662,7 +662,7 @@ async def test_failure_scenarios(
     client: Client,
     hank_binary_switch: Node,
     integration: ConfigEntry,
-):
+) -> None:
     """Test failure scenarios."""
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -19,6 +19,7 @@ from homeassistant.components.zwave_js.helpers import (
     get_device_id,
     get_zwave_value_from_config,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry
 from homeassistant.setup import async_setup_component
@@ -32,7 +33,9 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> None:
+async def test_get_conditions(
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected onditions from a zwave_js."""
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device(
@@ -88,7 +91,7 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
 
 
 async def test_node_status_state(
-    hass, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
 ) -> None:
     """Test for node_status conditions."""
     dev_reg = device_registry.async_get(hass)
@@ -249,7 +252,7 @@ async def test_node_status_state(
 
 
 async def test_config_parameter_state(
-    hass, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
 ) -> None:
     """Test for config_parameter conditions."""
     dev_reg = device_registry.async_get(hass)
@@ -365,7 +368,7 @@ async def test_config_parameter_state(
 
 
 async def test_value_state(
-    hass, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
 ) -> None:
     """Test for value conditions."""
     dev_reg = device_registry.async_get(hass)
@@ -413,8 +416,8 @@ async def test_value_state(
 
 
 async def test_get_condition_capabilities_node_status(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we don't get capabilities from a node_status condition."""
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device(
@@ -450,8 +453,8 @@ async def test_get_condition_capabilities_node_status(
 
 
 async def test_get_condition_capabilities_value(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a value condition."""
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device(
@@ -499,8 +502,8 @@ async def test_get_condition_capabilities_value(
 
 
 async def test_get_condition_capabilities_config_parameter(
-    hass, client, climate_radio_thermostat_ct100_plus, integration
-):
+    hass: HomeAssistant, client, climate_radio_thermostat_ct100_plus, integration
+) -> None:
     """Test we get the expected capabilities from a config_parameter condition."""
     node = climate_radio_thermostat_ct100_plus
     dev_reg = device_registry.async_get(hass)
@@ -581,7 +584,9 @@ async def test_get_condition_capabilities_config_parameter(
     assert not capabilities
 
 
-async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
+async def test_failure_scenarios(
+    hass: HomeAssistant, client, hank_binary_switch, integration
+) -> None:
     """Test failure scenarios."""
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device(
@@ -651,8 +656,8 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
 
 
 async def test_get_value_from_config_failure(
-    hass, client, hank_binary_switch, integration
-):
+    hass: HomeAssistant, client, hank_binary_switch, integration
+) -> None:
     """Test get_value_from_config invalid value ID."""
     with pytest.raises(vol.Invalid):
         get_zwave_value_from_config(

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -17,6 +17,7 @@ from homeassistant.components.zwave_js.helpers import (
     async_get_node_status_sensor_entity_id,
     get_device_id,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
@@ -36,7 +37,7 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_no_controller_triggers(hass, client, integration):
+async def test_no_controller_triggers(hass: HomeAssistant, client, integration) -> None:
     """Test that we do not get triggers for the controller."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -52,8 +53,8 @@ async def test_no_controller_triggers(hass, client, integration):
 
 
 async def test_get_notification_notification_triggers(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected triggers from a zwave_js device with the Notification CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -75,8 +76,8 @@ async def test_get_notification_notification_triggers(
 
 
 async def test_if_notification_notification_fires(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test for event.notification.notification trigger firing."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -172,8 +173,8 @@ async def test_if_notification_notification_fires(
 
 
 async def test_get_trigger_capabilities_notification_notification(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a notification.notification trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -206,8 +207,8 @@ async def test_get_trigger_capabilities_notification_notification(
 
 
 async def test_if_entry_control_notification_fires(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test for notification.entry_control trigger firing."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -302,8 +303,8 @@ async def test_if_entry_control_notification_fires(
 
 
 async def test_get_trigger_capabilities_entry_control_notification(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a notification.entry_control trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -333,7 +334,9 @@ async def test_get_trigger_capabilities_entry_control_notification(
     )
 
 
-async def test_get_node_status_triggers(hass, client, lock_schlage_be469, integration):
+async def test_get_node_status_triggers(
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected triggers from a device with node status sensor enabled."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -363,8 +366,8 @@ async def test_get_node_status_triggers(hass, client, lock_schlage_be469, integr
 
 
 async def test_if_node_status_change_fires(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -442,8 +445,8 @@ async def test_if_node_status_change_fires(
 
 
 async def test_get_trigger_capabilities_node_status(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a node_status trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -500,8 +503,8 @@ async def test_get_trigger_capabilities_node_status(
 
 
 async def test_get_basic_value_notification_triggers(
-    hass, client, ge_in_wall_dimmer_switch, integration
-):
+    hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration
+) -> None:
     """Test we get the expected triggers from a zwave_js device with the Basic CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -527,8 +530,8 @@ async def test_get_basic_value_notification_triggers(
 
 
 async def test_if_basic_value_notification_fires(
-    hass, client, ge_in_wall_dimmer_switch, integration, calls
-):
+    hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration, calls
+) -> None:
     """Test for event.value_notification.basic trigger firing."""
     node: Node = ge_in_wall_dimmer_switch
     dev_reg = async_get_dev_reg(hass)
@@ -639,8 +642,8 @@ async def test_if_basic_value_notification_fires(
 
 
 async def test_get_trigger_capabilities_basic_value_notification(
-    hass, client, ge_in_wall_dimmer_switch, integration
-):
+    hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration
+) -> None:
     """Test we get the expected capabilities from a value_notification.basic trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -677,8 +680,8 @@ async def test_get_trigger_capabilities_basic_value_notification(
 
 
 async def test_get_central_scene_value_notification_triggers(
-    hass, client, wallmote_central_scene, integration
-):
+    hass: HomeAssistant, client, wallmote_central_scene, integration
+) -> None:
     """Test we get the expected triggers from a zwave_js device with the Central Scene CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -704,8 +707,8 @@ async def test_get_central_scene_value_notification_triggers(
 
 
 async def test_if_central_scene_value_notification_fires(
-    hass, client, wallmote_central_scene, integration, calls
-):
+    hass: HomeAssistant, client, wallmote_central_scene, integration, calls
+) -> None:
     """Test for event.value_notification.central_scene trigger firing."""
     node: Node = wallmote_central_scene
     dev_reg = async_get_dev_reg(hass)
@@ -822,8 +825,8 @@ async def test_if_central_scene_value_notification_fires(
 
 
 async def test_get_trigger_capabilities_central_scene_value_notification(
-    hass, client, wallmote_central_scene, integration
-):
+    hass: HomeAssistant, client, wallmote_central_scene, integration
+) -> None:
     """Test we get the expected capabilities from a value_notification.central_scene trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -859,8 +862,8 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
 
 
 async def test_get_scene_activation_value_notification_triggers(
-    hass, client, hank_binary_switch, integration
-):
+    hass: HomeAssistant, client, hank_binary_switch, integration
+) -> None:
     """Test we get the expected triggers from a zwave_js device with the SceneActivation CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -886,8 +889,8 @@ async def test_get_scene_activation_value_notification_triggers(
 
 
 async def test_if_scene_activation_value_notification_fires(
-    hass, client, hank_binary_switch, integration, calls
-):
+    hass: HomeAssistant, client, hank_binary_switch, integration, calls
+) -> None:
     """Test for event.value_notification.scene_activation trigger firing."""
     node: Node = hank_binary_switch
     dev_reg = async_get_dev_reg(hass)
@@ -998,8 +1001,8 @@ async def test_if_scene_activation_value_notification_fires(
 
 
 async def test_get_trigger_capabilities_scene_activation_value_notification(
-    hass, client, hank_binary_switch, integration
-):
+    hass: HomeAssistant, client, hank_binary_switch, integration
+) -> None:
     """Test we get the expected capabilities from a value_notification.scene_activation trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1036,8 +1039,8 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
 
 
 async def test_get_value_updated_value_triggers(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the zwave_js.value_updated.value trigger from a zwave_js device."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1058,8 +1061,8 @@ async def test_get_value_updated_value_triggers(
 
 
 async def test_if_value_updated_value_fires(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test for zwave_js.value_updated.value trigger firing."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -1150,8 +1153,8 @@ async def test_if_value_updated_value_fires(
 
 
 async def test_value_updated_value_no_driver(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test zwave_js.value_updated.value trigger with missing driver."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -1221,8 +1224,8 @@ async def test_value_updated_value_no_driver(
 
 
 async def test_get_trigger_capabilities_value_updated_value(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a zwave_js.value_updated.value trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1272,8 +1275,8 @@ async def test_get_trigger_capabilities_value_updated_value(
 
 
 async def test_get_value_updated_config_parameter_triggers(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the zwave_js.value_updated.config_parameter trigger from a zwave_js device."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1299,8 +1302,8 @@ async def test_get_value_updated_config_parameter_triggers(
 
 
 async def test_if_value_updated_config_parameter_fires(
-    hass, client, lock_schlage_be469, integration, calls
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+) -> None:
     """Test for zwave_js.value_updated.config_parameter trigger firing."""
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
@@ -1370,8 +1373,8 @@ async def test_if_value_updated_config_parameter_fires(
 
 
 async def test_get_trigger_capabilities_value_updated_config_parameter_range(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from a range zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1415,8 +1418,8 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
 
 
 async def test_get_trigger_capabilities_value_updated_config_parameter_enumerated(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test we get the expected capabilities from an enumerated zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -1457,7 +1460,9 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
     ]
 
 
-async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
+async def test_failure_scenarios(
+    hass: HomeAssistant, client, hank_binary_switch, integration
+) -> None:
     """Test failure scenarios."""
     with pytest.raises(HomeAssistantError):
         await device_trigger.async_attach_trigger(

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -13,6 +13,7 @@ from homeassistant.components.zwave_js.helpers import (
     get_device_id,
     get_value_id_from_unique_id,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
 
@@ -22,15 +23,16 @@ from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
 )
+from tests.typing import ClientSessionGenerator
 
 
 async def test_config_entry_diagnostics(
-    hass,
-    hass_client,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     integration,
     config_entry_diagnostics,
     config_entry_diagnostics_redacted,
-):
+) -> None:
     """Test the config entry level diagnostics data dump."""
     with patch(
         "homeassistant.components.zwave_js.diagnostics.dump_msgs",
@@ -43,13 +45,13 @@ async def test_config_entry_diagnostics(
 
 
 async def test_device_diagnostics(
-    hass,
+    hass: HomeAssistant,
     client,
     multisensor_6,
     integration,
-    hass_client,
+    hass_client: ClientSessionGenerator,
     version_state,
-):
+) -> None:
     """Test the device level diagnostics data dump."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
@@ -102,7 +104,7 @@ async def test_device_diagnostics(
     }
 
 
-async def test_device_diagnostics_error(hass, integration):
+async def test_device_diagnostics_error(hass: HomeAssistant, integration) -> None:
     """Test the device diagnostics raises exception when an invalid device is used."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_or_create(
@@ -119,12 +121,12 @@ async def test_empty_zwave_value_matcher() -> None:
 
 
 async def test_device_diagnostics_missing_primary_value(
-    hass,
+    hass: HomeAssistant,
     client,
     multisensor_6,
     integration,
-    hass_client,
-):
+    hass_client: ClientSessionGenerator,
+) -> None:
     """Test that the device diagnostics handles an entity with a missing primary value."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -12,7 +12,7 @@ from homeassistant.components.zwave_js.discovery_data_template import (
 from homeassistant.core import HomeAssistant
 
 
-async def test_iblinds_v2(hass, client, iblinds_v2, integration):
+async def test_iblinds_v2(hass: HomeAssistant, client, iblinds_v2, integration) -> None:
     """Test that an iBlinds v2.0 multilevel switch value is discovered as a cover."""
     node = iblinds_v2
     assert node.device_class.specific.label == "Unused"
@@ -24,7 +24,7 @@ async def test_iblinds_v2(hass, client, iblinds_v2, integration):
     assert state
 
 
-async def test_ge_12730(hass, client, ge_12730, integration):
+async def test_ge_12730(hass: HomeAssistant, client, ge_12730, integration) -> None:
     """Test GE 12730 Fan Controller v2.0 multilevel switch is discovered as a fan."""
     node = ge_12730
     assert node.device_class.specific.label == "Multilevel Power Switch"
@@ -36,7 +36,9 @@ async def test_ge_12730(hass, client, ge_12730, integration):
     assert state
 
 
-async def test_inovelli_lzw36(hass, client, inovelli_lzw36, integration):
+async def test_inovelli_lzw36(
+    hass: HomeAssistant, client, inovelli_lzw36, integration
+) -> None:
     """Test LZW36 Fan Controller multilevel switch endpoint 2 is discovered as a fan."""
     node = inovelli_lzw36
     assert node.device_class.specific.label == "Unused"
@@ -49,8 +51,8 @@ async def test_inovelli_lzw36(hass, client, inovelli_lzw36, integration):
 
 
 async def test_vision_security_zl7432(
-    hass, client, vision_security_zl7432, integration
-):
+    hass: HomeAssistant, client, vision_security_zl7432, integration
+) -> None:
     """Test Vision Security ZL7432 is caught by the device specific discovery."""
     for entity_id in (
         "switch.in_wall_dual_relay_switch",
@@ -62,8 +64,8 @@ async def test_vision_security_zl7432(
 
 
 async def test_lock_popp_electric_strike_lock_control(
-    hass, client, lock_popp_electric_strike_lock_control, integration
-):
+    hass: HomeAssistant, client, lock_popp_electric_strike_lock_control, integration
+) -> None:
     """Test that the Popp Electric Strike Lock Control gets discovered correctly."""
     assert hass.states.get("lock.node_62") is not None
     assert (
@@ -72,7 +74,9 @@ async def test_lock_popp_electric_strike_lock_control(
     )
 
 
-async def test_fortrez_ssa3_siren(hass, client, fortrezz_ssa3_siren, integration):
+async def test_fortrez_ssa3_siren(
+    hass: HomeAssistant, client, fortrezz_ssa3_siren, integration
+) -> None:
     """Test Fortrezz SSA3 siren gets discovered correctly."""
     assert hass.states.get("select.siren_and_strobe_alarm") is not None
 
@@ -87,7 +91,9 @@ async def test_firmware_version_range_exception(hass: HomeAssistant) -> None:
         )
 
 
-async def test_dynamic_climate_data_discovery_template_failure(hass, multisensor_6):
+async def test_dynamic_climate_data_discovery_template_failure(
+    hass: HomeAssistant, multisensor_6
+) -> None:
     """Test that initing a DynamicCurrentTempClimateDataTemplate with no data raises."""
     node = multisensor_6
     with pytest.raises(ValueError):

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -5,10 +5,14 @@ import pytest
 from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 
+from homeassistant.core import HomeAssistant
+
 from tests.common import async_capture_events
 
 
-async def test_scenes(hass, hank_binary_switch, integration, client):
+async def test_scenes(
+    hass: HomeAssistant, hank_binary_switch, integration, client
+) -> None:
     """Test scene events."""
     # just pick a random node to fake the value notification events
     node = hank_binary_switch
@@ -137,7 +141,9 @@ async def test_scenes(hass, hank_binary_switch, integration, client):
     assert events[2].data["value_raw"] == 4
 
 
-async def test_notifications(hass, hank_binary_switch, integration, client):
+async def test_notifications(
+    hass: HomeAssistant, hank_binary_switch, integration, client
+) -> None:
     """Test notification events."""
     # just pick a random node to fake the value notification events
     node = hank_binary_switch
@@ -231,7 +237,9 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[2].data["command_class_name"] == "Multilevel Switch"
 
 
-async def test_value_updated(hass, vision_security_zl7432, integration, client):
+async def test_value_updated(
+    hass: HomeAssistant, vision_security_zl7432, integration, client
+) -> None:
     """Test value updated events."""
     node = vision_security_zl7432
     # Add states to the value we are updating to ensure the translation happens
@@ -298,7 +306,9 @@ async def test_value_updated(hass, vision_security_zl7432, integration, client):
     assert len(events) == 1
 
 
-async def test_power_level_notification(hass, hank_binary_switch, integration, client):
+async def test_power_level_notification(
+    hass: HomeAssistant, hank_binary_switch, integration, client
+) -> None:
     """Test power level notification events."""
     # just pick a random node to fake the notification event
     node = hank_binary_switch
@@ -330,7 +340,9 @@ async def test_power_level_notification(hass, hank_binary_switch, integration, c
     assert events[0].data["acknowledged_frames"] == 2
 
 
-async def test_unknown_notification(hass, hank_binary_switch, integration, client):
+async def test_unknown_notification(
+    hass: HomeAssistant, hank_binary_switch, integration, client
+) -> None:
     """Test behavior of unknown notification type events."""
     # just pick a random node to fake the notification event
     node = hank_binary_switch

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -28,11 +28,14 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry
 
 
-async def test_generic_fan(hass, client, fan_generic, integration):
+async def test_generic_fan(
+    hass: HomeAssistant, client, fan_generic, integration
+) -> None:
     """Test the fan entity for a generic fan that lacks specific speed configuration."""
     node = fan_generic
     entity_id = "fan.generic_fan_controller"
@@ -165,7 +168,9 @@ async def test_generic_fan(hass, client, fan_generic, integration):
     assert state.attributes[ATTR_PERCENTAGE] == 0
 
 
-async def test_configurable_speeds_fan(hass, client, hs_fc200, integration):
+async def test_configurable_speeds_fan(
+    hass: HomeAssistant, client, hs_fc200, integration
+) -> None:
     """Test a fan entity with configurable speeds."""
     node = hs_fc200
     node_id = 39
@@ -233,8 +238,8 @@ async def test_configurable_speeds_fan(hass, client, hs_fc200, integration):
 
 
 async def test_configurable_speeds_fan_with_missing_config_value(
-    hass, client, hs_fc200_state, integration
-):
+    hass: HomeAssistant, client, hs_fc200_state, integration
+) -> None:
     """Test a fan entity with configurable speeds."""
     entity_id = "fan.scene_capable_fan_control_switch"
 
@@ -261,8 +266,8 @@ async def test_configurable_speeds_fan_with_missing_config_value(
 
 
 async def test_configurable_speeds_fan_with_bad_config_value(
-    hass, client, hs_fc200_state, integration
-):
+    hass: HomeAssistant, client, hs_fc200_state, integration
+) -> None:
     """Test a fan entity with configurable speeds."""
     entity_id = "fan.scene_capable_fan_control_switch"
 
@@ -290,7 +295,7 @@ async def test_configurable_speeds_fan_with_bad_config_value(
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_ge_12730_fan(hass, client, ge_12730, integration):
+async def test_ge_12730_fan(hass: HomeAssistant, client, ge_12730, integration) -> None:
     """Test a GE 12730 fan with 3 fixed speeds."""
     node = ge_12730
     node_id = 24
@@ -357,7 +362,9 @@ async def test_ge_12730_fan(hass, client, ge_12730, integration):
     assert state.attributes[ATTR_PRESET_MODES] == []
 
 
-async def test_inovelli_lzw36(hass, client, inovelli_lzw36, integration):
+async def test_inovelli_lzw36(
+    hass: HomeAssistant, client, inovelli_lzw36, integration
+) -> None:
     """Test an LZW36."""
     node = inovelli_lzw36
     node_id = 19
@@ -460,7 +467,9 @@ async def test_inovelli_lzw36(hass, client, inovelli_lzw36, integration):
     assert len(client.async_send_command.call_args_list) == 0
 
 
-async def test_leviton_zw4sf_fan(hass, client, leviton_zw4sf, integration):
+async def test_leviton_zw4sf_fan(
+    hass: HomeAssistant, client, leviton_zw4sf, integration
+) -> None:
     """Test a Leviton ZW4SF fan with 4 fixed speeds."""
     node = leviton_zw4sf
     node_id = 88
@@ -528,7 +537,9 @@ async def test_leviton_zw4sf_fan(hass, client, leviton_zw4sf, integration):
     assert state.attributes[ATTR_PRESET_MODES] == []
 
 
-async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
+async def test_thermostat_fan(
+    hass: HomeAssistant, client, climate_adc_t3000, integration
+) -> None:
     """Test the fan entity for a z-wave fan."""
     node = climate_adc_t3000
     entity_id = "fan.adc_t3000"
@@ -758,8 +769,8 @@ async def test_thermostat_fan(hass, client, climate_adc_t3000, integration):
 
 
 async def test_thermostat_fan_without_off(
-    hass, client, climate_radio_thermostat_ct100_plus, integration
-):
+    hass: HomeAssistant, client, climate_radio_thermostat_ct100_plus, integration
+) -> None:
     """Test the fan entity for a z-wave fan without "off" property."""
     entity_id = "fan.z_wave_thermostat"
 
@@ -816,8 +827,8 @@ async def test_thermostat_fan_without_off(
 
 
 async def test_thermostat_fan_without_preset_modes(
-    hass, client, climate_adc_t3000_missing_fan_mode_states, integration
-):
+    hass: HomeAssistant, client, climate_adc_t3000_missing_fan_mode_states, integration
+) -> None:
     """Test the fan entity for a z-wave fan without "states" metadata."""
     entity_id = "fan.adc_t3000_missing_fan_mode_states"
 

--- a/tests/components/zwave_js/test_humidifier.py
+++ b/tests/components/zwave_js/test_humidifier.py
@@ -21,11 +21,14 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import DEHUMIDIFIER_ADC_T3000_ENTITY, HUMIDIFIER_ADC_T3000_ENTITY
 
 
-async def test_humidifier(hass, client, climate_adc_t3000, integration):
+async def test_humidifier(
+    hass: HomeAssistant, client, climate_adc_t3000, integration
+) -> None:
     """Test a humidity control command class entity."""
 
     node = climate_adc_t3000
@@ -424,8 +427,8 @@ async def test_humidifier(hass, client, climate_adc_t3000, integration):
 
 
 async def test_dehumidifier_missing_setpoint(
-    hass, client, climate_adc_t3000_missing_setpoint, integration
-):
+    hass: HomeAssistant, client, climate_adc_t3000_missing_setpoint, integration
+) -> None:
     """Test a humidity control command class entity."""
 
     entity_id = "humidifier.adc_t3000_missing_setpoint_dehumidifier"
@@ -455,8 +458,8 @@ async def test_dehumidifier_missing_setpoint(
 
 
 async def test_humidifier_missing_mode(
-    hass, client, climate_adc_t3000_missing_mode, integration
-):
+    hass: HomeAssistant, client, climate_adc_t3000_missing_mode, integration
+) -> None:
     """Test a humidity control command class entity."""
 
     node = climate_adc_t3000_missing_mode
@@ -513,7 +516,9 @@ async def test_humidifier_missing_mode(
     client.async_send_command.reset_mock()
 
 
-async def test_dehumidifier(hass, client, climate_adc_t3000, integration):
+async def test_dehumidifier(
+    hass: HomeAssistant, client, climate_adc_t3000, integration
+) -> None:
     """Test a humidity control command class entity."""
 
     node = climate_adc_t3000

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -35,7 +35,7 @@ def connect_timeout_fixture():
         yield timeout
 
 
-async def test_entry_setup_unload(hass, client, integration):
+async def test_entry_setup_unload(hass: HomeAssistant, client, integration) -> None:
     """Test the integration set up and unload."""
     entry = integration
 
@@ -48,14 +48,16 @@ async def test_entry_setup_unload(hass, client, integration):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_home_assistant_stop(hass, client, integration):
+async def test_home_assistant_stop(hass: HomeAssistant, client, integration) -> None:
     """Test we clean up on home assistant stop."""
     await hass.async_stop()
 
     assert client.disconnect.call_count == 1
 
 
-async def test_initialized_timeout(hass, client, connect_timeout):
+async def test_initialized_timeout(
+    hass: HomeAssistant, client, connect_timeout
+) -> None:
     """Test we handle a timeout during client initialization."""
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
@@ -66,7 +68,7 @@ async def test_initialized_timeout(hass, client, connect_timeout):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_enabled_statistics(hass, client):
+async def test_enabled_statistics(hass: HomeAssistant, client) -> None:
     """Test that we enabled statistics if the entry is opted in."""
     entry = MockConfigEntry(
         domain="zwave_js",
@@ -82,7 +84,7 @@ async def test_enabled_statistics(hass, client):
         assert mock_cmd.called
 
 
-async def test_disabled_statistics(hass, client):
+async def test_disabled_statistics(hass: HomeAssistant, client) -> None:
     """Test that we diisabled statistics if the entry is opted out."""
     entry = MockConfigEntry(
         domain="zwave_js",
@@ -98,7 +100,7 @@ async def test_disabled_statistics(hass, client):
         assert mock_cmd.called
 
 
-async def test_noop_statistics(hass, client):
+async def test_noop_statistics(hass: HomeAssistant, client) -> None:
     """Test that we don't make any statistics calls if user hasn't provided preference."""
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
@@ -115,7 +117,7 @@ async def test_noop_statistics(hass, client):
 
 
 @pytest.mark.parametrize("error", [BaseZwaveJSServerError("Boom"), Exception("Boom")])
-async def test_listen_failure(hass, client, error):
+async def test_listen_failure(hass: HomeAssistant, client, error) -> None:
     """Test we handle errors during client listen."""
 
     async def listen(driver_ready):
@@ -134,7 +136,9 @@ async def test_listen_failure(hass, client, error):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_new_entity_on_value_added(hass, multisensor_6, client, integration):
+async def test_new_entity_on_value_added(
+    hass: HomeAssistant, multisensor_6, client, integration
+) -> None:
     """Test we create a new entity if a value is added after the fact."""
     node: Node = multisensor_6
 
@@ -167,7 +171,9 @@ async def test_new_entity_on_value_added(hass, multisensor_6, client, integratio
     assert hass.states.get("sensor.multisensor_6_ultraviolet_10") is not None
 
 
-async def test_on_node_added_ready(hass, multisensor_6_state, client, integration):
+async def test_on_node_added_ready(
+    hass: HomeAssistant, multisensor_6_state, client, integration
+) -> None:
     """Test we handle a node added event with a ready node."""
     dev_reg = dr.async_get(hass)
     node = Node(client, deepcopy(multisensor_6_state))
@@ -192,8 +198,8 @@ async def test_on_node_added_ready(hass, multisensor_6_state, client, integratio
 
 
 async def test_on_node_added_not_ready(
-    hass, zp3111_not_ready_state, client, integration
-):
+    hass: HomeAssistant, zp3111_not_ready_state, client, integration
+) -> None:
     """Test we handle a node added event with a non-ready node."""
     dev_reg = dr.async_get(hass)
     device_id = f"{client.driver.controller.home_id}-{zp3111_not_ready_state['nodeId']}"
@@ -225,7 +231,9 @@ async def test_on_node_added_not_ready(
     assert len(device.identifiers) == 1
 
 
-async def test_existing_node_ready(hass, client, multisensor_6, integration):
+async def test_existing_node_ready(
+    hass: HomeAssistant, client, multisensor_6, integration
+) -> None:
     """Test we handle a ready node that exists during integration setup."""
     dev_reg = dr.async_get(hass)
     node = multisensor_6
@@ -302,7 +310,9 @@ async def test_existing_node_reinterview(
     assert device.sw_version == "1.13"
 
 
-async def test_existing_node_not_ready(hass, zp3111_not_ready, client, integration):
+async def test_existing_node_not_ready(
+    hass: HomeAssistant, zp3111_not_ready, client, integration
+) -> None:
     """Test we handle a non-ready node that exists during integration setup."""
     dev_reg = dr.async_get(hass)
     node = zp3111_not_ready
@@ -324,8 +334,13 @@ async def test_existing_node_not_ready(hass, zp3111_not_ready, client, integrati
 
 
 async def test_existing_node_not_replaced_when_not_ready(
-    hass, zp3111, zp3111_not_ready_state, zp3111_state, client, integration
-):
+    hass: HomeAssistant,
+    zp3111,
+    zp3111_not_ready_state,
+    zp3111_state,
+    client,
+    integration,
+) -> None:
     """Test when a node added event with a non-ready node is received.
 
     The existing node should not be replaced, and no customization should be lost.
@@ -442,15 +457,22 @@ async def test_existing_node_not_replaced_when_not_ready(
     assert state.name == "Custom Entity Name"
 
 
-async def test_null_name(hass, client, null_name_check, integration):
+async def test_null_name(
+    hass: HomeAssistant, client, null_name_check, integration
+) -> None:
     """Test that node without a name gets a generic node name."""
     node = null_name_check
     assert hass.states.get(f"switch.node_{node.node_id}")
 
 
 async def test_start_addon(
-    hass, addon_installed, install_addon, addon_options, set_addon_options, start_addon
-):
+    hass: HomeAssistant,
+    addon_installed,
+    install_addon,
+    addon_options,
+    set_addon_options,
+    start_addon,
+) -> None:
     """Test start the Z-Wave JS add-on during entry setup."""
     device = "/test"
     s0_legacy_key = "s0_legacy"
@@ -492,13 +514,13 @@ async def test_start_addon(
 
 
 async def test_install_addon(
-    hass,
+    hass: HomeAssistant,
     addon_not_installed,
     install_addon,
     addon_options,
     set_addon_options,
     start_addon,
-):
+) -> None:
     """Test install and start the Z-Wave JS add-on during entry setup."""
     device = "/test"
     s0_legacy_key = "s0_legacy"
@@ -542,13 +564,13 @@ async def test_install_addon(
 
 @pytest.mark.parametrize("addon_info_side_effect", [HassioAPIError("Boom")])
 async def test_addon_info_failure(
-    hass,
+    hass: HomeAssistant,
     addon_installed,
     install_addon,
     addon_options,
     set_addon_options,
     start_addon,
-):
+) -> None:
     """Test failure to get add-on info for Z-Wave JS add-on during entry setup."""
     device = "/test"
     network_key = "abc123"
@@ -596,7 +618,7 @@ async def test_addon_info_failure(
     ],
 )
 async def test_addon_options_changed(
-    hass,
+    hass: HomeAssistant,
     client,
     addon_installed,
     addon_running,
@@ -613,7 +635,7 @@ async def test_addon_options_changed(
     new_s2_authenticated_key,
     old_s2_unauthenticated_key,
     new_s2_unauthenticated_key,
-):
+) -> None:
     """Test update config entry data on entry setup if add-on options changed."""
     addon_options["device"] = new_device
     addon_options["s0_legacy_key"] = new_s0_legacy_key
@@ -665,7 +687,7 @@ async def test_addon_options_changed(
     ],
 )
 async def test_update_addon(
-    hass,
+    hass: HomeAssistant,
     client,
     addon_info,
     addon_installed,
@@ -680,7 +702,7 @@ async def test_update_addon(
     update_addon_side_effect,
     create_backup_side_effect,
     version_state,
-):
+) -> None:
     """Test update the Z-Wave JS add-on during entry setup."""
     device = "/test"
     network_key = "abc123"
@@ -713,7 +735,7 @@ async def test_update_addon(
     assert update_addon.call_count == update_calls
 
 
-async def test_issue_registry(hass, client, version_state):
+async def test_issue_registry(hass: HomeAssistant, client, version_state) -> None:
     """Test issue registry."""
     device = "/test"
     network_key = "abc123"
@@ -762,7 +784,7 @@ async def test_issue_registry(hass, client, version_state):
     ],
 )
 async def test_stop_addon(
-    hass,
+    hass: HomeAssistant,
     client,
     addon_installed,
     addon_running,
@@ -770,7 +792,7 @@ async def test_stop_addon(
     stop_addon,
     stop_addon_side_effect,
     entry_state,
-):
+) -> None:
     """Test stop the Z-Wave JS add-on on entry unload if entry is disabled."""
     stop_addon.side_effect = stop_addon_side_effect
     device = "/test"
@@ -805,8 +827,13 @@ async def test_stop_addon(
 
 
 async def test_remove_entry(
-    hass, addon_installed, stop_addon, create_backup, uninstall_addon, caplog
-):
+    hass: HomeAssistant,
+    addon_installed,
+    stop_addon,
+    create_backup,
+    uninstall_addon,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test remove the config entry."""
     # test successful remove without created add-on
     entry = MockConfigEntry(
@@ -916,8 +943,12 @@ async def test_remove_entry(
 
 
 async def test_removed_device(
-    hass, client, climate_radio_thermostat_ct100_plus, lock_schlage_be469, integration
-):
+    hass: HomeAssistant,
+    client,
+    climate_radio_thermostat_ct100_plus,
+    lock_schlage_be469,
+    integration,
+) -> None:
     """Test that the device registry gets updated when a device gets removed."""
     driver = client.driver
     assert driver
@@ -948,7 +979,7 @@ async def test_removed_device(
     assert dev_reg.async_get_device({get_device_id(driver, old_node)}) is None
 
 
-async def test_suggested_area(hass, client, eaton_rf9640_dimmer):
+async def test_suggested_area(hass: HomeAssistant, client, eaton_rf9640_dimmer) -> None:
     """Test that suggested area works."""
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -962,7 +993,9 @@ async def test_suggested_area(hass, client, eaton_rf9640_dimmer):
     assert dev_reg.async_get(entity.device_id).area_id is not None
 
 
-async def test_node_removed(hass, multisensor_6_state, client, integration):
+async def test_node_removed(
+    hass: HomeAssistant, multisensor_6_state, client, integration
+) -> None:
     """Test that device gets removed when node gets removed."""
     dev_reg = dr.async_get(hass)
     node = Node(client, deepcopy(multisensor_6_state))
@@ -988,8 +1021,8 @@ async def test_node_removed(hass, multisensor_6_state, client, integration):
 
 
 async def test_replace_same_node(
-    hass, multisensor_6, multisensor_6_state, client, integration
-):
+    hass: HomeAssistant, multisensor_6, multisensor_6_state, client, integration
+) -> None:
     """Test when a node is replaced with itself that the device remains."""
     dev_reg = dr.async_get(hass)
     node_id = multisensor_6.node_id
@@ -1094,13 +1127,13 @@ async def test_replace_same_node(
 
 
 async def test_replace_different_node(
-    hass,
+    hass: HomeAssistant,
     multisensor_6,
     multisensor_6_state,
     hank_binary_switch_state,
     client,
     integration,
-):
+) -> None:
     """Test when a node is replaced with a different node."""
     dev_reg = dr.async_get(hass)
     node_id = multisensor_6.node_id
@@ -1212,7 +1245,9 @@ async def test_replace_different_node(
     assert hass.states.get("switch.smart_plug_with_two_usb_ports")
 
 
-async def test_node_model_change(hass, zp3111, client, integration):
+async def test_node_model_change(
+    hass: HomeAssistant, zp3111, client, integration
+) -> None:
     """Test when a node's model is changed due to an updated device config file.
 
     The device and entities should not be removed.
@@ -1295,8 +1330,8 @@ async def test_node_model_change(hass, zp3111, client, integration):
 
 
 async def test_disabled_node_status_entity_on_node_replaced(
-    hass, zp3111_state, zp3111, client, integration
-):
+    hass: HomeAssistant, zp3111_state, zp3111, client, integration
+) -> None:
     """Test that when a node replacement event is received the node status sensor is removed."""
     node_status_entity = "sensor.4_in_1_sensor_node_status"
     state = hass.states.get(node_status_entity)
@@ -1320,7 +1355,9 @@ async def test_disabled_node_status_entity_on_node_replaced(
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_disabled_entity_on_value_removed(hass, zp3111, client, integration):
+async def test_disabled_entity_on_value_removed(
+    hass: HomeAssistant, zp3111, client, integration
+) -> None:
     """Test that when entity primary values are removed the entity is removed."""
     er_reg = er.async_get(hass)
 

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import (
     AEON_SMART_SWITCH_LIGHT_ENTITY,
@@ -35,7 +36,9 @@ from .common import (
 HSM200_V1_ENTITY = "light.hsm200"
 
 
-async def test_light(hass, client, bulb_6_multi_color, integration):
+async def test_light(
+    hass: HomeAssistant, client, bulb_6_multi_color, integration
+) -> None:
     """Test the light entity."""
     node = bulb_6_multi_color
     state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
@@ -395,7 +398,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert args["value"] == 0
 
 
-async def test_v4_dimmer_light(hass, client, eaton_rf9640_dimmer, integration):
+async def test_v4_dimmer_light(
+    hass: HomeAssistant, client, eaton_rf9640_dimmer, integration
+) -> None:
     """Test a light that supports MultiLevelSwitch CommandClass version 4."""
     state = hass.states.get(EATON_RF9640_ENTITY)
 
@@ -405,13 +410,15 @@ async def test_v4_dimmer_light(hass, client, eaton_rf9640_dimmer, integration):
     assert state.attributes[ATTR_BRIGHTNESS] == 57
 
 
-async def test_optional_light(hass, client, aeon_smart_switch_6, integration):
+async def test_optional_light(
+    hass: HomeAssistant, client, aeon_smart_switch_6, integration
+) -> None:
     """Test a device that has an additional light endpoint being identified as light."""
     state = hass.states.get(AEON_SMART_SWITCH_LIGHT_ENTITY)
     assert state.state == STATE_ON
 
 
-async def test_rgbw_light(hass, client, zen_31, integration):
+async def test_rgbw_light(hass: HomeAssistant, client, zen_31, integration) -> None:
     """Test the light entity."""
     state = hass.states.get(ZEN_31_ENTITY)
 
@@ -451,7 +458,9 @@ async def test_rgbw_light(hass, client, zen_31, integration):
     client.async_send_command.reset_mock()
 
 
-async def test_light_none_color_value(hass, light_color_null_values, integration):
+async def test_light_none_color_value(
+    hass: HomeAssistant, light_color_null_values, integration
+) -> None:
     """Test the light entity can handle None value in current color Value."""
     entity_id = "light.repeater"
     state = hass.states.get(entity_id)
@@ -462,7 +471,9 @@ async def test_light_none_color_value(hass, light_color_null_values, integration
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
 
 
-async def test_black_is_off(hass, client, express_controls_ezmultipli, integration):
+async def test_black_is_off(
+    hass: HomeAssistant, client, express_controls_ezmultipli, integration
+) -> None:
     """Test the black is off light entity."""
     node = express_controls_ezmultipli
     state = hass.states.get(HSM200_V1_ENTITY)

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -26,11 +26,14 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
+from homeassistant.core import HomeAssistant
 
 from .common import SCHLAGE_BE469_LOCK_ENTITY, replace_value_of_zwave_value
 
 
-async def test_door_lock(hass, client, lock_schlage_be469, integration):
+async def test_door_lock(
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test a lock entity with door lock command class."""
     node = lock_schlage_be469
     state = hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
@@ -164,12 +167,16 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY).state == STATE_UNAVAILABLE
 
 
-async def test_only_one_lock(hass, client, lock_home_connect_620, integration):
+async def test_only_one_lock(
+    hass: HomeAssistant, client, lock_home_connect_620, integration
+) -> None:
     """Test node with both Door Lock and Lock CC values only gets one lock entity."""
     assert len(hass.states.async_entity_ids("lock")) == 1
 
 
-async def test_door_lock_no_value(hass, client, lock_schlage_be469_state, integration):
+async def test_door_lock_no_value(
+    hass: HomeAssistant, client, lock_schlage_be469_state, integration
+) -> None:
     """Test a lock entity with door lock command class that has no value for mode."""
     node_state = replace_value_of_zwave_value(
         lock_schlage_be469_state,

--- a/tests/components/zwave_js/test_logbook.py
+++ b/tests/components/zwave_js/test_logbook.py
@@ -6,6 +6,7 @@ from homeassistant.components.zwave_js.const import (
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -13,8 +14,8 @@ from tests.components.logbook.common import MockRow, mock_humanify
 
 
 async def test_humanifying_zwave_js_notification_event(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test humanifying Z-Wave JS notification events."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_device(
@@ -96,8 +97,8 @@ async def test_humanifying_zwave_js_notification_event(
 
 
 async def test_humanifying_zwave_js_value_notification_event(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test humanifying Z-Wave JS value notification events."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_device(

--- a/tests/components/zwave_js/test_migrate.py
+++ b/tests/components/zwave_js/test_migrate.py
@@ -6,14 +6,15 @@ from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import AIR_TEMPERATURE_SENSOR, NOTIFICATION_MOTION_BINARY_SENSOR
 
 
 async def test_unique_id_migration_dupes(
-    hass, multisensor_6_state, client, integration
-):
+    hass: HomeAssistant, multisensor_6_state, client, integration
+) -> None:
     """Test we remove an entity when ."""
     ent_reg = er.async_get(hass)
 
@@ -72,7 +73,9 @@ async def test_unique_id_migration_dupes(
         "52-49-0-Air temperature-00-00",
     ],
 )
-async def test_unique_id_migration(hass, multisensor_6_state, client, integration, id):
+async def test_unique_id_migration(
+    hass: HomeAssistant, multisensor_6_state, client, integration, id
+) -> None:
     """Test unique ID is migrated from old format to new."""
     ent_reg = er.async_get(hass)
 
@@ -115,8 +118,8 @@ async def test_unique_id_migration(hass, multisensor_6_state, client, integratio
     ],
 )
 async def test_unique_id_migration_property_key(
-    hass, hank_binary_switch_state, client, integration, id
-):
+    hass: HomeAssistant, hank_binary_switch_state, client, integration, id
+) -> None:
     """Test unique ID with property key is migrated from old format to new."""
     ent_reg = er.async_get(hass)
 
@@ -151,8 +154,8 @@ async def test_unique_id_migration_property_key(
 
 
 async def test_unique_id_migration_notification_binary_sensor(
-    hass, multisensor_6_state, client, integration
-):
+    hass: HomeAssistant, multisensor_6_state, client, integration
+) -> None:
     """Test unique ID is migrated from old format to new for a notification binary sensor."""
     ent_reg = er.async_get(hass)
 
@@ -192,8 +195,8 @@ async def test_unique_id_migration_notification_binary_sensor(
 
 
 async def test_old_entity_migration(
-    hass, hank_binary_switch_state, client, integration
-):
+    hass: HomeAssistant, hank_binary_switch_state, client, integration
+) -> None:
     """Test old entity on a different endpoint is migrated to a new one."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
     driver = client.driver
@@ -240,8 +243,8 @@ async def test_old_entity_migration(
 
 
 async def test_different_endpoint_migration_status_sensor(
-    hass, hank_binary_switch_state, client, integration
-):
+    hass: HomeAssistant, hank_binary_switch_state, client, integration
+) -> None:
     """Test that the different endpoint migration logic skips over the status sensor."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
     driver = client.driver
@@ -286,8 +289,8 @@ async def test_different_endpoint_migration_status_sensor(
 
 
 async def test_skip_old_entity_migration_for_multiple(
-    hass, hank_binary_switch_state, client, integration
-):
+    hass: HomeAssistant, hank_binary_switch_state, client, integration
+) -> None:
     """Test that multiple entities of the same value but on a different endpoint get skipped."""
     node = Node(client, copy.deepcopy(hank_binary_switch_state))
     driver = client.driver
@@ -348,8 +351,8 @@ async def test_skip_old_entity_migration_for_multiple(
 
 
 async def test_old_entity_migration_notification_binary_sensor(
-    hass, multisensor_6_state, client, integration
-):
+    hass: HomeAssistant, multisensor_6_state, client, integration
+) -> None:
     """Test old entity on a different endpoint is migrated to a new one for a notification binary sensor."""
     node = Node(client, copy.deepcopy(multisensor_6_state))
     driver = client.driver

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -5,6 +5,7 @@ import pytest
 from zwave_js_server.event import Event
 
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -16,7 +17,9 @@ NUMBER_ENTITY = "number.thermostat_hvac_valve_control"
 VOLUME_NUMBER_ENTITY = "number.indoor_siren_6_default_volume_2"
 
 
-async def test_number(hass, client, aeotec_radiator_thermostat, integration):
+async def test_number(
+    hass: HomeAssistant, client, aeotec_radiator_thermostat, integration
+) -> None:
     """Test the number entity."""
     node = aeotec_radiator_thermostat
     state = hass.states.get(NUMBER_ENTITY)
@@ -81,8 +84,12 @@ def mock_client_fixture():
 
 
 async def test_number_no_target_value(
-    hass, client, no_target_value, aeotec_radiator_thermostat, integration
-):
+    hass: HomeAssistant,
+    client,
+    no_target_value,
+    aeotec_radiator_thermostat,
+    integration,
+) -> None:
     """Test the number entity with no target value."""
     # Test turn on setting value fails
     with pytest.raises(HomeAssistantError):
@@ -94,7 +101,9 @@ async def test_number_no_target_value(
         )
 
 
-async def test_number_writeable(hass, client, aeotec_radiator_thermostat):
+async def test_number_writeable(
+    hass: HomeAssistant, client, aeotec_radiator_thermostat
+) -> None:
     """Test the number entity where current value is writeable."""
     aeotec_radiator_thermostat.values["4-38-0-currentValue"].metadata.data[
         "writeable"
@@ -129,7 +138,9 @@ async def test_number_writeable(hass, client, aeotec_radiator_thermostat):
     client.async_send_command.reset_mock()
 
 
-async def test_volume_number(hass, client, aeotec_zw164_siren, integration):
+async def test_volume_number(
+    hass: HomeAssistant, client, aeotec_zw164_siren, integration
+) -> None:
     """Test the volume number entity."""
     node = aeotec_zw164_siren
     state = hass.states.get(VOLUME_NUMBER_ENTITY)
@@ -208,7 +219,9 @@ async def test_volume_number(hass, client, aeotec_zw164_siren, integration):
     assert state.state == STATE_UNKNOWN
 
 
-async def test_disabled_basic_number(hass, ge_in_wall_dimmer_switch, integration):
+async def test_disabled_basic_number(
+    hass: HomeAssistant, ge_in_wall_dimmer_switch, integration
+) -> None:
     """Test number is created from Basic CC and is disabled."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(BASIC_NUMBER_ENTITY)

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -210,7 +210,9 @@ async def test_protection_select(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_multilevel_switch_select(hass, client, fortrezz_ssa1_siren, integration):
+async def test_multilevel_switch_select(
+    hass: HomeAssistant, client, fortrezz_ssa1_siren, integration
+) -> None:
     """Test Multilevel Switch CC based select entity."""
     node = fortrezz_ssa1_siren
     state = hass.states.get(MULTILEVEL_SWITCH_SELECT_ENTITY)
@@ -271,8 +273,8 @@ async def test_multilevel_switch_select(hass, client, fortrezz_ssa1_siren, integ
 
 
 async def test_multilevel_switch_select_no_value(
-    hass, client, fortrezz_ssa1_siren_state, integration
-):
+    hass: HomeAssistant, client, fortrezz_ssa1_siren_state, integration
+) -> None:
     """Test Multilevel Switch CC based select entity with primary value is None."""
     node_state = replace_value_of_zwave_value(
         fortrezz_ssa1_siren_state,

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -1,6 +1,7 @@
 """Test the Z-Wave JS sensor platform."""
 import copy
 
+import pytest
 from zwave_js_server.const.command_class.meter import MeterType
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
@@ -33,6 +34,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
@@ -51,8 +53,8 @@ from .common import (
 
 
 async def test_numeric_sensor(
-    hass, multisensor_6, express_controls_ezmultipli, integration
-):
+    hass: HomeAssistant, multisensor_6, express_controls_ezmultipli, integration
+) -> None:
     """Test the numeric sensor."""
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
@@ -102,7 +104,9 @@ async def test_numeric_sensor(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
 
 
-async def test_energy_sensors(hass, hank_binary_switch, integration):
+async def test_energy_sensors(
+    hass: HomeAssistant, hank_binary_switch, integration
+) -> None:
     """Test power and energy sensors."""
     state = hass.states.get(POWER_SENSOR)
 
@@ -135,7 +139,9 @@ async def test_energy_sensors(hass, hank_binary_switch, integration):
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.CURRENT
 
 
-async def test_disabled_notification_sensor(hass, multisensor_6, integration):
+async def test_disabled_notification_sensor(
+    hass: HomeAssistant, multisensor_6, integration
+) -> None:
     """Test sensor is created from Notification CC and is disabled."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
@@ -161,8 +167,8 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
 
 
 async def test_disabled_indcator_sensor(
-    hass, climate_radio_thermostat_ct100_plus, integration
-):
+    hass: HomeAssistant, climate_radio_thermostat_ct100_plus, integration
+) -> None:
     """Test sensor is created from Indicator CC and is disabled."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(INDICATOR_SENSOR)
@@ -172,7 +178,9 @@ async def test_disabled_indcator_sensor(
     assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration):
+async def test_config_parameter_sensor(
+    hass: HomeAssistant, lock_id_lock_as_id150, integration
+) -> None:
     """Test config parameter sensor is created."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
@@ -180,7 +188,9 @@ async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration)
     assert entity_entry.disabled
 
 
-async def test_node_status_sensor(hass, client, lock_id_lock_as_id150, integration):
+async def test_node_status_sensor(
+    hass: HomeAssistant, client, lock_id_lock_as_id150, integration
+) -> None:
     """Test node status sensor is created and gets updated on node state changes."""
     NODE_STATUS_ENTITY = "sensor.z_wave_module_for_id_lock_150_and_101_node_status"
     node = lock_id_lock_as_id150
@@ -241,13 +251,13 @@ async def test_node_status_sensor(hass, client, lock_id_lock_as_id150, integrati
 
 
 async def test_node_status_sensor_not_ready(
-    hass,
+    hass: HomeAssistant,
     client,
     lock_id_lock_as_id150_not_ready,
     lock_id_lock_as_id150_state,
     integration,
-    caplog,
-):
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test node status sensor is created and available if node is not ready."""
     NODE_STATUS_ENTITY = "sensor.z_wave_module_for_id_lock_150_and_101_node_status"
     node = lock_id_lock_as_id150_not_ready
@@ -287,11 +297,11 @@ async def test_node_status_sensor_not_ready(
 
 
 async def test_reset_meter(
-    hass,
+    hass: HomeAssistant,
     client,
     aeon_smart_switch_6,
     integration,
-):
+) -> None:
     """Test reset_meter service."""
     client.async_send_command.return_value = {}
     client.async_send_command_no_wait.return_value = {}
@@ -338,11 +348,11 @@ async def test_reset_meter(
 
 
 async def test_meter_attributes(
-    hass,
+    hass: HomeAssistant,
     client,
     aeon_smart_switch_6,
     integration,
-):
+) -> None:
     """Test meter entity attributes."""
     state = hass.states.get(METER_ENERGY_SENSOR)
     assert state
@@ -352,7 +362,9 @@ async def test_meter_attributes(
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL_INCREASING
 
 
-async def test_special_meters(hass, aeon_smart_switch_6_state, client, integration):
+async def test_special_meters(
+    hass: HomeAssistant, aeon_smart_switch_6_state, client, integration
+) -> None:
     """Test meters that have special handling."""
     node_data = copy.deepcopy(
         aeon_smart_switch_6_state
@@ -419,7 +431,7 @@ async def test_special_meters(hass, aeon_smart_switch_6_state, client, integrati
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
 
 
-async def test_unit_change(hass, zp3111, client, integration):
+async def test_unit_change(hass: HomeAssistant, zp3111, client, integration) -> None:
     """Test unit change via metadata updated event is handled by numeric sensors."""
     entity_id = "sensor.4_in_1_sensor_air_temperature"
     state = hass.states.get(entity_id)

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -32,6 +32,7 @@ from homeassistant.components.zwave_js.const import (
 )
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.const import ATTR_AREA_ID, ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.area_registry import async_get as async_get_area_reg
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
@@ -51,7 +52,9 @@ from .common import (
 from tests.common import MockConfigEntry
 
 
-async def test_set_config_parameter(hass, client, multisensor_6, integration):
+async def test_set_config_parameter(
+    hass: HomeAssistant, client, multisensor_6, integration
+) -> None:
     """Test the set_config_parameter service."""
     dev_reg = async_get_dev_reg(hass)
     ent_reg = async_get_ent_reg(hass)
@@ -363,12 +366,12 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
 
 
 async def test_set_config_parameter_gather(
-    hass,
+    hass: HomeAssistant,
     client,
     multisensor_6,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test the set_config_parameter service gather functionality."""
     # Test setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
@@ -402,7 +405,9 @@ async def test_set_config_parameter_gather(
     client.async_send_command.reset_mock()
 
 
-async def test_bulk_set_config_parameters(hass, client, multisensor_6, integration):
+async def test_bulk_set_config_parameters(
+    hass: HomeAssistant, client, multisensor_6, integration
+) -> None:
     """Test the bulk_set_partial_config_parameters service."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
@@ -612,12 +617,12 @@ async def test_bulk_set_config_parameters(hass, client, multisensor_6, integrati
 
 
 async def test_bulk_set_config_parameters_gather(
-    hass,
+    hass: HomeAssistant,
     client,
     multisensor_6,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test the bulk_set_partial_config_parameters service gather functionality."""
     # Test bulk setting config parameter by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
@@ -651,8 +656,11 @@ async def test_bulk_set_config_parameters_gather(
 
 
 async def test_refresh_value(
-    hass, client, climate_radio_thermostat_ct100_plus_different_endpoints, integration
-):
+    hass: HomeAssistant,
+    client,
+    climate_radio_thermostat_ct100_plus_different_endpoints,
+    integration,
+) -> None:
     """Test the refresh_value service."""
     # Test polling the primary value
     client.async_send_command.return_value = {"result": 2}
@@ -731,7 +739,9 @@ async def test_refresh_value(
         )
 
 
-async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
+async def test_set_value(
+    hass: HomeAssistant, client, climate_danfoss_lc_13, integration
+) -> None:
     """Test set_value service."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
@@ -897,8 +907,8 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
 
 
 async def test_set_value_string(
-    hass, client, climate_danfoss_lc_13, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, climate_danfoss_lc_13, lock_schlage_be469, integration
+) -> None:
     """Test set_value service converts number to string when needed."""
     client.async_send_command.return_value = {"success": True}
 
@@ -929,7 +939,9 @@ async def test_set_value_string(
     assert args["value"] == "12345"
 
 
-async def test_set_value_options(hass, client, aeon_smart_switch_6, integration):
+async def test_set_value_options(
+    hass: HomeAssistant, client, aeon_smart_switch_6, integration
+) -> None:
     """Test set_value service with options."""
     await hass.services.async_call(
         DOMAIN,
@@ -960,12 +972,12 @@ async def test_set_value_options(hass, client, aeon_smart_switch_6, integration)
 
 
 async def test_set_value_gather(
-    hass,
+    hass: HomeAssistant,
     client,
     multisensor_6,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test the set_value service gather functionality."""
     # Test setting value by property and validate that the first node
     # which triggers an error doesn't prevent the second one to be called.
@@ -1003,12 +1015,12 @@ async def test_set_value_gather(
 
 
 async def test_multicast_set_value(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_danfoss_lc_13,
     climate_eurotronic_spirit_z,
     integration,
-):
+) -> None:
     """Test multicast_set_value service."""
     # Test successful multicast call
     await hass.services.async_call(
@@ -1279,12 +1291,12 @@ async def test_multicast_set_value(
 
 
 async def test_multicast_set_value_options(
-    hass,
+    hass: HomeAssistant,
     client,
     bulb_6_multi_color,
     light_color_null_values,
     integration,
-):
+) -> None:
     """Test multicast_set_value service with options."""
     await hass.services.async_call(
         DOMAIN,
@@ -1325,12 +1337,12 @@ async def test_multicast_set_value_options(
 
 
 async def test_multicast_set_value_string(
-    hass,
+    hass: HomeAssistant,
     client,
     lock_id_lock_as_id150,
     lock_schlage_be469,
     integration,
-):
+) -> None:
     """Test multicast_set_value service converts number to string when needed."""
     client.async_send_command.return_value = {"success": True}
 
@@ -1360,12 +1372,12 @@ async def test_multicast_set_value_string(
 
 
 async def test_ping(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_danfoss_lc_13,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test ping service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(
@@ -1498,12 +1510,12 @@ async def test_ping(
 
 
 async def test_invoke_cc_api(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_danfoss_lc_13,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test invoke_cc_api service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(

--- a/tests/components/zwave_js/test_siren.py
+++ b/tests/components/zwave_js/test_siren.py
@@ -7,6 +7,7 @@ from homeassistant.components.siren import (
     ATTR_VOLUME_LEVEL,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 
 SIREN_ENTITY = "siren.indoor_siren_6_2"
 
@@ -62,7 +63,9 @@ TONE_ID_VALUE_ID = {
 }
 
 
-async def test_siren(hass, client, aeotec_zw164_siren, integration):
+async def test_siren(
+    hass: HomeAssistant, client, aeotec_zw164_siren, integration
+) -> None:
     """Test the siren entity."""
     node = aeotec_zw164_siren
     state = hass.states.get(SIREN_ENTITY)

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -1,5 +1,4 @@
 """Test the Z-Wave JS switch platform."""
-
 from zwave_js_server.const import CURRENT_VALUE_PROPERTY, CommandClass
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
@@ -7,11 +6,14 @@ from zwave_js_server.model.node import Node
 from homeassistant.components.switch import DOMAIN, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
 
 from .common import SWITCH_ENTITY, replace_value_of_zwave_value
 
 
-async def test_switch(hass, hank_binary_switch, integration, client):
+async def test_switch(
+    hass: HomeAssistant, hank_binary_switch, integration, client
+) -> None:
     """Test the switch."""
     state = hass.states.get(SWITCH_ENTITY)
     node = hank_binary_switch
@@ -73,7 +75,9 @@ async def test_switch(hass, hank_binary_switch, integration, client):
     assert args["value"] is False
 
 
-async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
+async def test_barrier_signaling_switch(
+    hass: HomeAssistant, gdc_zw062, integration, client
+) -> None:
     """Test barrier signaling state switch."""
     node = gdc_zw062
     entity = "switch.aeon_labs_garage_door_controller_gen5_signaling_state_visual"
@@ -183,7 +187,9 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
     assert state.state == STATE_ON
 
 
-async def test_switch_no_value(hass, hank_binary_switch_state, integration, client):
+async def test_switch_no_value(
+    hass: HomeAssistant, hank_binary_switch_state, integration, client
+) -> None:
     """Test the switch where primary value value is None."""
     node_state = replace_value_of_zwave_value(
         hank_binary_switch_state,

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -24,7 +24,9 @@ from .common import SCHLAGE_BE469_LOCK_ENTITY
 from tests.common import async_capture_events
 
 
-async def test_zwave_js_value_updated(hass, client, lock_schlage_be469, integration):
+async def test_zwave_js_value_updated(
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test for zwave_js.value_updated automation trigger."""
     trigger_type = f"{DOMAIN}.value_updated"
     node: Node = lock_schlage_be469
@@ -272,8 +274,8 @@ async def test_zwave_js_value_updated(hass, client, lock_schlage_be469, integrat
 
 
 async def test_zwave_js_value_updated_bypass_dynamic_validation(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test zwave_js.value_updated trigger when bypassing dynamic validation."""
     trigger_type = f"{DOMAIN}.value_updated"
     node: Node = lock_schlage_be469
@@ -330,8 +332,8 @@ async def test_zwave_js_value_updated_bypass_dynamic_validation(
 
 
 async def test_zwave_js_value_updated_bypass_dynamic_validation_no_nodes(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test value_updated trigger when bypassing dynamic validation with no nodes."""
     trigger_type = f"{DOMAIN}.value_updated"
     node: Node = lock_schlage_be469
@@ -388,8 +390,8 @@ async def test_zwave_js_value_updated_bypass_dynamic_validation_no_nodes(
 
 
 async def test_zwave_js_value_updated_bypass_dynamic_validation_no_driver(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test zwave_js.value_updated trigger without driver."""
     trigger_type = f"{DOMAIN}.value_updated"
     node: Node = lock_schlage_be469
@@ -446,7 +448,9 @@ async def test_zwave_js_value_updated_bypass_dynamic_validation_no_driver(
     assert len(no_value_filter) == 0
 
 
-async def test_zwave_js_event(hass, client, lock_schlage_be469, integration):
+async def test_zwave_js_event(
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test for zwave_js.event automation trigger."""
     trigger_type = f"{DOMAIN}.event"
     node: Node = lock_schlage_be469
@@ -825,8 +829,8 @@ async def test_zwave_js_event(hass, client, lock_schlage_be469, integration):
 
 
 async def test_zwave_js_event_bypass_dynamic_validation(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test zwave_js.event trigger when bypassing dynamic config validation."""
     trigger_type = f"{DOMAIN}.event"
     node: Node = lock_schlage_be469
@@ -875,8 +879,8 @@ async def test_zwave_js_event_bypass_dynamic_validation(
 
 
 async def test_zwave_js_event_bypass_dynamic_validation_no_nodes(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test event trigger when bypassing dynamic validation with no nodes."""
     trigger_type = f"{DOMAIN}.event"
     node: Node = lock_schlage_be469
@@ -926,8 +930,8 @@ async def test_zwave_js_event_bypass_dynamic_validation_no_nodes(
 
 
 async def test_zwave_js_event_invalid_config_entry_id(
-    hass, client, integration, caplog
-):
+    hass: HomeAssistant, client, integration, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test zwave_js.event automation trigger fails when config entry ID is invalid."""
     trigger_type = f"{DOMAIN}.event"
 
@@ -993,8 +997,8 @@ async def test_invalid_trigger_configs(hass: HomeAssistant) -> None:
 
 
 async def test_zwave_js_trigger_config_entry_unloaded(
-    hass, client, lock_schlage_be469, integration
-):
+    hass: HomeAssistant, client, lock_schlage_be469, integration
+) -> None:
     """Test zwave_js triggers bypass dynamic validation when needed."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -21,11 +21,13 @@ from homeassistant.components.update import (
 from homeassistant.components.zwave_js.const import DOMAIN, SERVICE_REFRESH_VALUE
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 UPDATE_ENTITY = "update.z_wave_thermostat_firmware"
 FIRMWARE_UPDATES = {
@@ -69,13 +71,13 @@ FIRMWARE_UPDATE_MULTIPLE_FILES = {
 
 
 async def test_update_entity_states(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-    caplog,
-    hass_ws_client,
-):
+    caplog: pytest.LogCaptureFixture,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test update entity states."""
     ws_client = await hass_ws_client(hass)
 
@@ -154,11 +156,11 @@ async def test_update_entity_states(
 
 
 async def test_update_entity_install_raises(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test update entity install raises exception."""
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
@@ -180,11 +182,11 @@ async def test_update_entity_install_raises(
 
 
 async def test_update_entity_sleep(
-    hass,
+    hass: HomeAssistant,
     client,
     zen_31,
     integration,
-):
+) -> None:
     """Test update occurs when device is asleep after it wakes up."""
     event = Event(
         "sleep",
@@ -217,11 +219,11 @@ async def test_update_entity_sleep(
 
 
 async def test_update_entity_dead(
-    hass,
+    hass: HomeAssistant,
     client,
     zen_31,
     integration,
-):
+) -> None:
     """Test update occurs when device is dead after it becomes alive."""
     event = Event(
         "dead",
@@ -254,11 +256,11 @@ async def test_update_entity_dead(
 
 
 async def test_update_entity_ha_not_running(
-    hass,
+    hass: HomeAssistant,
     client,
     zen_31,
-    hass_ws_client,
-):
+    hass_ws_client: WebSocketGenerator,
+) -> None:
     """Test update occurs after HA starts."""
     await hass.async_stop()
 
@@ -278,11 +280,11 @@ async def test_update_entity_ha_not_running(
 
 
 async def test_update_entity_update_failure(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test update entity update failed."""
     assert len(client.async_send_command.call_args_list) == 0
     client.async_send_command.side_effect = FailedZWaveCommand("test", 260, "test")
@@ -303,11 +305,11 @@ async def test_update_entity_update_failure(
 
 
 async def test_update_entity_progress(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test update entity progress."""
     node = climate_radio_thermostat_ct100_plus_different_endpoints
     client.async_send_command.return_value = FIRMWARE_UPDATES
@@ -398,12 +400,12 @@ async def test_update_entity_progress(
 
 
 async def test_update_entity_install_failed(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-    caplog,
-):
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test update entity install returns error status."""
     node = climate_radio_thermostat_ct100_plus_different_endpoints
     client.async_send_command.return_value = FIRMWARE_UPDATES
@@ -491,11 +493,11 @@ async def test_update_entity_install_failed(
 
 
 async def test_update_entity_reload(
-    hass,
+    hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-):
+) -> None:
     """Test update entity maintains state after reload."""
     assert hass.states.get(UPDATE_ENTITY).state == STATE_OFF
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777 (batched in groups of about 50)

This second pass identifies more missing return types, and takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
