### PR TITLE
Move mock_setup_entry to conftest

### DIFF
--- a/script/scaffold/templates/config_flow/tests/conftest.py
+++ b/script/scaffold/templates/config_flow/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/script/scaffold/templates/config_flow/tests/conftest.py
+++ b/script/scaffold/templates/config_flow/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test the NEW_NAME config flow."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -11,8 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the NEW_NAME config flow."""
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,14 +9,7 @@ from homeassistant.components.NEW_DOMAIN.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:

--- a/script/scaffold/templates/config_flow_helper/tests/conftest.py
+++ b/script/scaffold/templates/config_flow_helper/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/script/scaffold/templates/config_flow_helper/tests/conftest.py
+++ b/script/scaffold/templates/config_flow_helper/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test the NEW_NAME config flow."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the NEW_NAME config flow."""
-from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -11,14 +10,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 @pytest.mark.parametrize("platform", ("sensor",))

--- a/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
@@ -12,8 +12,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry", return_value=True

--- a/tests/components/nibe_heatpump/conftest.py
+++ b/tests/components/nibe_heatpump/conftest.py
@@ -10,7 +10,7 @@ from nibe.exceptions import CoilReadException
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Make sure we never actually run setup."""
     with patch(

--- a/tests/components/nibe_heatpump/conftest.py
+++ b/tests/components/nibe_heatpump/conftest.py
@@ -1,5 +1,5 @@
 """Test configuration for Nibe Heat Pump."""
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Generator, Iterable
 from contextlib import ExitStack
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -8,6 +8,15 @@ from nibe.coil import Coil
 from nibe.connection import Connection
 from nibe.exceptions import CoilReadException
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Make sure we never actually run setup."""
+    with patch(
+        "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(autouse=True, name="mock_connection_constructor")

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Nibe Heat Pump config flow."""
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from nibe.coil import Coil
 from nibe.exceptions import (
@@ -32,13 +32,7 @@ MOCK_FLOW_MODBUS_USERDATA = {
 }
 
 
-@pytest.fixture(autouse=True)
-async def mock_setup_entry():
-    """Make sure we never actually run setup."""
-    with patch(
-        "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def _get_connection_form(

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -32,8 +32,8 @@ MOCK_FLOW_MODBUS_USERDATA = {
 }
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-async def fixture_mock_setup():
+@pytest.fixture(autouse=True)
+async def mock_setup_entry():
     """Make sure we never actually run setup."""
     with patch(
         "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -1,5 +1,6 @@
 """Provide common 1-Wire fixtures."""
-from unittest.mock import MagicMock, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyownet.protocol import ConnError
 import pytest
@@ -12,6 +13,15 @@ from homeassistant.core import HomeAssistant
 from .const import MOCK_OWPROXY_DEVICES
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.onewire.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(name="device_id", params=MOCK_OWPROXY_DEVICES.keys())

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -15,7 +15,7 @@ from .const import MOCK_OWPROXY_DEVICES
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for 1-Wire config flow."""
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from pyownet import protocol
@@ -19,14 +18,7 @@ from homeassistant.helpers.config_validation import ensure_list
 
 from .const import MOCK_OWPROXY_DEVICES
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.onewire.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 @pytest.fixture

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.config_validation import ensure_list
 from .const import MOCK_OWPROXY_DEVICES
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.onewire.async_setup_entry", return_value=True

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -12,7 +12,7 @@ from . import MOCK_CONFIG, MOCK_ENTITY_ID, MOCK_NAME, MOCK_SERIAL_NO, MOCK_SYSTE
 from tests.common import MockConfigEntry, mock_device_registry
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Disable component setup."""
     with patch(

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -1,5 +1,6 @@
 """Standard setup for tests."""
-from unittest.mock import create_autospec, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, create_autospec, patch
 
 from haphilipsjs import PhilipsTV
 import pytest
@@ -9,6 +10,17 @@ from homeassistant.components.philips_js.const import DOMAIN
 from . import MOCK_CONFIG, MOCK_ENTITY_ID, MOCK_NAME, MOCK_SERIAL_NO, MOCK_SYSTEM
 
 from tests.common import MockConfigEntry, mock_device_registry
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Disable component setup."""
+    with patch(
+        "homeassistant.components.philips_js.async_setup_entry", return_value=True
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.philips_js.async_unload_entry", return_value=True
+    ):
+        yield mock_setup_entry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -20,8 +20,8 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def mock_setup_entry_fixture():
+@pytest.fixture(autouse=True)
+def mock_setup_entry():
     """Disable component setup."""
     with patch(
         "homeassistant.components.philips_js.async_setup_entry", return_value=True

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Philips TV config flow."""
-from unittest.mock import ANY, patch
+from unittest.mock import ANY
 
 from haphilipsjs import PairingFailure
 import pytest
@@ -19,16 +19,7 @@ from . import (
 
 from tests.common import MockConfigEntry
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry():
-    """Disable component setup."""
-    with patch(
-        "homeassistant.components.philips_js.async_setup_entry", return_value=True
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.philips_js.async_unload_entry", return_value=True
-    ):
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 @pytest.fixture

--- a/tests/components/renault/conftest.py
+++ b/tests/components/renault/conftest.py
@@ -19,7 +19,7 @@ from .const import MOCK_ACCOUNT_ID, MOCK_CONFIG, MOCK_VEHICLES
 from tests.common import MockConfigEntry, load_fixture
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/tests/components/renault/conftest.py
+++ b/tests/components/renault/conftest.py
@@ -1,8 +1,9 @@
 """Provide common Renault fixtures."""
+from collections.abc import Generator
 import contextlib
 from types import MappingProxyType
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from renault_api.kamereon import exceptions, schemas
@@ -16,6 +17,15 @@ from homeassistant.helpers import aiohttp_client
 from .const import MOCK_ACCOUNT_ID, MOCK_CONFIG, MOCK_VEHICLES
 
 from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.renault.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(name="vehicle_type", params=MOCK_VEHICLES.keys())

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Renault config flow."""
-from collections.abc import Generator
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -22,14 +21,7 @@ from .const import MOCK_CONFIG
 
 from tests.common import load_fixture
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.renault.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_config_flow_single_account(

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Renault config flow."""
+from collections.abc import Generator
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -22,8 +23,8 @@ from .const import MOCK_CONFIG
 from tests.common import load_fixture
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> AsyncMock:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.renault.async_setup_entry", return_value=True

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 from .const import SAMPLE_DEVICE_INFO_UE48JU6400, SAMPLE_DEVICE_INFO_WIFI
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for Samsung TV."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from datetime import datetime
 from socket import AddressFamily
 from typing import Any
@@ -23,6 +23,15 @@ from homeassistant.components.samsungtv.const import WEBSOCKET_SSL_PORT
 import homeassistant.util.dt as dt_util
 
 from .const import SAMPLE_DEVICE_INFO_UE48JU6400, SAMPLE_DEVICE_INFO_WIFI
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.samsungtv.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -217,8 +217,8 @@ DEVICEINFO_WEBSOCKET_NO_SSL = {
 }
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.samsungtv.async_setup_entry", return_value=True

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for Samsung TV config flow."""
-from collections.abc import Generator
 import socket
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
@@ -216,14 +215,7 @@ DEVICEINFO_WEBSOCKET_NO_SSL = {
     "timeout": TIMEOUT_WEBSOCKET,
 }
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.samsungtv.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 @pytest.mark.usefixtures("remote", "rest_api_failing")

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -1,7 +1,7 @@
 """Provide common SFR Box fixtures."""
 from collections.abc import Generator
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sfrbox_api.models import DslInfo, SystemInfo
@@ -12,6 +12,15 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.sfr_box.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(name="config_entry")

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry, load_fixture
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/tests/components/sfr_box/test_config_flow.py
+++ b/tests/components/sfr_box/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the SFR Box config flow."""
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -15,14 +14,7 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import load_fixture
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.sfr_box.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_config_flow_skip_auth(

--- a/tests/components/sfr_box/test_config_flow.py
+++ b/tests/components/sfr_box/test_config_flow.py
@@ -16,8 +16,8 @@ from homeassistant.core import HomeAssistant
 from tests.common import load_fixture
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sfr_box.async_setup_entry", return_value=True

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 from asyncsleepiq import (
     Side,
@@ -38,6 +38,15 @@ SLEEPIQ_CONFIG = {
     CONF_USERNAME: "user@email.com",
     CONF_PASSWORD: "password",
 }
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.sleepiq.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -40,7 +40,7 @@ SLEEPIQ_CONFIG = {
 }
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -13,8 +13,8 @@ from homeassistant.core import HomeAssistant
 from .conftest import SLEEPIQ_CONFIG, setup_platform
 
 
-@pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sleepiq.async_setup_entry", return_value=True

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the SleepIQ config flow."""
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from asyncsleepiq import SleepIQLoginException, SleepIQTimeoutException
@@ -12,14 +11,7 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import SLEEPIQ_CONFIG, setup_platform
 
-
-@pytest.fixture(autouse=True)
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.sleepiq.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        yield mock_setup_entry
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_import(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust fixture naming for `mock_setup_entry`
Based on review comment https://github.com/home-assistant/core/pull/88319#discussion_r1109929854

cc @frenck, @emontnemery

WARNING: this is an alternative to #88481

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
