### PR TITLE
Cleanup mypy ignore list feature

### DIFF
--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -126,7 +126,7 @@ def _generate_and_validate_strict_typing(config: Config) -> str:
     return "\n".join(_sort_within_sections(lines)) + "\n"
 
 
-def _generate_and_validate_mypy_config(config: Config) -> str:  # noqa: C901
+def _generate_and_validate_mypy_config(config: Config) -> str:
     """Validate and generate mypy config."""
 
     # Filter empty and commented lines.

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -12,12 +12,6 @@ from homeassistant.const import REQUIRED_PYTHON_VER
 
 from .model import Config, Integration
 
-# Modules which have type hints which known to be broken.
-# If you are an author of component listed here, please fix these errors and
-# remove your component from this list to enable type checks.
-# Do your best to not add anything new here.
-IGNORED_MODULES: Final[list[str]] = []
-
 # Component modules which should set no_implicit_reexport = true.
 NO_IMPLICIT_REEXPORT_MODULES: set[str] = {
     "homeassistant.components",
@@ -98,19 +92,6 @@ PLUGIN_CONFIG: Final[dict[str, dict[str, str]]] = {
 }
 
 
-def _strict_module_in_ignore_list(
-    module: str, ignored_modules_set: set[str]
-) -> str | None:
-    if module in ignored_modules_set:
-        return module
-    if module.endswith("*"):
-        module = module[:-1]
-        for ignored_module in ignored_modules_set:
-            if ignored_module.startswith(module):
-                return ignored_module
-    return None
-
-
 def _sort_within_sections(line_iter: Iterable[str]) -> Iterable[str]:
     """Sort lines within sections.
 
@@ -163,27 +144,9 @@ def _generate_and_validate_mypy_config(config: Config) -> str:  # noqa: C901
         else:
             strict_core_modules.append(module)
 
-    ignored_modules_set: set[str] = set(IGNORED_MODULES)
-    for module in strict_modules:
-        if (
-            not module.startswith("homeassistant.components.")
-            and module != "homeassistant.components"
-        ):
-            config.add_error(
-                "mypy_config", f"Only components should be added: {module}"
-            )
-        if ignored_module := _strict_module_in_ignore_list(module, ignored_modules_set):
-            config.add_error(
-                "mypy_config",
-                f"Module '{ignored_module}' is in ignored list in mypy_config.py",
-            )
-
     # Validate that all modules exist.
     all_modules = (
-        strict_modules
-        + strict_core_modules
-        + IGNORED_MODULES
-        + list(NO_IMPLICIT_REEXPORT_MODULES)
+        strict_modules + strict_core_modules + list(NO_IMPLICIT_REEXPORT_MODULES)
     )
     for module in all_modules:
         if module.endswith(".*"):
@@ -258,11 +221,6 @@ def _generate_and_validate_mypy_config(config: Config) -> str:  # noqa: C901
     mypy_config.add_section(tests_section)
     for key in STRICT_SETTINGS:
         mypy_config.set(tests_section, key, "false")
-
-    for ignored_module in IGNORED_MODULES:
-        ignored_section = f"mypy-{ignored_module}"
-        mypy_config.add_section(ignored_section)
-        mypy_config.set(ignored_section, "ignore_errors", "true")
 
     with io.StringIO() as fp:
         mypy_config.write(fp)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The list of ignored modules is empty and this feature is no longer needed.
Thanks everyone who was working on fixing broken type hints!

Remove some dead code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
