### PR TITLE
Add type hints to integration tests (part 2)

### DIFF
--- a/tests/components/apcupsd/test_init.py
+++ b/tests/components/apcupsd/test_init.py
@@ -66,7 +66,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
         assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_unload_remove(hass):
+async def test_unload_remove(hass: HomeAssistant) -> None:
     """Test successful unload of entry."""
     # Load two integrations from two mock hosts.
     entries = (

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -3,7 +3,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, mock_component
@@ -27,7 +27,7 @@ def setup_comp(hass):
     mock_component(hass, "group")
 
 
-async def test_if_fires_on_event(hass, calls):
+async def test_if_fires_on_event(hass: HomeAssistant, calls) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -63,7 +63,7 @@ async def test_if_fires_on_event(hass, calls):
     assert calls[0].data["id"] == 0
 
 
-async def test_if_fires_on_templated_event(hass, calls):
+async def test_if_fires_on_templated_event(hass: HomeAssistant, calls) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -96,7 +96,7 @@ async def test_if_fires_on_templated_event(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_multiple_events(hass, calls):
+async def test_if_fires_on_multiple_events(hass: HomeAssistant, calls) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -123,7 +123,9 @@ async def test_if_fires_on_multiple_events(hass, calls):
     assert calls[1].context.parent_id == context.id
 
 
-async def test_if_fires_on_event_extra_data(hass, calls, context_with_user):
+async def test_if_fires_on_event_extra_data(
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test the firing of events still matches with event data and context."""
     assert await async_setup_component(
         hass,
@@ -153,7 +155,9 @@ async def test_if_fires_on_event_extra_data(hass, calls, context_with_user):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_with_data_and_context(hass, calls, context_with_user):
+async def test_if_fires_on_event_with_data_and_context(
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test the firing of events with data and context."""
     assert await async_setup_component(
         hass,
@@ -199,8 +203,8 @@ async def test_if_fires_on_event_with_data_and_context(hass, calls, context_with
 
 
 async def test_if_fires_on_event_with_templated_data_and_context(
-    hass, calls, context_with_user
-):
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test the firing of events with templated data and context."""
     assert await async_setup_component(
         hass,
@@ -251,8 +255,8 @@ async def test_if_fires_on_event_with_templated_data_and_context(
 
 
 async def test_if_fires_on_event_with_empty_data_and_context_config(
-    hass, calls, context_with_user
-):
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test the firing of events with empty data and context config.
 
     The frontend automation editor can produce configurations with an
@@ -283,7 +287,7 @@ async def test_if_fires_on_event_with_empty_data_and_context_config(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_with_nested_data(hass, calls):
+async def test_if_fires_on_event_with_nested_data(hass: HomeAssistant, calls) -> None:
     """Test the firing of events with nested data."""
     assert await async_setup_component(
         hass,
@@ -307,7 +311,9 @@ async def test_if_fires_on_event_with_nested_data(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_not_fires_if_event_data_not_matches(hass, calls):
+async def test_if_not_fires_if_event_data_not_matches(
+    hass: HomeAssistant, calls
+) -> None:
     """Test firing of event if no data match."""
     assert await async_setup_component(
         hass,
@@ -330,8 +336,8 @@ async def test_if_not_fires_if_event_data_not_matches(hass, calls):
 
 
 async def test_if_not_fires_if_event_context_not_matches(
-    hass, calls, context_with_user
-):
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test firing of event if no context match."""
     assert await async_setup_component(
         hass,
@@ -353,7 +359,9 @@ async def test_if_not_fires_if_event_context_not_matches(
     assert len(calls) == 0
 
 
-async def test_if_fires_on_multiple_user_ids(hass, calls, context_with_user):
+async def test_if_fires_on_multiple_user_ids(
+    hass: HomeAssistant, calls, context_with_user
+) -> None:
     """Test the firing of event when the trigger has multiple user ids."""
     assert await async_setup_component(
         hass,
@@ -376,7 +384,7 @@ async def test_if_fires_on_multiple_user_ids(hass, calls, context_with_user):
     assert len(calls) == 1
 
 
-async def test_event_data_with_list(hass, calls):
+async def test_event_data_with_list(hass: HomeAssistant, calls) -> None:
     """Test the (non)firing of event when the data schema has lists."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_homeassistant.py
+++ b/tests/components/homeassistant/triggers/test_homeassistant.py
@@ -51,7 +51,7 @@ async def test_if_fires_on_hass_start(
     assert calls[0].data["id"] == 0
 
 
-async def test_if_fires_on_hass_shutdown(hass):
+async def test_if_fires_on_hass_shutdown(hass: HomeAssistant) -> None:
     """Test the firing when Home Assistant shuts down."""
     calls = async_mock_service(hass, "test", "automation")
     hass.state = CoreState.not_running

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -11,7 +11,7 @@ from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -55,7 +55,9 @@ async def setup_comp(hass):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_not_fires_on_entity_removal(hass, calls, below):
+async def test_if_not_fires_on_entity_removal(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with removed entity."""
     hass.states.async_set("test.entity", 11)
 
@@ -83,7 +85,9 @@ async def test_if_not_fires_on_entity_removal(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_fires_on_entity_change_below(hass, calls, below):
+async def test_if_fires_on_entity_change_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -130,7 +134,9 @@ async def test_if_fires_on_entity_change_below(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_fires_on_entity_change_below_uuid(hass, calls, below):
+async def test_if_fires_on_entity_change_below_uuid(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entity specified by registry entry id."""
     registry = er.async_get(hass)
     entry = registry.async_get_or_create(
@@ -183,7 +189,9 @@ async def test_if_fires_on_entity_change_below_uuid(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_fires_on_entity_change_over_to_below(hass, calls, below):
+async def test_if_fires_on_entity_change_over_to_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -212,7 +220,9 @@ async def test_if_fires_on_entity_change_over_to_below(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_fires_on_entities_change_over_to_below(hass, calls, below):
+async def test_if_fires_on_entities_change_over_to_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entities."""
     hass.states.async_set("test.entity_1", 11)
     hass.states.async_set("test.entity_2", 11)
@@ -245,7 +255,9 @@ async def test_if_fires_on_entities_change_over_to_below(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_not_fires_on_entity_change_below_to_below(hass, calls, below):
+async def test_if_not_fires_on_entity_change_below_to_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entity."""
     context = Context()
     hass.states.async_set("test.entity", 11)
@@ -286,7 +298,9 @@ async def test_if_not_fires_on_entity_change_below_to_below(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_not_below_fires_on_entity_change_to_equal(hass, calls, below):
+async def test_if_not_below_fires_on_entity_change_to_equal(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -315,7 +329,9 @@ async def test_if_not_below_fires_on_entity_change_to_equal(hass, calls, below):
 @pytest.mark.parametrize(
     "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_not_fires_on_initial_entity_below(hass, calls, below):
+async def test_if_not_fires_on_initial_entity_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 9)
     await hass.async_block_till_done()
@@ -344,7 +360,9 @@ async def test_if_not_fires_on_initial_entity_below(hass, calls, below):
 @pytest.mark.parametrize(
     "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_not_fires_on_initial_entity_above(hass, calls, above):
+async def test_if_not_fires_on_initial_entity_above(
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -373,7 +391,9 @@ async def test_if_not_fires_on_initial_entity_above(hass, calls, above):
 @pytest.mark.parametrize(
     "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
 )
-async def test_if_fires_on_entity_change_above(hass, calls, above):
+async def test_if_fires_on_entity_change_above(
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 9)
     await hass.async_block_till_done()
@@ -398,7 +418,9 @@ async def test_if_fires_on_entity_change_above(hass, calls, above):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_unavailable_at_startup(hass, calls):
+async def test_if_fires_on_entity_unavailable_at_startup(
+    hass: HomeAssistant, calls
+) -> None:
     """Test the firing with changed entity at startup."""
     assert await async_setup_component(
         hass,
@@ -421,7 +443,9 @@ async def test_if_fires_on_entity_unavailable_at_startup(hass, calls):
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
-async def test_if_fires_on_entity_change_below_to_above(hass, calls, above):
+async def test_if_fires_on_entity_change_below_to_above(
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test the firing with changed entity."""
     # set initial state
     hass.states.async_set("test.entity", 9)
@@ -449,7 +473,9 @@ async def test_if_fires_on_entity_change_below_to_above(hass, calls, above):
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
-async def test_if_not_fires_on_entity_change_above_to_above(hass, calls, above):
+async def test_if_not_fires_on_entity_change_above_to_above(
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test the firing with changed entity."""
     # set initial state
     hass.states.async_set("test.entity", 9)
@@ -482,7 +508,9 @@ async def test_if_not_fires_on_entity_change_above_to_above(hass, calls, above):
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
-async def test_if_not_above_fires_on_entity_change_to_equal(hass, calls, above):
+async def test_if_not_above_fires_on_entity_change_to_equal(
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test the firing with changed entity."""
     # set initial state
     hass.states.async_set("test.entity", 9)
@@ -518,7 +546,9 @@ async def test_if_not_above_fires_on_entity_change_to_equal(hass, calls, above):
         ("input_number.value_5", "input_number.value_10"),
     ),
 )
-async def test_if_fires_on_entity_change_below_range(hass, calls, above, below):
+async def test_if_fires_on_entity_change_below_range(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -553,7 +583,9 @@ async def test_if_fires_on_entity_change_below_range(hass, calls, above, below):
         ("input_number.value_5", "input_number.value_10"),
     ),
 )
-async def test_if_fires_on_entity_change_below_above_range(hass, calls, above, below):
+async def test_if_fires_on_entity_change_below_above_range(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test the firing with changed entity."""
     assert await async_setup_component(
         hass,
@@ -585,7 +617,9 @@ async def test_if_fires_on_entity_change_below_above_range(hass, calls, above, b
         ("input_number.value_5", "input_number.value_10"),
     ),
 )
-async def test_if_fires_on_entity_change_over_to_below_range(hass, calls, above, below):
+async def test_if_fires_on_entity_change_over_to_below_range(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -622,8 +656,8 @@ async def test_if_fires_on_entity_change_over_to_below_range(hass, calls, above,
     ),
 )
 async def test_if_fires_on_entity_change_over_to_below_above_range(
-    hass, calls, above, below
-):
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -651,7 +685,9 @@ async def test_if_fires_on_entity_change_over_to_below_above_range(
 
 
 @pytest.mark.parametrize("below", (100, "input_number.value_100"))
-async def test_if_not_fires_if_entity_not_match(hass, calls, below):
+async def test_if_not_fires_if_entity_not_match(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test if not fired with non matching entity."""
     assert await async_setup_component(
         hass,
@@ -673,7 +709,9 @@ async def test_if_not_fires_if_entity_not_match(hass, calls, below):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_and_warns_if_below_entity_unknown(hass, caplog, calls):
+async def test_if_not_fires_and_warns_if_below_entity_unknown(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls
+) -> None:
     """Test if warns with unknown below entity."""
     assert await async_setup_component(
         hass,
@@ -702,7 +740,9 @@ async def test_if_not_fires_and_warns_if_below_entity_unknown(hass, caplog, call
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
-async def test_if_fires_on_entity_change_below_with_attribute(hass, calls, below):
+async def test_if_fires_on_entity_change_below_with_attribute(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     hass.states.async_set("test.entity", 11, {"test_attribute": 11})
     await hass.async_block_till_done()
@@ -729,8 +769,8 @@ async def test_if_fires_on_entity_change_below_with_attribute(hass, calls, below
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
 async def test_if_not_fires_on_entity_change_not_below_with_attribute(
-    hass, calls, below
-):
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes."""
     assert await async_setup_component(
         hass,
@@ -753,7 +793,9 @@ async def test_if_not_fires_on_entity_change_not_below_with_attribute(
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
-async def test_if_fires_on_attribute_change_with_attribute_below(hass, calls, below):
+async def test_if_fires_on_attribute_change_with_attribute_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": 11})
     await hass.async_block_till_done()
@@ -781,8 +823,8 @@ async def test_if_fires_on_attribute_change_with_attribute_below(hass, calls, be
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
 async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
-    hass, calls, below
-):
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     assert await async_setup_component(
         hass,
@@ -806,7 +848,9 @@ async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
-async def test_if_not_fires_on_entity_change_with_attribute_below(hass, calls, below):
+async def test_if_not_fires_on_entity_change_with_attribute_below(
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     assert await async_setup_component(
         hass,
@@ -831,8 +875,8 @@ async def test_if_not_fires_on_entity_change_with_attribute_below(hass, calls, b
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
 async def test_if_not_fires_on_entity_change_with_not_attribute_below(
-    hass, calls, below
-):
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     assert await async_setup_component(
         hass,
@@ -857,8 +901,8 @@ async def test_if_not_fires_on_entity_change_with_not_attribute_below(
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
 async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
-    hass, calls, below
-):
+    hass: HomeAssistant, calls, below
+) -> None:
     """Test attributes change."""
     hass.states.async_set(
         "test.entity", "entity", {"test_attribute": 11, "not_test_attribute": 11}
@@ -888,7 +932,7 @@ async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
-async def test_template_list(hass, calls, below):
+async def test_template_list(hass: HomeAssistant, calls, below) -> None:
     """Test template list."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
     await hass.async_block_till_done()
@@ -914,7 +958,7 @@ async def test_template_list(hass, calls, below):
 
 
 @pytest.mark.parametrize("below", (10.0, "input_number.value_10"))
-async def test_template_string(hass, calls, below):
+async def test_template_string(hass: HomeAssistant, calls, below) -> None:
     """Test template string."""
     assert await async_setup_component(
         hass,
@@ -957,7 +1001,9 @@ async def test_template_string(hass, calls, below):
     )
 
 
-async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(hass, calls):
+async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(
+    hass: HomeAssistant, calls
+) -> None:
     """Test if not fired changed attributes."""
     assert await async_setup_component(
         hass,
@@ -991,7 +1037,7 @@ async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(hass, 
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_action(hass, calls, above, below):
+async def test_if_action(hass: HomeAssistant, calls, above, below) -> None:
     """Test if action."""
     entity_id = "domain.test_entity"
     assert await async_setup_component(
@@ -1039,7 +1085,7 @@ async def test_if_action(hass, calls, above, below):
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fails_setup_bad_for(hass, calls, above, below):
+async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls, above, below) -> None:
     """Test for setup failure for bad for."""
     hass.states.async_set("test.entity", 5)
     await hass.async_block_till_done()
@@ -1063,7 +1109,9 @@ async def test_if_fails_setup_bad_for(hass, calls, above, below):
         )
 
 
-async def test_if_fails_setup_for_without_above_below(hass, calls):
+async def test_if_fails_setup_for_without_above_below(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for setup failures for missing above or below."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -1091,7 +1139,9 @@ async def test_if_fails_setup_for_without_above_below(hass, calls):
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_not_fires_on_entity_change_with_for(hass, calls, above, below):
+async def test_if_not_fires_on_entity_change_with_for(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for not firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -1129,8 +1179,8 @@ async def test_if_not_fires_on_entity_change_with_for(hass, calls, above, below)
     ),
 )
 async def test_if_not_fires_on_entities_change_with_for_after_stop(
-    hass, calls, above, below
-):
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for not firing on entities change with for after stop."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1187,8 +1237,8 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
     ),
 )
 async def test_if_fires_on_entity_change_with_for_attribute_change(
-    hass, calls, above, below
-):
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on entity change with for and attribute change."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1235,7 +1285,9 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_entity_change_with_for(hass, calls, above, below):
+async def test_if_fires_on_entity_change_with_for(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on entity change with for."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1265,7 +1317,7 @@ async def test_if_fires_on_entity_change_with_for(hass, calls, above, below):
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
-async def test_wait_template_with_trigger(hass, calls, above):
+async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     hass.states.async_set("test.entity", "0")
     await hass.async_block_till_done()
@@ -1314,7 +1366,9 @@ async def test_wait_template_with_trigger(hass, calls, above):
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_entities_change_no_overlap(hass, calls, above, below):
+async def test_if_fires_on_entities_change_no_overlap(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on entities change with no overlap."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1370,7 +1424,9 @@ async def test_if_fires_on_entities_change_no_overlap(hass, calls, above, below)
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_entities_change_overlap(hass, calls, above, below):
+async def test_if_fires_on_entities_change_overlap(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on entities change with overlap."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1437,7 +1493,9 @@ async def test_if_fires_on_entities_change_overlap(hass, calls, above, below):
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_change_with_for_template_1(hass, calls, above, below):
+async def test_if_fires_on_change_with_for_template_1(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1476,7 +1534,9 @@ async def test_if_fires_on_change_with_for_template_1(hass, calls, above, below)
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_change_with_for_template_2(hass, calls, above, below):
+async def test_if_fires_on_change_with_for_template_2(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1515,7 +1575,9 @@ async def test_if_fires_on_change_with_for_template_2(hass, calls, above, below)
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_if_fires_on_change_with_for_template_3(hass, calls, above, below):
+async def test_if_fires_on_change_with_for_template_3(
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1545,7 +1607,9 @@ async def test_if_fires_on_change_with_for_template_3(hass, calls, above, below)
     assert len(calls) == 1
 
 
-async def test_if_not_fires_on_error_with_for_template(hass, calls):
+async def test_if_not_fires_on_error_with_for_template(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing on error with for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1590,7 +1654,7 @@ async def test_if_not_fires_on_error_with_for_template(hass, calls):
         ("input_number.value_8", "input_number.value_12"),
     ),
 )
-async def test_invalid_for_template(hass, calls, above, below):
+async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) -> None:
     """Test for invalid for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1628,8 +1692,8 @@ async def test_invalid_for_template(hass, calls, above, below):
     ),
 )
 async def test_if_fires_on_entities_change_overlap_for_template(
-    hass, calls, above, below
-):
+    hass: HomeAssistant, calls, above, below
+) -> None:
     """Test for firing on entities change with overlap and for template."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1694,7 +1758,7 @@ async def test_if_fires_on_entities_change_overlap_for_template(
         assert calls[1].data["some"] == "test.entity_2 - 0:00:10"
 
 
-async def test_below_above(hass):
+async def test_below_above(hass: HomeAssistant) -> None:
     """Test above cannot be above below."""
     with pytest.raises(vol.Invalid):
         await numeric_state_trigger.async_validate_trigger_config(
@@ -1702,7 +1766,7 @@ async def test_below_above(hass):
         )
 
 
-async def test_schema_unacceptable_entities(hass):
+async def test_schema_unacceptable_entities(hass: HomeAssistant) -> None:
     """Test input_number, number & sensor only is accepted for above/below."""
     with pytest.raises(vol.Invalid):
         await numeric_state_trigger.async_validate_trigger_config(
@@ -1726,8 +1790,8 @@ async def test_schema_unacceptable_entities(hass):
 
 @pytest.mark.parametrize("above", (3, "input_number.value_3"))
 async def test_attribute_if_fires_on_entity_change_with_both_filters(
-    hass, calls, above
-):
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"test-measurement": 1})
 
@@ -1755,8 +1819,8 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(
 
 @pytest.mark.parametrize("above", (3, "input_number.value_3"))
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
-    hass, calls, above
-):
+    hass: HomeAssistant, calls, above
+) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     hass.states.async_set("test.entity", "bla", {"test-measurement": 1})
 
@@ -1790,7 +1854,7 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     ("above", "below"),
     ((8, 12),),
 )
-async def test_variables_priority(hass, calls, above, below):
+async def test_variables_priority(hass: HomeAssistant, calls, above, below) -> None:
     """Test an externally defined trigger variable is overridden."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1847,7 +1911,7 @@ async def test_variables_priority(hass, calls, above, below):
 
 
 @pytest.mark.parametrize("multiplier", (1, 5))
-async def test_template_variable(hass, calls, multiplier):
+async def test_template_variable(hass: HomeAssistant, calls, multiplier) -> None:
     """Test template variable."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
     await hass.async_block_till_done()

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -33,7 +33,7 @@ def setup_comp(hass):
     hass.states.async_set("test.entity", "hello")
 
 
-async def test_if_fires_on_entity_change(hass, calls):
+async def test_if_fires_on_entity_change(hass: HomeAssistant, calls) -> None:
     """Test for firing on entity change."""
     context = Context()
     hass.states.async_set("test.entity", "hello")
@@ -83,7 +83,7 @@ async def test_if_fires_on_entity_change(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_uuid(hass, calls):
+async def test_if_fires_on_entity_change_uuid(hass: HomeAssistant, calls) -> None:
     """Test for firing on entity change."""
     context = Context()
 
@@ -141,7 +141,9 @@ async def test_if_fires_on_entity_change_uuid(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_from_filter(hass, calls):
+async def test_if_fires_on_entity_change_with_from_filter(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with filter."""
     assert await async_setup_component(
         hass,
@@ -194,7 +196,9 @@ async def test_if_fires_on_entity_change_with_not_from_filter(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_to_filter(hass, calls):
+async def test_if_fires_on_entity_change_with_to_filter(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with to filter."""
     assert await async_setup_component(
         hass,
@@ -247,7 +251,9 @@ async def test_if_fires_on_entity_change_with_not_to_filter(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_from_filter_all(hass, calls):
+async def test_if_fires_on_entity_change_with_from_filter_all(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with filter."""
     assert await async_setup_component(
         hass,
@@ -271,7 +277,9 @@ async def test_if_fires_on_entity_change_with_from_filter_all(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_to_filter_all(hass, calls):
+async def test_if_fires_on_entity_change_with_to_filter_all(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with to filter."""
     assert await async_setup_component(
         hass,
@@ -295,7 +303,9 @@ async def test_if_fires_on_entity_change_with_to_filter_all(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_attribute_change_with_to_filter(hass, calls):
+async def test_if_fires_on_attribute_change_with_to_filter(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing on attribute change."""
     assert await async_setup_component(
         hass,
@@ -319,7 +329,9 @@ async def test_if_fires_on_attribute_change_with_to_filter(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_both_filters(hass, calls):
+async def test_if_fires_on_entity_change_with_both_filters(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if both filters are a non match."""
     assert await async_setup_component(
         hass,
@@ -437,7 +449,7 @@ async def test_if_fires_on_entity_change_with_from_not_to(
     assert len(calls) == 2
 
 
-async def test_if_not_fires_if_to_filter_not_match(hass, calls):
+async def test_if_not_fires_if_to_filter_not_match(hass: HomeAssistant, calls) -> None:
     """Test for not firing if to filter is not a match."""
     assert await async_setup_component(
         hass,
@@ -461,7 +473,9 @@ async def test_if_not_fires_if_to_filter_not_match(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_if_from_filter_not_match(hass, calls):
+async def test_if_not_fires_if_from_filter_not_match(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing if from filter is not a match."""
     hass.states.async_set("test.entity", "bye")
 
@@ -487,7 +501,7 @@ async def test_if_not_fires_if_from_filter_not_match(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_if_entity_not_match(hass, calls):
+async def test_if_not_fires_if_entity_not_match(hass: HomeAssistant, calls) -> None:
     """Test for not firing if entity is not matching."""
     assert await async_setup_component(
         hass,
@@ -506,7 +520,7 @@ async def test_if_not_fires_if_entity_not_match(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_action(hass, calls):
+async def test_if_action(hass: HomeAssistant, calls) -> None:
     """Test for to action."""
     entity_id = "domain.test_entity"
     test_state = "new_state"
@@ -538,7 +552,7 @@ async def test_if_action(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fails_setup_if_to_boolean_value(hass, calls):
+async def test_if_fails_setup_if_to_boolean_value(hass: HomeAssistant, calls) -> None:
     """Test for setup failure for boolean to."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -557,7 +571,7 @@ async def test_if_fails_setup_if_to_boolean_value(hass, calls):
         )
 
 
-async def test_if_fails_setup_if_from_boolean_value(hass, calls):
+async def test_if_fails_setup_if_from_boolean_value(hass: HomeAssistant, calls) -> None:
     """Test for setup failure for boolean from."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -576,7 +590,7 @@ async def test_if_fails_setup_if_from_boolean_value(hass, calls):
         )
 
 
-async def test_if_fails_setup_bad_for(hass, calls):
+async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls) -> None:
     """Test for setup failure for bad for."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -596,7 +610,9 @@ async def test_if_fails_setup_bad_for(hass, calls):
         )
 
 
-async def test_if_not_fires_on_entity_change_with_for(hass, calls):
+async def test_if_not_fires_on_entity_change_with_for(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -624,7 +640,9 @@ async def test_if_not_fires_on_entity_change_with_for(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_not_fires_on_entities_change_with_for_after_stop(hass, calls):
+async def test_if_not_fires_on_entities_change_with_for_after_stop(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     assert await async_setup_component(
         hass,
@@ -668,7 +686,9 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_for_attribute_change(hass, calls):
+async def test_if_fires_on_entity_change_with_for_attribute_change(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with for and attribute change."""
     assert await async_setup_component(
         hass,
@@ -705,7 +725,9 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(hass, calls):
         assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_for_multiple_force_update(hass, calls):
+async def test_if_fires_on_entity_change_with_for_multiple_force_update(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with for and force update."""
     assert await async_setup_component(
         hass,
@@ -741,7 +763,7 @@ async def test_if_fires_on_entity_change_with_for_multiple_force_update(hass, ca
         assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_for(hass, calls):
+async def test_if_fires_on_entity_change_with_for(hass: HomeAssistant, calls) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -767,7 +789,9 @@ async def test_if_fires_on_entity_change_with_for(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_for_without_to(hass, calls):
+async def test_if_fires_on_entity_change_with_for_without_to(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -804,7 +828,9 @@ async def test_if_fires_on_entity_change_with_for_without_to(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_does_not_fires_on_entity_change_with_for_without_to_2(hass, calls):
+async def test_if_does_not_fires_on_entity_change_with_for_without_to_2(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -837,7 +863,9 @@ async def test_if_does_not_fires_on_entity_change_with_for_without_to_2(hass, ca
     assert len(calls) == 0
 
 
-async def test_if_fires_on_entity_creation_and_removal(hass, calls):
+async def test_if_fires_on_entity_creation_and_removal(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entity creation and removal, with to/from constraints."""
     # set automations for multiple combinations to/from
     assert await async_setup_component(
@@ -902,7 +930,7 @@ async def test_if_fires_on_entity_creation_and_removal(hass, calls):
     assert calls[3].context.parent_id == context_0.id
 
 
-async def test_if_fires_on_for_condition(hass, calls):
+async def test_if_fires_on_for_condition(hass: HomeAssistant, calls) -> None:
     """Test for firing if condition is on."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)
@@ -939,7 +967,9 @@ async def test_if_fires_on_for_condition(hass, calls):
         assert len(calls) == 1
 
 
-async def test_if_fires_on_for_condition_attribute_change(hass, calls):
+async def test_if_fires_on_for_condition_attribute_change(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if condition is on with attribute change."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=4)
@@ -986,7 +1016,7 @@ async def test_if_fires_on_for_condition_attribute_change(hass, calls):
         assert len(calls) == 1
 
 
-async def test_if_fails_setup_for_without_time(hass, calls):
+async def test_if_fails_setup_for_without_time(hass: HomeAssistant, calls) -> None:
     """Test for setup failure if no time is provided."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -1007,7 +1037,7 @@ async def test_if_fails_setup_for_without_time(hass, calls):
         )
 
 
-async def test_if_fails_setup_for_without_entity(hass, calls):
+async def test_if_fails_setup_for_without_entity(hass: HomeAssistant, calls) -> None:
     """Test for setup failure if no entity is provided."""
     with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(
@@ -1027,7 +1057,7 @@ async def test_if_fails_setup_for_without_entity(hass, calls):
         )
 
 
-async def test_wait_template_with_trigger(hass, calls):
+async def test_wait_template_with_trigger(hass: HomeAssistant, calls) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     assert await async_setup_component(
         hass,
@@ -1069,7 +1099,9 @@ async def test_wait_template_with_trigger(hass, calls):
     assert calls[0].data["some"] == "state - test.entity - hello - world"
 
 
-async def test_if_fires_on_entities_change_no_overlap(hass, calls):
+async def test_if_fires_on_entities_change_no_overlap(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entities change with no overlap."""
     assert await async_setup_component(
         hass,
@@ -1111,7 +1143,7 @@ async def test_if_fires_on_entities_change_no_overlap(hass, calls):
         assert calls[1].data["some"] == "test.entity_2"
 
 
-async def test_if_fires_on_entities_change_overlap(hass, calls):
+async def test_if_fires_on_entities_change_overlap(hass: HomeAssistant, calls) -> None:
     """Test for firing on entities change with overlap."""
     assert await async_setup_component(
         hass,
@@ -1164,7 +1196,9 @@ async def test_if_fires_on_entities_change_overlap(hass, calls):
         assert calls[1].data["some"] == "test.entity_2"
 
 
-async def test_if_fires_on_change_with_for_template_1(hass, calls):
+async def test_if_fires_on_change_with_for_template_1(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
         hass,
@@ -1190,7 +1224,9 @@ async def test_if_fires_on_change_with_for_template_1(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_change_with_for_template_2(hass, calls):
+async def test_if_fires_on_change_with_for_template_2(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
         hass,
@@ -1216,7 +1252,9 @@ async def test_if_fires_on_change_with_for_template_2(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_change_with_for_template_3(hass, calls):
+async def test_if_fires_on_change_with_for_template_3(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
         hass,
@@ -1242,7 +1280,9 @@ async def test_if_fires_on_change_with_for_template_3(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_change_with_for_template_4(hass, calls):
+async def test_if_fires_on_change_with_for_template_4(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
         hass,
@@ -1269,7 +1309,7 @@ async def test_if_fires_on_change_with_for_template_4(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_change_from_with_for(hass, calls):
+async def test_if_fires_on_change_from_with_for(hass: HomeAssistant, calls) -> None:
     """Test for firing on change with from/for."""
     assert await async_setup_component(
         hass,
@@ -1298,7 +1338,7 @@ async def test_if_fires_on_change_from_with_for(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_not_fires_on_change_from_with_for(hass, calls):
+async def test_if_not_fires_on_change_from_with_for(hass: HomeAssistant, calls) -> None:
     """Test for firing on change with from/for."""
     assert await async_setup_component(
         hass,
@@ -1327,7 +1367,7 @@ async def test_if_not_fires_on_change_from_with_for(hass, calls):
     assert len(calls) == 0
 
 
-async def test_invalid_for_template_1(hass, calls):
+async def test_invalid_for_template_1(hass: HomeAssistant, calls) -> None:
     """Test for invalid for template."""
     assert await async_setup_component(
         hass,
@@ -1351,7 +1391,9 @@ async def test_invalid_for_template_1(hass, calls):
         assert mock_logger.error.called
 
 
-async def test_if_fires_on_entities_change_overlap_for_template(hass, calls):
+async def test_if_fires_on_entities_change_overlap_for_template(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing on entities change with overlap and for template."""
     assert await async_setup_component(
         hass,
@@ -1411,7 +1453,9 @@ async def test_if_fires_on_entities_change_overlap_for_template(hass, calls):
         assert calls[1].data["some"] == "test.entity_2 - 0:00:10"
 
 
-async def test_attribute_if_fires_on_entity_change_with_both_filters(hass, calls):
+async def test_attribute_if_fires_on_entity_change_with_both_filters(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"name": "hello"})
 
@@ -1438,7 +1482,9 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(hass, calls
     assert len(calls) == 1
 
 
-async def test_attribute_if_fires_on_entity_where_attr_stays_constant(hass, calls):
+async def test_attribute_if_fires_on_entity_where_attr_stays_constant(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
 
@@ -1475,8 +1521,8 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant(hass, call
 
 
 async def test_attribute_if_fires_on_entity_where_attr_stays_constant_filter(
-    hass, calls
-):
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "other_name"})
 
@@ -1519,7 +1565,9 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant_filter(
     assert len(calls) == 1
 
 
-async def test_attribute_if_fires_on_entity_where_attr_stays_constant_all(hass, calls):
+async def test_attribute_if_fires_on_entity_where_attr_stays_constant_all(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
 
@@ -1563,8 +1611,8 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant_all(hass, 
 
 
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
-    hass, calls
-):
+    hass: HomeAssistant, calls
+) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     hass.states.async_set("test.entity", "bla", {"name": "hello"})
 
@@ -1616,8 +1664,8 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
 
 
 async def test_attribute_if_fires_on_entity_change_with_both_filters_boolean(
-    hass, calls
-):
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"happening": False})
 
@@ -1644,7 +1692,7 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters_boolean(
     assert len(calls) == 1
 
 
-async def test_variables_priority(hass, calls):
+async def test_variables_priority(hass: HomeAssistant, calls) -> None:
     """Test an externally defined trigger variable is overridden."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -9,6 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.homeassistant.triggers import time
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -32,7 +33,7 @@ def setup_comp(hass):
     mock_component(hass, "group")
 
 
-async def test_if_fires_using_at(hass, calls):
+async def test_if_fires_using_at(hass: HomeAssistant, calls) -> None:
     """Test for firing at."""
     now = dt_util.now()
 
@@ -72,7 +73,9 @@ async def test_if_fires_using_at(hass, calls):
 @pytest.mark.parametrize(
     ("has_date", "has_time"), [(True, True), (True, False), (False, True)]
 )
-async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time):
+async def test_if_fires_using_at_input_datetime(
+    hass: HomeAssistant, calls, has_date, has_time
+) -> None:
     """Test for firing at input_datetime."""
     await async_setup_component(
         hass,
@@ -151,7 +154,7 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
     )
 
 
-async def test_if_fires_using_multiple_at(hass, calls):
+async def test_if_fires_using_multiple_at(hass: HomeAssistant, calls) -> None:
     """Test for firing at."""
 
     now = dt_util.now()
@@ -193,7 +196,7 @@ async def test_if_fires_using_multiple_at(hass, calls):
     assert calls[1].data["some"] == "time - 6"
 
 
-async def test_if_not_fires_using_wrong_at(hass, calls):
+async def test_if_not_fires_using_wrong_at(hass: HomeAssistant, calls) -> None:
     """YAML translates time values to total seconds.
 
     This should break the before rule.
@@ -232,7 +235,7 @@ async def test_if_not_fires_using_wrong_at(hass, calls):
     assert len(calls) == 0
 
 
-async def test_if_action_before(hass, calls):
+async def test_if_action_before(hass: HomeAssistant, calls) -> None:
     """Test for if action before."""
     assert await async_setup_component(
         hass,
@@ -263,7 +266,7 @@ async def test_if_action_before(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_action_after(hass, calls):
+async def test_if_action_after(hass: HomeAssistant, calls) -> None:
     """Test for if action after."""
     assert await async_setup_component(
         hass,
@@ -294,7 +297,7 @@ async def test_if_action_after(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_action_one_weekday(hass, calls):
+async def test_if_action_one_weekday(hass: HomeAssistant, calls) -> None:
     """Test for if action with one weekday."""
     assert await async_setup_component(
         hass,
@@ -326,7 +329,7 @@ async def test_if_action_one_weekday(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_action_list_weekday(hass, calls):
+async def test_if_action_list_weekday(hass: HomeAssistant, calls) -> None:
     """Test for action with a list of weekdays."""
     assert await async_setup_component(
         hass,
@@ -365,7 +368,7 @@ async def test_if_action_list_weekday(hass, calls):
     assert len(calls) == 2
 
 
-async def test_untrack_time_change(hass):
+async def test_untrack_time_change(hass: HomeAssistant) -> None:
     """Test for removing tracked time changes."""
     mock_track_time_change = Mock()
     with patch(
@@ -398,7 +401,7 @@ async def test_untrack_time_change(hass):
     assert len(mock_track_time_change.mock_calls) == 3
 
 
-async def test_if_fires_using_at_sensor(hass, calls):
+async def test_if_fires_using_at_sensor(hass: HomeAssistant, calls) -> None:
     """Test for firing at sensor time."""
     now = dt_util.now()
 
@@ -507,7 +510,7 @@ async def test_if_fires_using_at_sensor(hass, calls):
         {"platform": "time", "at": "12:34"},
     ],
 )
-def test_schema_valid(conf):
+def test_schema_valid(conf) -> None:
     """Make sure we don't accept number for 'at' value."""
     time.TRIGGER_SCHEMA(conf)
 
@@ -520,13 +523,13 @@ def test_schema_valid(conf):
         {"platform": "time", "at": "25:00"},
     ],
 )
-def test_schema_invalid(conf):
+def test_schema_invalid(conf) -> None:
     """Make sure we don't accept number for 'at' value."""
     with pytest.raises(vol.Invalid):
         time.TRIGGER_SCHEMA(conf)
 
 
-async def test_datetime_in_past_on_load(hass, calls):
+async def test_datetime_in_past_on_load(hass: HomeAssistant, calls) -> None:
     """Test time trigger works if input_datetime is in past."""
     await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 import homeassistant.components.automation as automation
 import homeassistant.components.homeassistant.triggers.time_pattern as time_pattern
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -26,7 +27,7 @@ def setup_comp(hass):
     mock_component(hass, "group")
 
 
-async def test_if_fires_when_hour_matches(hass, calls):
+async def test_if_fires_when_hour_matches(hass: HomeAssistant, calls) -> None:
     """Test for firing if hour is matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -71,7 +72,7 @@ async def test_if_fires_when_hour_matches(hass, calls):
     assert calls[0].data["id"] == 0
 
 
-async def test_if_fires_when_minute_matches(hass, calls):
+async def test_if_fires_when_minute_matches(hass: HomeAssistant, calls) -> None:
     """Test for firing if minutes are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -102,7 +103,7 @@ async def test_if_fires_when_minute_matches(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_when_second_matches(hass, calls):
+async def test_if_fires_when_second_matches(hass: HomeAssistant, calls) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -133,7 +134,9 @@ async def test_if_fires_when_second_matches(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_when_second_as_string_matches(hass, calls):
+async def test_if_fires_when_second_as_string_matches(
+    hass: HomeAssistant, calls
+) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -166,7 +169,7 @@ async def test_if_fires_when_second_as_string_matches(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_when_all_matches(hass, calls):
+async def test_if_fires_when_all_matches(hass: HomeAssistant, calls) -> None:
     """Test for firing if everything matches."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -199,7 +202,7 @@ async def test_if_fires_when_all_matches(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_periodic_seconds(hass, calls):
+async def test_if_fires_periodic_seconds(hass: HomeAssistant, calls) -> None:
     """Test for firing periodically every second."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -232,7 +235,7 @@ async def test_if_fires_periodic_seconds(hass, calls):
     assert len(calls) >= 1
 
 
-async def test_if_fires_periodic_minutes(hass, calls):
+async def test_if_fires_periodic_minutes(hass: HomeAssistant, calls) -> None:
     """Test for firing periodically every minute."""
 
     now = dt_util.utcnow()
@@ -266,7 +269,7 @@ async def test_if_fires_periodic_minutes(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_periodic_hours(hass, calls):
+async def test_if_fires_periodic_hours(hass: HomeAssistant, calls) -> None:
     """Test for firing periodically every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -299,7 +302,7 @@ async def test_if_fires_periodic_hours(hass, calls):
     assert len(calls) == 1
 
 
-async def test_default_values(hass, calls):
+async def test_default_values(hass: HomeAssistant, calls) -> None:
     """Test for firing at 2 minutes every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
@@ -341,7 +344,7 @@ async def test_default_values(hass, calls):
     assert len(calls) == 2
 
 
-async def test_invalid_schemas(hass, calls):
+async def test_invalid_schemas(hass: HomeAssistant, calls) -> None:
     """Test invalid schemas."""
     schemas = (
         None,

--- a/tests/components/homekit_controller/specific_devices/test_airversa_ap2.py
+++ b/tests/components/homekit_controller/specific_devices/test_airversa_ap2.py
@@ -1,7 +1,7 @@
 """Tests for Airversa AP2 Air Purifier."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, PERCENTAGE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
 from ..common import (
@@ -14,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_airversa_ap2_setup(hass):
+async def test_airversa_ap2_setup(hass: HomeAssistant) -> None:
     """Test that an Ecbobee occupancy sensor be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "airversa_ap2.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
+++ b/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
@@ -1,4 +1,5 @@
 """Test against characteristics captured from a eufycam."""
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -10,7 +11,7 @@ from ..common import (
 )
 
 
-async def test_eufycam_setup(hass):
+async def test_eufycam_setup(hass: HomeAssistant) -> None:
     """Test that a eufycam can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "anker_eufycam.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/20957
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
 from homeassistant.components.number import NumberMode
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -16,7 +17,7 @@ from ..common import (
 )
 
 
-async def test_aqara_gateway_setup(hass):
+async def test_aqara_gateway_setup(hass: HomeAssistant) -> None:
     """Test that a Aqara Gateway can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "aqara_gateway.json")
     await setup_test_accessories(hass, accessories)
@@ -75,7 +76,7 @@ async def test_aqara_gateway_setup(hass):
     )
 
 
-async def test_aqara_gateway_e1_setup(hass):
+async def test_aqara_gateway_e1_setup(hass: HomeAssistant) -> None:
     """Test that an Aqara E1 Gateway can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "aqara_e1.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
@@ -5,9 +5,9 @@ service-label-index despite not being linked to a service-label.
 
 https://github.com/home-assistant/core/pull/39090
 """
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -20,7 +20,7 @@ from ..common import (
 )
 
 
-async def test_aqara_switch_setup(hass):
+async def test_aqara_switch_setup(hass: HomeAssistant) -> None:
     """Test that a Aqara Switch can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "aqara_switch.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
+++ b/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
@@ -1,7 +1,7 @@
 """Make sure that an Arlo Baby can be setup."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +13,7 @@ from ..common import (
 )
 
 
-async def test_arlo_baby_setup(hass):
+async def test_arlo_baby_setup(hass: HomeAssistant) -> None:
     """Test that an Arlo Baby can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "arlo_baby.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_connectsense.py
+++ b/tests/components/homekit_controller/specific_devices/test_connectsense.py
@@ -1,11 +1,11 @@
 """Make sure that ConnectSense Smart Outlet2 / In-Wall Outlet is enumerated properly."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
     ELECTRIC_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
 )
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -17,7 +17,7 @@ from ..common import (
 )
 
 
-async def test_connectsense_setup(hass):
+async def test_connectsense_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "connectsense.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -2,7 +2,7 @@
 
 https://github.com/home-assistant/core/issues/15336
 """
-
+from typing import Any
 from unittest import mock
 
 from aiohomekit import AccessoryNotFoundError
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import TEMP_CELSIUS
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from ..common import (
@@ -30,7 +31,7 @@ from ..common import (
 )
 
 
-async def test_ecobee3_setup(hass):
+async def test_ecobee3_setup(hass: HomeAssistant) -> None:
     """Test that a Ecbobee 3 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
     await setup_test_accessories(hass, accessories)
@@ -140,7 +141,9 @@ async def test_ecobee3_setup(hass):
     )
 
 
-async def test_ecobee3_setup_from_cache(hass, hass_storage):
+async def test_ecobee3_setup_from_cache(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test that Ecbobee can be correctly setup from its cached entity map."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
 
@@ -175,7 +178,7 @@ async def test_ecobee3_setup_from_cache(hass, hass_storage):
     assert occ3.unique_id == "00:00:00:00:00:00_4_56"
 
 
-async def test_ecobee3_setup_connection_failure(hass):
+async def test_ecobee3_setup_connection_failure(hass: HomeAssistant) -> None:
     """Test that Ecbobee can be correctly setup from its cached entity map."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
 
@@ -215,7 +218,7 @@ async def test_ecobee3_setup_connection_failure(hass):
     assert occ3.unique_id == "00:00:00:00:00:00_4_56"
 
 
-async def test_ecobee3_add_sensors_at_runtime(hass):
+async def test_ecobee3_add_sensors_at_runtime(hass: HomeAssistant) -> None:
     """Test that new sensors are automatically added."""
     entity_registry = er.async_get(hass)
 

--- a/tests/components/homekit_controller/specific_devices/test_ecobee_501.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee_501.py
@@ -1,6 +1,4 @@
 """Tests for Ecobee 501."""
-
-
 from homeassistant.components.climate import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_HUMIDITY,
@@ -8,6 +6,7 @@ from homeassistant.components.climate import (
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -19,7 +18,7 @@ from ..common import (
 )
 
 
-async def test_ecobee501_setup(hass):
+async def test_ecobee501_setup(hass: HomeAssistant) -> None:
     """Test that a Ecobee 501 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "ecobee_501.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
@@ -2,6 +2,7 @@
 
 https://github.com/home-assistant/core/issues/31827
 """
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_ecobee_occupancy_setup(hass):
+async def test_ecobee_occupancy_setup(hass: HomeAssistant) -> None:
     """Test that an Ecbobee occupancy sensor be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "ecobee_occupancy.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_eve_degree.py
+++ b/tests/components/homekit_controller/specific_devices/test_eve_degree.py
@@ -1,8 +1,8 @@
 """Make sure that Eve Degree (via Eve Extend) is enumerated properly."""
-
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, EntityCategory, UnitOfPressure
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_eve_degree_setup(hass):
+async def test_eve_degree_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "eve_degree.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_eve_energy.py
+++ b/tests/components/homekit_controller/specific_devices/test_eve_energy.py
@@ -1,5 +1,4 @@
 """Make sure that Eve Degree (via Eve Extend) is enumerated properly."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
     ELECTRIC_CURRENT_AMPERE,
@@ -8,6 +7,7 @@ from homeassistant.const import (
     POWER_WATT,
     EntityCategory,
 )
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -19,7 +19,7 @@ from ..common import (
 )
 
 
-async def test_eve_energy_setup(hass):
+async def test_eve_energy_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "eve_energy.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_haa_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_haa_fan.py
@@ -1,7 +1,7 @@
 """Make sure that a H.A.A. fan can be setup."""
-
 from homeassistant.components.fan import ATTR_PERCENTAGE, FanEntityFeature
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +13,7 @@ from ..common import (
 )
 
 
-async def test_haa_fan_setup(hass):
+async def test_haa_fan_setup(hass: HomeAssistant) -> None:
     """Test that a H.A.A. fan can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "haa_fan.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -1,6 +1,6 @@
 """Test against characteristics captured from the Home Assistant HomeKit bridge running demo platforms."""
-
 from homeassistant.components.fan import FanEntityFeature
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -12,7 +12,7 @@ from ..common import (
 )
 
 
-async def test_homeassistant_bridge_fan_setup(hass):
+async def test_homeassistant_bridge_fan_setup(hass: HomeAssistant) -> None:
     """Test that a SIMPLEconnect fan can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(
         hass, "home_assistant_bridge_fan.json"

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -1,7 +1,7 @@
 """Tests for handling accessories on a Hue bridge via HomeKit."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_hue_bridge_setup(hass):
+async def test_hue_bridge_setup(hass: HomeAssistant) -> None:
     """Test that a Hue hub can be correctly setup in HA via HomeKit."""
     accessories = await setup_accessories_from_file(hass, "hue_bridge.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -1,5 +1,4 @@
 """Make sure that existing Koogeek LS1 support isn't broken."""
-
 from datetime import timedelta
 from unittest import mock
 
@@ -9,6 +8,7 @@ from aiohomekit.testing import FakePairing
 import pytest
 
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from ..common import (
@@ -26,7 +26,7 @@ from tests.common import async_fire_time_changed
 LIGHT_ON = ("lightbulb", "on")
 
 
-async def test_koogeek_ls1_setup(hass):
+async def test_koogeek_ls1_setup(hass: HomeAssistant) -> None:
     """Test that a Koogeek LS1 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
     await setup_test_accessories(hass, accessories)
@@ -64,7 +64,7 @@ async def test_koogeek_ls1_setup(hass):
 
 
 @pytest.mark.parametrize("failure_cls", [AccessoryDisconnectedError, EncryptionError])
-async def test_recover_from_failure(hass, utcnow, failure_cls):
+async def test_recover_from_failure(hass: HomeAssistant, utcnow, failure_cls) -> None:
     """Test that entity actually recovers from a network connection drop.
 
     See https://github.com/home-assistant/core/issues/18949

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -1,7 +1,7 @@
 """Make sure that existing Koogeek P1EU support isn't broken."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +13,7 @@ from ..common import (
 )
 
 
-async def test_koogeek_p1eu_setup(hass):
+async def test_koogeek_p1eu_setup(hass: HomeAssistant) -> None:
     """Test that a Koogeek P1EU can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "koogeek_p1eu.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -4,9 +4,9 @@ This Koogeek device has a custom power sensor that extra handling.
 
 It should have 2 entities - the actual switch and a sensor for power usage.
 """
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -18,7 +18,7 @@ from ..common import (
 )
 
 
-async def test_koogeek_sw2_setup(hass):
+async def test_koogeek_sw2_setup(hass: HomeAssistant) -> None:
     """Test that a Koogeek LS1 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "koogeek_sw2.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -2,11 +2,11 @@
 
 https://github.com/home-assistant/core/issues/20885
 """
-
 from homeassistant.components.climate import (
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -18,7 +18,7 @@ from ..common import (
 )
 
 
-async def test_lennox_e30_setup(hass):
+async def test_lennox_e30_setup(hass: HomeAssistant) -> None:
     """Test that a Lennox E30 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "lennox_e30.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -1,6 +1,6 @@
 """Make sure that handling real world LG HomeKit characteristics isn't broken."""
-
 from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -12,7 +12,7 @@ from ..common import (
 )
 
 
-async def test_lg_tv(hass):
+async def test_lg_tv(hass: HomeAssistant) -> None:
     """Test that a Koogeek LS1 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "lg_tv.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_lutron_caseta_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_lutron_caseta_bridge.py
@@ -1,6 +1,6 @@
 """Tests for handling accessories on a Lutron Caseta bridge via HomeKit."""
-
 from homeassistant.const import STATE_OFF
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -12,7 +12,7 @@ from ..common import (
 )
 
 
-async def test_lutron_caseta_bridge_setup(hass):
+async def test_lutron_caseta_bridge_setup(hass: HomeAssistant) -> None:
     """Test that a Lutron Caseta bridge can be correctly setup in HA via HomeKit."""
     accessories = await setup_accessories_from_file(hass, "lutron_caseta_bridge.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_mss425f.py
+++ b/tests/components/homekit_controller/specific_devices/test_mss425f.py
@@ -1,7 +1,6 @@
 """Tests for the Meross MSS425f power strip."""
-
-
 from homeassistant.const import STATE_ON, STATE_UNKNOWN, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +12,7 @@ from ..common import (
 )
 
 
-async def test_meross_mss425f_setup(hass):
+async def test_meross_mss425f_setup(hass: HomeAssistant) -> None:
     """Test that a MSS425f can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "mss425f.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_mss565.py
+++ b/tests/components/homekit_controller/specific_devices/test_mss565.py
@@ -1,7 +1,6 @@
 """Tests for the Meross MSS565 wall switch."""
-
-
 from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +12,7 @@ from ..common import (
 )
 
 
-async def test_meross_mss565_setup(hass):
+async def test_meross_mss565_setup(hass: HomeAssistant) -> None:
     """Test that a MSS565 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "mss565.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_mysa_living.py
+++ b/tests/components/homekit_controller/specific_devices/test_mysa_living.py
@@ -1,8 +1,8 @@
 """Make sure that Mysa Living is enumerated properly."""
-
 from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_mysa_living_setup(hass):
+async def test_mysa_living_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "mysa_living.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
+++ b/tests/components/homekit_controller/specific_devices/test_nanoleaf_strip_nl55.py
@@ -1,6 +1,6 @@
 """Make sure that Nanoleaf NL55 works with BLE."""
-
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +14,7 @@ from ..common import (
 LIGHT_ON = ("lightbulb", "on")
 
 
-async def test_nanoleaf_nl55_setup(hass):
+async def test_nanoleaf_nl55_setup(hass: HomeAssistant) -> None:
     """Test that a Nanoleaf NL55 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "nanoleaf_strip_nl55.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
+++ b/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
@@ -2,6 +2,7 @@
 
 https://github.com/home-assistant/core/issues/44596
 """
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +15,7 @@ from ..common import (
 )
 
 
-async def test_netamo_doorbell_setup(hass):
+async def test_netamo_doorbell_setup(hass: HomeAssistant) -> None:
     """Test that a Netamo Doorbell can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "netamo_doorbell.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_netamo_smart_co_alarm.py
+++ b/tests/components/homekit_controller/specific_devices/test_netamo_smart_co_alarm.py
@@ -3,6 +3,7 @@
 https://github.com/home-assistant/core/issues/78903
 """
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +15,7 @@ from ..common import (
 )
 
 
-async def test_netamo_smart_co_alarm_setup(hass):
+async def test_netamo_smart_co_alarm_setup(hass: HomeAssistant) -> None:
     """Test that a Netamo Smart CO Alarm can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "netamo_smart_co_alarm.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_netatmo_home_coach.py
+++ b/tests/components/homekit_controller/specific_devices/test_netatmo_home_coach.py
@@ -3,6 +3,7 @@
 https://github.com/home-assistant/core/issues/73360
 """
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -14,7 +15,7 @@ from ..common import (
 )
 
 
-async def test_netamo_smart_co_alarm_setup(hass):
+async def test_netamo_smart_co_alarm_setup(hass: HomeAssistant) -> None:
     """Test that a Netamo Smart CO Alarm can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "netatmo_home_coach.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
+++ b/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
@@ -2,6 +2,7 @@
 
 https://github.com/home-assistant/core/issues/31745
 """
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -13,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_rainmachine_pro_8_setup(hass):
+async def test_rainmachine_pro_8_setup(hass: HomeAssistant) -> None:
     """Test that a RainMachine can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "rainmachine-pro-8.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -1,8 +1,8 @@
 """Test against characteristics captured from a ryse smart bridge platforms."""
-
 from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -18,7 +18,7 @@ RYSE_SUPPORTED_FEATURES = (
 )
 
 
-async def test_ryse_smart_bridge_setup(hass):
+async def test_ryse_smart_bridge_setup(hass: HomeAssistant) -> None:
     """Test that a Ryse smart bridge can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "ryse_smart_bridge.json")
     await setup_test_accessories(hass, accessories)
@@ -95,7 +95,7 @@ async def test_ryse_smart_bridge_setup(hass):
     )
 
 
-async def test_ryse_smart_bridge_four_shades_setup(hass):
+async def test_ryse_smart_bridge_four_shades_setup(hass: HomeAssistant) -> None:
     """Test that a Ryse smart bridge with four shades can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(
         hass, "ryse_smart_bridge_four_shades.json"

--- a/tests/components/homekit_controller/specific_devices/test_schlage_sense.py
+++ b/tests/components/homekit_controller/specific_devices/test_schlage_sense.py
@@ -1,5 +1,5 @@
 """Make sure that Schlage Sense is enumerated properly."""
-
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -11,7 +11,7 @@ from ..common import (
 )
 
 
-async def test_schlage_sense_setup(hass):
+async def test_schlage_sense_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "schlage_sense.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
@@ -2,8 +2,8 @@
 
 https://github.com/home-assistant/core/issues/26180
 """
-
 from homeassistant.components.fan import FanEntityFeature
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -15,7 +15,7 @@ from ..common import (
 )
 
 
-async def test_simpleconnect_fan_setup(hass):
+async def test_simpleconnect_fan_setup(hass: HomeAssistant) -> None:
     """Test that a SIMPLEconnect fan can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "simpleconnect_fan.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
@@ -2,7 +2,6 @@
 
 https://github.com/home-assistant/core/issues/44314
 """
-
 from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
@@ -10,6 +9,7 @@ from homeassistant.const import (
     PERCENTAGE,
     TEMP_CELSIUS,
 )
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -21,7 +21,7 @@ from ..common import (
 )
 
 
-async def test_velux_cover_setup(hass):
+async def test_velux_cover_setup(hass: HomeAssistant) -> None:
     """Test that a velux gateway can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "velux_gateway.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -1,9 +1,9 @@
 """Make sure that Vocolinc Flowerbud is enumerated properly."""
-
 from homeassistant.components.humidifier import HumidifierEntityFeature
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant
 
 from ..common import (
     HUB_TEST_ACCESSORY_ID,
@@ -15,7 +15,7 @@ from ..common import (
 )
 
 
-async def test_vocolinc_flowerbud_setup(hass):
+async def test_vocolinc_flowerbud_setup(hass: HomeAssistant) -> None:
     """Test that a Vocolinc Flowerbud can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "vocolinc_flowerbud.json")
     await setup_test_accessories(hass, accessories)

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
@@ -1,7 +1,7 @@
 """Make sure that existing VOCOlinc VP3 support isn't broken."""
-
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from ..common import (
@@ -14,7 +14,7 @@ from ..common import (
 )
 
 
-async def test_vocolinc_vp3_setup(hass):
+async def test_vocolinc_vp3_setup(hass: HomeAssistant) -> None:
     """Test that a VOCOlinc VP3 can be correctly setup in HA."""
 
     entity_registry = er.async_get(hass)

--- a/tests/components/shelly/bluetooth/test_scanner.py
+++ b/tests/components/shelly/bluetooth/test_scanner.py
@@ -2,14 +2,16 @@
 from __future__ import annotations
 
 from aioshelly.ble.const import BLE_SCAN_RESULT_EVENT
+import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.shelly.const import CONF_BLE_SCANNER_MODE, BLEScannerMode
+from homeassistant.core import HomeAssistant
 
 from .. import init_integration, inject_rpc_device_event
 
 
-async def test_scanner(hass, mock_rpc_device, monkeypatch):
+async def test_scanner(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
     """Test injecting data into the scanner."""
     await init_integration(
         hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
@@ -47,7 +49,9 @@ async def test_scanner(hass, mock_rpc_device, monkeypatch):
     assert ble_device is None
 
 
-async def test_scanner_ignores_non_ble_events(hass, mock_rpc_device, monkeypatch):
+async def test_scanner_ignores_non_ble_events(
+    hass: HomeAssistant, mock_rpc_device, monkeypatch
+) -> None:
     """Test injecting non ble data into the scanner."""
     await init_integration(
         hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
@@ -72,8 +76,8 @@ async def test_scanner_ignores_non_ble_events(hass, mock_rpc_device, monkeypatch
 
 
 async def test_scanner_ignores_wrong_version_and_logs(
-    hass, mock_rpc_device, monkeypatch, caplog
-):
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test injecting wrong version of ble data into the scanner."""
     await init_integration(
         hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
@@ -105,8 +109,8 @@ async def test_scanner_ignores_wrong_version_and_logs(
 
 
 async def test_scanner_minimum_firmware_log_error(
-    hass, mock_rpc_device, monkeypatch, caplog
-):
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test scanner log error if device firmware incompatible."""
     monkeypatch.setattr(mock_rpc_device, "version", "0.11.0")
     await init_integration(
@@ -118,8 +122,8 @@ async def test_scanner_minimum_firmware_log_error(
 
 
 async def test_scanner_warns_on_corrupt_event(
-    hass, mock_rpc_device, monkeypatch, caplog
-):
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test injecting garbage ble data into the scanner."""
     await init_integration(
         hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #88476

I missed these because I originally only looked at the integration top level.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
