### PR TITLE
Refactor Elgato tests

### DIFF
--- a/homeassistant/components/elgato/button.py
+++ b/homeassistant/components/elgato/button.py
@@ -94,5 +94,5 @@ class ElgatoButtonEntity(ElgatoEntity, ButtonEntity):
             await self.entity_description.press_fn(self.coordinator.client)
         except ElgatoError as error:
             raise HomeAssistantError(
-                "An error occurred while identifying the Elgato Light"
+                "An error occurred while communicating with the Elgato Light"
             ) from error

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -60,26 +60,15 @@ def mock_onboarding() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_elgato_config_flow(device_fixtures: str) -> Generator[None, MagicMock, None]:
-    """Return a mocked Elgato client."""
-    with patch(
-        "homeassistant.components.elgato.config_flow.Elgato", autospec=True
-    ) as elgato_mock:
-        elgato = elgato_mock.return_value
-        elgato.info.return_value = Info.parse_raw(
-            load_fixture(f"{device_fixtures}/info.json", DOMAIN)
-        )
-        yield elgato
-
-
-@pytest.fixture
 def mock_elgato(
     device_fixtures: str, state_variant: str
 ) -> Generator[None, MagicMock, None]:
     """Return a mocked Elgato client."""
     with patch(
         "homeassistant.components.elgato.coordinator.Elgato", autospec=True
-    ) as elgato_mock:
+    ) as elgato_mock, patch(
+        "homeassistant.components.elgato.config_flow.Elgato", new=elgato_mock
+    ):
         elgato = elgato_mock.return_value
         elgato.info.return_value = Info.parse_raw(
             load_fixture(f"{device_fixtures}/info.json", DOMAIN)

--- a/tests/components/elgato/snapshots/test_button.ambr
+++ b/tests/components/elgato/snapshots/test_button.ambr
@@ -1,0 +1,149 @@
+# serializer version: 1
+# name: test_buttons[button.frenck_identify-identify-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Frenck Identify',
+      'icon': 'mdi:help',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.frenck_identify',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_buttons[button.frenck_identify-identify-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.frenck_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:help',
+    'original_name': 'Identify',
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'GW24L1A02987_identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.frenck_identify-identify-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_buttons[button.frenck_restart-restart-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Frenck Restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.frenck_restart',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_buttons[button.frenck_restart-restart-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.frenck_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart',
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'GW24L1A02987_restart',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.frenck_restart-restart-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/snapshots/test_light.ambr
+++ b/tests/components/elgato/snapshots/test_light.ambr
@@ -1,0 +1,321 @@
+# serializer version: 1
+# name: test_light_state_temperature[key-light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': 54,
+      'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
+      'color_temp': 297,
+      'color_temp_kelvin': 3367,
+      'friendly_name': 'Frenck',
+      'hs_color': tuple(
+        27.316,
+        47.743,
+      ),
+      'max_color_temp_kelvin': 6993,
+      'max_mireds': 344,
+      'min_color_temp_kelvin': 2906,
+      'min_mireds': 143,
+      'rgb_color': tuple(
+        255,
+        188,
+        133,
+      ),
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+      ]),
+      'supported_features': <LightEntityFeature.0: 0>,
+      'xy_color': tuple(
+        0.465,
+        0.376,
+      ),
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.frenck',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_light_state_temperature[key-light-state].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max_color_temp_kelvin': 6993,
+      'max_mireds': 344,
+      'min_color_temp_kelvin': 2906,
+      'min_mireds': 143,
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.frenck',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CN11A1A00001',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_state_temperature[key-light-state].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state-color-temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': 54,
+      'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
+      'color_temp': 297,
+      'color_temp_kelvin': 3367,
+      'friendly_name': 'Frenck',
+      'hs_color': tuple(
+        27.316,
+        47.743,
+      ),
+      'max_color_temp_kelvin': 6535,
+      'max_mireds': 285,
+      'min_color_temp_kelvin': 3508,
+      'min_mireds': 153,
+      'rgb_color': tuple(
+        255,
+        188,
+        133,
+      ),
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+        <ColorMode.HS: 'hs'>,
+      ]),
+      'supported_features': <LightEntityFeature.0: 0>,
+      'xy_color': tuple(
+        0.465,
+        0.376,
+      ),
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.frenck',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state-color-temperature].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max_color_temp_kelvin': 6535,
+      'max_mireds': 285,
+      'min_color_temp_kelvin': 3508,
+      'min_mireds': 153,
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+        <ColorMode.HS: 'hs'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.frenck',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CN11A1A00001',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state-color-temperature].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': 128,
+      'color_mode': <ColorMode.HS: 'hs'>,
+      'friendly_name': 'Frenck',
+      'hs_color': tuple(
+        358.0,
+        6.0,
+      ),
+      'max_color_temp_kelvin': 6535,
+      'max_mireds': 285,
+      'min_color_temp_kelvin': 3508,
+      'min_mireds': 153,
+      'rgb_color': tuple(
+        255,
+        239,
+        240,
+      ),
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+        <ColorMode.HS: 'hs'>,
+      ]),
+      'supported_features': <LightEntityFeature.0: 0>,
+      'xy_color': tuple(
+        0.34,
+        0.327,
+      ),
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.frenck',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max_color_temp_kelvin': 6535,
+      'max_mireds': 285,
+      'min_color_temp_kelvin': 3508,
+      'min_mireds': 153,
+      'supported_color_modes': list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+        <ColorMode.HS: 'hs'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.frenck',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CN11A1A00001',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_state_temperature[light-strip-state].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '53',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'CN11A1A00001',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.3 (192)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/snapshots/test_light.ambr
+++ b/tests/components/elgato/snapshots/test_light.ambr
@@ -23,7 +23,7 @@
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
       ]),
-      'supported_features': <LightEntityFeature.0: 0>,
+      'supported_features': 0,
       'xy_color': tuple(
         0.465,
         0.376,
@@ -130,7 +130,7 @@
         <ColorMode.COLOR_TEMP: 'color_temp'>,
         <ColorMode.HS: 'hs'>,
       ]),
-      'supported_features': <LightEntityFeature.0: 0>,
+      'supported_features': 0,
       'xy_color': tuple(
         0.465,
         0.376,
@@ -236,7 +236,7 @@
         <ColorMode.COLOR_TEMP: 'color_temp'>,
         <ColorMode.HS: 'hs'>,
       ]),
-      'supported_features': <LightEntityFeature.0: 0>,
+      'supported_features': 0,
       'xy_color': tuple(
         0.34,
         0.327,

--- a/tests/components/elgato/snapshots/test_switch.ambr
+++ b/tests/components/elgato/snapshots/test_switch.ambr
@@ -1,0 +1,149 @@
+# serializer version: 1
+# name: test_switches[switch.frenck_energy_saving-energy_saving-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Frenck Energy saving',
+      'icon': 'mdi:leaf',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.frenck_energy_saving',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.frenck_energy_saving-energy_saving-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.frenck_energy_saving',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:leaf',
+    'original_name': 'Energy saving',
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'GW24L1A02987_energy_saving',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.frenck_energy_saving-energy_saving-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---
+# name: test_switches[switch.frenck_studio_mode-battery_bypass-key-light-mini]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Frenck Studio mode',
+      'icon': 'mdi:battery-off-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.frenck_studio_mode',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.frenck_studio_mode-battery_bypass-key-light-mini].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.frenck_studio_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:battery-off-outline',
+    'original_name': 'Studio mode',
+    'platform': 'elgato',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'GW24L1A02987_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.frenck_studio_mode-battery_bypass-key-light-mini].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '202',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'elgato',
+        'GW24L1A02987',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'Elgato',
+    'model': 'Elgato Key Light Mini',
+    'name': 'Frenck',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '1.0.4 (229)',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/elgato/test_button.py
+++ b/tests/components/elgato/test_button.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 
 from elgato import ElgatoError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.components.elgato.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN, EntityCategory
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -18,97 +18,59 @@ pytestmark = [
 ]
 
 
-async def test_button_identify(
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        ("button.frenck_identify", "identify"),
+        ("button.frenck_restart", "restart"),
+    ],
+)
+async def test_buttons(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_elgato: MagicMock,
+    snapshot: SnapshotAssertion,
+    entity_id: str,
+    method: str,
 ) -> None:
     """Test the Elgato identify button."""
-    state = hass.states.get("button.frenck_identify")
-    assert state
-    assert state.attributes.get(ATTR_ICON) == "mdi:help"
-    assert state.state == STATE_UNKNOWN
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot
 
-    entry = entity_registry.async_get("button.frenck_identify")
-    assert entry
-    assert entry.unique_id == "GW24L1A02987_identify"
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry == snapshot
 
     assert entry.device_id
-    device_entry = device_registry.async_get(entry.device_id)
-    assert device_entry
-    assert device_entry.configuration_url is None
-    assert device_entry.connections == {
-        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")
-    }
-    assert device_entry.entry_type is None
-    assert device_entry.identifiers == {(DOMAIN, "GW24L1A02987")}
-    assert device_entry.manufacturer == "Elgato"
-    assert device_entry.model == "Elgato Key Light Mini"
-    assert device_entry.name == "Frenck"
-    assert device_entry.sw_version == "1.0.4 (229)"
-    assert device_entry.hw_version == "202"
+    assert (device_entry := device_registry.async_get(entry.device_id))
+    assert device_entry == snapshot
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.frenck_identify"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
 
-    assert len(mock_elgato.identify.mock_calls) == 1
-    mock_elgato.identify.assert_called_with()
+    mocked_method = getattr(mock_elgato, method)
+    assert len(mocked_method.mock_calls) == 1
+    mocked_method.assert_called_with()
 
-    state = hass.states.get("button.frenck_identify")
+    state = hass.states.get(entity_id)
     assert state
     assert state.state == "2021-11-13T11:48:00+00:00"
 
-
-async def test_button_restart(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    mock_elgato: MagicMock,
-) -> None:
-    """Test the Elgato restart button."""
-    state = hass.states.get("button.frenck_restart")
-    assert state
-    assert state.state == STATE_UNKNOWN
-    assert not state.attributes.get(ATTR_ICON)
-
-    entry = entity_registry.async_get("button.frenck_restart")
-    assert entry
-    assert entry.unique_id == "GW24L1A02987_restart"
-    assert entry.entity_category == EntityCategory.CONFIG
-
-    await hass.services.async_call(
-        BUTTON_DOMAIN,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.frenck_restart"},
-        blocking=True,
-    )
-
-    assert len(mock_elgato.restart.mock_calls) == 1
-    mock_elgato.restart.assert_called_with()
-
-    state = hass.states.get("button.frenck_restart")
-    assert state
-    assert state.state == "2021-11-13T11:48:00+00:00"
-
-
-async def test_button_error(hass: HomeAssistant, mock_elgato: MagicMock) -> None:
-    """Test an error occurs with the Elgato buttons."""
-    mock_elgato.identify.side_effect = ElgatoError
+    mocked_method.side_effect = ElgatoError
 
     with pytest.raises(
-        HomeAssistantError, match="An error occurred while identifying the Elgato Light"
+        HomeAssistantError,
+        match="An error occurred while communicating with the Elgato Light",
     ):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
-            {ATTR_ENTITY_ID: "button.frenck_identify"},
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
 
-    assert len(mock_elgato.identify.mock_calls) == 1
+    assert len(mocked_method.mock_calls) == 2

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistant,
-    mock_elgato_config_flow: MagicMock,
+    mock_elgato: MagicMock,
     mock_setup_entry: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -38,12 +38,12 @@ async def test_full_user_flow_implementation(
     assert result2 == snapshot
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_elgato_config_flow.info.mock_calls) == 1
+    assert len(mock_elgato.info.mock_calls) == 1
 
 
 async def test_full_zeroconf_flow_implementation(
     hass: HomeAssistant,
-    mock_elgato_config_flow: MagicMock,
+    mock_elgato: MagicMock,
     mock_setup_entry: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -80,15 +80,15 @@ async def test_full_zeroconf_flow_implementation(
     assert result2 == snapshot
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_elgato_config_flow.info.mock_calls) == 1
+    assert len(mock_elgato.info.mock_calls) == 1
 
 
 async def test_connection_error(
     hass: HomeAssistant,
-    mock_elgato_config_flow: MagicMock,
+    mock_elgato: MagicMock,
 ) -> None:
     """Test we show user form on Elgato Key Light connection error."""
-    mock_elgato_config_flow.info.side_effect = ElgatoConnectionError
+    mock_elgato.info.side_effect = ElgatoConnectionError
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -102,10 +102,10 @@ async def test_connection_error(
 
 async def test_zeroconf_connection_error(
     hass: HomeAssistant,
-    mock_elgato_config_flow: MagicMock,
+    mock_elgato: MagicMock,
 ) -> None:
     """Test we abort zeroconf flow on Elgato Key Light connection error."""
-    mock_elgato_config_flow.info.side_effect = ElgatoConnectionError
+    mock_elgato.info.side_effect = ElgatoConnectionError
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
@@ -124,7 +124,7 @@ async def test_zeroconf_connection_error(
     assert result.get("type") == FlowResultType.ABORT
 
 
-@pytest.mark.usefixtures("mock_elgato_config_flow")
+@pytest.mark.usefixtures("mock_elgato")
 async def test_user_device_exists_abort(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -140,7 +140,7 @@ async def test_user_device_exists_abort(
     assert result.get("reason") == "already_configured"
 
 
-@pytest.mark.usefixtures("mock_elgato_config_flow")
+@pytest.mark.usefixtures("mock_elgato")
 async def test_zeroconf_device_exists_abort(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -190,7 +190,7 @@ async def test_zeroconf_device_exists_abort(
 
 async def test_zeroconf_during_onboarding(
     hass: HomeAssistant,
-    mock_elgato_config_flow: MagicMock,
+    mock_elgato: MagicMock,
     mock_setup_entry: AsyncMock,
     mock_onboarding: MagicMock,
     snapshot: SnapshotAssertion,
@@ -214,5 +214,5 @@ async def test_zeroconf_during_onboarding(
     assert result == snapshot
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_elgato_config_flow.info.mock_calls) == 1
+    assert len(mock_elgato.info.mock_calls) == 1
     assert len(mock_onboarding.mock_calls) == 1

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -3,18 +3,14 @@ from unittest.mock import MagicMock
 
 from elgato import ElgatoError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.elgato.const import DOMAIN, SERVICE_IDENTIFY
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
-    ATTR_MAX_MIREDS,
-    ATTR_MIN_MIREDS,
-    ATTR_SUPPORTED_COLOR_MODES,
     DOMAIN as LIGHT_DOMAIN,
-    ColorMode,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -27,69 +23,36 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+pytestmark = pytest.mark.usefixtures("init_integration")
 
-@pytest.mark.usefixtures("init_integration", "mock_elgato")
-async def test_light_state_temperature(hass: HomeAssistant) -> None:
+
+@pytest.mark.usefixtures("mock_elgato")
+@pytest.mark.parametrize(
+    ("device_fixtures", "state_variant"),
+    [
+        ("key-light", "state"),
+        ("light-strip", "state"),
+        ("light-strip", "state-color-temperature"),
+    ],
+)
+async def test_light_state_temperature(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceEntry,
+    entity_registry: er.RegistryEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
     """Test the creation and values of the Elgato Lights in temperature mode."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.frenck")
-    assert state
-    assert state.attributes.get(ATTR_BRIGHTNESS) == 54
-    assert state.attributes.get(ATTR_COLOR_TEMP) == 297
-    assert state.attributes.get(ATTR_HS_COLOR) == (27.316, 47.743)
-    assert state.attributes.get(ATTR_COLOR_MODE) == ColorMode.COLOR_TEMP
-    assert state.attributes.get(ATTR_MIN_MIREDS) == 143
-    assert state.attributes.get(ATTR_MAX_MIREDS) == 344
-    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [ColorMode.COLOR_TEMP]
-    assert state.state == STATE_ON
+    assert (state := hass.states.get("light.frenck"))
+    assert state == snapshot
 
-    entry = entity_registry.async_get("light.frenck")
-    assert entry
-    assert entry.unique_id == "CN11A1A00001"
+    assert (entry := entity_registry.async_get("light.frenck"))
+    assert entry == snapshot
 
     assert entry.device_id
-    device_entry = device_registry.async_get(entry.device_id)
-    assert device_entry
-    assert device_entry.configuration_url is None
-    assert device_entry.connections == {
-        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")
-    }
-    assert device_entry.entry_type is None
-    assert device_entry.identifiers == {(DOMAIN, "CN11A1A00001")}
-    assert device_entry.manufacturer == "Elgato"
-    assert device_entry.model == "Elgato Key Light"
-    assert device_entry.name == "Frenck"
-    assert device_entry.sw_version == "1.0.3 (192)"
-    assert device_entry.hw_version == "53"
-
-
-@pytest.mark.parametrize("device_fixtures", ["light-strip"])
-@pytest.mark.usefixtures("device_fixtures", "init_integration", "mock_elgato")
-async def test_light_state_color(hass: HomeAssistant) -> None:
-    """Test the creation and values of the Elgato Lights in temperature mode."""
-    entity_registry = er.async_get(hass)
-
-    # First segment of the strip
-    state = hass.states.get("light.frenck")
-    assert state
-    assert state.attributes.get(ATTR_BRIGHTNESS) == 128
-    assert state.attributes.get(ATTR_COLOR_TEMP) is None
-    assert state.attributes.get(ATTR_HS_COLOR) == (358.0, 6.0)
-    assert state.attributes.get(ATTR_MIN_MIREDS) == 153
-    assert state.attributes.get(ATTR_MAX_MIREDS) == 285
-    assert state.attributes.get(ATTR_COLOR_MODE) == ColorMode.HS
-    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-    ]
-    assert state.state == STATE_ON
-
-    entry = entity_registry.async_get("light.frenck")
-    assert entry
-    assert entry.unique_id == "CN11A1A00001"
+    assert (device_entry := device_registry.async_get(entry.device_id))
+    assert device_entry == snapshot
 
 
 @pytest.mark.parametrize(
@@ -101,8 +64,7 @@ async def test_light_change_state_temperature(
     mock_elgato: MagicMock,
 ) -> None:
     """Test the change of state of a Elgato Key Light device."""
-    state = hass.states.get("light.frenck")
-    assert state
+    assert (state := hass.states.get("light.frenck"))
     assert state.state == STATE_ON
 
     await hass.services.async_call(
@@ -115,7 +77,6 @@ async def test_light_change_state_temperature(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(mock_elgato.light.mock_calls) == 1
     mock_elgato.light.assert_called_with(
         on=True, brightness=100, temperature=100, hue=None, saturation=None
@@ -130,7 +91,6 @@ async def test_light_change_state_temperature(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(mock_elgato.light.mock_calls) == 2
     mock_elgato.light.assert_called_with(
         on=True, brightness=100, temperature=297, hue=None, saturation=None
@@ -142,7 +102,6 @@ async def test_light_change_state_temperature(
         {ATTR_ENTITY_ID: "light.frenck"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(mock_elgato.light.mock_calls) == 3
     mock_elgato.light.assert_called_with(on=False)
 
@@ -156,7 +115,6 @@ async def test_light_change_state_temperature(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(mock_elgato.light.mock_calls) == 4
     mock_elgato.light.assert_called_with(
         on=True, brightness=100, temperature=None, hue=10.1, saturation=20.2
@@ -164,7 +122,6 @@ async def test_light_change_state_temperature(
 
 
 @pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
-@pytest.mark.usefixtures("init_integration")
 async def test_light_unavailable(
     hass: HomeAssistant, mock_elgato: MagicMock, service: str
 ) -> None:
@@ -180,8 +137,7 @@ async def test_light_unavailable(
             blocking=True,
         )
 
-    state = hass.states.get("light.frenck")
-    assert state
+    assert (state := hass.states.get("light.frenck"))
     assert state.state == STATE_UNAVAILABLE
 
 
@@ -196,17 +152,11 @@ async def test_light_identify(hass: HomeAssistant, mock_elgato: MagicMock) -> No
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(mock_elgato.identify.mock_calls) == 1
     mock_elgato.identify.assert_called_with()
 
-
-@pytest.mark.usefixtures("init_integration")
-async def test_light_identify_error(
-    hass: HomeAssistant, mock_elgato: MagicMock
-) -> None:
-    """Test error occurred during identifying an Elgato Light."""
     mock_elgato.identify.side_effect = ElgatoError
+
     with pytest.raises(
         HomeAssistantError, match="An error occurred while identifying the Elgato Light"
     ):
@@ -219,4 +169,4 @@ async def test_light_identify_error(
             blocking=True,
         )
 
-    assert len(mock_elgato.identify.mock_calls) == 1
+    assert len(mock_elgato.identify.mock_calls) == 2

--- a/tests/components/elgato/test_sensor.py
+++ b/tests/components/elgato/test_sensor.py
@@ -31,14 +31,14 @@ async def test_sensors(
 ) -> None:
     """Test the Elgato sensors."""
 
-    state = hass.states.get(entity_id)
+    assert (state := hass.states.get(entity_id))
     assert state == snapshot
 
-    entry = entity_registry.async_get(entity_id)
+    assert (entry := entity_registry.async_get(entity_id))
     assert entry == snapshot
 
     assert entry.device_id
-    device_entry = device_registry.async_get(entry.device_id)
+    assert (device_entry := device_registry.async_get(entry.device_id))
     assert device_entry == snapshot
 
 
@@ -55,10 +55,8 @@ async def test_disabled_by_default_sensors(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, entity_id: str
 ) -> None:
     """Test the disabled by default Elgato sensors."""
-    state = hass.states.get(entity_id)
-    assert state is None
+    assert not hass.states.get(entity_id)
 
-    entry = entity_registry.async_get(entity_id)
-    assert entry
+    assert (entry := entity_registry.async_get(entity_id))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR refactors the Elgato tests.
- Combines tests by parameterizing
- Removes unneeded `hass.async_block_till_done()` calls
- Combines Elgato client mocks fixtures for config flow and coordinator
- Use snapshots instead of asserts in some places
- The Walrus operator is actually nice at times

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
