### PR TITLE
Load custom sentences for language variations (en-us, etc.)

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -321,6 +321,9 @@ class DefaultAgent(AbstractConversationAgent):
             intents_dict = lang_intents.intents_dict
             loaded_components = lang_intents.loaded_components
 
+        # en-US, en_US, en, ...
+        language_variations = list(_get_language_variations(language))
+
         # Check if any new components have been loaded
         intents_changed = False
         for component in hass_components:
@@ -332,7 +335,7 @@ class DefaultAgent(AbstractConversationAgent):
 
             # Check for intents for this component with the target language.
             # Try en-US, en, etc.
-            for language_variation in _get_language_variations(language):
+            for language_variation in language_variations:
                 component_intents = get_intents(
                     component, language_variation, json_load=json_load
                 )
@@ -343,7 +346,10 @@ class DefaultAgent(AbstractConversationAgent):
                     # Will need to recreate graph
                     intents_changed = True
                     _LOGGER.debug(
-                        "Loaded intents component=%s, language=%s", component, language
+                        "Loaded intents component=%s, language=%s (%s)",
+                        component,
+                        language,
+                        language_variation,
                     )
                     break
 
@@ -351,24 +357,31 @@ class DefaultAgent(AbstractConversationAgent):
         if lang_intents is None:
             # Only load custom sentences once, otherwise they will be re-loaded
             # when components change.
-            custom_sentences_dir = Path(
-                self.hass.config.path("custom_sentences", language)
-            )
-            if custom_sentences_dir.is_dir():
-                for custom_sentences_path in custom_sentences_dir.rglob("*.yaml"):
-                    with custom_sentences_path.open(
-                        encoding="utf-8"
-                    ) as custom_sentences_file:
-                        # Merge custom sentences
-                        merge_dict(intents_dict, yaml.safe_load(custom_sentences_file))
+            for language_variation in language_variations:
+                custom_sentences_dir = Path(
+                    self.hass.config.path("custom_sentences", language_variation)
+                )
+                if custom_sentences_dir.is_dir():
+                    for custom_sentences_path in custom_sentences_dir.rglob("*.yaml"):
+                        with custom_sentences_path.open(
+                            encoding="utf-8"
+                        ) as custom_sentences_file:
+                            # Merge custom sentences
+                            merge_dict(
+                                intents_dict, yaml.safe_load(custom_sentences_file)
+                            )
 
-                    # Will need to recreate graph
-                    intents_changed = True
-                    _LOGGER.debug(
-                        "Loaded custom sentences language=%s, path=%s",
-                        language,
-                        custom_sentences_path,
-                    )
+                        # Will need to recreate graph
+                        intents_changed = True
+                        _LOGGER.debug(
+                            "Loaded custom sentences language=%s (%s), path=%s",
+                            language,
+                            language_variation,
+                            custom_sentences_path,
+                        )
+
+                    # Stop after first matched language variation
+                    break
 
             # Load sentences from HA config for default language only
             if self._config_intents and (language == self.hass.config.language):

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -595,12 +595,18 @@ async def test_custom_sentences(
     # Expecting testing_config/custom_sentences/en/beer.yaml
     intent.async_register(hass, OrderBeerIntentHandler())
 
+    # Don't use "en" to test loading custom sentences with language variants.
+    language = "en-us"
+
     # Invoke intent via HTTP API
     client = await hass_client()
     for beer_style in ("stout", "lager"):
         resp = await client.post(
             "/api/conversation/process",
-            json={"text": f"I'd like to order a {beer_style}, please"},
+            json={
+                "text": f"I'd like to order a {beer_style}, please",
+                "language": language,
+            },
         )
         assert resp.status == HTTPStatus.OK
         data = await resp.json()
@@ -614,7 +620,7 @@ async def test_custom_sentences(
                         "speech": f"You ordered a {beer_style}",
                     }
                 },
-                "language": hass.config.language,
+                "language": language,
                 "response_type": "action_done",
                 "data": {
                     "targets": [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Custom sentences are now loaded for variations of the language code provided to `conversation/process`.
For example, "en_US" will try "en-us" and "en" too. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/iOS/issues/2308
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
