### PR TITLE
Refactor WLED button tests

### DIFF
--- a/tests/components/wled/snapshots/test_button.ambr
+++ b/tests/components/wled/snapshots/test_button.ambr
@@ -1,0 +1,75 @@
+# serializer version: 1
+# name: test_button_restart
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'WLED RGB Light Restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.wled_rgb_light_restart',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_restart.1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.wled_rgb_light_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart',
+    'platform': 'wled',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aabbccddeeff_restart',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_restart.2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': 'http://127.0.0.1',
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': 'esp8266',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'wled',
+        'aabbccddeeff',
+      ),
+    }),
+    'is_new': False,
+    'manufacturer': 'WLED',
+    'model': 'DIY light',
+    'name': 'WLED RGB Light',
+    'name_by_user': None,
+    'suggested_area': None,
+    'sw_version': '0.8.5',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -1,41 +1,41 @@
 """Tests for the WLED button platform."""
 from unittest.mock import MagicMock
 
-from freezegun import freeze_time
 import pytest
+from syrupy.assertion import SnapshotAssertion
 from wled import WLEDConnectionError, WLEDError
 
-from homeassistant.components.button import (
-    DOMAIN as BUTTON_DOMAIN,
-    SERVICE_PRESS,
-    ButtonDeviceClass,
-)
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_ENTITY_ID,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    EntityCategory,
-)
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-pytestmark = pytest.mark.usefixtures("init_integration")
+pytestmark = [
+    pytest.mark.usefixtures("init_integration"),
+    pytest.mark.freeze_time("2021-11-04 17:37:00+01:00"),
+]
 
 
 async def test_button_restart(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_wled: MagicMock
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_wled: MagicMock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the creation and values of the WLED button."""
     assert (state := hass.states.get("button.wled_rgb_light_restart"))
+    assert state == snapshot
+
+    assert (entity_entry := entity_registry.async_get(state.entity_id))
+    assert entity_entry == snapshot
+
+    assert entity_entry.device_id
+    assert (device_entry := device_registry.async_get(entity_entry.device_id))
+    assert device_entry == snapshot
+
     assert state.state == STATE_UNKNOWN
-    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.RESTART
-
-    assert (entry := entity_registry.async_get("button.wled_rgb_light_restart"))
-    assert entry.unique_id == "aabbccddeeff_restart"
-    assert entry.entity_category is EntityCategory.CONFIG
-
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
@@ -45,15 +45,11 @@ async def test_button_restart(
     assert mock_wled.reset.call_count == 1
     mock_wled.reset.assert_called_with()
 
+    assert (state := hass.states.get("button.wled_rgb_light_restart"))
+    assert state.state == "2021-11-04T16:37:00+00:00"
 
-@freeze_time("2021-11-04 17:37:00", tz_offset=-1)
-async def test_button_error(
-    hass: HomeAssistant,
-    mock_wled: MagicMock,
-) -> None:
-    """Test error handling of the WLED buttons."""
+    # Test with WLED error
     mock_wled.reset.side_effect = WLEDError
-
     with pytest.raises(HomeAssistantError, match="Invalid response from WLED API"):
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -63,17 +59,12 @@ async def test_button_error(
         )
         await hass.async_block_till_done()
 
+    # Ensure this didn't made the entity unavailable
     assert (state := hass.states.get("button.wled_rgb_light_restart"))
-    assert state.state == "2021-11-04T16:37:00+00:00"
+    assert state.state != STATE_UNAVAILABLE
 
-
-async def test_button_connection_error(
-    hass: HomeAssistant,
-    mock_wled: MagicMock,
-) -> None:
-    """Test error handling of the WLED buttons."""
+    # Test with WLED connection error
     mock_wled.reset.side_effect = WLEDConnectionError
-
     with pytest.raises(HomeAssistantError, match="Error communicating with WLED API"):
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -82,5 +73,6 @@ async def test_button_connection_error(
             blocking=True,
         )
 
+    # Ensure this made the entity unavailable
     assert (state := hass.states.get("button.wled_rgb_light_restart"))
     assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactors the button tests of the WLED integration.

More compact uses snapshot testing, testing the device entry.

Restructure effort in order to be able to support a fair amount of tests needed in #75248

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
