### PR TITLE
Bump zwave-js-server-python to 0.46.0

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -35,11 +35,11 @@ from zwave_js_server.model.controller import (
     QRProvisioningInformation,
 )
 from zwave_js_server.model.driver import Driver
-from zwave_js_server.model.firmware import FirmwareUpdateData
 from zwave_js_server.model.log_config import LogConfig
 from zwave_js_server.model.log_message import LogMessage
 from zwave_js_server.model.node import Node, NodeStatistics
 from zwave_js_server.model.node.firmware import (
+    NodeFirmwareUpdateData,
     NodeFirmwareUpdateProgress,
     NodeFirmwareUpdateResult,
 )
@@ -2072,7 +2072,7 @@ class FirmwareUploadView(HomeAssistantView):
                 node.client.ws_server_url,
                 node,
                 [
-                    FirmwareUpdateData(
+                    NodeFirmwareUpdateData(
                         uploaded_file.filename,
                         await hass.async_add_executor_job(uploaded_file.file.read),
                     )

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.45.2"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.46.0"],
   "usb": [
     {
       "vid": "0658",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2727,7 +2727,7 @@ zigpy==0.53.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.45.2
+zwave-js-server-python==0.46.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1931,7 +1931,7 @@ zigpy-znp==0.9.2
 zigpy==0.53.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.45.2
+zwave-js-server-python==0.46.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.3.1

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -28,8 +28,8 @@ from zwave_js_server.model.controller import (
     ProvisioningEntry,
     QRProvisioningInformation,
 )
-from zwave_js_server.model.firmware import FirmwareUpdateData
 from zwave_js_server.model.node import Node
+from zwave_js_server.model.node.firmware import NodeFirmwareUpdateData
 
 from homeassistant.components.websocket_api import ERR_INVALID_FORMAT, ERR_NOT_FOUND
 from homeassistant.components.zwave_js.api import (
@@ -2915,7 +2915,7 @@ async def test_firmware_upload_view(
         )
         assert mock_cmd.call_args[0][1:3] == (
             multisensor_6,
-            [FirmwareUpdateData("file", bytes(10))],
+            [NodeFirmwareUpdateData("file", bytes(10))],
         )
         assert mock_cmd.call_args[1] == {
             "additional_user_agent_components": {"HomeAssistant": "0.0.0"},


### PR DESCRIPTION
## Breaking change
You must use `zwave-js-server` 1.26.0 or greater (schema 24).

With this release, you will need to update your `zwave-js-server` instance.

- If you use the `Z-Wave JS` addon, you need to have at least version 0.1.76.
- If you use the `Z-Wave JS UI` addon, you need to have at least version 1.6.3.
- If you use the `Z-Wave JS UI` Docker container, you need to have at least version 8.8.6.
- If you run your own Docker container, or some other installation method, you will need to update your `zwave-js-server` instance to at least 1.26.0.

## Proposed change
Relevant changelogs:
- https://github.com/zwave-js/zwave-js-server/releases/tag/1.26.0
- https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.46.0

Only change that impacts the integration is re-namespacing and renaming one of the classes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
