### PR TITLE
Dismiss discoveries when the underlying device disappears

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -315,6 +315,7 @@ class BluetoothManager:
                     # the device from all the interval tracking since it is no longer
                     # available for both connectable and non-connectable
                     tracker.async_remove_address(address)
+                    self._integration_matcher.async_clear_address(address)
                     self._async_dismiss_discoveries(address)
 
                 service_info = history.pop(address)

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -315,6 +315,7 @@ class BluetoothManager:
                     # the device from all the interval tracking since it is no longer
                     # available for both connectable and non-connectable
                     tracker.async_remove_address(address)
+                    self._async_dismiss_discoveries(address)
 
                 service_info = history.pop(address)
 
@@ -326,6 +327,14 @@ class BluetoothManager:
                         callback(service_info)
                     except Exception:  # pylint: disable=broad-except
                         _LOGGER.exception("Error in unavailable callback")
+
+    def _async_dismiss_discoveries(self, address: str) -> None:
+        """Dismiss all discoveries for the given address."""
+        for flow in self.hass.config_entries.flow.async_progress_by_init_data_type(
+            BluetoothServiceInfoBleak,
+            lambda service_info: bool(service_info.address == address),
+        ):
+            self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
     def _prefer_previous_adv_from_different_source(
         self,

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -518,7 +518,11 @@ class Scanner:
                 CaseInsensitiveDict(combined_headers.as_dict(), **info_desc)
             )
 
-        if not callbacks and not matching_domains:
+        if (
+            not callbacks
+            and not matching_domains
+            and source != SsdpSource.ADVERTISEMENT_BYEBYE
+        ):
             return
 
         discovery_info = discovery_info_from_headers_and_description(
@@ -535,6 +539,7 @@ class Scanner:
         # Config flows should only be created for alive/update messages from alive devices
         if source == SsdpSource.ADVERTISEMENT_BYEBYE:
             self._async_dismiss_discoveries(discovery_info)
+            return
 
         _LOGGER.debug("Discovery info: %s", discovery_info)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -378,6 +378,14 @@ class ZeroconfDiscovery:
         if self.async_service_browser:
             await self.async_service_browser.async_cancel()
 
+    def _async_dismiss_discoveries(self, name: str) -> None:
+        """Dismiss all discoveries for the given name."""
+        for flow in self.hass.config_entries.flow.async_progress_by_init_data_type(
+            ZeroconfServiceInfo,
+            lambda service_info: bool(service_info.name == name),
+        ):
+            self.hass.config_entries.flow.async_abort(flow["flow_id"])
+
     @callback
     def async_service_update(
         self,
@@ -395,6 +403,7 @@ class ZeroconfDiscovery:
         )
 
         if state_change == ServiceStateChange.Removed:
+            self._async_dismiss_discoveries(name)
             return
 
         try:

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -803,3 +803,138 @@ async def test_goes_unavailable_connectable_only_and_recovers(
     unsetup_connectable_scanner_2()
     cancel_not_connectable_scanner()
     unsetup_not_connectable_scanner()
+
+
+async def test_goes_unavailable_dismisses_discovery(
+    hass: HomeAssistant, mock_bluetooth_adapters: None
+) -> None:
+    """Test that unavailable will dismiss any active discoveries."""
+    assert await async_setup_component(hass, bluetooth.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert async_scanner_count(hass, connectable=False) == 0
+    switchbot_device_non_connectable = BLEDevice(
+        "44:44:33:11:23:45",
+        "wohand",
+        {},
+        rssi=-100,
+    )
+    switchbot_device_adv = generate_advertisement_data(
+        local_name="wohand",
+        service_uuids=["050a021a-0000-1000-8000-00805f9b34fb"],
+        service_data={"050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff"},
+        manufacturer_data={1: b"\x01"},
+        rssi=-100,
+    )
+    callbacks = []
+
+    def _fake_subscriber(
+        service_info: BluetoothServiceInfo,
+        change: BluetoothChange,
+    ) -> None:
+        """Fake subscriber for the BleakScanner."""
+        callbacks.append((service_info, change))
+
+    cancel = bluetooth.async_register_callback(
+        hass,
+        _fake_subscriber,
+        {"address": "44:44:33:11:23:45", "connectable": False},
+        BluetoothScanningMode.ACTIVE,
+    )
+
+    class FakeScanner(BaseHaRemoteScanner):
+        def inject_advertisement(
+            self, device: BLEDevice, advertisement_data: AdvertisementData
+        ) -> None:
+            """Inject an advertisement."""
+            self._async_on_advertisement(
+                device.address,
+                advertisement_data.rssi,
+                device.name,
+                advertisement_data.service_uuids,
+                advertisement_data.service_data,
+                advertisement_data.manufacturer_data,
+                advertisement_data.tx_power,
+                {"scanner_specific_data": "test"},
+            )
+
+        def clear_all_devices(self) -> None:
+            """Clear all devices."""
+            self._discovered_device_advertisement_datas.clear()
+            self._discovered_device_timestamps.clear()
+
+    new_info_callback = async_get_advertisement_callback(hass)
+    connector = (
+        HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
+    )
+    non_connectable_scanner = FakeScanner(
+        hass,
+        "connectable",
+        "connectable",
+        new_info_callback,
+        connector,
+        False,
+    )
+    unsetup_connectable_scanner = non_connectable_scanner.async_setup()
+    cancel_connectable_scanner = _get_manager().async_register_scanner(
+        non_connectable_scanner, True
+    )
+    non_connectable_scanner.inject_advertisement(
+        switchbot_device_non_connectable, switchbot_device_adv
+    )
+    assert async_ble_device_from_address(hass, "44:44:33:11:23:45", False) is not None
+    assert async_scanner_count(hass, connectable=True) == 1
+    assert len(callbacks) == 1
+
+    assert (
+        "44:44:33:11:23:45"
+        in non_connectable_scanner.discovered_devices_and_advertisement_data
+    )
+
+    unavailable_callbacks: list[BluetoothServiceInfoBleak] = []
+
+    @callback
+    def _unavailable_callback(service_info: BluetoothServiceInfoBleak) -> None:
+        """Wrong device unavailable callback."""
+        nonlocal unavailable_callbacks
+        unavailable_callbacks.append(service_info.address)
+
+    cancel_unavailable = async_track_unavailable(
+        hass,
+        _unavailable_callback,
+        switchbot_device_non_connectable.address,
+        connectable=False,
+    )
+
+    assert async_scanner_count(hass, connectable=False) == 1
+
+    non_connectable_scanner.clear_all_devices()
+    assert (
+        "44:44:33:11:23:45"
+        not in non_connectable_scanner.discovered_devices_and_advertisement_data
+    )
+    monotonic_now = time.monotonic()
+    with patch.object(
+        hass.config_entries.flow,
+        "async_progress_by_init_data_type",
+        return_value=[{"flow_id": "mock_flow_id"}],
+    ) as mock_async_progress_by_init_data_type, patch.object(
+        hass.config_entries.flow, "async_abort"
+    ) as mock_async_abort, patch(
+        "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
+        return_value=monotonic_now + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+    ):
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=UNAVAILABLE_TRACK_SECONDS)
+        )
+    await hass.async_block_till_done()
+    assert "44:44:33:11:23:45" in unavailable_callbacks
+
+    assert len(mock_async_progress_by_init_data_type.mock_calls) == 1
+    assert mock_async_abort.mock_calls[0][1][0] == "mock_flow_id"
+
+    cancel_unavailable()
+
+    cancel()
+    unsetup_connectable_scanner()
+    cancel_connectable_scanner()

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1,4 +1,5 @@
 """Test the flow classes."""
+import dataclasses
 import logging
 from unittest.mock import Mock, patch
 
@@ -73,7 +74,7 @@ async def test_configure_reuses_handler_instance(manager):
     assert len(manager.mock_created_entries) == 0
 
 
-async def test_configure_two_steps(manager):
+async def test_configure_two_steps(manager: data_entry_flow.FlowManager) -> None:
     """Test that we reuse instances."""
 
     @manager.mock_reg_handler("test")
@@ -82,7 +83,6 @@ async def test_configure_two_steps(manager):
 
         async def async_step_first(self, user_input=None):
             if user_input is not None:
-                self.init_data = user_input
                 return await self.async_step_second()
             return self.async_show_form(step_id="first", data_schema=vol.Schema([str]))
 
@@ -93,12 +93,13 @@ async def test_configure_two_steps(manager):
                 )
             return self.async_show_form(step_id="second", data_schema=vol.Schema([str]))
 
-    form = await manager.async_init("test", context={"init_step": "first"})
+    form = await manager.async_init(
+        "test", context={"init_step": "first"}, data=["INIT-DATA"]
+    )
 
     with pytest.raises(vol.Invalid):
         form = await manager.async_configure(form["flow_id"], "INCORRECT-DATA")
 
-    form = await manager.async_configure(form["flow_id"], ["INIT-DATA"])
     form = await manager.async_configure(form["flow_id"], ["SECOND-DATA"])
     assert form["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert len(manager.async_progress()) == 0
@@ -553,3 +554,74 @@ async def test_show_menu(hass, manager, menu_options):
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "target1"
+
+
+async def test_find_flows_by_init_data_type(
+    manager: data_entry_flow.FlowManager,
+) -> None:
+    """Test we can find flows by init data type."""
+
+    @dataclasses.dataclass
+    class BluetoothDiscoveryData:
+        """Bluetooth Discovery data."""
+
+        address: str
+
+    @dataclasses.dataclass
+    class WiFiDiscoveryData:
+        """WiFi Discovery data."""
+
+        address: str
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 1
+
+        async def async_step_first(self, user_input=None):
+            if user_input is not None:
+                return await self.async_step_second()
+            return self.async_show_form(step_id="first", data_schema=vol.Schema([str]))
+
+        async def async_step_second(self, user_input=None):
+            if user_input is not None:
+                return self.async_create_entry(
+                    title="Test Entry",
+                    data={"init": self.init_data, "user": user_input},
+                )
+            return self.async_show_form(step_id="second", data_schema=vol.Schema([str]))
+
+    bluetooth_data = BluetoothDiscoveryData("aa:bb:cc:dd:ee:ff")
+    wifi_data = WiFiDiscoveryData("host")
+
+    bluetooth_form = await manager.async_init(
+        "test", context={"init_step": "first"}, data=bluetooth_data
+    )
+    await manager.async_init("test", context={"init_step": "first"}, data=wifi_data)
+
+    bluetooth_flows = manager.async_progress_by_init_data_type(BluetoothDiscoveryData)
+    assert len(bluetooth_flows) == 1
+
+    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    assert len(wifi_flows) == 1
+
+    bluetooth_result = await manager.async_configure(
+        bluetooth_form["flow_id"], ["SECOND-DATA"]
+    )
+    assert bluetooth_result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert len(manager.async_progress()) == 1
+    assert len(manager.mock_created_entries) == 1
+    result = manager.mock_created_entries[0]
+    assert result["handler"] == "test"
+    assert result["data"] == {"init": bluetooth_data, "user": ["SECOND-DATA"]}
+
+    bluetooth_flows = manager.async_progress_by_init_data_type(BluetoothDiscoveryData)
+    assert len(bluetooth_flows) == 0
+
+    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    assert len(wifi_flows) == 1
+
+    manager.async_abort(wifi_flows[0]["flow_id"])
+
+    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    assert len(wifi_flows) == 0
+    assert len(manager.async_progress()) == 0

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -598,10 +598,32 @@ async def test_find_flows_by_init_data_type(
     )
     await manager.async_init("test", context={"init_step": "first"}, data=wifi_data)
 
-    bluetooth_flows = manager.async_progress_by_init_data_type(BluetoothDiscoveryData)
-    assert len(bluetooth_flows) == 1
+    assert (
+        len(
+            manager.async_progress_by_init_data_type(
+                BluetoothDiscoveryData, lambda data: True
+            )
+        )
+    ) == 1
+    assert (
+        len(
+            manager.async_progress_by_init_data_type(
+                BluetoothDiscoveryData,
+                lambda data: bool(data.address == "aa:bb:cc:dd:ee:ff"),
+            )
+        )
+    ) == 1
+    assert (
+        len(
+            manager.async_progress_by_init_data_type(
+                BluetoothDiscoveryData, lambda data: bool(data.address == "not it")
+            )
+        )
+    ) == 0
 
-    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    wifi_flows = manager.async_progress_by_init_data_type(
+        WiFiDiscoveryData, lambda data: True
+    )
     assert len(wifi_flows) == 1
 
     bluetooth_result = await manager.async_configure(
@@ -614,14 +636,20 @@ async def test_find_flows_by_init_data_type(
     assert result["handler"] == "test"
     assert result["data"] == {"init": bluetooth_data, "user": ["SECOND-DATA"]}
 
-    bluetooth_flows = manager.async_progress_by_init_data_type(BluetoothDiscoveryData)
+    bluetooth_flows = manager.async_progress_by_init_data_type(
+        BluetoothDiscoveryData, lambda data: True
+    )
     assert len(bluetooth_flows) == 0
 
-    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    wifi_flows = manager.async_progress_by_init_data_type(
+        WiFiDiscoveryData, lambda data: True
+    )
     assert len(wifi_flows) == 1
 
     manager.async_abort(wifi_flows[0]["flow_id"])
 
-    wifi_flows = manager.async_progress_by_init_data_type(WiFiDiscoveryData)
+    wifi_flows = manager.async_progress_by_init_data_type(
+        WiFiDiscoveryData, lambda data: True
+    )
     assert len(wifi_flows) == 0
     assert len(manager.async_progress()) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there are devices on the network that are only there temporarily they would get discovered, but we would never remove the discoveries when we received remove/byebye events for the discovery types that support these type of events.

Bluetooth, HomeKit, SSDP, and Zeroconf discovery types now implement dismissing discoveries when the underlying discovered device disappears.  Note that SSDP doesn't require a BYEBYE so it will only work for the ones that do send it.

DHCP and USB discovery types currently do not track when a device goes away but this was designed to work for these use cases as well if we ever add support for tracking them.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
