### PR TITLE
Bump brother to 2.2.0

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 
 import async_timeout
-from brother import Brother, BrotherSensors, SnmpError, UnsupportedModel
+from brother import Brother, BrotherSensors, SnmpError, UnsupportedModelError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE, Platform
@@ -81,6 +81,6 @@ class BrotherDataUpdateCoordinator(DataUpdateCoordinator[BrotherSensors]):
         try:
             async with async_timeout.timeout(20):
                 data = await self.brother.async_update()
-        except (ConnectionError, SnmpError, UnsupportedModel) as error:
+        except (ConnectionError, SnmpError, UnsupportedModelError) as error:
             raise UpdateFailed(error) from error
         return data

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from brother import Brother, SnmpError, UnsupportedModel
+from brother import Brother, SnmpError, UnsupportedModelError
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
@@ -62,7 +62,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except SnmpError:
                 errors["base"] = "snmp_error"
-            except UnsupportedModel:
+            except UnsupportedModelError:
                 return self.async_abort(reason="unsupported_model")
 
         return self.async_show_form(
@@ -86,7 +86,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.host, snmp_engine=snmp_engine, model=model
             )
             await self.brother.async_update()
-        except UnsupportedModel:
+        except UnsupportedModelError:
             return self.async_abort(reason="unsupported_model")
         except (ConnectionError, SnmpError):
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["brother", "pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "platinum",
-  "requirements": ["brother==2.1.1"],
+  "requirements": ["brother==2.2.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -480,7 +480,7 @@ boto3==1.20.24
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.1.1
+brother==2.2.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -393,7 +393,7 @@ boschshcpy==0.2.35
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.1.1
+brother==2.2.0
 
 # homeassistant.components.brunt
 brunt==1.2.0

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -2,7 +2,7 @@
 import json
 from unittest.mock import patch
 
-from brother import SnmpError, UnsupportedModel
+from brother import SnmpError, UnsupportedModelError
 
 from homeassistant import data_entry_flow
 from homeassistant.components import zeroconf
@@ -116,7 +116,7 @@ async def test_snmp_error(hass: HomeAssistant) -> None:
 async def test_unsupported_model_error(hass: HomeAssistant) -> None:
     """Test unsupported printer model error."""
     with patch("brother.Brother.initialize"), patch(
-        "brother.Brother._get_data", side_effect=UnsupportedModel("error")
+        "brother.Brother._get_data", side_effect=UnsupportedModelError("error")
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG

--- a/tests/components/brother/test_diagnostics.py
+++ b/tests/components/brother/test_diagnostics.py
@@ -22,7 +22,7 @@ async def test_entry_diagnostics(
     diagnostics_data = json.loads(load_fixture("diagnostics_data.json", "brother"))
     test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=UTC)
     with patch("brother.Brother.initialize"), patch(
-        "brother.datetime", utcnow=Mock(return_value=test_time)
+        "brother.datetime", now=Mock(return_value=test_time)
     ), patch(
         "brother.Brother._get_data",
         return_value=json.loads(load_fixture("printer_data.json", "brother")),

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -48,7 +48,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     )
     test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=UTC)
     with patch("brother.Brother.initialize"), patch(
-        "brother.datetime", utcnow=Mock(return_value=test_time)
+        "brother.datetime", now=Mock(return_value=test_time)
     ), patch(
         "brother.Brother._get_data",
         return_value=json.loads(load_fixture("printer_data.json", "brother")),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `brother` library to version 2.2.0.
Exception names have been unified and small changes in tests were needed.

Changelog: https://github.com/bieniu/brother/compare/2.1.1...2.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
