### PR TITLE
Refactor WLED binary sensor test

### DIFF
--- a/tests/components/wled/snapshots/test_binary_sensor.ambr
+++ b/tests/components/wled/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,44 @@
+# serializer version: 1
+# name: test_update_available
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'update',
+      'friendly_name': 'WLED RGB Light Firmware',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.wled_rgb_light_firmware',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_update_available.1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.wled_rgb_light_firmware',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.UPDATE: 'update'>,
+    'original_icon': None,
+    'original_name': 'Firmware',
+    'platform': 'wled',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aabbccddeeff_update',
+    'unit_of_measurement': None,
+  })
+# ---

--- a/tests/components/wled/snapshots/test_binary_sensor.ambr
+++ b/tests/components/wled/snapshots/test_binary_sensor.ambr
@@ -42,3 +42,34 @@
     'unit_of_measurement': None,
   })
 # ---
+# name: test_update_available.2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': 'http://127.0.0.1',
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': 'esp8266',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'wled',
+        'aabbccddeeff',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'WLED',
+    'model': 'DIY light',
+    'name': 'WLED RGB Light',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '0.8.5',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/wled/test_binary_sensor.py
+++ b/tests/components/wled/test_binary_sensor.py
@@ -1,56 +1,46 @@
 """Tests for the WLED binary sensor platform."""
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_ICON,
-    STATE_OFF,
-    STATE_ON,
-    EntityCategory,
-)
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 pytestmark = pytest.mark.usefixtures("init_integration")
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_available(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the firmware update binary sensor."""
     assert (state := hass.states.get("binary_sensor.wled_rgb_light_firmware"))
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
-    assert state.state == STATE_ON
-    assert ATTR_ICON not in state.attributes
+    assert state == snapshot
 
-    assert (entry := entity_registry.async_get("binary_sensor.wled_rgb_light_firmware"))
-    assert entry.unique_id == "aabbccddeeff_update"
-    assert entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert (entity_entry := entity_registry.async_get(state.entity_id))
+    assert entity_entry == snapshot
+
+    assert entity_entry.device_id
+    assert (device_entry := device_registry.async_get(entity_entry.device_id))
+    assert device_entry == snapshot
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("device_fixture", ["rgb_websocket"])
-async def test_no_update_available(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
+async def test_no_update_available(hass: HomeAssistant) -> None:
     """Test the update binary sensor. There is no update available."""
     assert (state := hass.states.get("binary_sensor.wled_websocket_firmware"))
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
     assert state.state == STATE_OFF
-    assert ATTR_ICON not in state.attributes
-
-    assert (entry := entity_registry.async_get("binary_sensor.wled_websocket_firmware"))
-    assert entry.unique_id == "aabbccddeeff_update"
-    assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
 async def test_disabled_by_default(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that the binary update sensor is disabled by default."""
-    assert hass.states.get("binary_sensor.wled_rgb_light_firmware") is None
+    assert not hass.states.get("binary_sensor.wled_rgb_light_firmware")
 
     assert (entry := entity_registry.async_get("binary_sensor.wled_rgb_light_firmware"))
     assert entry.disabled


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactors the binary sensor tests of the WLED integration.

More compact, uses snapshot testing, test the device entry.

Restructure effort in order to be able to support a fair amount of tests needed in #75248

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
