### PR TITLE
Update async_matching_config_entries to use async_get_integrations

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -492,6 +492,7 @@ async def async_matching_config_entries(
         return [entry_json(entry) for entry in entries]
 
     integrations = {}
+    # Fetch all the integrations so we can check their type
     domains = {entry.domain for entry in entries}
     for domain_key, integration_or_exc in (
         await async_get_integrations(hass, domains)

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -491,7 +491,6 @@ async def async_matching_config_entries(
     if not type_filter:
         return [entry_json(entry) for entry in entries]
 
-    # Fetch all the integrations so we can check their type
     integrations = {}
     domains = {entry.domain for entry in entries}
     for domain_key, integration_or_exc in (

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -1,7 +1,6 @@
 """Http views to control the config manager."""
 from __future__ import annotations
 
-import asyncio
 from http import HTTPStatus
 from typing import Any
 
@@ -26,6 +25,7 @@ from homeassistant.loader import (
     IntegrationNotFound,
     async_get_config_flows,
     async_get_integration,
+    async_get_integrations,
 )
 
 
@@ -491,16 +491,14 @@ async def async_matching_config_entries(
     if not type_filter:
         return [entry_json(entry) for entry in entries]
 
-    integrations = {}
     # Fetch all the integrations so we can check their type
-    tasks = (
-        async_get_integration(hass, domain)
-        for domain in {entry.domain for entry in entries}
-    )
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for integration_or_exc in results:
+    integrations = {}
+    domains = {entry.domain for entry in entries}
+    for domain_key, integration_or_exc in (
+        await async_get_integrations(hass, domains)
+    ).items():
         if isinstance(integration_or_exc, Integration):
-            integrations[integration_or_exc.domain] = integration_or_exc
+            integrations[domain_key] = integration_or_exc
         elif not isinstance(integration_or_exc, IntegrationNotFound):
             raise integration_or_exc
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1446,8 +1446,8 @@ async def test_get_entries_ws(
 
     # Verify we skip broken integrations
     with patch(
-        "homeassistant.components.config.config_entries.async_get_integration",
-        side_effect=IntegrationNotFound("any"),
+        "homeassistant.components.config.config_entries.async_get_integrations",
+        return_value={"any": IntegrationNotFound("any")},
     ):
         await ws_client.send_json(
             {
@@ -1534,8 +1534,8 @@ async def test_get_entries_ws(
 
     # Verify we don't send config entries when only helpers are requested
     with patch(
-        "homeassistant.components.config.config_entries.async_get_integration",
-        side_effect=IntegrationNotFound("any"),
+        "homeassistant.components.config.config_entries.async_get_integrations",
+        return_value={"any": IntegrationNotFound("any")},
     ):
         await ws_client.send_json(
             {
@@ -1552,8 +1552,8 @@ async def test_get_entries_ws(
     # Verify we raise if something really goes wrong
 
     with patch(
-        "homeassistant.components.config.config_entries.async_get_integration",
-        side_effect=Exception,
+        "homeassistant.components.config.config_entries.async_get_integrations",
+        return_value={"any": Exception()},
     ):
         await ws_client.send_json(
             {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change speeds up loading the integrations page

Update `async_matching_config_entries` to use `async_get_integrations` as its much more efficient than creating hundreds of tasks if we already have most of them loaded.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
