### PR TITLE
Jinja templating improvements

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1926,7 +1926,7 @@ class _MutableList(list):
 
 
 def as_mutable(value):
-    """Create a mutable copy of a dict, set, or list."""
+    """Create a mutable copy of a dict or list."""
     if isinstance(value, dict):
         return _MutableDict(value)
     if isinstance(value, list):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1917,6 +1917,23 @@ def to_json(value, ensure_ascii=True):
     return json.dumps(value, ensure_ascii=ensure_ascii)
 
 
+class _MutableDict(dict):
+    pass
+
+
+class _MutableList(list):
+    pass
+
+
+def as_mutable(value):
+    """Create a mutable copy of a dict, set, or list."""
+    if isinstance(value, dict):
+        return _MutableDict(value)
+    if isinstance(value, list):
+        return _MutableList(value)
+    raise ValueError("Can only create mutable lists or dicts.")
+
+
 @pass_context
 def random_every_time(context, values):
     """Choose a random value.
@@ -2063,6 +2080,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.template_cache: weakref.WeakValueDictionary[
             str | jinja2.nodes.Template, CodeType | str | None
         ] = weakref.WeakValueDictionary()
+        self.add_extension("jinja2.ext.do")
+        self.add_extension("jinja2.ext.loopcontrols")
         self.filters["round"] = forgiving_round
         self.filters["multiply"] = multiply
         self.filters["log"] = logarithm
@@ -2084,6 +2103,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["timestamp_utc"] = timestamp_utc
         self.filters["to_json"] = to_json
         self.filters["from_json"] = from_json
+        self.filters["as_mutable"] = as_mutable
         self.filters["is_defined"] = fail_when_undefined
         self.filters["average"] = average
         self.filters["random"] = random_every_time
@@ -2231,6 +2251,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 self.filters[filt] = unsupported(filt)
             return
 
+        self.loader = jinja2.FileSystemLoader(hass.config.path("custom_jinja"))
+
         self.globals["expand"] = hassfunction(expand)
         self.filters["expand"] = pass_context(self.globals["expand"])
         self.globals["closest"] = hassfunction(closest)
@@ -2253,6 +2275,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
     def is_safe_attribute(self, obj, attr, value):
         """Test if attribute is safe."""
+
+        if isinstance(obj, (_MutableDict, _MutableList)):
+            return True
+
         if isinstance(
             obj, (AllStates, DomainStates, TemplateState, LoopContext, AsyncLoopContext)
         ):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2082,6 +2082,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         ] = weakref.WeakValueDictionary()
         self.add_extension("jinja2.ext.do")
         self.add_extension("jinja2.ext.loopcontrols")
+        if hass is not None:
+            self.loader = jinja2.FileSystemLoader(hass.config.path("custom_jinja"))
         self.filters["round"] = forgiving_round
         self.filters["multiply"] = multiply
         self.filters["log"] = logarithm
@@ -2250,8 +2252,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
             for filt in hass_filters:
                 self.filters[filt] = unsupported(filt)
             return
-
-        self.loader = jinja2.FileSystemLoader(hass.config.path("custom_jinja"))
 
         self.globals["expand"] = hassfunction(expand)
         self.filters["expand"] = pass_context(self.globals["expand"])

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -993,6 +993,54 @@ def test_from_json(hass: HomeAssistant) -> None:
     assert actual_result == expected_result
 
 
+def test_mutables(hass: HomeAssistant) -> None:
+    """Test as_mutable and mutability of those objects."""
+    assert (
+        template.Template(
+            """
+            {% set d = {} | as_mutable %}
+            {% do d.update({'foo': 'bar'}) %}
+            {{ d.foo }}
+            """,
+            hass,
+        ).async_render()
+        == "bar"
+    )
+
+    assert (
+        template.Template(
+            """
+            {% set l = [] | as_mutable %}
+            {% do l.append('bar') %}
+            {{ l[0] }}
+            """,
+            hass,
+        ).async_render()
+        == "bar"
+    )
+
+    # Ensure that without as_mutable, updates still don't work.
+    with pytest.raises(TemplateError):
+        template.Template(
+            """
+            {% set d = {} %}
+            {% do d.update({'foo': 'bar'}) %}
+            {{ d.foo }}
+            """,
+            hass,
+        ).async_render()
+
+    with pytest.raises(TemplateError):
+        template.Template(
+            """
+            {% set l = [] %}
+            {% do l.append('bar') %}
+            {{ l[0] }}
+            """,
+            hass,
+        ).async_render()
+
+
 def test_average(hass: HomeAssistant) -> None:
     """Test the average filter."""
     assert template.Template("{{ [1, 2, 3] | average }}", hass).async_render() == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I've made some minor changes to the Jinja environment to add a few things that make it possible to improve performance and/or code reuse:

* [`break` and `continue` for for loops](https://jinja.palletsprojects.com/en/3.0.x/extensions/#loop-controls)
* Enabling [importing/including](https://jinja.palletsprojects.com/en/3.1.x/templates/#include) shared jinja code/macros from a `custom_jinja` folder in your config folder
* `as_mutable` filter so that one can efficiently mutate a list or dictionary without rebuilding it from scratch in a loop
* [`do` extension](https://jinja.palletsprojects.com/en/3.0.x/extensions/#expression-statement) to make it possible to mutate lists/dicts.

All of this enables the following code:

In shared.jinja:
```jinja2
{% macro some_macro() -%}
A macro
{%- endmacro %}
{%- set some_constant = "A constant" %}
```

Elsewhere:
```jinja2
{% set mutableDict = {} | as_mutable %}
{% do mutableDict.update({'foo': 'bar'}) %}
{% set mutableList = [] | as_mutable %}
{% do mutableList.append("baz") %}

{{ mutableDict }}
{{ mutableList }}

{%- import "shared.jinja" as shared %}
{{ shared.some_constant }}
{{ shared.some_macro() }}
```
With the following output:
```
{'foo': 'bar'}
['baz']
A constant
A macro
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

I'm happy to update the documentation as well but wanted to first clear that this would be a welcome change.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
