### PR TITLE
Reduce overhead to save json data to postgresql

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -83,24 +83,14 @@ def json_bytes(data: Any) -> bytes:
     )
 
 
-def _strip_null_process_dict(_dict: dict[Any, Any]) -> dict[Any, Any]:
-    """Strip NUL from items in a dict."""
-    return {key: _strip_null(o) for key, o in _dict.items()}
-
-
-def _strip_null_process_list(_list: list[Any]) -> list[Any]:
-    """Strip NUL from items in a list."""
-    return [_strip_null(o) for o in _list]
-
-
 def _strip_null(obj: Any) -> Any:
     """Strip NUL from an object."""
     if isinstance(obj, str):
         return obj.split("\0", 1)[0]
     if isinstance(obj, dict):
-        return _strip_null_process_dict(obj)
+        return {key: _strip_null(o) for key, o in obj.items()}
     if isinstance(obj, list):
-        return _strip_null_process_list(obj)
+        return [_strip_null(o) for o in obj]
     return obj
 
 

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -99,14 +99,12 @@ def json_bytes_strip_null(data: Any) -> bytes:
     # We expect null-characters to be very rare, hence try encoding first and look
     # for an escaped null-character in the output.
     result = json_bytes(data)
-    if b"\\u0000" in result:
-        # We work on the processed result so we don't need to worry about
-        # Home Assistant extensions which allows encoding sets, tuples, etc.
-        data_processed = orjson.loads(result)
-        data_processed = _strip_null(data_processed)
-        result = json_bytes(data_processed)
+    if b"\\u0000" not in result:
+        return result
 
-    return result
+    # We work on the processed result so we don't need to worry about
+    # Home Assistant extensions which allows encoding sets, tuples, etc.
+    return json_bytes(_strip_null(orjson.loads(result)))
 
 
 def json_dumps(data: Any) -> str:

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -83,27 +83,29 @@ def json_bytes(data: Any) -> bytes:
     )
 
 
+def _strip_null_process_dict(_dict: dict[Any, Any]) -> dict[Any, Any]:
+    """Strip NUL from items in a dict."""
+    return {key: _strip_null(o) for key, o in _dict.items()}
+
+
+def _strip_null_process_list(_list: list[Any]) -> list[Any]:
+    """Strip NUL from items in a list."""
+    return [_strip_null(o) for o in _list]
+
+
+def _strip_null(obj: Any) -> Any:
+    """Strip NUL from an object."""
+    if isinstance(obj, str):
+        return obj.split("\0", 1)[0]
+    if isinstance(obj, dict):
+        return _strip_null_process_dict(obj)
+    if isinstance(obj, list):
+        return _strip_null_process_list(obj)
+    return obj
+
+
 def json_bytes_strip_null(data: Any) -> bytes:
     """Dump json bytes after terminating strings at the first NUL."""
-
-    def process_dict(_dict: dict[Any, Any]) -> dict[Any, Any]:
-        """Strip NUL from items in a dict."""
-        return {key: strip_null(o) for key, o in _dict.items()}
-
-    def process_list(_list: list[Any]) -> list[Any]:
-        """Strip NUL from items in a list."""
-        return [strip_null(o) for o in _list]
-
-    def strip_null(obj: Any) -> Any:
-        """Strip NUL from an object."""
-        if isinstance(obj, str):
-            return obj.split("\0", 1)[0]
-        if isinstance(obj, dict):
-            return process_dict(obj)
-        if isinstance(obj, list):
-            return process_list(obj)
-        return obj
-
     # We expect null-characters to be very rare, hence try encoding first and look
     # for an escaped null-character in the output.
     result = json_bytes(data)
@@ -111,7 +113,7 @@ def json_bytes_strip_null(data: Any) -> bytes:
         # We work on the processed result so we don't need to worry about
         # Home Assistant extensions which allows encoding sets, tuples, etc.
         data_processed = orjson.loads(result)
-        data_processed = strip_null(data_processed)
+        data_processed = _strip_null(data_processed)
         result = json_bytes(data_processed)
 
     return result


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reduce overhead to strip nulls from json (originally added in #86687 but I didn't have a good data set to optimize against until now).   I noticed this when I had left my test instance running postgresql when doing the testing for #88712

https://github.com/home-assistant/core/blob/69a3738bdb984a0d564d3846e0ec319074408032/homeassistant/components/recorder/db_schema.py#L291
https://github.com/home-assistant/core/blob/69a3738bdb984a0d564d3846e0ec319074408032/homeassistant/components/recorder/db_schema.py#L486


before

<img width="1423" alt="Screenshot 2023-02-24 at 12 45 19 PM" src="https://user-images.githubusercontent.com/663432/221266141-b5bed42d-9dbe-410e-abba-11c174936dd8.png">

after
<img width="1186" alt="Screenshot 2023-02-24 at 12 53 24 PM" src="https://user-images.githubusercontent.com/663432/221267055-ffebab74-7c61-42f5-8aa4-5cb10bee44d5.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
