### PR TITLE
Improve performance of websocket_api dispatch

### DIFF
--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -75,12 +75,13 @@ class ActiveConnection:
         """Handle a single incoming message."""
         if (
             # Not using isinstance as we don't care about children
+            # as these are always coming from JSON
             type(msg) is not dict  # pylint: disable=unidiomatic-typecheck
             or (
                 not (cur_id := msg.get("id"))
-                or not isinstance(cur_id, int)
+                or type(cur_id) is not int  # pylint: disable=unidiomatic-typecheck
                 or not (type_ := msg.get("type"))
-                or not isinstance(type_, str)
+                or type(type_) is not str  # pylint: disable=unidiomatic-typecheck
             )
         ):
             self.logger.error("Received invalid command", msg)

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -74,6 +74,8 @@ class ActiveConnection:
     def async_handle(self, msg: dict[str, Any]) -> None:
         """Handle a single incoming message."""
         if (
+            # Not using isinstance as we don't care about children
+            type(msg) is dict and
             not (cur_id := msg.get("id"))
             or not isinstance(cur_id, int)
             or not (type_ := msg.get("type"))

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -46,6 +46,7 @@ class ActiveConnection:
         self.subscriptions: dict[Hashable, Callable[[], Any]] = {}
         self.last_id = 0
         self.supported_features: dict[str, float] = {}
+        self.handlers = self.hass.data[const.DOMAIN]
         current_connection.set(self)
 
     def get_description(self, request: web.Request | None) -> str:
@@ -72,12 +73,12 @@ class ActiveConnection:
     @callback
     def async_handle(self, msg: dict[str, Any]) -> None:
         """Handle a single incoming message."""
-        handlers = self.hass.data[const.DOMAIN]
-
-        try:
-            msg = messages.MINIMAL_MESSAGE_SCHEMA(msg)
-            cur_id = msg["id"]
-        except vol.Invalid:
+        if (
+            not (cur_id := msg.get("id"))
+            or not isinstance(cur_id, int)
+            or not (type_ := msg.get("type"))
+            or not isinstance(type_, str)
+        ):
             self.logger.error("Received invalid command", msg)
             self.send_message(
                 messages.error_message(
@@ -96,8 +97,8 @@ class ActiveConnection:
             )
             return
 
-        if msg["type"] not in handlers:
-            self.logger.info("Received unknown command: {}".format(msg["type"]))
+        if not (handler_schema := self.handlers.get(type_)):
+            self.logger.info(f"Received unknown command: {type_}")
             self.send_message(
                 messages.error_message(
                     cur_id, const.ERR_UNKNOWN_COMMAND, "Unknown command."
@@ -105,7 +106,7 @@ class ActiveConnection:
             )
             return
 
-        handler, schema = handlers[msg["type"]]
+        handler, schema = handler_schema
 
         try:
             handler(self.hass, self, schema(msg))

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -75,11 +75,13 @@ class ActiveConnection:
         """Handle a single incoming message."""
         if (
             # Not using isinstance as we don't care about children
-            type(msg) is dict and
-            not (cur_id := msg.get("id"))
-            or not isinstance(cur_id, int)
-            or not (type_ := msg.get("type"))
-            or not isinstance(type_, str)
+            type(msg) is not dict  # pylint: disable=unidiomatic-typecheck
+            or (
+                not (cur_id := msg.get("id"))
+                or not isinstance(cur_id, int)
+                or not (type_ := msg.get("type"))
+                or not isinstance(type_, str)
+            )
         ):
             self.logger.error("Received invalid command", msg)
             self.send_message(

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -10,6 +10,8 @@ import voluptuous as vol
 
 from homeassistant import exceptions
 from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockUser
 
@@ -56,6 +58,7 @@ from tests.common import MockUser
     ],
 )
 async def test_exception_handling(
+    hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     exc: Exception,
     code: str,
@@ -67,6 +70,7 @@ async def test_exception_handling(
     user = MockUser()
     refresh_token = Mock()
     current_request = AsyncMock()
+    hass.data[DOMAIN] = {}
 
     def get_extra_info(key: str) -> Any:
         if key == "sslcontext":
@@ -89,7 +93,7 @@ async def test_exception_handling(
     ) as current_request:
         current_request.get.return_value = mocked_request
         conn = websocket_api.ActiveConnection(
-            logging.getLogger(__name__), None, send_messages.append, user, refresh_token
+            logging.getLogger(__name__), hass, send_messages.append, user, refresh_token
         )
 
         conn.async_handle_exception({"id": 5}, exc)

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -17,7 +17,7 @@ from tests.typing import WebSocketGenerator
 @pytest.fixture
 def mock_low_queue():
     """Mock a low queue."""
-    with patch("homeassistant.components.websocket_api.http.MAX_PENDING_MSG", 5):
+    with patch("homeassistant.components.websocket_api.http.MAX_PENDING_MSG", 1):
         yield
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The minimal message schema validation was most of the overhead and can be simplified to improve the throughput since every websocket request has to pass through the handler dispatch.

This was surprisingly slow, and I only noticed since I put 20 stats graphs on a dashboard for testing. `validate_mapping` is a bit complex https://github.com/alecthomas/voluptuous/blob/ecb0cdc27ca4859152cdc2bb85e81cb194447add/voluptuous/schema_builder.py#L353

before
<img width="1399" alt="Screenshot 2023-02-20 at 9 56 01 AM" src="https://user-images.githubusercontent.com/663432/220154502-9036b647-8822-449f-b72a-7235e108c846.png">

after
<img width="1382" alt="Screenshot 2023-02-20 at 10 10 35 AM" src="https://user-images.githubusercontent.com/663432/220155590-5a606978-54f8-4f9c-9a8b-6850937d5ee9.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
