### PR TITLE
Exclude event_id and event_score from being recorded in unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/recorder.py
+++ b/homeassistant/components/unifiprotect/recorder.py
@@ -8,5 +8,5 @@ from .const import ATTR_EVENT_ID, ATTR_EVENT_SCORE
 
 @callback
 def exclude_attributes(hass: HomeAssistant) -> set[str]:
-    """Exclude event_id from being recorded in the database."""
+    """Exclude event_id and event_score from being recorded in the database."""
     return {ATTR_EVENT_ID, ATTR_EVENT_SCORE}

--- a/homeassistant/components/unifiprotect/recorder.py
+++ b/homeassistant/components/unifiprotect/recorder.py
@@ -1,0 +1,12 @@
+"""Integration platform for recorder."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+
+from .const import ATTR_EVENT_ID, ATTR_EVENT_SCORE
+
+
+@callback
+def exclude_attributes(hass: HomeAssistant) -> set[str]:
+    """Exclude event_id from being recorded in the database."""
+    return {ATTR_EVENT_ID, ATTR_EVENT_SCORE}

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -1,4 +1,4 @@
-"""The tests for camera recorder."""
+"""The tests for unifiprotect recorder."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -1,0 +1,91 @@
+"""The tests for camera recorder."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+from pyunifiprotect.data import Camera, Event, EventType
+
+from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.db_schema import StateAttributes, States
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.unifiprotect.binary_sensor import EVENT_SENSORS
+from homeassistant.components.unifiprotect.const import (
+    ATTR_EVENT_ID,
+    ATTR_EVENT_SCORE,
+    DEFAULT_ATTRIBUTION,
+)
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, STATE_ON, Platform
+from homeassistant.core import HomeAssistant, State
+
+from .utils import MockUFPFixture, ids_from_device_description, init_entry
+
+from tests.components.recorder.common import async_wait_recording_done
+
+
+async def test_exclude_attributes(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test binary_sensor has event_id and event_score excluded from recording."""
+
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+
+    _, entity_id = ids_from_device_description(
+        Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[1]
+    )
+
+    event = Event(
+        id="test_event_id",
+        type=EventType.MOTION,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+    )
+
+    new_camera = doorbell.copy()
+    new_camera.is_motion_detected = True
+    new_camera.last_motion_event_id = event.id
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = new_camera
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+    ufp.ws_msg(mock_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    assert state.attributes[ATTR_EVENT_SCORE] == 100
+    await async_wait_recording_done(hass)
+
+    def _fetch_states() -> list[State]:
+        with session_scope(hass=hass) as session:
+            native_states = []
+            for db_state, db_state_attributes in session.query(
+                States, StateAttributes
+            ).outerjoin(
+                StateAttributes, States.attributes_id == StateAttributes.attributes_id
+            ):
+                state = db_state.to_native()
+                state.attributes = db_state_attributes.to_native()
+                native_states.append(state)
+            return native_states
+
+    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    assert len(states) > 1
+    for state in states:
+        assert ATTR_EVENT_SCORE not in state.attributes
+        assert ATTR_EVENT_ID not in state.attributes
+        assert ATTR_FRIENDLY_NAME in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Exclude event_id and event_score from being recorded in unifiprotect. These attributes will no longer be recorded in the database but remain available for use in automations.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As these values produce a unique combination and change frequently as they are fired at the start and end of an event, they generate a significant amount of state attributes rows in the database. In many cases they can be 80-90% of the rows in the `state_attributes` table in a typical install.

These values are typically used for automations and to link unifiprotect sensors to camera events, which leaves them with little historical value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
