### PR TITLE
Only build the field_map once in recorder history

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -919,7 +919,8 @@ def _sorted_states_to_dict(
         if row := initial_states.pop(ent_id, None):
             prev_state = row.state
             ent_results.append(state_class(row, attr_cache, start_time))
-            field_map |= {key: idx for idx, key in enumerate(row._fields)}
+            if not field_map:
+                field_map = {key: idx for idx, key in enumerate(row._fields)}
 
         if not minimal_response or split_entity_id(ent_id)[0] in NEED_ATTRIBUTE_DOMAINS:
             ent_results.extend(
@@ -936,7 +937,8 @@ def _sorted_states_to_dict(
                 continue
             prev_state = first_state.state
             ent_results.append(state_class(first_state, attr_cache, None))
-            field_map |= {key: idx for idx, key in enumerate(first_state._fields)}
+            if not field_map:
+                field_map = {key: idx for idx, key in enumerate(first_state._fields)}
 
         state_idx = field_map["state"]
 

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -856,7 +856,7 @@ def _sorted_states_to_dict(
     """
     schema_version = _schema_version(hass)
     _process_timestamp: Callable[[datetime], float | str]
-    field_map: dict[str, int]
+    field_map: dict[str, int] = {}
     state_class: Callable[
         [Row, dict[str, dict[str, Any]], datetime | None], State | dict[str, Any]
     ]
@@ -919,7 +919,7 @@ def _sorted_states_to_dict(
         if row := initial_states.pop(ent_id, None):
             prev_state = row.state
             ent_results.append(state_class(row, attr_cache, start_time))
-            field_map = {key: idx for idx, key in enumerate(row._fields)}
+            field_map |= {key: idx for idx, key in enumerate(row._fields)}
 
         if not minimal_response or split_entity_id(ent_id)[0] in NEED_ATTRIBUTE_DOMAINS:
             ent_results.extend(
@@ -936,7 +936,7 @@ def _sorted_states_to_dict(
                 continue
             prev_state = first_state.state
             ent_results.append(state_class(first_state, attr_cache, None))
-            field_map = {key: idx for idx, key in enumerate(first_state._fields)}
+            field_map |= {key: idx for idx, key in enumerate(first_state._fields)}
 
         state_idx = field_map["state"]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the field_map will always be the same for each row, we should only build it once at compile time for `_sorted_states_to_dict`. During the every 5m statistics compile we request history for a lot of entities in a single call which meant we could build the dict hundreds of times with that exact same result.

Before
<img width="1385" alt="Screenshot 2023-02-21 at 12 15 27 AM" src="https://user-images.githubusercontent.com/663432/220262868-675e4ae5-ab15-4f7e-a4d1-20c9db02b9ce.png">

After with that large branch out to `_fields` completely gone and we can only see the call to `_get_rows_with_session` taking up time to get the start time state.
<img width="1398" alt="Screenshot 2023-02-21 at 3 17 01 AM" src="https://user-images.githubusercontent.com/663432/220301730-90ec5aaa-9a49-419c-8772-4a815643cacf.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
