### PR TITLE
Activate thread integration if thread border routers are present

### DIFF
--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -17,6 +17,7 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Set up because the user has border routers."""
+        self.async_set_unique_id(DOMAIN)
         if self._async_current_entries():
             return self.async_abort(reason="already_configured")
         return self.async_create_entry(title="Thread", data={})
@@ -25,6 +26,7 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
         self, import_data: dict[str, str] | None = None
     ) -> FlowResult:
         """Set up by import from async_setup."""
-        if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
+        self.async_set_unique_id(DOMAIN)
+        # We don't check for existing config entries here because the check
+        # already happened in async_setup
         return self.async_create_entry(title="Thread", data={})

--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -17,16 +17,14 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Set up because the user has border routers."""
-        self.async_set_unique_id(DOMAIN)
-        if self._async_current_entries():
-            return self.async_abort(reason="already_configured")
+        await self._async_handle_discovery_without_unique_id()
         return self.async_create_entry(title="Thread", data={})
 
     async def async_step_import(
         self, import_data: dict[str, str] | None = None
     ) -> FlowResult:
         """Set up by import from async_setup."""
-        self.async_set_unique_id(DOMAIN)
+        await self._async_handle_discovery_without_unique_id()
         # We don't check for existing config entries here because the check
         # already happened in async_setup
         return self.async_create_entry(title="Thread", data={})

--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -25,6 +25,4 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Set up by import from async_setup."""
         await self._async_handle_discovery_without_unique_id()
-        # We don't check for existing config entries here because the check
-        # already happened in async_setup
         return self.async_create_entry(title="Thread", data={})

--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for the Thread integration."""
 from __future__ import annotations
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.data_entry_flow import FlowResult
 
@@ -12,8 +13,18 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Set up because the user has border routers."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+        return self.async_create_entry(title="Thread", data={})
+
     async def async_step_import(
         self, import_data: dict[str, str] | None = None
     ) -> FlowResult:
         """Set up by import from async_setup."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
         return self.async_create_entry(title="Thread", data={})

--- a/homeassistant/components/thread/manifest.json
+++ b/homeassistant/components/thread/manifest.json
@@ -7,5 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/thread",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["python-otbr-api==1.0.3"]
+  "requirements": ["python-otbr-api==1.0.3"],
+  "zeroconf": ["_meshcop._udp.local."]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -522,6 +522,11 @@ ZEROCONF = {
             "domain": "apple_tv",
         },
     ],
+    "_meshcop._udp.local.": [
+        {
+            "domain": "thread",
+        },
+    ],
     "_miio._udp.local.": [
         {
             "domain": "xiaomi_aqara",

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -99,28 +99,3 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert config_entry.options == {}
     assert config_entry.title == "Thread"
     assert config_entry.unique_id is None
-
-
-async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
-    """Test the import flow."""
-    with patch(
-        "homeassistant.components.thread.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
-        )
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-
-    with patch(
-        "homeassistant.components.thread.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "import"}
-        )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -1,9 +1,33 @@
 """Test the Thread config flow."""
 from unittest.mock import patch
 
-from homeassistant.components import thread
+from homeassistant.components import thread, zeroconf
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+TEST_ZEROCONF_RECORD = zeroconf.ZeroconfServiceInfo(
+    host="127.0.0.1",
+    hostname="HomeAssistant OpenThreadBorderRouter #0BBF",
+    name="HomeAssistant OpenThreadBorderRouter #0BBF._meshcop._udp.local.",
+    addresses=["127.0.0.1"],
+    port=8080,
+    properties={
+        "rv": "1",
+        "vn": "HomeAssistant",
+        "mn": "OpenThreadBorderRouter",
+        "nn": "OpenThread HC",
+        "xp": "\xe6\x0f\xc7\xc1\x86!,\xe5",
+        "tv": "1.3.0",
+        "xa": "\xae\xeb/YKW\x0b\xbf",
+        "sb": "\x00\x00\x01\xb1",
+        "at": "\x00\x00\x00\x00\x00\x01\x00\x00",
+        "pt": "\x8f\x06Q~",
+        "sq": "3",
+        "bb": "\xf0\xbf",
+        "dn": "DefaultDomain",
+    },
+    type="_meshcop._udp.local.",
+)
 
 
 async def test_import(hass: HomeAssistant) -> None:
@@ -46,7 +70,7 @@ async def test_import_then_zeroconf(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "zeroconf"}
+            thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
         )
 
     assert result["type"] == FlowResultType.ABORT
@@ -61,7 +85,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "zeroconf"}
+            thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
@@ -84,7 +108,7 @@ async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            thread.DOMAIN, context={"source": "zeroconf"}
+            thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -99,3 +99,28 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert config_entry.options == {}
     assert config_entry.title == "Thread"
     assert config_entry.unique_id is None
+
+
+async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
+    """Test the import flow."""
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "zeroconf"}, data=TEST_ZEROCONF_RECORD
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "import"}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -27,3 +27,76 @@ async def test_import(hass: HomeAssistant) -> None:
     assert config_entry.options == {}
     assert config_entry.title == "Thread"
     assert config_entry.unique_id is None
+
+
+async def test_import_then_zeroconf(hass: HomeAssistant) -> None:
+    """Test the import flow."""
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "import"}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "zeroconf"}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_zeroconf(hass: HomeAssistant) -> None:
+    """Test the zeroconf flow."""
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "zeroconf"}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Thread"
+    assert result["data"] == {}
+    assert result["options"] == {}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(thread.DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {}
+    assert config_entry.title == "Thread"
+    assert config_entry.unique_id is None
+
+
+async def test_zeroconf_then_import(hass: HomeAssistant) -> None:
+    """Test the import flow."""
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "zeroconf"}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    with patch(
+        "homeassistant.components.thread.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            thread.DOMAIN, context={"source": "import"}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0


### PR DESCRIPTION
## Proposed change

Based on conversation with @balloob and @emontnemery. It makes sense for users to be able to use this integration if they have any border routers, especially with diagnostics like #88541. It is possible for them to use third party border routers with HA without HA knowing the secret key or creating a merged network with OTBR, and it makes sense that they'd be able to get some diagnostics for those cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
