### PR TITLE
Add fan and automatic fan speed support to Airversa air purifiers

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -53,6 +53,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     ServicesTypes.TELEVISION: "media_player",
     ServicesTypes.VALVE: "switch",
     ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT: "camera",
+    ServicesTypes.AIR_PURIFIER: "fan",
 }
 
 CHARACTERISTIC_PLATFORMS = {
@@ -98,6 +99,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.MUTE: "switch",
     CharacteristicsTypes.FILTER_LIFE_LEVEL: "sensor",
     CharacteristicsTypes.VENDOR_AIRVERSA_SLEEP_MODE: "switch",
+    CharacteristicsTypes.AIR_PURIFIER_STATE_TARGET: "switch",
 }
 
 STARTUP_EXCEPTIONS = (

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -186,6 +186,7 @@ class HomeKitFanV2(BaseHomeKitFan):
 ENTITY_TYPES = {
     ServicesTypes.FAN: HomeKitFanV1,
     ServicesTypes.FAN_V2: HomeKitFanV2,
+    ServicesTypes.AIR_PURIFIER: HomeKitFanV2,
 }
 
 

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -69,6 +69,12 @@ SWITCH_ENTITIES: dict[str, DeclarativeSwitchEntityDescription] = {
         icon="mdi:power-sleep",
         entity_category=EntityCategory.CONFIG,
     ),
+    CharacteristicsTypes.AIR_PURIFIER_STATE_TARGET: DeclarativeSwitchEntityDescription(
+        key=CharacteristicsTypes.AIR_PURIFIER_STATE_TARGET,
+        name="Automatic Fan Speed",
+        icon="mdi:fan-auto",
+        entity_category=EntityCategory.CONFIG,
+    ),
 }
 
 

--- a/tests/components/homekit_controller/specific_devices/test_airversa_ap2.py
+++ b/tests/components/homekit_controller/specific_devices/test_airversa_ap2.py
@@ -1,5 +1,6 @@
 """Tests for Airversa AP2 Air Purifier."""
 
+from homeassistant.components.fan import FanEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, PERCENTAGE
 from homeassistant.helpers.entity import EntityCategory
@@ -15,7 +16,7 @@ from ..common import (
 
 
 async def test_airversa_ap2_setup(hass):
-    """Test that an Ecbobee occupancy sensor be correctly setup in HA."""
+    """Test that an Airversa air purifier is correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "airversa_ap2.json")
     await setup_test_accessories(hass, accessories)
 
@@ -31,6 +32,23 @@ async def test_airversa_ap2_setup(hass):
             serial_number="1234",
             devices=[],
             entities=[
+                EntityTestInfo(
+                    entity_id="fan.airversa_ap2_1808_airpurifier",
+                    friendly_name="Airversa AP2 1808 AirPurifier",
+                    unique_id="00:00:00:00:00:00_1_32832",
+                    supported_features=FanEntityFeature.SET_SPEED,
+                    capabilities={
+                        "preset_modes": None,
+                    },
+                    state="off",
+                ),
+                EntityTestInfo(
+                    entity_id="switch.airversa_ap2_1808_automatic_fan_speed",
+                    friendly_name="Airversa AP2 1808 Automatic Fan Speed",
+                    unique_id="00:00:00:00:00:00_1_32832_32837",
+                    entity_category=EntityCategory.CONFIG,
+                    state="on",
+                ),
                 EntityTestInfo(
                     entity_id="switch.airversa_ap2_1808_lock_physical_controls",
                     friendly_name="Airversa AP2 1808 Lock Physical Controls",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for fan speed control, and automatic fan speed setting for Airversa Air Purifiers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85475
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
