### PR TITLE
Add missing kelvin attributes to light recorder platform

### DIFF
--- a/homeassistant/components/light/recorder.py
+++ b/homeassistant/components/light/recorder.py
@@ -5,7 +5,9 @@ from homeassistant.core import HomeAssistant, callback
 
 from . import (
     ATTR_EFFECT_LIST,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_MAX_MIREDS,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
     ATTR_MIN_MIREDS,
     ATTR_SUPPORTED_COLOR_MODES,
 )
@@ -19,4 +21,6 @@ def exclude_attributes(hass: HomeAssistant) -> set[str]:
         ATTR_EFFECT_LIST,
         ATTR_MIN_MIREDS,
         ATTR_MAX_MIREDS,
+        ATTR_MIN_COLOR_TEMP_KELVIN,
+        ATTR_MAX_COLOR_TEMP_KELVIN,
     }

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -6,7 +6,9 @@ from datetime import timedelta
 from homeassistant.components import light
 from homeassistant.components.light import (
     ATTR_EFFECT,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_MAX_MIREDS,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
     ATTR_MIN_MIREDS,
     ATTR_SUPPORTED_COLOR_MODES,
 )
@@ -53,3 +55,5 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
         assert ATTR_SUPPORTED_COLOR_MODES not in state.attributes
         assert ATTR_EFFECT not in state.attributes
         assert ATTR_FRIENDLY_NAME in state.attributes
+        assert ATTR_MAX_COLOR_TEMP_KELVIN not in state.attributes
+        assert ATTR_MIN_COLOR_TEMP_KELVIN not in state.attributes


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we added the new kelvin attributes we forgot to add them to the recorder platform


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
