### PR TITLE
Add type hints to integration tests

### DIFF
--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -37,8 +37,8 @@ pytestmark = pytest.mark.usefixtures("init_integration")
 )
 async def test_light_state_temperature(
     hass: HomeAssistant,
-    device_registry: dr.DeviceEntry,
-    entity_registry: er.RegistryEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the creation and values of the Elgato Lights in temperature mode."""

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -22,7 +22,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import async_fire_time_changed, get_fixture_path
 
 
-async def test_setup(recorder_mock, hass):
+async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor setup."""
 
     config = {
@@ -44,7 +44,9 @@ async def test_setup(recorder_mock, hass):
     assert state.state == "0.0"
 
 
-async def test_setup_multiple_states(recorder_mock, hass):
+async def test_setup_multiple_states(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor setup for multiple states."""
 
     config = {
@@ -95,7 +97,7 @@ async def test_setup_multiple_states(recorder_mock, hass):
         },
     ],
 )
-def test_setup_invalid_config(config):
+def test_setup_invalid_config(config) -> None:
     """Test the history statistics sensor setup with invalid config."""
 
     with pytest.raises(vol.Invalid):

--- a/tests/components/insteon/test_api_scenes.py
+++ b/tests/components/insteon/test_api_scenes.py
@@ -1,5 +1,4 @@
 """Test the Insteon Scenes APIs."""
-
 import json
 import os
 from unittest.mock import AsyncMock, patch
@@ -10,10 +9,12 @@ import pytest
 
 from homeassistant.components.insteon.api import async_load_api, scenes
 from homeassistant.components.insteon.const import ID, TYPE
+from homeassistant.core import HomeAssistant
 
 from .mock_devices import MockDevices
 
 from tests.common import load_fixture
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="scene_data", scope="session")
@@ -58,7 +59,9 @@ async def _setup(hass, hass_ws_client, scene_data):
     return ws_client, devices
 
 
-async def test_get_scenes(hass, hass_ws_client, scene_data):
+async def test_get_scenes(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data
+) -> None:
     """Test getting all Insteon scenes."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 
@@ -70,7 +73,9 @@ async def test_get_scenes(hass, hass_ws_client, scene_data):
         assert len(result["20"]) == 3
 
 
-async def test_get_scene(hass, hass_ws_client, scene_data):
+async def test_get_scene(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data
+) -> None:
     """Test getting an Insteon scene."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 
@@ -81,7 +86,9 @@ async def test_get_scene(hass, hass_ws_client, scene_data):
         assert len(result["devices"]) == 3
 
 
-async def test_save_scene(hass, hass_ws_client, scene_data, remove_json):
+async def test_save_scene(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data, remove_json
+) -> None:
     """Test saving an Insteon scene."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 
@@ -108,7 +115,9 @@ async def test_save_scene(hass, hass_ws_client, scene_data, remove_json):
         assert result["scene_id"] == 20
 
 
-async def test_save_new_scene(hass, hass_ws_client, scene_data, remove_json):
+async def test_save_new_scene(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data, remove_json
+) -> None:
     """Test saving a new Insteon scene."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 
@@ -135,7 +144,9 @@ async def test_save_new_scene(hass, hass_ws_client, scene_data, remove_json):
         assert result["scene_id"] == 21
 
 
-async def test_save_scene_error(hass, hass_ws_client, scene_data, remove_json):
+async def test_save_scene_error(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data, remove_json
+) -> None:
     """Test saving an Insteon scene with error."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 
@@ -162,7 +173,9 @@ async def test_save_scene_error(hass, hass_ws_client, scene_data, remove_json):
         assert result["scene_id"] == 20
 
 
-async def test_delete_scene(hass, hass_ws_client, scene_data, remove_json):
+async def test_delete_scene(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data, remove_json
+) -> None:
     """Test delete an Insteon scene."""
     ws_client, devices = await _setup(hass, hass_ws_client, scene_data)
 

--- a/tests/components/litejet/test_light.py
+++ b/tests/components/litejet/test_light.py
@@ -178,7 +178,7 @@ async def test_deactivated_event(hass: HomeAssistant, mock_litejet) -> None:
     assert hass.states.get(ENTITY_OTHER_LIGHT).state == "off"
 
 
-async def test_connected_event(hass, mock_litejet):
+async def test_connected_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass)

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -47,7 +47,7 @@ async def test_activate(hass: HomeAssistant, mock_litejet) -> None:
     mock_litejet.activate_scene.assert_called_once_with(ENTITY_SCENE_NUMBER)
 
 
-async def test_connected_event(hass, mock_litejet):
+async def test_connected_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass, use_scene=True)

--- a/tests/components/litejet/test_switch.py
+++ b/tests/components/litejet/test_switch.py
@@ -84,7 +84,7 @@ async def test_released_event(hass: HomeAssistant, mock_litejet) -> None:
     assert hass.states.get(ENTITY_OTHER_SWITCH).state == STATE_OFF
 
 
-async def test_connected_event(hass, mock_litejet):
+async def test_connected_event(hass: HomeAssistant, mock_litejet) -> None:
     """Test handling an event from LiteJet."""
 
     await async_init_integration(hass, use_switch=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #87777

These are new since the second pass.
It takes more fixtures into account:
```
    "aioclient_mock": "AiohttpClientMocker",
    "aiohttp_client": "ClientSessionGenerator",
    "area_registry": "ar.AreaRegistry",
    "async_setup_recorder_instance": "RecorderInstanceGenerator",
    "caplog": "pytest.LogCaptureFixture",
    "current_request_with_host": "None",
    "device_registry": "dr.DeviceRegistry",
    "enable_bluetooth": "None",
    "enable_custom_integrations": "None",
    "enable_nightly_purge": "bool",
    "enable_statistics": "bool",
    "enable_statistics_table_validation": "bool",
    "entity_registry": "er.EntityRegistry",
    "hass": "HomeAssistant",
    "hass_access_token": "str",
    "hass_admin_credential": "Credentials",
    "hass_admin_user": "MockUser",
    "hass_client": "ClientSessionGenerator",
    "hass_client_no_auth": "ClientSessionGenerator",
    "hass_owner_user": "MockUser",
    "hass_read_only_access_token": "str",
    "hass_read_only_user": "MockUser",
    "hass_recorder": "Callable[..., HomeAssistant]",
    "hass_storage": "dict[str, Any]",
    "hass_supervisor_access_token": "str",
    "hass_supervisor_user": "MockUser",
    "hass_ws_client": "WebSocketGenerator",
    "issue_registry": "ir.IssueRegistry",
    "legacy_auth": "LegacyApiPasswordAuthProvider",
    "local_auth": "HassAuthProvider",
    "mock_async_zeroconf": "None",
    "mock_bleak_scanner_start": "MagicMock",
    "mock_bluetooth": "None",
    "mock_bluetooth_adapters": "None",
    "mock_device_tracker_conf": "list[legacy.Device]",
    "mock_zeroconf": "None",
    "mqtt_client_mock": "MqttMockPahoClient",
    "mqtt_mock": "MqttMockHAClient",
    "mqtt_mock_entry_no_yaml_config": "MqttMockHAClientGenerator",
    "mqtt_mock_entry_with_yaml_config": "MqttMockHAClientGenerator",
    "recorder_db_url": "str",
    "recorder_mock": "Recorder",
    "requests_mock": "requests_mock.Mocker",
    "tmp_path": "Path",
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
