### PR TITLE
Use load_json_object in ps4

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.json import save_json
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import location
-from homeassistant.util.json import load_json
+from homeassistant.util.json import JsonObjectType, load_json_object
 
 from .config_flow import PlayStation4FlowHandler  # noqa: F401
 from .const import (
@@ -165,18 +165,14 @@ def format_unique_id(creds, mac_address):
     return f"{mac_address}_{suffix}"
 
 
-def load_games(hass: HomeAssistant, unique_id: str) -> dict:
+def load_games(hass: HomeAssistant, unique_id: str) -> JsonObjectType:
     """Load games for sources."""
     g_file = hass.config.path(GAMES_FILE.format(unique_id))
     try:
-        games = load_json(g_file)
+        games = load_json_object(g_file)
     except HomeAssistantError as error:
         games = {}
         _LOGGER.error("Failed to load games file: %s", error)
-
-    if not isinstance(games, dict):
-        _LOGGER.error("Games file was not parsed correctly")
-        games = {}
 
     # If file exists
     if os.path.isfile(g_file):

--- a/tests/components/ps4/conftest.py
+++ b/tests/components/ps4/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration for PS4."""
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from pyps4_2ndscreen.ddp import DEFAULT_UDP_PORT, DDPProtocol
@@ -6,28 +7,30 @@ import pytest
 
 
 @pytest.fixture
-def patch_load_json():
+def patch_load_json_object() -> Generator[MagicMock, None, None]:
     """Prevent load JSON being used."""
-    with patch("homeassistant.components.ps4.load_json", return_value={}) as mock_load:
+    with patch(
+        "homeassistant.components.ps4.load_json_object", return_value={}
+    ) as mock_load:
         yield mock_load
 
 
 @pytest.fixture
-def patch_save_json():
+def patch_save_json() -> Generator[MagicMock, None, None]:
     """Prevent save JSON being used."""
     with patch("homeassistant.components.ps4.save_json") as mock_save:
         yield mock_save
 
 
 @pytest.fixture
-def patch_get_status():
+def patch_get_status() -> Generator[MagicMock, None, None]:
     """Prevent save JSON being used."""
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=None) as mock_get_status:
         yield mock_get_status
 
 
 @pytest.fixture
-def mock_ddp_endpoint():
+def mock_ddp_endpoint() -> Generator[None, None, None]:
     """Mock pyps4_2ndscreen.ddp.async_create_ddp_endpoint."""
     protocol = DDPProtocol()
     protocol._local_port = DEFAULT_UDP_PORT
@@ -40,5 +43,10 @@ def mock_ddp_endpoint():
 
 
 @pytest.fixture(autouse=True)
-def patch_io(patch_load_json, patch_save_json, patch_get_status, mock_ddp_endpoint):
+def patch_io(
+    patch_load_json_object: MagicMock,
+    patch_save_json: MagicMock,
+    patch_get_status: MagicMock,
+    mock_ddp_endpoint: None,
+) -> None:
     """Prevent PS4 doing I/O."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -198,14 +198,14 @@ async def setup_mock_component(hass):
     await hass.async_block_till_done()
 
 
-def test_games_reformat_to_dict(hass: HomeAssistant) -> None:
+def test_games_reformat_to_dict(
+    hass: HomeAssistant, patch_load_json_object: MagicMock
+) -> None:
     """Test old data format is converted to new format."""
+    patch_load_json_object.return_value = MOCK_GAMES_DATA_OLD_STR_FORMAT
     with patch(
-        "homeassistant.components.ps4.load_json",
-        return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT,
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+        "homeassistant.components.ps4.save_json", side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     # New format is a nested dict.
@@ -221,13 +221,12 @@ def test_games_reformat_to_dict(hass: HomeAssistant) -> None:
         assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MediaType.GAME
 
 
-def test_load_games(hass: HomeAssistant) -> None:
+def test_load_games(hass: HomeAssistant, patch_load_json_object: MagicMock) -> None:
     """Test that games are loaded correctly."""
+    patch_load_json_object.return_value = MOCK_GAMES
     with patch(
-        "homeassistant.components.ps4.load_json", return_value=MOCK_GAMES
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+        "homeassistant.components.ps4.save_json", side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
 
     assert isinstance(mock_games, dict)
@@ -240,29 +239,12 @@ def test_load_games(hass: HomeAssistant) -> None:
     assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MediaType.GAME
 
 
-def test_loading_games_returns_dict(hass: HomeAssistant) -> None:
+def test_loading_games_returns_dict(
+    hass: HomeAssistant, patch_load_json_object: MagicMock
+) -> None:
     """Test that loading games always returns a dict."""
+    patch_load_json_object.side_effect = HomeAssistantError
     with patch(
-        "homeassistant.components.ps4.load_json", side_effect=HomeAssistantError
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
-        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
-
-    assert isinstance(mock_games, dict)
-    assert not mock_games
-
-    with patch(
-        "homeassistant.components.ps4.load_json", return_value="Some String"
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
-        mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)
-
-    assert isinstance(mock_games, dict)
-    assert not mock_games
-
-    with patch("homeassistant.components.ps4.load_json", return_value=[]), patch(
         "homeassistant.components.ps4.save_json", side_effect=MagicMock()
     ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass, MOCK_ENTRY_ID)

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -263,11 +263,11 @@ async def test_media_attributes_are_fetched(hass: HomeAssistant) -> None:
 
 
 async def test_media_attributes_are_loaded(
-    hass: HomeAssistant, patch_load_json
+    hass: HomeAssistant, patch_load_json_object: MagicMock
 ) -> None:
     """Test that media attributes are loaded."""
     mock_entity_id = await setup_mock_component(hass)
-    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA_LOCKED}
+    patch_load_json_object.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA_LOCKED}
 
     with patch(
         "homeassistant.components.ps4.media_player."
@@ -451,9 +451,11 @@ async def test_media_stop(hass: HomeAssistant) -> None:
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source(hass: HomeAssistant, patch_load_json) -> None:
+async def test_select_source(
+    hass: HomeAssistant, patch_load_json_object: MagicMock
+) -> None:
     """Test that select source service calls function with title."""
-    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    patch_load_json_object.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 
@@ -471,9 +473,11 @@ async def test_select_source(hass: HomeAssistant, patch_load_json) -> None:
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_caps(hass: HomeAssistant, patch_load_json) -> None:
+async def test_select_source_caps(
+    hass: HomeAssistant, patch_load_json_object: MagicMock
+) -> None:
     """Test that select source service calls function with upper case title."""
-    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    patch_load_json_object.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 
@@ -494,9 +498,11 @@ async def test_select_source_caps(hass: HomeAssistant, patch_load_json) -> None:
     assert len(mock_call.mock_calls) == 1
 
 
-async def test_select_source_id(hass: HomeAssistant, patch_load_json) -> None:
+async def test_select_source_id(
+    hass: HomeAssistant, patch_load_json_object: MagicMock
+) -> None:
     """Test that select source service calls function with Title ID."""
-    patch_load_json.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
+    patch_load_json_object.return_value = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE):
         mock_entity_id = await setup_mock_component(hass)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #88534

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
