### PR TITLE
Cleanups in WLED tests

### DIFF
--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for WLED integration tests."""
 from collections.abc import Generator
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,7 +9,7 @@ from homeassistant.components.wled.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
@@ -25,7 +24,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, AsyncMock, None]:
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.wled.async_setup_entry", return_value=True
@@ -34,7 +33,7 @@ def mock_setup_entry() -> Generator[None, AsyncMock, None]:
 
 
 @pytest.fixture
-def mock_onboarding() -> Generator[None, MagicMock, None]:
+def mock_onboarding() -> Generator[MagicMock, None, None]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -44,31 +43,23 @@ def mock_onboarding() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_wled_config_flow(
-    request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
-    """Return a mocked WLED client."""
-    with patch(
-        "homeassistant.components.wled.config_flow.WLED", autospec=True
-    ) as wled_mock:
-        wled = wled_mock.return_value
-        wled.update.return_value = WLEDDevice(json.loads(load_fixture("wled/rgb.json")))
-        yield wled
+def device_fixture() -> str:
+    """Return the device fixture for a specific device."""
+    return "rgb"
 
 
 @pytest.fixture
-def mock_wled(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_wled(device_fixture: str) -> Generator[MagicMock, None, None]:
     """Return a mocked WLED client."""
-    fixture: str = "wled/rgb.json"
-    if hasattr(request, "param") and request.param:
-        fixture = request.param
-
-    device = WLEDDevice(json.loads(load_fixture(fixture)))
     with patch(
         "homeassistant.components.wled.coordinator.WLED", autospec=True
-    ) as wled_mock:
+    ) as wled_mock, patch(
+        "homeassistant.components.wled.config_flow.WLED", new=wled_mock
+    ):
         wled = wled_mock.return_value
-        wled.update.return_value = device
+        wled.update.return_value = WLEDDevice(
+            load_json_object_fixture(f"{device_fixture}.json", DOMAIN)
+        )
         wled.connected = False
         wled.host = "127.0.0.1"
         yield wled

--- a/tests/components/wled/test_binary_sensor.py
+++ b/tests/components/wled/test_binary_sensor.py
@@ -1,6 +1,4 @@
 """Tests for the WLED binary sensor platform."""
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -14,62 +12,46 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_available(
-    hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
-    init_integration: MockConfigEntry,
-    mock_wled: MagicMock,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the firmware update binary sensor."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("binary_sensor.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("binary_sensor.wled_rgb_light_firmware"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
     assert state.state == STATE_ON
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("binary_sensor.wled_rgb_light_firmware")
-    assert entry
+    assert (entry := entity_registry.async_get("binary_sensor.wled_rgb_light_firmware"))
     assert entry.unique_id == "aabbccddeeff_update"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_no_update_available(
-    hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
-    init_integration: MockConfigEntry,
-    mock_wled: MagicMock,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the update binary sensor. There is no update available."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("binary_sensor.wled_websocket_firmware")
-    assert state
+    assert (state := hass.states.get("binary_sensor.wled_websocket_firmware"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
     assert state.state == STATE_OFF
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("binary_sensor.wled_websocket_firmware")
-    assert entry
+    assert (entry := entity_registry.async_get("binary_sensor.wled_websocket_firmware"))
     assert entry.unique_id == "aabbccddeeff_update"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
 async def test_disabled_by_default(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that the binary update sensor is disabled by default."""
-    registry = er.async_get(hass)
+    assert hass.states.get("binary_sensor.wled_rgb_light_firmware") is None
 
-    state = hass.states.get("binary_sensor.wled_rgb_light_firmware")
-    assert state is None
-
-    entry = registry.async_get("binary_sensor.wled_rgb_light_firmware")
-    assert entry
+    assert (entry := entity_registry.async_get("binary_sensor.wled_rgb_light_firmware"))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -21,22 +21,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 async def test_button_restart(
-    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_wled: MagicMock
 ) -> None:
     """Test the creation and values of the WLED button."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("button.wled_rgb_light_restart")
-    assert state
+    assert (state := hass.states.get("button.wled_rgb_light_restart"))
     assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.RESTART
 
-    entry = entity_registry.async_get("button.wled_rgb_light_restart")
-    assert entry
+    assert (entry := entity_registry.async_get("button.wled_rgb_light_restart"))
     assert entry.unique_id == "aabbccddeeff_restart"
     assert entry.entity_category is EntityCategory.CONFIG
 
@@ -46,7 +42,6 @@ async def test_button_restart(
         {ATTR_ENTITY_ID: "button.wled_rgb_light_restart"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.reset.call_count == 1
     mock_wled.reset.assert_called_with()
 
@@ -54,7 +49,6 @@ async def test_button_restart(
 @freeze_time("2021-11-04 17:37:00", tz_offset=-1)
 async def test_button_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED buttons."""
@@ -69,14 +63,12 @@ async def test_button_error(
         )
         await hass.async_block_till_done()
 
-    state = hass.states.get("button.wled_rgb_light_restart")
-    assert state
+    assert (state := hass.states.get("button.wled_rgb_light_restart"))
     assert state.state == "2021-11-04T16:37:00+00:00"
 
 
 async def test_button_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED buttons."""
@@ -89,8 +81,6 @@ async def test_button_connection_error(
             {ATTR_ENTITY_ID: "button.wled_rgb_light_restart"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("button.wled_rgb_light_restart")
-    assert state
+    assert (state := hass.states.get("button.wled_rgb_light_restart"))
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the WLED config flow."""
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from wled import WLEDConnectionError
 
 from homeassistant.components import zeroconf
@@ -13,9 +14,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_full_user_flow_implementation(
-    hass: HomeAssistant, mock_wled_config_flow: MagicMock, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry", "mock_wled")
+async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     """Test the full manual user flow from start to finish."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -37,9 +37,8 @@ async def test_full_user_flow_implementation(
     assert result["result"].unique_id == "aabbccddeeff"
 
 
-async def test_full_zeroconf_flow_implementation(
-    hass: HomeAssistant, mock_wled_config_flow: MagicMock, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry", "mock_wled")
+async def test_full_zeroconf_flow_implementation(hass: HomeAssistant) -> None:
     """Test the full manual user flow from start to finish."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -78,9 +77,9 @@ async def test_full_zeroconf_flow_implementation(
     assert result2["result"].unique_id == "aabbccddeeff"
 
 
+@pytest.mark.usefixtures("mock_wled")
 async def test_zeroconf_during_onboarding(
     hass: HomeAssistant,
-    mock_wled_config_flow: MagicMock,
     mock_setup_entry: AsyncMock,
     mock_onboarding: MagicMock,
 ) -> None:
@@ -110,11 +109,9 @@ async def test_zeroconf_during_onboarding(
     assert len(mock_onboarding.mock_calls) == 1
 
 
-async def test_connection_error(
-    hass: HomeAssistant, mock_wled_config_flow: MagicMock
-) -> None:
+async def test_connection_error(hass: HomeAssistant, mock_wled: MagicMock) -> None:
     """Test we show user form on WLED connection error."""
-    mock_wled_config_flow.update.side_effect = WLEDConnectionError
+    mock_wled.update.side_effect = WLEDConnectionError
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -127,10 +124,10 @@ async def test_connection_error(
 
 
 async def test_zeroconf_connection_error(
-    hass: HomeAssistant, mock_wled_config_flow: MagicMock
+    hass: HomeAssistant, mock_wled: MagicMock
 ) -> None:
     """Test we abort zeroconf flow on WLED connection error."""
-    mock_wled_config_flow.update.side_effect = WLEDConnectionError
+    mock_wled.update.side_effect = WLEDConnectionError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -150,10 +147,11 @@ async def test_zeroconf_connection_error(
     assert result.get("reason") == "cannot_connect"
 
 
+@pytest.mark.usefixtures("mock_wled")
 async def test_user_device_exists_abort(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_wled_config_flow: MagicMock,
+    mock_wled: MagicMock,
 ) -> None:
     """Test we abort zeroconf flow if WLED device already configured."""
     mock_config_entry.add_to_hass(hass)
@@ -169,10 +167,10 @@ async def test_user_device_exists_abort(
 
 async def test_user_with_cct_channel_abort(
     hass: HomeAssistant,
-    mock_wled_config_flow: MagicMock,
+    mock_wled: MagicMock,
 ) -> None:
     """Test we abort user flow if WLED device uses a CCT channel."""
-    mock_wled_config_flow.update.return_value.info.leds.cct = True
+    mock_wled.update.return_value.info.leds.cct = True
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -184,10 +182,10 @@ async def test_user_with_cct_channel_abort(
     assert result.get("reason") == "cct_unsupported"
 
 
+@pytest.mark.usefixtures("mock_wled")
 async def test_zeroconf_without_mac_device_exists_abort(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_wled_config_flow: MagicMock,
 ) -> None:
     """Test we abort zeroconf flow if WLED device already configured."""
     mock_config_entry.add_to_hass(hass)
@@ -212,7 +210,7 @@ async def test_zeroconf_without_mac_device_exists_abort(
 async def test_zeroconf_with_mac_device_exists_abort(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_wled_config_flow: MagicMock,
+    mock_wled: MagicMock,
 ) -> None:
     """Test we abort zeroconf flow if WLED device already configured."""
     mock_config_entry.add_to_hass(hass)
@@ -236,10 +234,10 @@ async def test_zeroconf_with_mac_device_exists_abort(
 
 async def test_zeroconf_with_cct_channel_abort(
     hass: HomeAssistant,
-    mock_wled_config_flow: MagicMock,
+    mock_wled: MagicMock,
 ) -> None:
     """Test we abort zeroconf flow if WLED device uses a CCT channel."""
-    mock_wled_config_flow.update.return_value.info.leds.cct = True
+    mock_wled.update.return_value.info.leds.cct = True
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/wled/test_coordinator.py
+++ b/tests/components/wled/test_coordinator.py
@@ -32,7 +32,7 @@ async def test_not_supporting_websocket(
     assert mock_wled.connect.call_count == 0
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_websocket_already_connected(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
@@ -46,7 +46,7 @@ async def test_websocket_already_connected(
     assert mock_wled.connect.call_count == 1
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_websocket_connect_error_no_listen(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -64,7 +64,7 @@ async def test_websocket_connect_error_no_listen(
     assert mock_wled.listen.call_count == 1
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_websocket(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -137,7 +137,7 @@ async def test_websocket(
     assert state.state == STATE_OFF
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_websocket_error(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -169,7 +169,7 @@ async def test_websocket_error(
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_websocket_disconnect_on_home_assistant_stop(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_load_unload_config_entry(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_wled: AsyncMock
 ) -> None:

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -24,18 +24,17 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import async_fire_time_changed, load_fixture
+
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 async def test_color_palette_state(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the creation and values of the WLED selects."""
-    entity_registry = er.async_get(hass)
-
     # First segment of the strip
-    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_segment_1_color_palette"))
     assert state.attributes.get(ATTR_ICON) == "mdi:palette-outline"
     assert state.attributes.get(ATTR_OPTIONS) == [
         "Analogous",
@@ -91,15 +90,17 @@ async def test_color_palette_state(
     ]
     assert state.state == "Random Cycle"
 
-    entry = entity_registry.async_get("select.wled_rgb_light_segment_1_color_palette")
-    assert entry
+    assert (
+        entry := entity_registry.async_get(
+            "select.wled_rgb_light_segment_1_color_palette"
+        )
+    )
     assert entry.unique_id == "aabbccddeeff_palette_1"
     assert entry.entity_category is EntityCategory.CONFIG
 
 
 async def test_color_palette_segment_change_state(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test the option change of state of the WLED segments."""
@@ -112,7 +113,6 @@ async def test_color_palette_segment_change_state(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(
         segment_id=1,
@@ -120,18 +120,15 @@ async def test_color_palette_segment_change_state(
     )
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_single_segment"])
 async def test_color_palette_dynamically_handle_segments(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test if a new/deleted segment is dynamically added/removed."""
-    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
-    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert segment0
+    assert (segment0 := hass.states.get("select.wled_rgb_light_color_palette"))
     assert segment0.state == "Default"
-    assert not segment1
+    assert not hass.states.get("select.wled_rgb_light_segment_1_color_palette")
 
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice(
@@ -141,11 +138,11 @@ async def test_color_palette_dynamically_handle_segments(
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
-    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert segment0
+    assert (segment0 := hass.states.get("select.wled_rgb_light_color_palette"))
     assert segment0.state == "Default"
-    assert segment1
+    assert (
+        segment1 := hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    )
     assert segment1.state == "Random Cycle"
 
     # Test adding if segment shows up again, including the master entity
@@ -153,17 +150,16 @@ async def test_color_palette_dynamically_handle_segments(
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
-    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert segment0
+    assert (segment0 := hass.states.get("select.wled_rgb_light_color_palette"))
     assert segment0.state == "Default"
-    assert segment1
+    assert (
+        segment1 := hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    )
     assert segment1.state == STATE_UNAVAILABLE
 
 
 async def test_color_palette_select_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -179,10 +175,8 @@ async def test_color_palette_select_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_segment_1_color_palette"))
     assert state.state == "Random Cycle"
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, palette="Icefire")
@@ -190,7 +184,6 @@ async def test_color_palette_select_error(
 
 async def test_color_palette_select_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -206,42 +199,32 @@ async def test_color_palette_select_connection_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_segment_1_color_palette"))
     assert state.state == STATE_UNAVAILABLE
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, palette="Icefire")
 
 
-async def test_preset_unavailable_without_presets(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-) -> None:
+async def test_preset_unavailable_without_presets(hass: HomeAssistant) -> None:
     """Test WLED preset entity is unavailable when presets are not available."""
-    state = hass.states.get("select.wled_rgb_light_preset")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_preset"))
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_preset_state(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the creation and values of the WLED selects."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("select.wled_rgbw_light_preset")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_preset"))
     assert state.attributes.get(ATTR_ICON) == "mdi:playlist-play"
     assert state.attributes.get(ATTR_OPTIONS) == ["Preset 1", "Preset 2"]
     assert state.state == "Preset 1"
 
-    entry = entity_registry.async_get("select.wled_rgbw_light_preset")
-    assert entry
+    assert (entry := entity_registry.async_get("select.wled_rgbw_light_preset"))
     assert entry.unique_id == "aabbccddee11_preset"
 
     await hass.services.async_call(
@@ -253,17 +236,14 @@ async def test_preset_state(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.preset.call_count == 1
     mock_wled.preset.assert_called_with(preset="Preset 2")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_old_style_preset_active(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test unknown preset returned (when old style/unknown) preset is active."""
     # Set device preset state to a random number
@@ -272,15 +252,13 @@ async def test_old_style_preset_active(
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_preset")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_preset"))
     assert state.state == STATE_UNKNOWN
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_preset_select_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -298,17 +276,15 @@ async def test_preset_select_error(
         )
         await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_preset")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_preset"))
     assert state.state == "Preset 1"
     assert mock_wled.preset.call_count == 1
     mock_wled.preset.assert_called_with(preset="Preset 2")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_preset_select_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -324,42 +300,33 @@ async def test_preset_select_connection_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_preset")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_preset"))
     assert state.state == STATE_UNAVAILABLE
     assert mock_wled.preset.call_count == 1
     mock_wled.preset.assert_called_with(preset="Preset 2")
 
 
-async def test_playlist_unavailable_without_playlists(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-) -> None:
+async def test_playlist_unavailable_without_playlists(hass: HomeAssistant) -> None:
     """Test WLED playlist entity is unavailable when playlists are not available."""
-    state = hass.states.get("select.wled_rgb_light_playlist")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_playlist"))
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_playlist_state(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the creation and values of the WLED selects."""
-    entity_registry = er.async_get(hass)
 
-    state = hass.states.get("select.wled_rgbw_light_playlist")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_playlist"))
     assert state.attributes.get(ATTR_ICON) == "mdi:play-speed"
     assert state.attributes.get(ATTR_OPTIONS) == ["Playlist 1", "Playlist 2"]
     assert state.state == "Playlist 1"
 
-    entry = entity_registry.async_get("select.wled_rgbw_light_playlist")
-    assert entry
+    assert (entry := entity_registry.async_get("select.wled_rgbw_light_playlist"))
     assert entry.unique_id == "aabbccddee11_playlist"
 
     await hass.services.async_call(
@@ -371,17 +338,14 @@ async def test_playlist_state(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.playlist.call_count == 1
     mock_wled.playlist.assert_called_with(playlist="Playlist 2")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_old_style_playlist_active(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test when old style playlist cycle is active."""
     # Set device playlist to 0, which meant "cycle" previously.
@@ -390,15 +354,13 @@ async def test_old_style_playlist_active(
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_playlist")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_playlist"))
     assert state.state == STATE_UNKNOWN
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_playlist_select_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -414,19 +376,16 @@ async def test_playlist_select_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_playlist")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_playlist"))
     assert state.state == "Playlist 1"
     assert mock_wled.playlist.call_count == 1
     mock_wled.playlist.assert_called_with(playlist="Playlist 2")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_playlist_select_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -442,10 +401,8 @@ async def test_playlist_select_connection_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgbw_light_playlist")
-    assert state
+    assert (state := hass.states.get("select.wled_rgbw_light_playlist"))
     assert state.state == STATE_UNAVAILABLE
     assert mock_wled.playlist.call_count == 1
     mock_wled.playlist.assert_called_with(playlist="Playlist 2")
@@ -453,20 +410,16 @@ async def test_playlist_select_connection_error(
 
 async def test_live_override(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the creation and values of the WLED selects."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("select.wled_rgb_light_live_override")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_live_override"))
     assert state.attributes.get(ATTR_ICON) == "mdi:theater"
     assert state.attributes.get(ATTR_OPTIONS) == ["0", "1", "2"]
     assert state.state == "0"
 
-    entry = entity_registry.async_get("select.wled_rgb_light_live_override")
-    assert entry
+    assert (entry := entity_registry.async_get("select.wled_rgb_light_live_override"))
     assert entry.unique_id == "aabbccddeeff_live_override"
 
     await hass.services.async_call(
@@ -478,14 +431,12 @@ async def test_live_override(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live=2)
 
 
 async def test_live_select_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -501,10 +452,8 @@ async def test_live_select_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgb_light_live_override")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_live_override"))
     assert state.state == "0"
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live=1)
@@ -512,7 +461,6 @@ async def test_live_select_error(
 
 async def test_live_select_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED selects."""
@@ -528,10 +476,8 @@ async def test_live_select_connection_error(
             },
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("select.wled_rgb_light_live_override")
-    assert state
+    assert (state := hass.states.get("select.wled_rgb_light_live_override"))
     assert state.state == STATE_UNAVAILABLE
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live=2)

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -1,11 +1,10 @@
 """Tests for the WLED sensor platform."""
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
-from homeassistant.components.wled.const import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
@@ -24,14 +23,13 @@ from homeassistant.util import dt as dt_util
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_wled")
 async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_wled: MagicMock,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the creation and values of the WLED sensors."""
-    registry = er.async_get(hass)
     mock_config_entry.add_to_hass(hass)
 
     test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=dt_util.UTC)
@@ -39,8 +37,7 @@ async def test_sensors(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.wled_rgb_light_estimated_current")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_estimated_current"))
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == UnitOfElectricCurrent.MILLIAMPERE
@@ -48,48 +45,42 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.CURRENT
     assert state.state == "470"
 
-    entry = registry.async_get("sensor.wled_rgb_light_estimated_current")
-    assert entry
+    assert (
+        entry := entity_registry.async_get("sensor.wled_rgb_light_estimated_current")
+    )
     assert entry.unique_id == "aabbccddeeff_estimated_current"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_uptime")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_uptime"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "2019-11-11T09:10:00+00:00"
 
-    entry = registry.async_get("sensor.wled_rgb_light_uptime")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_uptime"))
     assert entry.unique_id == "aabbccddeeff_uptime"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_free_memory")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_free_memory"))
     assert state.attributes.get(ATTR_ICON) == "mdi:memory"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfInformation.BYTES
     assert state.state == "14600"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    entry = registry.async_get("sensor.wled_rgb_light_free_memory")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_free_memory"))
     assert entry.unique_id == "aabbccddeeff_free_heap"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wi_fi_signal")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_wi_fi_signal"))
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "76"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_signal")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_wi_fi_signal"))
     assert entry.unique_id == "aabbccddeeff_wifi_signal"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wi_fi_rssi")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_wi_fi_rssi"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.SIGNAL_STRENGTH
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -97,30 +88,25 @@ async def test_sensors(
     )
     assert state.state == "-62"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_rssi")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_wi_fi_rssi"))
     assert entry.unique_id == "aabbccddeeff_wifi_rssi"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wi_fi_channel")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_wi_fi_channel"))
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "11"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_channel")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_wi_fi_channel"))
     assert entry.unique_id == "aabbccddeeff_wifi_channel"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wi_fi_bssid")
-    assert state
+    assert (state := hass.states.get("sensor.wled_rgb_light_wi_fi_bssid"))
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "AA:AA:AA:AA:AA:BB"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_bssid")
-    assert entry
+    assert (entry := entity_registry.async_get("sensor.wled_rgb_light_wi_fi_bssid"))
     assert entry.unique_id == "aabbccddeeff_wifi_bssid"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
@@ -136,17 +122,14 @@ async def test_sensors(
         "sensor.wled_rgb_light_wi_fi_bssid",
     ),
 )
+@pytest.mark.usefixtures("init_integration")
 async def test_disabled_by_default_sensors(
-    hass: HomeAssistant, init_integration: MockConfigEntry, entity_id: str
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, entity_id: str
 ) -> None:
     """Test the disabled by default WLED sensors."""
-    registry = er.async_get(hass)
+    assert hass.states.get(entity_id) is None
 
-    state = hass.states.get(entity_id)
-    assert state is None
-
-    entry = registry.async_get(entity_id)
-    assert entry
+    assert (entry := entity_registry.async_get(entity_id))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
@@ -160,6 +143,7 @@ async def test_disabled_by_default_sensors(
         "signal",
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_no_wifi_support(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -167,17 +151,6 @@ async def test_no_wifi_support(
     key: str,
 ) -> None:
     """Test missing Wi-Fi information from WLED device."""
-    registry = er.async_get(hass)
-
-    # Pre-create registry entries for disabled by default sensors
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        f"aabbccddeeff_wifi_{key}",
-        suggested_object_id=f"wled_rgb_light_wifi_{key}",
-        disabled_by=None,
-    )
-
     # Remove Wi-Fi info
     device = mock_wled.update.return_value
     device.info.wifi = None
@@ -187,8 +160,7 @@ async def test_no_wifi_support(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get(f"sensor.wled_rgb_light_wifi_{key}")
-    assert state
+    assert (state := hass.states.get(f"sensor.wled_rgb_light_wi_fi_{key}"))
     assert state.state == STATE_UNKNOWN
 
 

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -28,64 +28,54 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import async_fire_time_changed, load_fixture
+
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 async def test_switch_state(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the creation and values of the WLED switches."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("switch.wled_rgb_light_nightlight")
-    assert state
+    assert (state := hass.states.get("switch.wled_rgb_light_nightlight"))
     assert state.attributes.get(ATTR_DURATION) == 60
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-night"
     assert state.attributes.get(ATTR_TARGET_BRIGHTNESS) == 0
     assert state.attributes.get(ATTR_FADE)
     assert state.state == STATE_OFF
 
-    entry = entity_registry.async_get("switch.wled_rgb_light_nightlight")
-    assert entry
+    assert (entry := entity_registry.async_get("switch.wled_rgb_light_nightlight"))
     assert entry.unique_id == "aabbccddeeff_nightlight"
     assert entry.entity_category is EntityCategory.CONFIG
 
-    state = hass.states.get("switch.wled_rgb_light_sync_send")
-    assert state
+    assert (state := hass.states.get("switch.wled_rgb_light_sync_send"))
     assert state.attributes.get(ATTR_ICON) == "mdi:upload-network-outline"
     assert state.attributes.get(ATTR_UDP_PORT) == 21324
     assert state.state == STATE_OFF
 
-    entry = entity_registry.async_get("switch.wled_rgb_light_sync_send")
-    assert entry
+    assert (entry := entity_registry.async_get("switch.wled_rgb_light_sync_send"))
     assert entry.unique_id == "aabbccddeeff_sync_send"
     assert entry.entity_category is EntityCategory.CONFIG
 
-    state = hass.states.get("switch.wled_rgb_light_sync_receive")
-    assert state
+    assert (state := hass.states.get("switch.wled_rgb_light_sync_receive"))
     assert state.attributes.get(ATTR_ICON) == "mdi:download-network-outline"
     assert state.attributes.get(ATTR_UDP_PORT) == 21324
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("switch.wled_rgb_light_sync_receive")
-    assert entry
+    assert (entry := entity_registry.async_get("switch.wled_rgb_light_sync_receive"))
     assert entry.unique_id == "aabbccddeeff_sync_receive"
     assert entry.entity_category is EntityCategory.CONFIG
 
-    state = hass.states.get("switch.wled_rgb_light_reverse")
-    assert state
+    assert (state := hass.states.get("switch.wled_rgb_light_reverse"))
     assert state.attributes.get(ATTR_ICON) == "mdi:swap-horizontal-bold"
     assert state.state == STATE_OFF
 
-    entry = entity_registry.async_get("switch.wled_rgb_light_reverse")
-    assert entry
+    assert (entry := entity_registry.async_get("switch.wled_rgb_light_reverse"))
     assert entry.unique_id == "aabbccddeeff_reverse_0"
     assert entry.entity_category is EntityCategory.CONFIG
 
 
-async def test_switch_change_state(
-    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
-) -> None:
+async def test_switch_change_state(hass: HomeAssistant, mock_wled: MagicMock) -> None:
     """Test the change of state of the WLED switches."""
 
     # Nightlight
@@ -95,7 +85,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.nightlight.call_count == 1
     mock_wled.nightlight.assert_called_with(on=True)
 
@@ -105,7 +94,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.nightlight.call_count == 2
     mock_wled.nightlight.assert_called_with(on=False)
 
@@ -116,7 +104,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_send"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.sync.call_count == 1
     mock_wled.sync.assert_called_with(send=True)
 
@@ -126,7 +113,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_send"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.sync.call_count == 2
     mock_wled.sync.assert_called_with(send=False)
 
@@ -137,7 +123,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_receive"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.sync.call_count == 3
     mock_wled.sync.assert_called_with(receive=False)
 
@@ -147,7 +132,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_receive"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.sync.call_count == 4
     mock_wled.sync.assert_called_with(receive=True)
 
@@ -157,7 +141,6 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_reverse"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=0, reverse=True)
 
@@ -167,14 +150,12 @@ async def test_switch_change_state(
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_reverse"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.segment.call_count == 2
     mock_wled.segment.assert_called_with(segment_id=0, reverse=False)
 
 
 async def test_switch_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED switches."""
@@ -187,7 +168,6 @@ async def test_switch_error(
             {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
     state = hass.states.get("switch.wled_rgb_light_nightlight")
     assert state
@@ -196,7 +176,6 @@ async def test_switch_error(
 
 async def test_switch_connection_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test error handling of the WLED switches."""
@@ -209,17 +188,14 @@ async def test_switch_connection_error(
             {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-    state = hass.states.get("switch.wled_rgb_light_nightlight")
-    assert state
+    assert (state := hass.states.get("switch.wled_rgb_light_nightlight"))
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_single_segment"])
 async def test_switch_dynamically_handle_segments(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test if a new/deleted segment is dynamically added/removed."""

--- a/tests/components/wled/test_update.py
+++ b/tests/components/wled/test_update.py
@@ -1,5 +1,5 @@
 """Tests for the WLED update platform."""
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from wled import WLEDError
@@ -30,19 +30,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 async def test_update_available(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_wled: MagicMock,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the firmware update available."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("update.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgb_light_firmware"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == UpdateDeviceClass.FIRMWARE
     assert state.state == STATE_ON
     assert (
@@ -63,23 +58,17 @@ async def test_update_available(
     assert state.attributes[ATTR_TITLE] == "WLED"
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("update.wled_rgb_light_firmware")
-    assert entry
+    assert (entry := entity_registry.async_get("update.wled_rgb_light_firmware"))
     assert entry.unique_id == "aabbccddeeff"
     assert entry.entity_category is EntityCategory.CONFIG
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_no_update.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_no_update"])
 async def test_update_information_available(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_wled: MagicMock,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test having no update information available at all."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("update.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgb_light_firmware"))
     assert state.attributes.get(ATTR_DEVICE_CLASS) == UpdateDeviceClass.FIRMWARE
     assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_INSTALLED_VERSION] is None
@@ -99,18 +88,13 @@ async def test_update_information_available(
     assert entry.entity_category is EntityCategory.CONFIG
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
 async def test_no_update_available(
-    hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
-    init_integration: MockConfigEntry,
-    mock_wled: MagicMock,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test there is no update available."""
-    entity_registry = er.async_get(hass)
-
-    state = hass.states.get("update.wled_websocket_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_websocket_firmware"))
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_DEVICE_CLASS) == UpdateDeviceClass.FIRMWARE
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.12.0-b2"
@@ -129,15 +113,13 @@ async def test_no_update_available(
 
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("update.wled_websocket_firmware")
-    assert entry
+    assert (entry := entity_registry.async_get("update.wled_websocket_firmware"))
     assert entry.unique_id == "aabbccddeeff"
     assert entry.entity_category is EntityCategory.CONFIG
 
 
 async def test_update_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -150,17 +132,14 @@ async def test_update_error(
         {ATTR_ENTITY_ID: "update.wled_rgb_light_firmware"},
         blocking=True,
     )
-    await hass.async_block_till_done()
 
-    state = hass.states.get("update.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgb_light_firmware"))
     assert state.state == STATE_UNAVAILABLE
     assert "Invalid response from API" in caplog.text
 
 
 async def test_update_stay_stable(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test the update entity staying on stable.
@@ -169,8 +148,7 @@ async def test_update_stay_stable(
     is currently running a stable version. Therefore, the update entity should
     update to the next stable (even though beta is newer).
     """
-    state = hass.states.get("update.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgb_light_firmware"))
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.8.5"
     assert state.attributes[ATTR_LATEST_VERSION] == "0.12.0"
@@ -181,15 +159,13 @@ async def test_update_stay_stable(
         {ATTR_ENTITY_ID: "update.wled_rgb_light_firmware"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.upgrade.call_count == 1
     mock_wled.upgrade.assert_called_with(version="0.12.0")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgbw"])
 async def test_update_beta_to_stable(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test the update entity.
@@ -198,8 +174,7 @@ async def test_update_beta_to_stable(
     is currently a beta, however, a newer stable is available. Therefore, the
     update entity should update to the next stable.
     """
-    state = hass.states.get("update.wled_rgbw_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgbw_light_firmware"))
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.8.6b4"
     assert state.attributes[ATTR_LATEST_VERSION] == "0.8.6"
@@ -210,15 +185,13 @@ async def test_update_beta_to_stable(
         {ATTR_ENTITY_ID: "update.wled_rgbw_light_firmware"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.upgrade.call_count == 1
     mock_wled.upgrade.assert_called_with(version="0.8.6")
 
 
-@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
+@pytest.mark.parametrize("device_fixture", ["rgb_single_segment"])
 async def test_update_stay_beta(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test the update entity.
@@ -226,8 +199,7 @@ async def test_update_stay_beta(
     There is an update for beta and the device is currently a beta. Therefore,
     the update entity should update to the next beta.
     """
-    state = hass.states.get("update.wled_rgb_light_firmware")
-    assert state
+    assert (state := hass.states.get("update.wled_rgb_light_firmware"))
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "0.8.6b1"
     assert state.attributes[ATTR_LATEST_VERSION] == "0.8.6b2"
@@ -238,6 +210,5 @@ async def test_update_stay_beta(
         {ATTR_ENTITY_ID: "update.wled_rgb_light_firmware"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert mock_wled.upgrade.call_count == 1
     mock_wled.upgrade.assert_called_with(version="0.8.6b2")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleanups of WLED tests. Mostly cleaning up fixture use, remove lots of unneeded waiting calls after a service call, make use of some walrus operators and leverage the new entity registry fixture.

This is a small sweep before doing a larger refactor, needed to have extensive tests for #75248

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
