### PR TITLE
Tweak typing of Entity.platform

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -323,7 +323,6 @@ class RflinkDevice(Entity):
     Contains the common logic for Rflink entities.
     """
 
-    platform = None
     _state: bool | None = None
     _available = True
     _attr_should_poll = False

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -236,9 +236,6 @@ class UpdateEntity(RestoreEntity):
         Update entities return the brand icon based on the integration
         domain by default.
         """
-        if self.platform is None:
-            return None
-
         return (
             f"https://brands.home-assistant.io/_/{self.platform.platform_name}/icon.png"
         )

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -235,12 +235,12 @@ class Entity(ABC):
     # this class. These may be used to customize the behavior of the entity.
     entity_id: str = None  # type: ignore[assignment]
 
-    # Owning hass instance. Will be set by EntityPlatform
+    # Owning hass instance. Set by EntityPlatform by calling add_to_platform_start
     # While not purely typed, it makes typehinting more useful for us
     # and removes the need for constant None checks or asserts.
     hass: HomeAssistant = None  # type: ignore[assignment]
 
-    # Owning platform instance. Will be set by EntityPlatform
+    # Owning platform instance. Set by EntityPlatform by calling add_to_platform_start
     # While not purely typed, it makes typehinting more useful for us
     # and removes the need for constant None checks or asserts.
     platform: EntityPlatform = None  # type: ignore[assignment]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -241,7 +241,9 @@ class Entity(ABC):
     hass: HomeAssistant = None  # type: ignore[assignment]
 
     # Owning platform instance. Will be set by EntityPlatform
-    platform: EntityPlatform | None = None
+    # While not purely typed, it makes typehinting more useful for us
+    # and removes the need for constant None checks or asserts.
+    platform: EntityPlatform = None  # type: ignore[assignment]
 
     # Entity description instance for this Entity
     entity_description: EntityDescription
@@ -840,7 +842,7 @@ class Entity(ABC):
         self._call_on_remove_callbacks()
 
         self.hass = None  # type: ignore[assignment]
-        self.platform = None
+        self.platform = None  # type: ignore[assignment]
         self.parallel_updates = None
 
     async def add_to_platform_finish(self) -> None:

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -49,6 +49,7 @@ async def test_update(hass: HomeAssistant) -> None:
     """Test getting data from the mocked update entity."""
     update = MockUpdateEntity()
     update.hass = hass
+    update.platform = MockEntityPlatform(hass)
 
     update._attr_installed_version = "1.0.0"
     update._attr_latest_version = "1.0.1"
@@ -57,7 +58,10 @@ async def test_update(hass: HomeAssistant) -> None:
     update._attr_title = "Title"
 
     assert update.entity_category is EntityCategory.DIAGNOSTIC
-    assert update.entity_picture is None
+    assert (
+        update.entity_picture
+        == "https://brands.home-assistant.io/_/test_platform/icon.png"
+    )
     assert update.installed_version == "1.0.0"
     assert update.latest_version == "1.0.1"
     assert update.release_summary == "Summary"
@@ -75,13 +79,6 @@ async def test_update(hass: HomeAssistant) -> None:
         ATTR_SKIPPED_VERSION: None,
         ATTR_TITLE: "Title",
     }
-
-    # Test with platform
-    update.platform = MockEntityPlatform(hass)
-    assert (
-        update.entity_picture
-        == "https://brands.home-assistant.io/_/test_platform/icon.png"
-    )
 
     # Test no update available
     update._attr_installed_version = "1.0.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tweak typing of `Entity.platform` in a similar manner as we type `Entity.hass` to avoid unnecessary None-checks or asserts

Background:
Both `Entity.hass` and `Entity.platform` are assigned in `Entity.add_to_platform_start` and unassigned in `Entity.add_to_platform_abort`. This means that for basically the entire life cycle of an `Entity` object, both its `hass` and `platform` members have a valid value.

Needs https://github.com/home-assistant/core/pull/90585

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
