### PR TITLE
Use async_timeout in integrations

### DIFF
--- a/homeassistant/components/hlk_sw16/config_flow.py
+++ b/homeassistant/components/hlk_sw16/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for HLK-SW16."""
 import asyncio
 
+import async_timeout
 from hlk_sw16 import create_hlk_sw16_connection
 import voluptuous as vol
 
@@ -35,7 +36,8 @@ async def connect_client(hass, user_input):
         reconnect_interval=DEFAULT_RECONNECT_INTERVAL,
         keep_alive_interval=DEFAULT_KEEP_ALIVE_INTERVAL,
     )
-    return await asyncio.wait_for(client_aw, timeout=CONNECTION_TIMEOUT)
+    async with async_timeout.timeout(CONNECTION_TIMEOUT):
+        return await client_aw
 
 
 async def validate_input(hass: HomeAssistant, user_input):

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import date, datetime
 import logging
 
+import async_timeout
 import pyotgw
 import pyotgw.vars as gw_vars
 from serial import SerialException
@@ -112,10 +113,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     config_entry.add_update_listener(options_updated)
 
     try:
-        await asyncio.wait_for(
-            gateway.connect_and_subscribe(),
-            timeout=CONNECTION_TIMEOUT,
-        )
+        async with async_timeout.timeout(CONNECTION_TIMEOUT):
+            await gateway.connect_and_subscribe()
     except (asyncio.TimeoutError, ConnectionError, SerialException) as ex:
         await gateway.cleanup()
         raise ConfigEntryNotReady(

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 
+import async_timeout
 import pyotgw
 from pyotgw import vars as gw_vars
 from serial import SerialException
@@ -68,10 +69,8 @@ class OpenThermGwConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return status[gw_vars.OTGW].get(gw_vars.OTGW_ABOUT)
 
             try:
-                await asyncio.wait_for(
-                    test_connection(),
-                    timeout=CONNECTION_TIMEOUT,
-                )
+                async with async_timeout.timeout(CONNECTION_TIMEOUT):
+                    await test_connection()
             except asyncio.TimeoutError:
                 return self._show_form({"base": "timeout_connect"})
             except (ConnectionError, SerialException):

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -8,6 +8,7 @@ import logging
 import re
 from typing import Any
 
+import async_timeout
 from icmplib import NameLookupError, async_ping
 import voluptuous as vol
 
@@ -230,9 +231,8 @@ class PingDataSubProcess(PingData):
             close_fds=False,  # required for posix_spawn
         )
         try:
-            out_data, out_error = await asyncio.wait_for(
-                pinger.communicate(), self._count + PING_TIMEOUT
-            )
+            async with async_timeout.timeout(self._count + PING_TIMEOUT):
+                out_data, out_error = await pinger.communicate()
 
             if out_data:
                 _LOGGER.debug(

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING
 
+import async_timeout
 from pysqueezebox import Server, async_discover
 import voluptuous as vol
 
@@ -130,7 +131,8 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # no host specified, see if we can discover an unconfigured LMS server
         try:
-            await asyncio.wait_for(self._discover(), timeout=TIMEOUT)
+            async with async_timeout.timeout(TIMEOUT):
+                await self._discover()
             return await self.async_step_edit()
         except asyncio.TimeoutError:
             errors["base"] = "no_server_found"

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 
+import async_timeout
 from async_upnp_client.exceptions import UpnpConnectionError
 
 from homeassistant.components import ssdp
@@ -70,7 +71,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     try:
-        await asyncio.wait_for(device_discovered_event.wait(), timeout=10)
+        async with async_timeout.timeout(10):
+            await device_discovered_event.wait()
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady(f"Device not discovered: {usn}") from err
     finally:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
wait_for creates a task, async_timeout does the same work and avoids the task creation

cc @bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
