### PR TITLE
Increase the maximum value for the transition parameter in the service hue.activate_scene 

### DIFF
--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
                 vol.Coerce(int), vol.Range(min=0, max=100)
             ),
             vol.Optional(ATTR_TRANSITION): vol.All(
-                vol.Coerce(float), vol.Range(min=0, max=600)
+                vol.Coerce(float), vol.Range(min=0, max=6000)
             ),
             vol.Optional(ATTR_BRIGHTNESS): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=255)

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
                 vol.Coerce(int), vol.Range(min=0, max=100)
             ),
             vol.Optional(ATTR_TRANSITION): vol.All(
-                vol.Coerce(float), vol.Range(min=0, max=6000)
+                vol.Coerce(float), vol.Range(min=0, max=3600)
             ),
             vol.Optional(ATTR_BRIGHTNESS): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=255)

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -39,7 +39,7 @@ activate_scene:
       selector:
         number:
           min: 0
-          max: 300
+          max: 6000
           unit_of_measurement: seconds
     dynamic:
       name: Dynamic

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -39,7 +39,7 @@ activate_scene:
       selector:
         number:
           min: 0
-          max: 6000
+          max: 3600
           unit_of_measurement: seconds
     dynamic:
       name: Dynamic


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The service `hue.activate_scene` should allow a bigger number for the transition parameter. 

The Phillips Hue bridge supports a transition up to 6000 seconds when recalling a scene.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Community Threads discussing this issue: https://community.home-assistant.io/t/use-long-transition-time-on-hub-bridge-v2/480093

I've tested the maximum value in the API of my Phillips hue Bridge (version 1.45.1956046040).

- 6000000ms (6000s) is allowed and working perfectly:
![Screenshot 2023-02-18 151728](https://user-images.githubusercontent.com/8711046/219899397-ddf7549a-62be-4988-bc9e-7a5d423374f1.png)
- Any values higher are invalid:
![Screenshot 2023-02-18 151659](https://user-images.githubusercontent.com/8711046/219899401-f3bac451-ccec-45a3-ad81-568204be083f.png)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
