### PR TITLE
Bump pyairnow to 1.2.1

### DIFF
--- a/homeassistant/components/airnow/manifest.json
+++ b/homeassistant/components/airnow/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airnow",
   "iot_class": "cloud_polling",
   "loggers": ["pyairnow"],
-  "requirements": ["pyairnow==1.1.0"]
+  "requirements": ["pyairnow==1.2.0"]
 }

--- a/homeassistant/components/airnow/manifest.json
+++ b/homeassistant/components/airnow/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airnow",
   "iot_class": "cloud_polling",
   "loggers": ["pyairnow"],
-  "requirements": ["pyairnow==1.2.0"]
+  "requirements": ["pyairnow==1.2.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1494,7 +1494,7 @@ pyaehw4a1==0.3.9
 pyaftership==21.11.0
 
 # homeassistant.components.airnow
-pyairnow==1.1.0
+pyairnow==1.2.0
 
 # homeassistant.components.airvisual
 # homeassistant.components.airvisual_pro

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1494,7 +1494,7 @@ pyaehw4a1==0.3.9
 pyaftership==21.11.0
 
 # homeassistant.components.airnow
-pyairnow==1.2.0
+pyairnow==1.2.1
 
 # homeassistant.components.airvisual
 # homeassistant.components.airvisual_pro

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1088,7 +1088,7 @@ py_nextbusnext==0.1.5
 pyaehw4a1==0.3.9
 
 # homeassistant.components.airnow
-pyairnow==1.2.0
+pyairnow==1.2.1
 
 # homeassistant.components.airvisual
 # homeassistant.components.airvisual_pro

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1088,7 +1088,7 @@ py_nextbusnext==0.1.5
 pyaehw4a1==0.3.9
 
 # homeassistant.components.airnow
-pyairnow==1.1.0
+pyairnow==1.2.0
 
 # homeassistant.components.airvisual
 # homeassistant.components.airvisual_pro


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Bump pyairnow to 1.2.1 to comply with new AirNow API requirements. This does not cause any breaking changes.

Release Notes: https://github.com/asymworks/pyairnow/releases/tag/v1.2.0
Patch 1.2.1 unmasks Python 3.11 compatibility

https://github.com/asymworks/pyairnow/compare/v1.1.0...v1.2.1

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
