### PR TITLE
Remove deprecated callback support for MQTT subscribe

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -164,8 +164,8 @@ async def async_subscribe(
         raise HomeAssistantError(
             f"Cannot subscribe to topic '{topic}', MQTT is not enabled"
         )
-    # Support for a deprecated callback type will be removed from HA core 2023.2.0
-    # Count callback parameters which don't have a default value
+    # Support for a deprecated callback type was removed with HA core 2023.3.0
+    # The signature validation code can be removed from HA core 2023.5.0
     non_default = 0
     if msg_callback:
         non_default = sum(
@@ -173,7 +173,8 @@ async def async_subscribe(
             for _, p in inspect.signature(msg_callback).parameters.items()
         )
 
-    # Bail out for not supported callback signatures
+    # Check for not supported callback signatures
+    # Can be removed from HA core 2023.5.0
     if non_default != 1:
         module = inspect.getmodule(msg_callback)
         raise HomeAssistantError(

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine, Iterable
-from functools import lru_cache, partial, wraps
+from functools import lru_cache
 import inspect
 from itertools import chain, groupby
 import logging
 from operator import attrgetter
 import ssl
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 import uuid
 
 import async_timeout
@@ -72,7 +72,6 @@ from .models import (
     PublishMessage,
     PublishPayloadType,
     ReceiveMessage,
-    ReceivePayloadType,
 )
 from .util import get_file_path, get_mqtt_data, mqtt_config_entry_enabled
 
@@ -148,55 +147,11 @@ async def async_publish(
     )
 
 
-AsyncDeprecatedMessageCallbackType = Callable[
-    [str, ReceivePayloadType, int], Coroutine[Any, Any, None]
-]
-DeprecatedMessageCallbackType = Callable[[str, ReceivePayloadType, int], None]
-DeprecatedMessageCallbackTypes = (
-    AsyncDeprecatedMessageCallbackType | DeprecatedMessageCallbackType
-)
-
-
-# Support for a deprecated callback type will be removed from HA core 2023.2.0
-def wrap_msg_callback(
-    msg_callback: DeprecatedMessageCallbackTypes,
-) -> AsyncMessageCallbackType | MessageCallbackType:
-    """Wrap an MQTT message callback to support deprecated signature."""
-    # Check for partials to properly determine if coroutine function
-    check_func = msg_callback
-    while isinstance(check_func, partial):
-        check_func = check_func.func  # type: ignore[unreachable]
-
-    wrapper_func: AsyncMessageCallbackType | MessageCallbackType
-    if asyncio.iscoroutinefunction(check_func):
-
-        @wraps(msg_callback)
-        async def async_wrapper(msg: ReceiveMessage) -> None:
-            """Call with deprecated signature."""
-            await cast(AsyncDeprecatedMessageCallbackType, msg_callback)(
-                msg.topic, msg.payload, msg.qos
-            )
-
-        wrapper_func = async_wrapper
-        return wrapper_func
-
-    @wraps(msg_callback)
-    def wrapper(msg: ReceiveMessage) -> None:
-        """Call with deprecated signature."""
-        msg_callback(msg.topic, msg.payload, msg.qos)
-
-    wrapper_func = wrapper
-
-    return wrapper_func
-
-
 @bind_hass
 async def async_subscribe(
     hass: HomeAssistant,
     topic: str,
-    msg_callback: AsyncMessageCallbackType
-    | MessageCallbackType
-    | DeprecatedMessageCallbackTypes,
+    msg_callback: AsyncMessageCallbackType | MessageCallbackType,
     qos: int = DEFAULT_QOS,
     encoding: str | None = DEFAULT_ENCODING,
 ) -> CALLBACK_TYPE:
@@ -218,26 +173,19 @@ async def async_subscribe(
             for _, p in inspect.signature(msg_callback).parameters.items()
         )
 
-    wrapped_msg_callback = msg_callback
-    # If we have 3 parameters with no default value, wrap the callback
-    if non_default == 3:
+    # Bail out for not supported callback signatures
+    if non_default != 1:
         module = inspect.getmodule(msg_callback)
-        _LOGGER.warning(
-            (
-                "Signature of MQTT msg_callback '%s.%s' is deprecated, "
-                "this will stop working with HA core 2023.2"
-            ),
-            module.__name__ if module else "<unknown>",
-            msg_callback.__name__,
-        )
-        wrapped_msg_callback = wrap_msg_callback(
-            cast(DeprecatedMessageCallbackTypes, msg_callback)
+        raise HomeAssistantError(
+            "Signature for MQTT msg_callback '{}.{}' is not supported".format(
+                module.__name__ if module else "<unknown>", msg_callback.__name__
+            )
         )
 
     async_remove = await mqtt_data.client.async_subscribe(
         topic,
         catch_log_exception(
-            wrapped_msg_callback,
+            msg_callback,
             lambda msg: (
                 f"Exception in {msg_callback.__name__} when handling msg on "
                 f"'{msg.topic}': '{msg.payload}'"

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -920,109 +920,38 @@ async def test_subscribe_bad_topic(
         await mqtt.async_subscribe(hass, 55, record_calls)  # type: ignore[arg-type]
 
 
-# Support for a deprecated callback type will be removed from HA core 2023.2.0
-async def test_subscribe_deprecated(
+async def test_subscribe_with_deprecated_callback_fails(
     hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
-    """Test the subscription of a topic using deprecated callback signature."""
-    calls: list[tuple[str, ReceivePayloadType, int]]
-
-    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
+    """Test the subscription of a topic using deprecated callback signature fails."""
 
     async def record_calls(topic: str, payload: ReceivePayloadType, qos: int) -> None:
         """Record calls."""
-        calls.append((topic, payload, qos))
 
-    calls = []
-    unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls)
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0][0] == "test-topic"
-    assert calls[0][1] == "test-payload"
-
-    unsub()
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    mqtt_mock.async_publish.reset_mock()
-
+    with pytest.raises(HomeAssistantError):
+        await mqtt.async_subscribe(hass, "test-topic", record_calls)
     # Test with partial wrapper
-    calls = []
-    unsub = await mqtt.async_subscribe(
-        hass, "test-topic", RecordCallsPartial(record_calls)
-    )
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0][0] == "test-topic"
-    assert calls[0][1] == "test-payload"
-
-    unsub()
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
+    with pytest.raises(HomeAssistantError):
+        await mqtt.async_subscribe(hass, "test-topic", RecordCallsPartial(record_calls))
 
 
-# Support for a deprecated callback type will be removed from HA core 2023.2.0
-async def test_subscribe_deprecated_async(
+async def test_subscribe_deprecated_async_fails(
     hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
-    """Test the subscription of a topic using deprecated coroutine signature."""
-    calls: list[tuple[str, ReceivePayloadType, int]]
-
-    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
+    """Test the subscription of a topic using deprecated coroutine signature fails."""
 
     @callback
     def async_record_calls(topic: str, payload: ReceivePayloadType, qos: int) -> None:
         """Record calls."""
-        calls.append((topic, payload, qos))
 
-    calls = []
-    unsub = await mqtt.async_subscribe(hass, "test-topic", async_record_calls)
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0][0] == "test-topic"
-    assert calls[0][1] == "test-payload"
-
-    unsub()
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    mqtt_mock.async_publish.reset_mock()
+    with pytest.raises(HomeAssistantError):
+        await mqtt.async_subscribe(hass, "test-topic", async_record_calls)
 
     # Test with partial wrapper
-    calls = []
-    unsub = await mqtt.async_subscribe(
-        hass, "test-topic", RecordCallsPartial(async_record_calls)
-    )
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0][0] == "test-topic"
-    assert calls[0][1] == "test-payload"
-
-    unsub()
-
-    async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
-    await hass.async_block_till_done()
-    assert len(calls) == 1
+    with pytest.raises(HomeAssistantError):
+        await mqtt.async_subscribe(
+            hass, "test-topic", RecordCallsPartial(async_record_calls)
+        )
 
 
 async def test_subscribe_topic_not_match(
@@ -1300,25 +1229,32 @@ async def test_subscribe_same_topic(
     # Fake that the client is connected
     mqtt_mock().connected = True
 
-    calls_a = MagicMock()
-    await mqtt.async_subscribe(hass, "test/state", calls_a)
+    calls_a: list[ReceiveMessage] = []
+    calls_b: list[ReceiveMessage] = []
+
+    def _callback_a(msg: ReceiveMessage) -> None:
+        calls_a.append(msg)
+
+    def _callback_b(msg: ReceiveMessage) -> None:
+        calls_b.append(msg)
+
+    await mqtt.async_subscribe(hass, "test/state", _callback_a)
     async_fire_mqtt_message(
         hass, "test/state", "online"
     )  # Simulate a (retained) message
     await hass.async_block_till_done()
-    assert calls_a.called
+    assert len(calls_a) == 1
     mqtt_client_mock.subscribe.assert_called()
-    calls_a.reset_mock()
+    calls_a = []
     mqtt_client_mock.reset_mock()
 
-    calls_b = MagicMock()
-    await mqtt.async_subscribe(hass, "test/state", calls_b)
+    await mqtt.async_subscribe(hass, "test/state", _callback_b)
     async_fire_mqtt_message(
         hass, "test/state", "online"
     )  # Simulate a (retained) message
     await hass.async_block_till_done()
-    assert calls_a.called
-    assert calls_b.called
+    assert len(calls_a) == 1
+    assert len(calls_b) == 1
     mqtt_client_mock.subscribe.assert_called()
 
 
@@ -1353,19 +1289,25 @@ async def test_unsubscribe_race(
     # Fake that the client is connected
     mqtt_mock().connected = True
 
-    calls_a = MagicMock()
-    calls_b = MagicMock()
+    calls_a: list[ReceiveMessage] = []
+    calls_b: list[ReceiveMessage] = []
+
+    def _callback_a(msg: ReceiveMessage) -> None:
+        calls_a.append(msg)
+
+    def _callback_b(msg: ReceiveMessage) -> None:
+        calls_b.append(msg)
 
     mqtt_client_mock.reset_mock()
-    unsub = await mqtt.async_subscribe(hass, "test/state", calls_a)
+    unsub = await mqtt.async_subscribe(hass, "test/state", _callback_a)
     unsub()
-    await mqtt.async_subscribe(hass, "test/state", calls_b)
+    await mqtt.async_subscribe(hass, "test/state", _callback_b)
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "test/state", "online")
     await hass.async_block_till_done()
-    assert not calls_a.called
-    assert calls_b.called
+    assert not calls_a
+    assert calls_b
 
     # We allow either calls [subscribe, unsubscribe, subscribe] or [subscribe, subscribe]
     expected_calls_1 = [
@@ -1905,7 +1847,7 @@ async def test_custom_birth_message(
     await mqtt_mock_entry_no_yaml_config()
     birth = asyncio.Event()
 
-    async def wait_birth(topic, payload, qos) -> None:
+    async def wait_birth(msg: ReceiveMessage) -> None:
         """Handle birth message."""
         birth.set()
 
@@ -1940,7 +1882,7 @@ async def test_default_birth_message(
     await mqtt_mock_entry_no_yaml_config()
     birth = asyncio.Event()
 
-    async def wait_birth(topic, payload, qos) -> None:
+    async def wait_birth(msg: ReceiveMessage) -> None:
         """Handle birth message."""
         birth.set()
 
@@ -2015,7 +1957,7 @@ async def test_delayed_birth_message(
     mqtt_mock = hass.data["mqtt"].client
     mqtt_mock.reset_mock()
 
-    async def wait_birth(topic, payload, qos) -> None:
+    async def wait_birth(msg: ReceiveMessage) -> None:
         """Handle birth message."""
         birth.set()
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -920,6 +920,8 @@ async def test_subscribe_bad_topic(
         await mqtt.async_subscribe(hass, 55, record_calls)  # type: ignore[arg-type]
 
 
+# Support for a deprecated callback type was removed with HA core 2023.3.0
+# Test can be removed from HA core 2023.5.0
 async def test_subscribe_with_deprecated_callback_fails(
     hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
@@ -935,6 +937,8 @@ async def test_subscribe_with_deprecated_callback_fails(
         await mqtt.async_subscribe(hass, "test-topic", RecordCallsPartial(record_calls))
 
 
+# Support for a deprecated callback type was removed with HA core 2023.3.0
+# Test can be removed from HA core 2023.5.0
 async def test_subscribe_deprecated_async_fails(
     hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the support for the deprecated callback signatues for MQTT subscribe.

Custom integrations that still use the deprecated callback signature for the callback functions passed to MQTT subscribe will no longer work. An exception will be raised if an unsupported callback type is detected.

Impact might be on custom integration using MQTT. This article was made to explain the changes to developers:
https://github.com/home-assistant/developers.home-assistant/pull/1692

Examples of deprecated callback functions that will no longer work:

```python
async def async_deprecated_callback1(topic: str, payload: ReceivePayloadType, qos: int) -> None:
    """Deprecated async callback example 1."""
    ...


@callback
def async_deprecated_callback2(topic: str, payload: ReceivePayloadType, qos: int) -> None:
    """Deprecated async callback example 2."""
    ...
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
