### PR TITLE
Add an API to homekit_controller for integrating into thread panel

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -119,3 +119,24 @@ async def async_remove_config_entry_device(
             ATTR_IDENTIFIERS
         ]
     )
+
+
+def async_get_uncommissioned_devices(hass: HomeAssistant) -> list[ConfigEntry]:
+    """Return a list of config entries for devices that support Thread, but are not currently on Thread."""
+    devices: dict[str, HKDevice] = hass.data[KNOWN_DEVICES]
+    entries = []
+
+    for device in devices.values():
+        if device.is_unprovisioned_thread_device:
+            entries.append(device.config_entry)
+
+    return entries
+
+
+async def async_commission_device(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Given its config entry, migrate a device to Thread."""
+    hkid = config_entry.data["AccessoryPairingID"]
+    connection: HKDevice = hass.data[KNOWN_DEVICES][hkid]
+    await connection.async_thread_provision()

--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -154,29 +154,6 @@ class HomeKitEcobeeClearHoldButton(CharacteristicEntity, ButtonEntity):
             await self.async_put_characteristics({key: val})
 
 
-class HomeKitProvisionPreferredThreadCredentials(CharacteristicEntity, ButtonEntity):
-    """A button users can press to migrate their HomeKit BLE device to Thread."""
-
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def get_characteristic_types(self) -> list[str]:
-        """Define the homekit characteristics the entity is tracking."""
-        return []
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        prefix = ""
-        if name := super().name:
-            prefix = name
-        return f"{prefix} Provision Preferred Thread Credentials"
-
-    async def async_press(self) -> None:
-        """Press the button."""
-        await self._accessory.async_thread_provision()
-
-
 BUTTON_ENTITY_CLASSES: dict[str, type] = {
-    CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD: HomeKitEcobeeClearHoldButton,
-    CharacteristicsTypes.THREAD_CONTROL_POINT: HomeKitProvisionPreferredThreadCredentials,
+    CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD: HomeKitEcobeeClearHoldButton
 }

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -778,7 +778,7 @@ class HKDevice:
     @property
     def is_unprovisioned_thread_device(self) -> bool:
         """Is this a thread capable device not connected by CoAP."""
-        if self.pairing.controller.transport_type != TransportType.BLE:
+        if self.pairing.transport != Transport.BLE:
             return False
 
         if not self.entity_map.aid(1).services.first(

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -94,7 +94,6 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.DENSITY_VOC: "sensor",
     CharacteristicsTypes.IDENTIFY: "button",
     CharacteristicsTypes.THREAD_NODE_CAPABILITIES: "sensor",
-    CharacteristicsTypes.THREAD_CONTROL_POINT: "button",
     CharacteristicsTypes.MUTE: "switch",
     CharacteristicsTypes.FILTER_LIFE_LEVEL: "sensor",
     CharacteristicsTypes.VENDOR_AIRVERSA_SLEEP_MODE: "switch",

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==2.6.1"],
+  "requirements": ["aiohomekit==2.6.2"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.6.1
+aiohomekit==2.6.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -158,7 +158,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.6.1
+aiohomekit==2.6.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -228,7 +228,7 @@ async def test_thread_provision(hass: HomeAssistant) -> None:
         version=1,
         domain="homekit_controller",
         entry_id="TestData",
-        data={"AccessoryPairingID": "00:00:00:00:00:00"},
+        data={"AccessoryPairingID": "00:00:00:00:00:00", "Connection": "BLE"},
         title="test",
         unique_id="00:00:00:00:00:00",
     )


### PR DESCRIPTION
## Proposed change

@balloob and I had a conversation about whether we should show compatible HomeKit thread devices in the thread panel. The idea is that we'd be able to quickly migrate a compatible HomeKit BLE pairing to a HomeKit Thread pairing and be able to use any border router HA has the Meshcop TLV for.

Right now on `dev`, there is a button entity to trigger this migration. If we were able to show up in the thread panel, we'd ditch that button.

This PR removes that button entity and adds 2 API's:

* `async_get_uncommissioned_devices` returns `ConfigEntry` for homekit devices that can be added to a Thread network. This are compatible devices that are not currently on *any* thread network.
* `async_commission_device` moves a `ConfigEntry` onto the users preferred thread network. If it return without error, then the device popped up on zeroconf so it worked. It takes about 30s for the migration (typically less).

I am not especially attached to the names.

This is meant to be a straw man, as I don't know what we can/can't do on the thread panel, and whoever is working on that probably doesn't know homekit_controller internals.

## Type  of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
