### PR TITLE
Prepare for refactoring of MQTT related tests

### DIFF
--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -33,13 +33,13 @@ from tests.common import (
     async_fire_time_changed,
 )
 from tests.components.alarm_control_panel import common
-from tests.typing import MqttMockHAClientGenerator
+from tests.typing import MqttMockHAClient
 
 CODE = "HELLO_CODE"
 
 
 async def test_fail_setup_without_state_topic(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test for failing with no state topic."""
     with assert_setup_component(0, alarm_control_panel.DOMAIN) as config:
@@ -57,7 +57,7 @@ async def test_fail_setup_without_state_topic(
 
 
 async def test_fail_setup_without_command_topic(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test failing with no command topic."""
     with assert_setup_component(0, alarm_control_panel.DOMAIN):
@@ -87,7 +87,7 @@ async def test_no_pending(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Test arm method."""
     assert await async_setup_component(
@@ -135,7 +135,7 @@ async def test_no_pending_when_code_not_req(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Test arm method."""
     assert await async_setup_component(
@@ -184,7 +184,7 @@ async def test_with_pending(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Test arm method."""
     assert await async_setup_component(
@@ -256,7 +256,7 @@ async def test_with_invalid_code(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Attempt to arm without a valid code."""
     assert await async_setup_component(
@@ -304,7 +304,7 @@ async def test_with_template_code(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Attempt to arm with a template-based code."""
     assert await async_setup_component(
@@ -353,7 +353,7 @@ async def test_with_specific_pending(
     hass: HomeAssistant,
     service,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Test arm method."""
     assert await async_setup_component(
@@ -395,7 +395,7 @@ async def test_with_specific_pending(
 
 
 async def test_trigger_no_pending(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test triggering when no pending submitted method."""
     assert await async_setup_component(
@@ -435,7 +435,7 @@ async def test_trigger_no_pending(
 
 
 async def test_trigger_with_delay(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
@@ -483,7 +483,7 @@ async def test_trigger_with_delay(
 
 
 async def test_trigger_zero_trigger_time(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
@@ -513,7 +513,7 @@ async def test_trigger_zero_trigger_time(
 
 
 async def test_trigger_zero_trigger_time_with_pending(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disabled trigger."""
     assert await async_setup_component(
@@ -543,7 +543,7 @@ async def test_trigger_zero_trigger_time_with_pending(
 
 
 async def test_trigger_with_pending(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test arm home method."""
     assert await async_setup_component(
@@ -596,7 +596,7 @@ async def test_trigger_with_pending(
 
 
 async def test_trigger_with_disarm_after_trigger(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
@@ -636,7 +636,7 @@ async def test_trigger_with_disarm_after_trigger(
 
 
 async def test_trigger_with_zero_specific_trigger_time(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method."""
     assert await async_setup_component(
@@ -667,7 +667,7 @@ async def test_trigger_with_zero_specific_trigger_time(
 
 
 async def test_trigger_with_unused_zero_specific_trigger_time(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
@@ -708,7 +708,7 @@ async def test_trigger_with_unused_zero_specific_trigger_time(
 
 
 async def test_trigger_with_specific_trigger_time(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
@@ -748,7 +748,7 @@ async def test_trigger_with_specific_trigger_time(
 
 
 async def test_back_to_back_trigger_with_no_disarm_after_trigger(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test no disarm after back to back trigger."""
     assert await async_setup_component(
@@ -806,7 +806,7 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(
 
 
 async def test_disarm_while_pending_trigger(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarming while pending state."""
     assert await async_setup_component(
@@ -849,7 +849,7 @@ async def test_disarm_while_pending_trigger(
 
 
 async def test_disarm_during_trigger_with_invalid_code(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarming while code is invalid."""
     assert await async_setup_component(
@@ -897,7 +897,7 @@ async def test_disarm_during_trigger_with_invalid_code(
 
 
 async def test_trigger_with_unused_specific_delay(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
@@ -946,7 +946,7 @@ async def test_trigger_with_unused_specific_delay(
 
 
 async def test_trigger_with_specific_delay(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
@@ -995,7 +995,7 @@ async def test_trigger_with_specific_delay(
 
 
 async def test_trigger_with_pending_and_delay(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
@@ -1056,7 +1056,7 @@ async def test_trigger_with_pending_and_delay(
 
 
 async def test_trigger_with_pending_and_specific_delay(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test trigger method and switch from pending to triggered."""
     assert await async_setup_component(
@@ -1118,7 +1118,7 @@ async def test_trigger_with_pending_and_specific_delay(
 
 
 async def test_trigger_with_specific_pending(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test arm home method."""
     assert await async_setup_component(
@@ -1167,7 +1167,7 @@ async def test_trigger_with_specific_pending(
 
 
 async def test_trigger_with_no_disarm_after_trigger(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarm after trigger."""
     assert await async_setup_component(
@@ -1212,7 +1212,7 @@ async def test_trigger_with_no_disarm_after_trigger(
 
 
 async def test_arm_away_after_disabled_disarmed(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test pending state with and without zero trigger time."""
     assert await async_setup_component(
@@ -1278,7 +1278,7 @@ async def test_arm_away_after_disabled_disarmed(
 
 
 async def test_disarm_with_template_code(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Attempt to disarm with a valid or invalid template-based code."""
     assert await async_setup_component(
@@ -1332,7 +1332,7 @@ async def test_arm_via_command_topic(
     hass: HomeAssistant,
     config,
     expected_state,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock: MqttMockHAClient,
 ) -> None:
     """Test arming via command topic."""
     command = config[8:].upper()
@@ -1374,7 +1374,7 @@ async def test_arm_via_command_topic(
 
 
 async def test_disarm_pending_via_command_topic(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test disarming pending alarm via command topic."""
     assert await async_setup_component(
@@ -1410,7 +1410,7 @@ async def test_disarm_pending_via_command_topic(
 
 
 async def test_state_changes_are_published_to_mqtt(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test publishing of MQTT messages when state changes."""
     assert await async_setup_component(
@@ -1431,7 +1431,6 @@ async def test_state_changes_are_published_to_mqtt(
 
     # Component should send disarmed alarm state on startup
     await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
     mqtt_mock.async_publish.assert_called_once_with(
         "alarm/state", STATE_ALARM_DISARMED, 0, True
     )

--- a/tests/components/mqtt_json/test_device_tracker.py
+++ b/tests/components/mqtt_json/test_device_tracker.py
@@ -1,4 +1,5 @@
 """The tests for the JSON MQTT device tracker platform."""
+from collections.abc import Generator
 import json
 import logging
 import os
@@ -15,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_mqtt_message
+from tests.typing import MqttMockHAClient
 
 LOCATION_MESSAGE = {
     "longitude": 1.0,
@@ -27,7 +29,9 @@ LOCATION_MESSAGE_INCOMPLETE = {"longitude": 2.0}
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass, mqtt_mock_entry_with_yaml_config):
+async def setup_comp(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
+) -> Generator[None, None, None]:
     """Initialize components."""
     yaml_devices = hass.config.path(YAML_DEVICES)
     yield

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.common import async_fire_mqtt_message
-from tests.typing import MqttMockHAClientGenerator
+from tests.typing import MqttMockHAClient
 
 DEVICE_ID = "123TESTMAC"
 NAME = "test_device"
@@ -56,9 +56,7 @@ async def assert_distance(hass, distance):
     assert state.attributes.get("distance") == distance
 
 
-async def test_room_update(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
+async def test_room_update(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> None:
     """Test the updating between rooms."""
     assert await async_setup_component(
         hass,
@@ -96,7 +94,7 @@ async def test_room_update(
 
 
 async def test_unique_id_is_set(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient
 ) -> None:
     """Test the updating between rooms."""
     unique_name = "my_unique_name_0123456789"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -846,12 +846,14 @@ def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient, None,
 @pytest.fixture
 async def mqtt_mock(
     hass: HomeAssistant,
+    mock_hass_config: None,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
     mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
 ) -> AsyncGenerator[MqttMockHAClient, None]:
     """Fixture to mock MQTT component."""
-    return await mqtt_mock_entry_no_yaml_config()
+    with patch("homeassistant.components.mqtt.PLATFORMS", []):
+        return await mqtt_mock_entry_no_yaml_config()
 
 
 @asynccontextmanager


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integrations that use the MQTT integration should use `mqtt_mock`. This will ensure the Home Assistant config (`configration.yaml`) is mocked and that no additional MQTT platforms are set up.
Preventing set up of additional platforms will:
- make the CI tests faster
- prevent component setup conflicts. Fixture `mqtt_mock_entry_with_yaml_config` was used that aim before, but is deprecated now as the MQTT integration can only be set up through the config entry.

PR #87987 holds the bigger picture of the change that is prepared, but that PR is to large to process at once.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
