### PR TITLE
Bump devolo_plc_api to 1.2.0

### DIFF
--- a/homeassistant/components/devolo_home_network/manifest.json
+++ b/homeassistant/components/devolo_home_network/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["devolo_plc_api"],
   "quality_scale": "platinum",
-  "requirements": ["devolo-plc-api==1.1.0"],
+  "requirements": ["devolo-plc-api==1.2.0"],
   "zeroconf": [
     {
       "type": "_dvl-deviceapi._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -592,7 +592,7 @@ denonavr==0.11.1
 devolo-home-control-api==0.18.2
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.1.0
+devolo-plc-api==1.2.0
 
 # homeassistant.components.directv
 directv==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -469,7 +469,7 @@ denonavr==0.11.1
 devolo-home-control-api==0.18.2
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.1.0
+devolo-plc-api==1.2.0
 
 # homeassistant.components.directv
 directv==0.4.0

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -63,7 +63,7 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]):
 
 @pytest.mark.parametrize(
     ("exception_type", "expected_error"),
-    [[DeviceNotFound, "cannot_connect"], [Exception, "unknown"]],
+    [[DeviceNotFound(IP), "cannot_connect"], [Exception, "unknown"]],
 )
 async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -> None:
     """Test we handle errors."""

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -49,7 +49,7 @@ async def test_setup_device_not_found(hass: HomeAssistant) -> None:
     entry = configure_integration(hass)
     with patch(
         "homeassistant.components.devolo_home_network.Device.async_connect",
-        side_effect=DeviceNotFound,
+        side_effect=DeviceNotFound(IP),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upcoming devolo home network firmware version will have password protected API endpoints, that weren't protected before. This bump makes the library handle those endpoints properly.

Changelog: https://github.com/2Fake/devolo_plc_api/releases/tag/v1.2.0
Commit compare: https://github.com/2Fake/devolo_plc_api/compare/v1.1.0...v1.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
