### PR TITLE
Add lifetime_total helper integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -650,6 +650,8 @@ build.json @home-assistant/supervisor
 /tests/components/lidarr/ @tkdrob
 /homeassistant/components/life360/ @pnbruckner
 /tests/components/life360/ @pnbruckner
+/homeassistant/components/lifetime_total/ @avee87
+/tests/components/lifetime_total/ @avee87
 /homeassistant/components/lifx/ @bdraco @Djelibeybi
 /tests/components/lifx/ @bdraco @Djelibeybi
 /homeassistant/components/light/ @home-assistant/core

--- a/homeassistant/components/lifetime_total/__init__.py
+++ b/homeassistant/components/lifetime_total/__init__.py
@@ -1,0 +1,18 @@
+"""The Lifetime Total integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Lifetime Total from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, (Platform.SENSOR,))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, (Platform.SENSOR,))

--- a/homeassistant/components/lifetime_total/config_flow.py
+++ b/homeassistant/components/lifetime_total/config_flow.py
@@ -1,0 +1,41 @@
+"""Config flow for Lifetime Total integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+    SchemaFlowMenuStep,
+)
+
+from .const import DOMAIN
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN)
+        ),
+    }
+)
+
+CONFIG_FLOW: dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
+    "user": SchemaFlowFormStep(CONFIG_SCHEMA)
+}
+
+
+class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config or options flow for Lifetime Total."""
+
+    config_flow = CONFIG_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options[CONF_NAME]) if CONF_NAME in options else ""

--- a/homeassistant/components/lifetime_total/const.py
+++ b/homeassistant/components/lifetime_total/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Lifetime Total integration."""
+
+DOMAIN = "lifetime_total"

--- a/homeassistant/components/lifetime_total/manifest.json
+++ b/homeassistant/components/lifetime_total/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "lifetime_total",
+  "name": "Lifetime Total",
+  "codeowners": ["@avee87"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/lifetime_total",
+  "integration_type": "helper",
+  "iot_class": "calculated"
+}

--- a/homeassistant/components/lifetime_total/sensor.py
+++ b/homeassistant/components/lifetime_total/sensor.py
@@ -101,10 +101,10 @@ class LifetimeTotalSensorEntity(RestoreEntity, SensorEntity):
 
             try:
                 new_value = Decimal(new_state.state)
-                if new_value > self._prev_value:
-                    delta = new_value - self._prev_value
-                else:
+                if new_value < self._prev_value:
                     delta = new_value
+                else:
+                    delta = new_value - self._prev_value
             except ValueError as err:
                 _LOGGER.warning("While calculating total: %s", err)
             except DecimalException as err:

--- a/homeassistant/components/lifetime_total/sensor.py
+++ b/homeassistant/components/lifetime_total/sensor.py
@@ -1,0 +1,145 @@
+"""Sensor platform for Lifetime Total integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal, DecimalException
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Event, HomeAssistant, State, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.restore_state import RestoreEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Lifetime Total config entry."""
+    registry = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_ENTITY_ID]
+    )
+    name = config_entry.title
+    unique_id = config_entry.entry_id
+
+    async_add_entities([LifetimeTotalSensorEntity(unique_id, name, entity_id)])
+
+
+class LifetimeTotalSensorEntity(RestoreEntity, SensorEntity):
+    """Lifetime Total Sensor."""
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_should_poll = False
+
+    def __init__(self, unique_id: str, name: str, wrapped_entity_id: str) -> None:
+        """Initialize Lifetime Total Sensor."""
+        super().__init__()
+        self._wrapped_entity_id = wrapped_entity_id
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+
+        self._value: Decimal = Decimal(0)
+        self._prev_value: Decimal = Decimal(0)
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        if state := await self.async_get_last_state():
+            try:
+                self._value = Decimal(state.state)
+            except (DecimalException, ValueError) as err:
+                _LOGGER.warning(
+                    "%s could not restore last state %s: %s",
+                    self.entity_id,
+                    state.state,
+                    err,
+                )
+            try:
+                last_reading = state.attributes.get("last_reading")
+                self._prev_value = Decimal(last_reading or 0)
+            except (DecimalException, ValueError) as err:
+                _LOGGER.warning(
+                    "%s could not restore previous reading %s: %s",
+                    self.entity_id,
+                    last_reading,
+                    err,
+                )
+            else:
+                self._attr_device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+                self._attr_unit_of_measurement = state.attributes.get(
+                    ATTR_UNIT_OF_MEASUREMENT
+                )
+        else:
+            self._value = Decimal(0)
+            self._prev_value = Decimal(0)
+
+        @callback
+        def calc_total(event: Event) -> None:
+            """Handle the sensor state changes."""
+            new_state: State | None = event.data.get("new_state")
+
+            if new_state is None or new_state.state in (
+                STATE_UNKNOWN,
+                STATE_UNAVAILABLE,
+            ):
+                return
+
+            try:
+                new_value = Decimal(new_state.state)
+                if new_value > self._prev_value:
+                    delta = new_value - self._prev_value
+                else:
+                    delta = new_value
+            except ValueError as err:
+                _LOGGER.warning("While calculating total: %s", err)
+            except DecimalException as err:
+                _LOGGER.warning("Invalid state (%s): %s", new_state.state, err)
+            else:
+                self._value += delta
+                self._prev_value = new_value
+
+                if unit := new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT):
+                    self._attr_native_unit_of_measurement = unit
+
+                if device_class := new_state.attributes.get(ATTR_DEVICE_CLASS):
+                    self._attr_device_class = device_class
+
+                self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._wrapped_entity_id], calc_total
+            )
+        )
+        state = self.hass.states.get(self._wrapped_entity_id)
+        state_event = Event(
+            "", {"entity_id": self._wrapped_entity_id, "new_state": state}
+        )
+        calc_total(state_event)
+
+    @property
+    def native_value(self) -> float:
+        """Return the state of the sensor."""
+        return float(self._value)
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return entity specific state attributes."""
+        return {
+            "last_reading": float(self._prev_value),
+        }

--- a/homeassistant/components/lifetime_total/strings.json
+++ b/homeassistant/components/lifetime_total/strings.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Create Lifetime Total Sensor",
+        "description": "Convert periodically resetting sensor (like utility meter reading) into a lifetime total sensor",
+        "data": {
+          "entity_id": "Source entity",
+          "name": "Name"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -8,6 +8,7 @@ FLOWS = {
         "derivative",
         "group",
         "integration",
+        "lifetime_total",
         "min_max",
         "switch_as_x",
         "threshold",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6507,6 +6507,12 @@
       "config_flow": true,
       "iot_class": "local_push"
     },
+    "lifetime_total": {
+      "name": "Lifetime Total",
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "calculated"
+    },
     "min_max": {
       "integration_type": "helper",
       "config_flow": true,

--- a/tests/components/lifetime_total/__init__.py
+++ b/tests/components/lifetime_total/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Lifetime Total integration."""

--- a/tests/components/lifetime_total/test_config_flow.py
+++ b/tests/components/lifetime_total/test_config_flow.py
@@ -1,0 +1,67 @@
+"""Test the Lifetime Total config flow."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.lifetime_total.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+@pytest.fixture(autouse=True, name="mock_setup_entry")
+def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.lifetime_total.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.mark.parametrize("platform", ("sensor",))
+async def test_config_flow(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, platform
+) -> None:
+    """Test the config flow."""
+    input_sensor_entity_id = "sensor.input"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "My lifetime_total", "entity_id": input_sensor_entity_id},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My lifetime_total"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "entity_id": input_sensor_entity_id,
+        "name": "My lifetime_total",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "entity_id": input_sensor_entity_id,
+        "name": "My lifetime_total",
+    }
+    assert config_entry.title == "My lifetime_total"
+
+
+def get_suggested(schema, key):
+    """Get suggested value for key in voluptuous schema."""
+    for k in schema:
+        if k == key:
+            if k.description is None or "suggested_value" not in k.description:
+                return None
+            return k.description["suggested_value"]
+    # Wanted key absent from schema
+    raise Exception

--- a/tests/components/lifetime_total/test_init.py
+++ b/tests/components/lifetime_total/test_init.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.lifetime_total.const import DOMAIN
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -37,7 +38,7 @@ async def test_setup_and_remove_config_entry(
     state = hass.states.get(lifetime_total_entity_id)
     assert state.state == "0.0"
     assert state.attributes == {
-        "friendly_name": "My lifetime_total",
+        ATTR_FRIENDLY_NAME: "My lifetime_total",
         "last_reading": 0.0,
         "state_class": SensorStateClass.TOTAL_INCREASING,
     }

--- a/tests/components/lifetime_total/test_init.py
+++ b/tests/components/lifetime_total/test_init.py
@@ -1,0 +1,48 @@
+"""Test the Lifetime Total integration."""
+
+from homeassistant.components.lifetime_total.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_remove_config_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test setting up and removing a config entry."""
+    input_sensor_entity_id = "sensor.input"
+    registry = er.async_get(hass)
+    lifetime_total_entity_id = "sensor.my_lifetime_total"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "entity_id": input_sensor_entity_id,
+            "name": "My lifetime_total",
+        },
+        title="My lifetime_total",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the entity is registered in the entity registry
+    assert registry.async_get(lifetime_total_entity_id) is not None
+
+    # Check the platform is setup correctly
+    state = hass.states.get(lifetime_total_entity_id)
+    assert state.state == "0.0"
+    assert state.attributes == {
+        "last_reading": 0,
+    }
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get(lifetime_total_entity_id) is None
+    assert registry.async_get(lifetime_total_entity_id) is None

--- a/tests/components/lifetime_total/test_init.py
+++ b/tests/components/lifetime_total/test_init.py
@@ -1,6 +1,7 @@
 """Test the Lifetime Total integration."""
 
 from homeassistant.components.lifetime_total.const import DOMAIN
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -36,7 +37,9 @@ async def test_setup_and_remove_config_entry(
     state = hass.states.get(lifetime_total_entity_id)
     assert state.state == "0.0"
     assert state.attributes == {
-        "last_reading": 0,
+        "friendly_name": "My lifetime_total",
+        "last_reading": 0.0,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
     }
 
     # Remove the config entry

--- a/tests/components/lifetime_total/test_sensor.py
+++ b/tests/components/lifetime_total/test_sensor.py
@@ -1,6 +1,12 @@
 """Test the Lifetime Total integration."""
 
 from homeassistant.components.lifetime_total.const import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    UnitOfEnergy,
+)
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -14,6 +20,10 @@ async def test_update_input_sensor(
     hass.states.async_set(
         input_sensor_entity_id,
         10,
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        },
     )
     lifetime_total_entity_id = "sensor.my_lifetime_total"
 
@@ -50,6 +60,16 @@ async def test_update_input_sensor(
     hass.states.async_set(
         "sensor.input",
         5,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(lifetime_total_entity_id)
+    assert state.state == "25.0"
+    assert state.attributes["last_reading"] == 5.0
+
+    # Check input sensor invalid value
+    hass.states.async_set(
+        "sensor.input",
+        "abcde",
     )
     await hass.async_block_till_done()
     state = hass.states.get(lifetime_total_entity_id)

--- a/tests/components/lifetime_total/test_sensor.py
+++ b/tests/components/lifetime_total/test_sensor.py
@@ -1,0 +1,57 @@
+"""Test the Lifetime Total integration."""
+
+from homeassistant.components.lifetime_total.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_update_input_sensor(
+    hass: HomeAssistant,
+) -> None:
+    """Test that sensor updates correctly when input sensor changes."""
+    input_sensor_entity_id = "sensor.input"
+    hass.states.async_set(
+        input_sensor_entity_id,
+        10,
+    )
+    lifetime_total_entity_id = "sensor.my_lifetime_total"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "entity_id": input_sensor_entity_id,
+            "name": "My lifetime_total",
+        },
+        title="My lifetime_total",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check initial value is set correctly
+    state = hass.states.get(lifetime_total_entity_id)
+    assert state.state == "10.0"
+    assert state.attributes["last_reading"] == 10.0
+
+    # Check input sensor increasing
+    hass.states.async_set(
+        "sensor.input",
+        20,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(lifetime_total_entity_id)
+    assert state.state == "20.0"
+    assert state.attributes["last_reading"] == 20.0
+
+    # Check input sensor decreasing
+    hass.states.async_set(
+        "sensor.input",
+        5,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(lifetime_total_entity_id)
+    assert state.state == "25.0"
+    assert state.attributes["last_reading"] == 5.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a new helper for converting periodically resetting sensor (like utility meter) into always-increasing lifetime total similar to how statistics recorder treats `total_increasing` entities. Use case is writing statistics to external storage like InfluxDB where it's easier to work with lifetime totals.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26369

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
