### PR TITLE
Allow loading UniFi entities on config options change

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -228,7 +228,7 @@ class UniFiController:
 
             @callback
             def async_options_updated() -> None:
-                """Load new entities based on changed options.."""
+                """Load new entities based on changed options."""
                 async_add_unifi_entity(list(api_handler))
 
             self.config_entry.async_on_unload(

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -228,7 +228,7 @@ class UniFiController:
 
             @callback
             def async_options_updated() -> None:
-                """Create new UniFi entity on event."""
+                """Load new entities based on changed options.."""
                 async_add_unifi_entity(list(api_handler))
 
             self.config_entry.async_on_unload(

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -103,6 +103,8 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
         self.controller = controller
         self.entity_description = description
 
+        controller.known_objects.add((description.key, obj_id))
+
         self._removed = False
 
         self._attr_available = description.available_fn(controller, obj_id)
@@ -117,6 +119,13 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
         """Register callbacks."""
         description = self.entity_description
         handler = description.api_handler_fn(self.controller.api)
+
+        @callback
+        def unlist_object() -> None:
+            """Remove entity from known_objects when unloaded."""
+            self.controller.known_objects.discard((description.key, self._obj_id))
+
+        self.async_on_remove(unlist_object)
 
         # New data from handler
         self.async_on_remove(

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -121,11 +121,11 @@ class UnifiEntity(Entity, Generic[HandlerT, DataT]):
         handler = description.api_handler_fn(self.controller.api)
 
         @callback
-        def unlist_object() -> None:
-            """Remove entity from known_objects when unloaded."""
+        def unregister_object() -> None:
+            """Remove object ID from known_objects when unloaded."""
             self.controller.known_objects.discard((description.key, self._obj_id))
 
-        self.async_on_remove(unlist_object)
+        self.async_on_remove(unregister_object)
 
         # New data from handler
         self.async_on_remove(

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -635,6 +635,15 @@ async def test_option_track_devices(
     assert hass.states.get("device_tracker.client")
     assert not hass.states.get("device_tracker.device")
 
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={CONF_TRACK_DEVICES: True},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client")
+    assert hass.states.get("device_tracker.device")
+
 
 async def test_option_ssid_filter(
     hass: HomeAssistant,
@@ -1041,7 +1050,7 @@ async def test_dont_track_devices(
         "version": "4.0.42.10433",
     }
 
-    await setup_unifi_integration(
+    config_entry = await setup_unifi_integration(
         hass,
         aioclient_mock,
         options={CONF_TRACK_DEVICES: False},
@@ -1052,6 +1061,16 @@ async def test_dont_track_devices(
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
     assert hass.states.get("device_tracker.client")
     assert not hass.states.get("device_tracker.device")
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={CONF_TRACK_DEVICES: True},
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert hass.states.get("device_tracker.client")
+    assert hass.states.get("device_tracker.device")
 
 
 async def test_dont_track_wired_clients(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -14,11 +14,13 @@ from homeassistant.components.unifi.const import (
     CONF_ALLOW_UPTIME_SENSORS,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
+    DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 import homeassistant.util.dt as dt_util
 
@@ -183,6 +185,37 @@ async def test_bandwidth_sensors(
     assert hass.states.get("sensor.wired_client_rx") is None
     assert hass.states.get("sensor.wired_client_tx") is None
 
+    # Enable option
+
+    options[CONF_ALLOW_BANDWIDTH_SENSORS] = True
+    hass.config_entries.async_update_entry(config_entry, options=options.copy())
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert hass.states.get("sensor.wireless_client_rx")
+    assert hass.states.get("sensor.wireless_client_tx")
+    assert hass.states.get("sensor.wired_client_rx")
+    assert hass.states.get("sensor.wired_client_tx")
+
+    # Try to add the sensors again, using a signal
+
+    clients_connected = {wired_client["mac"], wireless_client["mac"]}
+    devices_connected = set()
+
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    async_dispatcher_send(
+        hass,
+        controller.signal_update,
+        clients_connected,
+        devices_connected,
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+
 
 @pytest.mark.parametrize(
     ("initial_uptime", "event_uptime", "new_uptime"),
@@ -266,6 +299,35 @@ async def test_uptime_sensors(
     assert len(hass.states.async_all()) == 1
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
     assert hass.states.get("sensor.client1_uptime") is None
+
+    # Enable option
+
+    options[CONF_ALLOW_UPTIME_SENSORS] = True
+    with patch("homeassistant.util.dt.now", return_value=now):
+        hass.config_entries.async_update_entry(config_entry, options=options.copy())
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+    assert hass.states.get("sensor.client1_uptime")
+
+    # Try to add the sensors again, using a signal
+
+    clients_connected = {uptime_client["mac"]}
+    devices_connected = set()
+
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    async_dispatcher_send(
+        hass,
+        controller.signal_update,
+        clients_connected,
+        devices_connected,
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
 
 
 async def test_remove_sensors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Builds on #88571
Unblocks #84942
During the refactoring of UniFi I didn't take care of how to trigger loading of entities based on changed config options. This PR brings this functionality back.

PR consists of two parts
1. Controller and entity keep registry of loaded objects
2. Fix tests to once again validate loading entities on changed options work

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
