### PR TITLE
Prevent new discovery flows from being created when stopping

### DIFF
--- a/homeassistant/helpers/discovery_flow.py
+++ b/homeassistant/helpers/discovery_flow.py
@@ -47,6 +47,9 @@ def _async_init_flow(
     if hass.config_entries.flow.async_has_matching_flow(domain, context, data):
         return None
 
+    if hass.is_stopping:
+        return None
+
     return hass.config_entries.flow.async_init(domain, context=context, data=data)
 
 

--- a/homeassistant/helpers/discovery_flow.py
+++ b/homeassistant/helpers/discovery_flow.py
@@ -44,10 +44,9 @@ def _async_init_flow(
     # as ones in progress as it may cause additional device probing
     # which can overload devices since zeroconf/ssdp updates can happen
     # multiple times in the same minute
-    if hass.config_entries.flow.async_has_matching_flow(domain, context, data):
-        return None
-
-    if hass.is_stopping:
+    if hass.is_stopping or hass.config_entries.flow.async_has_matching_flow(
+        domain, context, data
+    ):
         return None
 
     return hass.config_entries.flow.async_init(domain, context=context, data=data)

--- a/tests/helpers/test_discovery_flow.py
+++ b/tests/helpers/test_discovery_flow.py
@@ -96,3 +96,20 @@ async def test_async_create_flow_checks_existing_flows_before_startup(
             data={"properties": {"id": "aa:bb:cc:dd:ee:ff"}},
         )
     ]
+
+
+async def test_async_create_flow_does_nothing_after_stop(
+    hass: HomeAssistant, mock_flow_init
+) -> None:
+    """Test we no longer create flows when hass is stopping."""
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    hass.state = CoreState.stopping
+    mock_flow_init.reset_mock()
+    discovery_flow.async_create_flow(
+        hass,
+        "hue",
+        {"source": config_entries.SOURCE_HOMEKIT},
+        {"properties": {"id": "aa:bb:cc:dd:ee:ff"}},
+    )
+    assert len(mock_flow_init.mock_calls) == 0


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent new discovery flows from being created when stopping

related to `#beta` feedback:
https://ptb.discord.com/channels/330944238910963714/427516175237382144/1078803343394209904

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
