### PR TITLE
Fix sleepiq test to not contact the API

### DIFF
--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -14,7 +14,10 @@ from .conftest import SLEEPIQ_CONFIG, setup_platform
 
 async def test_import(hass: HomeAssistant) -> None:
     """Test that we can import a config entry."""
-    with patch("asyncsleepiq.AsyncSleepIQ.login"):
+    with patch("asyncsleepiq.AsyncSleepIQ.login"), patch(
+        "homeassistant.components.sleepiq.async_setup_entry",
+        return_value=True,
+    ):
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: SLEEPIQ_CONFIG})
         await hass.async_block_till_done()
 

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the SleepIQ config flow."""
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
 
 from asyncsleepiq import SleepIQLoginException, SleepIQTimeoutException
 import pytest
@@ -12,12 +13,18 @@ from homeassistant.core import HomeAssistant
 from .conftest import SLEEPIQ_CONFIG, setup_platform
 
 
+@pytest.fixture(autouse=True, name="mock_setup_entry")
+def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.sleepiq.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
 async def test_import(hass: HomeAssistant) -> None:
     """Test that we can import a config entry."""
-    with patch("asyncsleepiq.AsyncSleepIQ.login"), patch(
-        "homeassistant.components.sleepiq.async_setup_entry",
-        return_value=True,
-    ):
+    with patch("asyncsleepiq.AsyncSleepIQ.login"):
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: SLEEPIQ_CONFIG})
         await hass.async_block_till_done()
 
@@ -75,7 +82,7 @@ async def test_login_failure(hass: HomeAssistant, side_effect, error) -> None:
         assert result["errors"] == {"base": error}
 
 
-async def test_success(hass: HomeAssistant) -> None:
+async def test_success(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test successful flow provides entry creation data."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -83,10 +90,7 @@ async def test_success(hass: HomeAssistant) -> None:
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch("asyncsleepiq.AsyncSleepIQ.login", return_value=True), patch(
-        "homeassistant.components.sleepiq.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    with patch("asyncsleepiq.AsyncSleepIQ.login", return_value=True):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], SLEEPIQ_CONFIG
         )
@@ -119,9 +123,6 @@ async def test_reauth_password(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.sleepiq.config_flow.AsyncSleepIQ.login",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.sleepiq.async_setup_entry",
         return_value=True,
     ):
         result2 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
