### PR TITLE
Default `hass_config` to contain an empty config

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -109,7 +109,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "hass_admin_user": "MockUser",
     "hass_client": "ClientSessionGenerator",
     "hass_client_no_auth": "ClientSessionGenerator",
-    "hass_config": "ConfigType | None",
+    "hass_config": "ConfigType",
     "hass_config_yaml": "str | None",
     "hass_config_yaml_files": "dict[str, str] | None",
     "hass_owner_user": "MockUser",

--- a/tests/components/homeassistant/triggers/test_homeassistant.py
+++ b/tests/components/homeassistant/triggers/test_homeassistant.py
@@ -27,7 +27,7 @@ from tests.common import async_mock_service
     ],
 )
 async def test_if_fires_on_hass_start(
-    hass: HomeAssistant, mock_hass_config: None, hass_config: ConfigType | None
+    hass: HomeAssistant, mock_hass_config: None, hass_config: ConfigType
 ) -> None:
     """Test the firing when Home Assistant starts."""
     calls = async_mock_service(hass, "test", "automation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -920,14 +920,14 @@ async def _mqtt_mock_entry(
 
 
 @pytest.fixture
-def hass_config() -> ConfigType | None:
+def hass_config() -> ConfigType:
     """Fixture to parametrize the content of main configuration using mock_hass_config.
 
     To set a configuration, tests can be marked with:
     @pytest.mark.parametrize("hass_config", [{integration: {...}}])
     Add the `mock_hass_config: None` fixture to the test.
     """
-    return None
+    return {}
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,7 +932,7 @@ def hass_config() -> ConfigType:
 
 @pytest.fixture
 def mock_hass_config(
-    hass: HomeAssistant, hass_config: ConfigType | None
+    hass: HomeAssistant, hass_config: ConfigType
 ) -> Generator[None, None, None]:
     """Fixture to mock the content of main configuration.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixture `hass_config` was introduced with https://github.com/home-assistant/core/pull/87981.
The default value of the fixture is `None`. Bet set to `None` is is not useful.
In cases where an empty config is needed it would be better to have `{}` as default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
