### PR TITLE
Fix lock services not removing entity fields

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -33,6 +33,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.service import remove_entity_service_fields
 from homeassistant.helpers.typing import ConfigType, StateType
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,7 +93,7 @@ async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
         raise ValueError(
             f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
-    await entity.async_lock(**service_call.data)
+    await entity.async_lock(**remove_entity_service_fields(service_call))
 
 
 async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
@@ -102,7 +103,7 @@ async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
         raise ValueError(
             f"Code '{code}' for unlocking {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
-    await entity.async_unlock(**service_call.data)
+    await entity.async_unlock(**remove_entity_service_fields(service_call))
 
 
 async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
@@ -112,7 +113,7 @@ async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
         raise ValueError(
             f"Code '{code}' for opening {entity.entity_id} doesn't match pattern {entity.code_format}"
         )
-    await entity.async_open(**service_call.data)
+    await entity.async_open(**remove_entity_service_fields(service_call))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -514,6 +514,16 @@ async def async_get_all_descriptions(
 
 
 @callback
+def remove_entity_service_fields(call: ServiceCall) -> dict[Any, Any]:
+    """Remove entity service fields."""
+    return {
+        key: val
+        for key, val in call.data.items()
+        if key not in cv.ENTITY_SERVICE_FIELDS
+    }
+
+
+@callback
 @bind_hass
 def async_set_service_schema(
     hass: HomeAssistant, domain: str, service: str, schema: dict[str, Any]
@@ -567,11 +577,7 @@ async def entity_service_call(  # noqa: C901
 
     # If the service function is a string, we'll pass it the service call data
     if isinstance(func, str):
-        data: dict | ServiceCall = {
-            key: val
-            for key, val in call.data.items()
-            if key not in cv.ENTITY_SERVICE_FIELDS
-        }
+        data: dict | ServiceCall = remove_entity_service_fields(call)
     # If the service function is not a string, we pass the service call
     else:
         data = call


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix lock services not removing entity fields (missing from #85842)

This should probably be refactored in the future to change register function to something like the below (untested), but I didn't want to make that large of a change at this stage:
```diff
diff --git a/homeassistant/components/lock/__init__.py b/homeassistant/components/lock/__init__.py
index 86a63538a6..bef8576e78 100644
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -73,48 +73,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_UNLOCK, LOCK_SERVICE_SCHEMA, _async_unlock
+        SERVICE_UNLOCK, LOCK_SERVICE_SCHEMA, "_async_unlock"
     )
     component.async_register_entity_service(
-        SERVICE_LOCK, LOCK_SERVICE_SCHEMA, _async_lock
+        SERVICE_LOCK, LOCK_SERVICE_SCHEMA, "_async_lock"
     )
     component.async_register_entity_service(
-        SERVICE_OPEN, LOCK_SERVICE_SCHEMA, _async_open, [LockEntityFeature.OPEN]
+        SERVICE_OPEN, LOCK_SERVICE_SCHEMA, "_async_open", [LockEntityFeature.OPEN]
     )
 
     return True
 
 
-async def _async_lock(entity: LockEntity, service_call: ServiceCall) -> None:
-    """Lock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
-        raise ValueError(
-            f"Code '{code}' for locking {entity.entity_id} doesn't match pattern {entity.code_format}"
-        )
-    await entity.async_lock(**service_call.data)
-
-
-async def _async_unlock(entity: LockEntity, service_call: ServiceCall) -> None:
-    """Unlock the lock."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
-        raise ValueError(
-            f"Code '{code}' for unlocking {entity.entity_id} doesn't match pattern {entity.code_format}"
-        )
-    await entity.async_unlock(**service_call.data)
-
-
-async def _async_open(entity: LockEntity, service_call: ServiceCall) -> None:
-    """Open the door latch."""
-    code: str = service_call.data.get(ATTR_CODE, "")
-    if entity.code_format_cmp and not entity.code_format_cmp.match(code):
-        raise ValueError(
-            f"Code '{code}' for opening {entity.entity_id} doesn't match pattern {entity.code_format}"
-        )
-    await entity.async_open(**service_call.data)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     component: EntityComponent[LockEntity] = hass.data[DOMAIN]
@@ -198,6 +168,15 @@ class LockEntity(Entity):
         """Lock the lock."""
         await self.hass.async_add_executor_job(ft.partial(self.lock, **kwargs))
 
+    async def _async_lock(self, **kwargs: Any) -> None:
+        """Lock the lock."""
+        code: str = kwargs.get(ATTR_CODE, "")
+        if self.code_format_cmp and not self.code_format_cmp.match(code):
+            raise ValueError(
+                f"Code '{code}' for locking {self.entity_id} doesn't match pattern {self.code_format}"
+            )
+        await self.async_lock(**kwargs)
+
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         raise NotImplementedError()
@@ -206,6 +185,15 @@ class LockEntity(Entity):
         """Unlock the lock."""
         await self.hass.async_add_executor_job(ft.partial(self.unlock, **kwargs))
 
+    async def _async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the lock."""
+        code: str = kwargs.get(ATTR_CODE, "")
+        if self.code_format_cmp and not self.code_format_cmp.match(code):
+            raise ValueError(
+                f"Code '{code}' for unlocking {self.entity_id} doesn't match pattern {self.code_format}"
+            )
+        await self.async_unlock(**kwargs)
+
     def open(self, **kwargs: Any) -> None:
         """Open the door latch."""
         raise NotImplementedError()
@@ -214,6 +202,15 @@ class LockEntity(Entity):
         """Open the door latch."""
         await self.hass.async_add_executor_job(ft.partial(self.open, **kwargs))
 
+    async def _async_open(self, **kwargs: Any) -> None:
+        """Open the door latch."""
+        code: str = kwargs.get(ATTR_CODE, "")
+        if self.code_format_cmp and not self.code_format_cmp.match(code):
+            raise ValueError(
+                f"Code '{code}' for opening {self.entity_id} doesn't match pattern {self.code_format}"
+            )
+        await self.async_open(**kwargs)
+
     @final
     @property
     def state_attributes(self) -> dict[str, StateType]:

```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
