### PR TITLE
Fix local calendar issue with events created with fixed UTC offsets

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -66,6 +66,55 @@ SCAN_INTERVAL = datetime.timedelta(seconds=60)
 # Don't support rrules more often than daily
 VALID_FREQS = {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}
 
+
+def _has_consistent_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that all datetime values have a consistent timezone."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys that are datetime values have the same timezone."""
+        tzinfos = []
+        for key in keys:
+            if not (value := obj.get(key)) or not isinstance(value, datetime.datetime):
+                return obj
+            tzinfos.append(value.tzinfo)
+        uniq_values = groupby(tzinfos)
+        if len(list(uniq_values)) > 1:
+            raise vol.Invalid("Expected all values to have the same timezone")
+        return obj
+
+    return validate
+
+
+def _as_local_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Convert all datetime values to the local timezone."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys that are datetime values have the same timezone."""
+        for k in keys:
+            if (value := obj.get(k)) and isinstance(value, datetime.datetime):
+                obj[k] = dt.as_local(value)
+        return obj
+
+    return validate
+
+
+def _is_sorted(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that the specified values are sequential."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys in the dict are in order."""
+        values = []
+        for k in keys:
+            if not (value := obj.get(k)):
+                return obj
+            values.append(value)
+        if all(values) and values != sorted(values):
+            raise vol.Invalid(f"Values were not in order: {values}")
+        return obj
+
+    return validate
+
+
 CREATE_EVENT_SERVICE = "create_event"
 CREATE_EVENT_SCHEMA = vol.All(
     cv.has_at_least_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
@@ -98,6 +147,10 @@ CREATE_EVENT_SCHEMA = vol.All(
             ),
         },
     ),
+    _has_consistent_timezone(EVENT_START_DATETIME, EVENT_END_DATETIME),
+    _as_local_timezone(EVENT_START_DATETIME, EVENT_END_DATETIME),
+    _is_sorted(EVENT_START_DATE, EVENT_END_DATE),
+    _is_sorted(EVENT_START_DATETIME, EVENT_END_DATETIME),
 )
 
 
@@ -439,36 +492,6 @@ def _has_same_type(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
     return validate
 
 
-def _has_consistent_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Verify that all datetime values have a consistent timezone."""
-
-    def validate(obj: dict[str, Any]) -> dict[str, Any]:
-        """Test that all keys that are datetime values have the same timezone."""
-        values = [obj[k] for k in keys]
-        if all(isinstance(value, datetime.datetime) for value in values):
-            uniq_values = groupby(value.tzinfo for value in values)
-            if len(list(uniq_values)) > 1:
-                raise vol.Invalid(
-                    f"Expected all values to have the same timezone: {values}"
-                )
-        return obj
-
-    return validate
-
-
-def _is_sorted(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Verify that the specified values are sequential."""
-
-    def validate(obj: dict[str, Any]) -> dict[str, Any]:
-        """Test that all keys in the dict are in order."""
-        values = [obj[k] for k in keys]
-        if values != sorted(values):
-            raise vol.Invalid(f"Values were not in order: {values}")
-        return obj
-
-    return validate
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "calendar/event/create",
@@ -484,6 +507,7 @@ def _is_sorted(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
                 },
                 _has_same_type(EVENT_START, EVENT_END),
                 _has_consistent_timezone(EVENT_START, EVENT_END),
+                _as_local_timezone(EVENT_START, EVENT_END),
                 _is_sorted(EVENT_START, EVENT_END),
             )
         ),
@@ -580,6 +604,7 @@ async def handle_calendar_event_delete(
                 },
                 _has_same_type(EVENT_START, EVENT_END),
                 _has_consistent_timezone(EVENT_START, EVENT_END),
+                _as_local_timezone(EVENT_START, EVENT_END),
                 _is_sorted(EVENT_START, EVENT_END),
             )
         ),

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -15,7 +15,9 @@ from pydantic import ValidationError
 import voluptuous as vol
 
 from homeassistant.components.calendar import (
+    EVENT_END,
     EVENT_RRULE,
+    EVENT_START,
     CalendarEntity,
     CalendarEntityFeature,
     CalendarEvent,
@@ -151,6 +153,21 @@ def _parse_event(event: dict[str, Any]) -> Event:
     """Parse an ical event from a home assistant event dictionary."""
     if rrule := event.get(EVENT_RRULE):
         event[EVENT_RRULE] = Recur.from_rrule(rrule)
+
+    # This function is called with new events created in the local timezone,
+    # however ical library does not properly return recurrence_ids for
+    # start dates with a timezone. For now, ensure any datetime is stored as a
+    # floating local time to ensure we still apply proper local timezone rules.
+    # This can be removed when ical is updated with a new recurrence_id format
+    # https://github.com/home-assistant/core/issues/87759
+    for key in (EVENT_START, EVENT_END):
+        if (
+            (value := event[key])
+            and isinstance(value, datetime)
+            and value.tzinfo is not None
+        ):
+            event[key] = dt_util.as_local(value).replace(tzinfo=None)
+
     try:
         return Event.parse_obj(event)
     except ValidationError as err:
@@ -162,8 +179,12 @@ def _get_calendar_event(event: Event) -> CalendarEvent:
     """Return a CalendarEvent from an API event."""
     return CalendarEvent(
         summary=event.summary,
-        start=event.start,
-        end=event.end,
+        start=dt_util.as_local(event.start)
+        if isinstance(event.start, datetime)
+        else event.start,
+        end=dt_util.as_local(event.end)
+        if isinstance(event.end, datetime)
+        else event.end,
         description=event.description,
         uid=event.uid,
         rrule=event.rrule.as_rrule_str() if event.rrule else None,

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -299,6 +299,30 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
             vol.error.MultipleInvalid,
             "must contain at most one of start_date, start_date_time, in.",
         ),
+        (
+            {
+                "start_date_time": "2022-04-01T06:00:00+00:00",
+                "end_date_time": "2022-04-01T07:00:00+01:00",
+            },
+            vol.error.MultipleInvalid,
+            "Expected all values to have the same timezone",
+        ),
+        (
+            {
+                "start_date_time": "2022-04-01T07:00:00",
+                "end_date_time": "2022-04-01T06:00:00",
+            },
+            vol.error.MultipleInvalid,
+            "Values were not in order",
+        ),
+        (
+            {
+                "start_date": "2022-04-02",
+                "end_date": "2022-04-01",
+            },
+            vol.error.MultipleInvalid,
+            "Values were not in order",
+        ),
     ],
     ids=[
         "missing_all",
@@ -313,6 +337,9 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
         "multiple_in",
         "unexpected_in_with_date",
         "unexpected_in_with_datetime",
+        "inconsistent_timezone",
+        "incorrect_date_order",
+        "incorrect_datetime_order",
     ],
 )
 async def test_create_event_service_invalid_params(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix an issue where events are created with a UTC offset and are improperly persisted with a timezone of a UTC offset.  UTC offsets are not correct timezones (e.g. they do not respect DST) and so it is not appropriate to use them for creating an event.

There are a few changes to related to improving consistency that are connected:
- Add the existing websocket validation rules to the event creation service, and update tests to verify. Note, the logic for the validation had to move, but it was also rewritten because the mypy rules are more strict now.
- Convert all incoming event start/end datetimes to a local timezone, avoiding an UTC offsets
- As a temporary workaround for local calendar behavior, ensure all events are in local timezone then strip when persisting to preserve existing behavior. 
   - The specific issue is that the `recurrence_id` field which is the datetime of the event does not properly encode the timezone at the moment and needs to be updated. (still working through a solution for this)
  - The code for returning events has been updated to more explicitly convert to local timezone on the way back out just to show that its defensive against spreading complexity of local times outside of calendar.  (This will be further hardened, but waiting for more approvals on https://github.com/home-assistant/architecture/discussions/853)
- Add a test that exercises the bug in https://github.com/home-assistant/core/issues/87759 -- this requires creating the event, then persisting it, then parsing it again so the test does a reload. This also required fixing the test fixture to preserve data across integration restarts.

Note: Once this is fixed, I will also probably ical to be more lenient of calendars persisted this way to make it possible to repair broken users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #87759
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
