### PR TITLE
Bump `nettigo-air-monitor` to version 2.1.0

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -9,9 +9,9 @@ from aiohttp.client_exceptions import ClientConnectorError, ClientError
 import async_timeout
 from nettigo_air_monitor import (
     ApiError,
-    AuthFailed,
+    AuthFailedError,
     ConnectionOptions,
-    InvalidSensorData,
+    InvalidSensorDataError,
     NAMSensors,
     NettigoAirMonitor,
 )
@@ -58,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await nam.async_check_credentials()
     except ApiError as err:
         raise ConfigEntryNotReady from err
-    except AuthFailed as err:
+    except AuthFailedError as err:
         raise ConfigEntryAuthFailed from err
 
     coordinator = NAMDataUpdateCoordinator(hass, nam, entry.unique_id)
@@ -116,7 +116,7 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator[NAMSensors]):
                 data = await self.nam.async_update()
         # We do not need to catch AuthFailed exception here because sensor data is
         # always available without authorization.
-        except (ApiError, ClientConnectorError, InvalidSensorData) as error:
+        except (ApiError, ClientConnectorError, InvalidSensorDataError) as error:
             raise UpdateFailed(error) from error
 
         return data

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["nettigo_air_monitor"],
   "quality_scale": "platinum",
-  "requirements": ["nettigo-air-monitor==2.0.0"],
+  "requirements": ["nettigo-air-monitor==2.1.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1183,7 +1183,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==2.0.0
+nettigo-air-monitor==2.1.0
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -879,7 +879,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==2.0.0
+nettigo-air-monitor==2.1.0
 
 # homeassistant.components.nexia
 nexia==2.0.6

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import patch
 
-from nettigo_air_monitor import ApiError, AuthFailed, CannotGetMac
+from nettigo_air_monitor import ApiError, AuthFailedError, CannotGetMacError
 import pytest
 
 from homeassistant import data_entry_flow
@@ -169,7 +169,7 @@ async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
     "error",
     [
         (ApiError("API Error"), "cannot_connect"),
-        (AuthFailed("Auth Error"), "invalid_auth"),
+        (AuthFailedError("Auth Error"), "invalid_auth"),
         (asyncio.TimeoutError, "cannot_connect"),
         (ValueError, "unknown"),
     ],
@@ -179,7 +179,7 @@ async def test_form_with_auth_errors(hass: HomeAssistant, error) -> None:
     exc, base_error = error
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-        side_effect=AuthFailed("Auth Error"),
+        side_effect=AuthFailedError("Auth Error"),
     ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
@@ -236,7 +236,7 @@ async def test_form_abort(hass: HomeAssistant) -> None:
         return_value=DEVICE_CONFIG,
     ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        side_effect=CannotGetMac("Cannot get MAC address from device"),
+        side_effect=CannotGetMacError("Cannot get MAC address from device"),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -323,7 +323,7 @@ async def test_zeroconf_with_auth(hass: HomeAssistant) -> None:
     """Test that the zeroconf step with auth works."""
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-        side_effect=AuthFailed("Auth Error"),
+        side_effect=AuthFailedError("Auth Error"),
     ), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
@@ -388,7 +388,7 @@ async def test_zeroconf_host_already_configured(hass: HomeAssistant) -> None:
     "error",
     [
         (ApiError("API Error"), "cannot_connect"),
-        (CannotGetMac("Cannot get MAC address from device"), "device_unsupported"),
+        (CannotGetMacError("Cannot get MAC address from device"), "device_unsupported"),
     ],
 )
 async def test_zeroconf_errors(hass: HomeAssistant, error) -> None:

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -1,7 +1,7 @@
 """Test init of Nettigo Air Monitor integration."""
 from unittest.mock import patch
 
-from nettigo_air_monitor import ApiError, AuthFailed
+from nettigo_air_monitor import ApiError, AuthFailedError
 
 from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.components.nam.const import DOMAIN
@@ -73,7 +73,7 @@ async def test_config_auth_failed(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-        side_effect=AuthFailed("Authorization has failed"),
+        side_effect=AuthFailedError("Authorization has failed"),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         assert entry.state is ConfigEntryState.SETUP_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `nettigo-air-monitor` library to version 2.1.0. Exception names have been unified.

Changelog: https://github.com/bieniu/nettigo-air-monitor/compare/2.0.0...2.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
