### PR TITLE
Use load_json_object in nanoleaf

### DIFF
--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.json import save_json
-from homeassistant.util.json import JsonObjectType, load_json_object
+from homeassistant.util.json import JsonObjectType, JsonValueType, load_json_object
 
 from .const import DOMAIN
 
@@ -136,17 +136,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             load_json_object, self.hass.config.path(CONFIG_FILE)
         )
 
-        auth_token: str | None = None
+        auth_token: JsonValueType = None
         if device_conf := self.discovery_conf.get(self.device_id):  # >= 2021.4
-            auth_token = cast(
-                str | None, cast(JsonObjectType, device_conf).get("token")
-            )
+            auth_token = cast(JsonObjectType, device_conf).get("token")
         if not auth_token and (host_conf := self.discovery_conf.get(host)):  # < 2021.4
-            auth_token = cast(str | None, cast(JsonObjectType, host_conf).get("token"))
+            auth_token = cast(JsonObjectType, host_conf).get("token")
 
         if auth_token is not None:
             self.nanoleaf = Nanoleaf(
-                async_get_clientsession(self.hass), host, auth_token
+                async_get_clientsession(self.hass), host, cast(str, auth_token)
             )
             _LOGGER.warning(
                 "Importing Nanoleaf %s from the discovery integration", name

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -141,9 +141,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             auth_token = cast(
                 str | None, cast(JsonObjectType, device_conf).get("token")
             )
-        if auth_token is None and (
-            host_conf := self.discovery_conf.get(host)
-        ):  # < 2021.4
+        if not auth_token and (host_conf := self.discovery_conf.get(host)):  # < 2021.4
             auth_token = cast(str | None, cast(JsonObjectType, host_conf).get("token"))
 
         if auth_token is not None:

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.json import save_json
-from homeassistant.util.json import load_json
+from homeassistant.util.json import JsonObjectType, load_json_object
 
 from .const import DOMAIN
 
@@ -36,15 +36,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     reauth_entry: config_entries.ConfigEntry | None = None
 
+    nanoleaf: Nanoleaf
+
+    # For discovery integration import
+    discovery_conf: JsonObjectType
+    device_id: str
+
     VERSION = 1
-
-    def __init__(self) -> None:
-        """Initialize a Nanoleaf flow."""
-        self.nanoleaf: Nanoleaf
-
-        # For discovery integration import
-        self.discovery_conf: dict
-        self.device_id: str
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -134,16 +132,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Import from discovery integration
         self.device_id = device_id
-        self.discovery_conf = cast(
-            dict,
-            await self.hass.async_add_executor_job(
-                load_json, self.hass.config.path(CONFIG_FILE)
-            ),
+        self.discovery_conf = await self.hass.async_add_executor_job(
+            load_json_object, self.hass.config.path(CONFIG_FILE)
         )
-        auth_token: str | None = self.discovery_conf.get(self.device_id, {}).get(
-            "token",  # >= 2021.4
-            self.discovery_conf.get(host, {}).get("token"),  # < 2021.4
-        )
+
+        auth_token: str | None = None
+        if device_conf := self.discovery_conf.get(self.device_id):  # >= 2021.4
+            auth_token = cast(
+                str | None, cast(JsonObjectType, device_conf).get("token")
+            )
+        if auth_token is None and (
+            host_conf := self.discovery_conf.get(host)
+        ):  # < 2021.4
+            auth_token = cast(str | None, cast(JsonObjectType, host_conf).get("token"))
+
         if auth_token is not None:
             self.nanoleaf = Nanoleaf(
                 async_get_clientsession(self.hass), host, auth_token

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -230,7 +230,7 @@ async def test_discovery_link_unavailable(
     with patch(
         "homeassistant.components.nanoleaf.config_flow.Nanoleaf.get_info",
     ), patch(
-        "homeassistant.components.nanoleaf.config_flow.load_json",
+        "homeassistant.components.nanoleaf.config_flow.load_json_object",
         return_value={},
     ):
         result = await hass.config_entries.flow.async_init(
@@ -353,7 +353,7 @@ async def test_import_discovery_integration(
     Test updating the .nanoleaf_conf file if it was not the only device in the file.
     """
     with patch(
-        "homeassistant.components.nanoleaf.config_flow.load_json",
+        "homeassistant.components.nanoleaf.config_flow.load_json_object",
         return_value=dict(nanoleaf_conf_file),
     ), patch(
         "homeassistant.components.nanoleaf.config_flow.Nanoleaf",
@@ -402,7 +402,7 @@ async def test_import_discovery_integration(
 async def test_ssdp_discovery(hass: HomeAssistant) -> None:
     """Test SSDP discovery."""
     with patch(
-        "homeassistant.components.nanoleaf.config_flow.load_json",
+        "homeassistant.components.nanoleaf.config_flow.load_json_object",
         return_value={},
     ), patch(
         "homeassistant.components.nanoleaf.config_flow.Nanoleaf",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #88534

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
