### PR TITLE
Also set `hass.config_entries` when `mock_hass_config` fixture is used

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ from homeassistant.components.websocket_api.auth import (
 )
 from homeassistant.components.websocket_api.http import URL
 from homeassistant.config import YAML_CONFIG_FILE
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntries, ConfigEntry
 from homeassistant.const import HASSIO_USER_NAME
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import (
@@ -936,8 +936,14 @@ def mock_hass_config(
 ) -> Generator[None, None, None]:
     """Fixture to mock the content of main configuration.
 
-    Patches homeassistant.config.load_yaml_config_file with `hass_config` parameterized as content.
+    Patches homeassistant.config.load_yaml_config_file and hass.config_entries
+    with `hass_config` as parameterized.
     """
+    if hass_config:
+        hass.config_entries = ConfigEntries(
+            hass,
+            hass_config,
+        )
     with patch("homeassistant.config.load_yaml_config_file", return_value=hass_config):
         yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -940,10 +940,7 @@ def mock_hass_config(
     with `hass_config` as parameterized.
     """
     if hass_config:
-        hass.config_entries = ConfigEntries(
-            hass,
-            hass_config,
-        )
+        hass.config_entries = ConfigEntries(hass, hass_config)
     with patch("homeassistant.config.load_yaml_config_file", return_value=hass_config):
         yield
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The fixture `mock_hass_config` patches the return value of `homeassistant.config.load_yaml_config_file`. But in tests `hass.config_entries` is not set.
This means that when `async_setup_component` is triggered, and is not directly called from a tests, `hass_config` is not set.

An alternative applying the patch in in the integration (see #88622):

https://github.com/home-assistant/core/pull/88622/files#diff-557862cdcece4dd316144c34475177c126e0d31a5c10d29ad32c61ac9998ff2bR14-R30

This PR initializes `hass.config_entries` to make sure the context is consistent.

### Background
MQTT still uses `async_setup`. The tests will be updated with parametrizing `hass_config` and remove `async_setup_platform` statements from the tests.
This PR ensures that the config that is set via the `hass_config` fixture will also be be forwarded to `async_setup`. The tests will be paramtrized with `hass` config and set up the MQTT entry, but as long as `async_setup` exists, that will be called first. When `async_setup` is removed, then the tests do not to change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
