### PR TITLE
Check circular dependencies

### DIFF
--- a/homeassistant/components/hassio/manifest.json
+++ b/homeassistant/components/hassio/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "hassio",
   "name": "Home Assistant Supervisor",
-  "after_dependencies": ["panel_custom"],
   "codeowners": ["@home-assistant/supervisor"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/hassio",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -1,12 +1,7 @@
 {
   "domain": "zha",
   "name": "Zigbee Home Automation",
-  "after_dependencies": [
-    "onboarding",
-    "usb",
-    "zeroconf",
-    "homeassistant_yellow"
-  ],
+  "after_dependencies": ["onboarding", "usb"],
   "codeowners": ["@dmulcahey", "@adminiuga", "@puddly"],
   "config_flow": true,
   "dependencies": ["file_upload"],

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ast
+from collections import deque
 from pathlib import Path
 
 from homeassistant.const import Platform
@@ -118,6 +119,7 @@ ALLOWED_USED_COMPONENTS = {
     "input_text",
     "media_source",
     "onboarding",
+    "panel_custom",
     "persistent_notification",
     "person",
     "script",
@@ -138,22 +140,19 @@ IGNORE_VIOLATIONS = {
     # Has same requirement, gets defaults.
     ("sql", "recorder"),
     # Sharing a base class
-    ("openalpr_cloud", "openalpr_local"),
     ("lutron_caseta", "lutron"),
     ("ffmpeg_noise", "ffmpeg_motion"),
     # Demo
     ("demo", "manual"),
-    ("demo", "openalpr_local"),
     # This would be a circular dep
     ("http", "network"),
     # This would be a circular dep
     ("zha", "homeassistant_hardware"),
+    ("zha", "homeassistant_yellow"),
     # This should become a helper method that integrations can submit data to
     ("websocket_api", "lovelace"),
     ("websocket_api", "shopping_list"),
     "logbook",
-    # Migration wizard from zwave to zwave_js.
-    "zwave_js",
 }
 
 
@@ -231,6 +230,7 @@ def find_non_referenced_integrations(
 def validate_dependencies(
     integrations: dict[str, Integration],
     integration: Integration,
+    check_dependencies: bool,
 ) -> None:
     """Validate all dependencies."""
     # Some integrations are allowed to have violations.
@@ -252,12 +252,60 @@ def validate_dependencies(
             "or 'after_dependencies'",
         )
 
+    if check_dependencies:
+        _check_circular_deps(
+            integrations, integration.domain, integration, set(), deque()
+        )
+
+
+def _check_circular_deps(
+    integrations: dict[str, Integration],
+    start_domain: str,
+    integration: Integration,
+    checked: set[str],
+    checking: deque[str],
+) -> None:
+    """Check for circular dependencies pointing at starting_domain."""
+    if integration.domain in checked or integration.domain in checking:
+        return
+
+    checking.append(integration.domain)
+    for domain in integration.manifest.get("dependencies", []):
+        if domain == start_domain:
+            integrations[start_domain].add_error(
+                "dependencies",
+                f"Found a circular dependency with {integration.domain} ({', '.join(checking)})",
+            )
+            break
+
+        _check_circular_deps(
+            integrations, start_domain, integrations[domain], checked, checking
+        )
+    else:
+        for domain in integration.manifest.get("after_dependencies", []):
+            if domain == start_domain:
+                integrations[start_domain].add_error(
+                    "dependencies",
+                    f"Found a circular dependency with after dependencies of {integration.domain} ({', '.join(checking)})",
+                )
+                break
+
+            _check_circular_deps(
+                integrations, start_domain, integrations[domain], checked, checking
+            )
+    checked.add(integration.domain)
+    checking.remove(integration.domain)
+
 
 def validate(integrations: dict[str, Integration], config: Config) -> None:
     """Handle dependencies for integrations."""
     # check for non-existing dependencies
     for integration in integrations.values():
-        validate_dependencies(integrations, integration)
+        validate_dependencies(
+            integrations,
+            integration,
+            check_dependencies=not config.specific_integrations,
+        )
 
         if config.specific_integrations:
             continue


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improves checking for circular dependencies.

Changes based on the results:

- Marked `panel_custom` as usable without a dependency (it builds on top of `frontend`, which is marked the same)
- Remove exceptions for `openalpr_local` as integration has been removed
- Remove dependency on Yellow from ZHA, just like we did for SkyConnect in #88751
- Remove `zeroconf` from after dependencies of `zha`, as it's automatically marked as approved because it has zeroconf discovery step.

Sample output

```
Integration homeassistant_hardware:
* [ERROR] [DEPENDENCIES] Found a circular dependency with homeassistant_yellow (homeassistant_hardware, zha, homeassistant_yellow)

Integration homeassistant_yellow:
* [ERROR] [DEPENDENCIES] Found a circular dependency with after dependencies of zha (homeassistant_yellow, homeassistant_hardware, zha)

Integration zha:
* [ERROR] [DEPENDENCIES] Found a circular dependency with after dependencies of homeassistant_hardware (zha, homeassistant_yellow, homeassistant_hardware)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
