### PR TITLE
Mark LiteJet as Platinum integration

### DIFF
--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -6,5 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/litejet",
   "iot_class": "local_push",
   "loggers": ["pylitejet"],
-  "requirements": ["pylitejet==0.5.0"]
+  "requirements": ["pylitejet==0.5.0"],
+  "integration_type": "hub",
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@joncar"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/litejet",
+  "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pylitejet"],
-  "requirements": ["pylitejet==0.5.0"],
-  "integration_type": "hub",
-  "quality_scale": "platinum"
+  "quality_scale": "platinum",
+  "requirements": ["pylitejet==0.5.0"]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Marks the LiteJet integration as meeting the platinum scale requirements. Thank you to everyone who has reviewed my PRs to flesh out the missing bullets!

### Silver 🥈

- ✅ Satisfying all No score level requirements.
- ✅ Connection/configuration is handled via a component.
- N/A Set an appropriate `SCAN_INTERVAL` (if a polling integration)
- ✅ Raise [`PlatformNotReady`](integration_setup_failures.md/#integrations-using-async_setup_platform) if unable to connect during platform setup (if appropriate)
- N/A Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.  ([docs](config_entries_config_flow_handler.md#reauthentication))
- N/A Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- ✅ Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- ✅ Operations like service calls and entity methods (e.g. *Set HVAC Mode*) have proper exception handling. Raise `ValueError` on invalid user input and raise `HomeAssistantError` for other failures such as a problem communicating with a device.
- ✅ Set `available` property to `False` if appropriate ([docs](core/entity.md#generic-properties))
- ✅ Entities have unique ID (if available) ([docs](entity_registry_index.md#unique-id-requirements))

### Gold 🥇

- ✅ Satisfying all Silver level requirements.
- ✅ Configurable via config entries.
  - ✅ Don't allow configuring already configured device/service (example: no 2 entries for same hub)
  - N/A Discoverable (if available)
  - N/A Set unique ID in config flow (if available)
  - ✅ Raise [`ConfigEntryNotReady`](integration_setup_failures.md/#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate)
- ✅ Entities have device info (if available) ([docs](device_registry_index.md#defining-devices))
- ✅ Tests
  - ✅ Full test coverage for the config flow
  - ✅ Above average test coverage for all integration modules (96%)
  - ✅ Tests for fetching data from the integration and controlling it ([docs](development_testing.md))
- ✅ Has a code owner ([docs](creating_integration_manifest.md#code-owners))
- ✅ Entities only subscribe to updates inside `async_added_to_hass` and unsubscribe inside `async_will_remove_from_hass` ([docs](core/entity.md#lifecycle-hooks))
- ✅ Entities have correct device classes where appropriate ([docs](core/entity.md#generic-properties))
- ✅ Supports entities being disabled and leverages `Entity.entity_registry_enabled_default` to disable less popular entities ([docs](core/entity.md#advanced-properties))
- N/A If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
- ✅ When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information.

### Platinum 🏆

- ✅ Satisfying all Gold level requirements.
- N/A Set appropriate `PARALLEL_UPDATES` constant
- ✅ Support config entry unloading (called when config entry is removed)
- ✅ Integration + dependency are async ([docs](asyncio_working_with_async.md))
- N/A Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)
- N/A [Handles expired credentials](integration_setup_failures.md/#handling-expired-credentials) (if appropriate)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
