### PR TITLE
Bump intents package version; hassil==1.0.5; home-assistant-intents==2023.2.22

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==0.2.6", "home-assistant-intents==2023.1.31"]
+  "requirements": ["hassil==1.0.5", "home-assistant-intents==2023.2.22"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,10 +21,10 @@ cryptography==39.0.1
 dbus-fast==1.84.1
 fnvhash==0.1.0
 hass-nabucasa==0.61.0
-hassil==0.2.6
+hassil==1.0.5
 home-assistant-bluetooth==1.9.3
 home-assistant-frontend==20230202.0
-home-assistant-intents==2023.1.31
+home-assistant-intents==2023.2.22
 httpx==0.23.3
 ifaddr==0.1.7
 janus==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -874,7 +874,7 @@ hass-nabucasa==0.61.0
 hass_splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==0.2.6
+hassil==1.0.5
 
 # homeassistant.components.tasmota
 hatasmota==0.6.4
@@ -910,7 +910,7 @@ holidays==0.18.0
 home-assistant-frontend==20230202.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.1.31
+home-assistant-intents==2023.2.22
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -666,7 +666,7 @@ habitipy==0.2.0
 hass-nabucasa==0.61.0
 
 # homeassistant.components.conversation
-hassil==0.2.6
+hassil==1.0.5
 
 # homeassistant.components.tasmota
 hatasmota==0.6.4
@@ -693,7 +693,7 @@ holidays==0.18.0
 home-assistant-frontend==20230202.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.1.31
+home-assistant-intents==2023.2.22
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -79,7 +79,7 @@ async def test_http_processing_intent(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Turned on my cool light",
+                    "speech": "Turned on light",
                 }
             },
             "language": hass.config.language,
@@ -127,7 +127,7 @@ async def test_http_processing_intent_target_ha_agent(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Turned on my cool light",
+                    "speech": "Turned on light",
                 }
             },
             "language": hass.config.language,
@@ -176,7 +176,7 @@ async def test_http_processing_intent_entity_added(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Turned on my cool light",
+                    "speech": "Turned on light",
                 }
             },
             "language": hass.config.language,
@@ -210,7 +210,7 @@ async def test_http_processing_intent_entity_added(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Turned on friendly light",
+                    "speech": "Turned on light",
                 }
             },
             "language": hass.config.language,
@@ -243,7 +243,7 @@ async def test_http_processing_intent_entity_added(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Turned on late added light",
+                    "speech": "Turned on light",
                 }
             },
             "language": hass.config.language,
@@ -278,7 +278,7 @@ async def test_http_processing_intent_entity_added(
             "speech": {
                 "plain": {
                     "extra_data": None,
-                    "speech": "Sorry, I couldn't understand " "that",
+                    "speech": "Sorry, I couldn't understand that",
                 }
             },
         },
@@ -783,7 +783,7 @@ async def test_non_default_response(hass: HomeAssistant, init_components) -> Non
         )
     )
     assert len(calls) == 1
-    assert result.response.speech["plain"]["speech"] == "Opened front door"
+    assert result.response.speech["plain"]["speech"] == "Opened"
 
 
 async def test_turn_on_area(hass: HomeAssistant, init_components) -> None:

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -157,19 +157,19 @@ def test_async_validate_slots() -> None:
     )
 
 
-async def test_cant_turn_on_sensor(hass: HomeAssistant) -> None:
+async def test_cant_turn_on_lock(hass: HomeAssistant) -> None:
     """Test that we can't turn on entities that don't support it."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
     assert await async_setup_component(hass, "intent", {})
-    assert await async_setup_component(hass, "sensor", {})
+    assert await async_setup_component(hass, "lock", {})
 
     hass.states.async_set(
-        "sensor.test", "123", attributes={ATTR_FRIENDLY_NAME: "Test Sensor"}
+        "lock.test", "123", attributes={ATTR_FRIENDLY_NAME: "Test Lock"}
     )
 
     result = await conversation.async_converse(
-        hass, "turn on test sensor", None, Context(), None
+        hass, "turn on test lock", None, Context(), None
     )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps hassil/home-assistant-intents and adjusts tests for abbreviated responses.
hassil changes: https://github.com/home-assistant/hassil/compare/v0.2.5...v1.0.5
intents changes: https://github.com/home-assistant/intents/compare/2023.1.31...2023.2.22

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
