### PR TITLE
Rename mock_setup_entry fixture

### DIFF
--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -11,8 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True

--- a/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
@@ -12,8 +12,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Nibe Heat Pump config flow."""
-from unittest.mock import Mock, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
 
 from nibe.coil import Coil
 from nibe.exceptions import (
@@ -33,7 +34,7 @@ MOCK_FLOW_MODBUS_USERDATA = {
 
 
 @pytest.fixture(autouse=True)
-async def mock_setup_entry():
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Make sure we never actually run setup."""
     with patch(
         "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -32,8 +32,8 @@ MOCK_FLOW_MODBUS_USERDATA = {
 }
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-async def fixture_mock_setup():
+@pytest.fixture(autouse=True)
+async def mock_setup_entry():
     """Make sure we never actually run setup."""
     with patch(
         "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.config_validation import ensure_list
 from .const import MOCK_OWPROXY_DEVICES
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.onewire.async_setup_entry", return_value=True

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -20,8 +20,8 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def mock_setup_entry_fixture():
+@pytest.fixture(autouse=True)
+def mock_setup_entry():
     """Disable component setup."""
     with patch(
         "homeassistant.components.philips_js.async_setup_entry", return_value=True

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Philips TV config flow."""
-from unittest.mock import ANY, patch
+from collections.abc import Generator
+from unittest.mock import ANY, AsyncMock, patch
 
 from haphilipsjs import PairingFailure
 import pytest
@@ -21,7 +22,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-def mock_setup_entry():
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Disable component setup."""
     with patch(
         "homeassistant.components.philips_js.async_setup_entry", return_value=True

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Renault config flow."""
+from collections.abc import Generator
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -22,8 +23,8 @@ from .const import MOCK_CONFIG
 from tests.common import load_fixture
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> AsyncMock:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.renault.async_setup_entry", return_value=True

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -217,8 +217,8 @@ DEVICEINFO_WEBSOCKET_NO_SSL = {
 }
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.samsungtv.async_setup_entry", return_value=True

--- a/tests/components/sfr_box/test_config_flow.py
+++ b/tests/components/sfr_box/test_config_flow.py
@@ -16,8 +16,8 @@ from homeassistant.core import HomeAssistant
 from tests.common import load_fixture
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sfr_box.async_setup_entry", return_value=True

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -13,8 +13,8 @@ from homeassistant.core import HomeAssistant
 from .conftest import SLEEPIQ_CONFIG, setup_platform
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sleepiq.async_setup_entry", return_value=True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust fixture naming for `mock_setup_entry`
Based on review comment https://github.com/home-assistant/core/pull/88319#discussion_r1109929854

cc @frenck, @emontnemery

WARNING: this is an alternative to #88484

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
