### PR TITLE
Filter replaying unrelated retained MQTT messages when subscribing to share topics

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -623,7 +623,6 @@ class MQTT:
             """Remove subscription."""
             self._async_untrack_subscription(subscription)
             self._matching_subscriptions.cache_clear()
-            # Cleanup the track record for retained topics for this subscription
             if subscription in self._retained_topics:
                 del self._retained_topics[subscription]
             # Only unsubscribe if currently connected

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -376,6 +376,7 @@ class MQTT:
 
         self._simple_subscriptions: dict[str, list[Subscription]] = {}
         self._wildcard_subscriptions: list[Subscription] = []
+        self._retained_init: dict[Subscription, bool] = {}
         self.connected = False
         self._ha_started = asyncio.Event()
         self._cleanup_on_unload: list[Callable[[], None]] = []
@@ -712,6 +713,7 @@ class MQTT:
         # pylint: disable-next=import-outside-toplevel
         import paho.mqtt.client as mqtt
 
+        self._retained_init.clear()
         if result_code != mqtt.CONNACK_ACCEPTED:
             _LOGGER.error(
                 "Unable to connect to the MQTT broker: %s",
@@ -799,6 +801,12 @@ class MQTT:
         subscriptions = self._matching_subscriptions(msg.topic)
 
         for subscription in subscriptions:
+            if (init_status := self._retained_init.get(subscription)) is None:
+                self._retained_init[subscription] = msg.retain
+            if msg.retain and init_status is True:
+                # do not replay already initialized subscriptions
+                continue
+
             payload: SubscribePayloadType = msg.payload
             if subscription.encoding is not None:
                 try:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -806,12 +806,11 @@ class MQTT:
         subscriptions = self._matching_subscriptions(msg.topic)
 
         for subscription in subscriptions:
-            init_status = self._retained_init.setdefault(subscription, set())
-            # skip already initialized subscriptions
-            if msg.topic in init_status:
-                if msg.retain:
+            if msg.retain:
+                init_status = self._retained_init.setdefault(subscription, set())
+                # skip already initialized subscriptions
+                if msg.topic in init_status:
                     continue
-            elif msg.retain:
                 # remember the subscription had an initial retained payload
                 self._retained_init[subscription].add(msg.topic)
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -802,7 +802,11 @@ class MQTT:
 
         for subscription in subscriptions:
             if (init_status := self._retained_init.get(subscription)) is None:
-                self._retained_init[subscription] = msg.retain
+                if subscription in self._wildcard_subscriptions:
+                    self._retained_init[subscription] = False
+                else:
+                    self._retained_init[subscription] = msg.retain
+
             if msg.retain and init_status is True:
                 # do not replay already initialized subscriptions
                 continue

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -620,7 +620,8 @@ class MQTT:
             self._async_untrack_subscription(subscription)
             self._matching_subscriptions.cache_clear()
             # make sure we allow retained payloads when resubscribing
-            del self._retained_init[subscription]
+            if subscription in self._retained_init:
+                del self._retained_init[subscription]
             # Only unsubscribe if currently connected
             if self.connected:
                 self._async_unsubscribe(topic)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -621,7 +621,7 @@ class MQTT:
             """Remove subscription."""
             self._async_untrack_subscription(subscription)
             self._matching_subscriptions.cache_clear()
-            # make sure we allow retained payloads when resubscribing
+            # Make sure we allow retained payloads when resubscribing
             if subscription in self._retained_init:
                 del self._retained_init[subscription]
             # Only unsubscribe if currently connected
@@ -643,7 +643,7 @@ class MQTT:
         if topic in self._max_qos:
             del self._max_qos[topic]
         if topic in self._pending_subscriptions:
-            # avoid any pending subscription to be executed
+            # Avoid any pending subscription to be executed
             del self._pending_subscriptions[topic]
 
         self._pending_unsubscribes.add(topic)
@@ -808,10 +808,10 @@ class MQTT:
         for subscription in subscriptions:
             if msg.retain:
                 init_status = self._retained_init.setdefault(subscription, set())
-                # skip already initialized subscriptions
+                # Skip already initialized subscriptions
                 if msg.topic in init_status:
                     continue
-                # remember the subscription had an initial retained payload
+                # Remember the subscription had an initial retained payload
                 self._retained_init[subscription].add(msg.topic)
 
             payload: SubscribePayloadType = msg.payload

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -808,10 +808,12 @@ class MQTT:
         for subscription in subscriptions:
             init_status = self._retained_init.setdefault(subscription, set())
             # skip already initialized subscriptions
-            if msg.retain and msg.topic in init_status:
-                continue
-            # remember the subscription had an initial payload
-            self._retained_init[subscription].add(msg.topic)
+            if msg.topic in init_status:
+                if msg.retain:
+                    continue
+            elif msg.retain:
+                # remember the subscription had an initial retained payload
+                self._retained_init[subscription].add(msg.topic)
 
             payload: SubscribePayloadType = msg.payload
             if subscription.encoding is not None:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -619,6 +619,8 @@ class MQTT:
             """Remove subscription."""
             self._async_untrack_subscription(subscription)
             self._matching_subscriptions.cache_clear()
+            # make sure we allow retained payloads when resubscribing
+            del self._retained_init[subscription]
             # Only unsubscribe if currently connected
             if self.connected:
                 self._async_unsubscribe(topic)
@@ -713,7 +715,6 @@ class MQTT:
         # pylint: disable-next=import-outside-toplevel
         import paho.mqtt.client as mqtt
 
-        self._retained_init.clear()
         if result_code != mqtt.CONNACK_ACCEPTED:
             _LOGGER.error(
                 "Unable to connect to the MQTT broker: %s",
@@ -758,6 +759,7 @@ class MQTT:
         """Resubscribe on reconnect."""
         # Group subscriptions to only re-subscribe once for each topic.
         self._max_qos.clear()
+        self._retained_init.clear()
         keyfunc = attrgetter("topic")
         self._async_queue_subscriptions(
             [

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -376,6 +376,8 @@ class MQTT:
 
         self._simple_subscriptions: dict[str, list[Subscription]] = {}
         self._wildcard_subscriptions: list[Subscription] = []
+        # _retained_init remembers we had an initial payload and should filter
+        # incoming retained payloads that are stale
         self._retained_init: dict[Subscription, set[str]] = {}
         self.connected = False
         self._ha_started = asyncio.Event()

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1292,9 +1292,8 @@ async def test_subscribe_same_topic(
         calls_b.append(msg)
 
     await mqtt.async_subscribe(hass, "test/state", _callback_a, qos=0)
-    async_fire_mqtt_message(
-        hass, "test/state", "online", qos=0, retain=False
-    )  # Simulate a non retained message after the first subscription
+    # Simulate a non retained message after the first subscription
+    async_fire_mqtt_message(hass, "test/state", "online", qos=0, retain=False)
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(calls_a) == 1
@@ -1305,9 +1304,8 @@ async def test_subscribe_same_topic(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))
     await hass.async_block_till_done()
     await mqtt.async_subscribe(hass, "test/state", _callback_b, qos=1)
-    async_fire_mqtt_message(
-        hass, "test/state", "online", qos=0, retain=False
-    )  # Simulate an other non retained message after the second subscription
+    # Simulate an other non retained message after the second subscription
+    async_fire_mqtt_message(hass, "test/state", "online", qos=0, retain=False)
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1324,7 +1324,7 @@ async def test_subscribe_same_topic(
 async def test_replaying_payload_same_topic(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
-    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test replaying retained messages.
 
@@ -1333,7 +1333,7 @@ async def test_replaying_payload_same_topic(
     Retained messages must only be replayed for new subscriptions, except
     when the MQTT client is reconnection.
     """
-    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
+    mqtt_mock = await mqtt_mock_entry()
 
     # Fake that the client is connected
     mqtt_mock().connected = True
@@ -1411,7 +1411,7 @@ async def test_replaying_payload_same_topic(
 async def test_replaying_payload_after_resubscribing(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
-    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test replaying and filtering retained messages after resubscribing.
 
@@ -1420,7 +1420,7 @@ async def test_replaying_payload_after_resubscribing(
     Retained messages must only be replayed for new subscriptions, except
     when the MQTT client is reconnection.
     """
-    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
+    mqtt_mock = await mqtt_mock_entry()
 
     # Fake that the client is connected
     mqtt_mock().connected = True
@@ -1473,7 +1473,7 @@ async def test_replaying_payload_after_resubscribing(
 async def test_replaying_payload_wildcard_topic(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
-    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test replaying retained messages.
 
@@ -1483,7 +1483,7 @@ async def test_replaying_payload_wildcard_topic(
     Retained messages should only be replayed for new subscriptions, except
     when the MQTT client is reconnection.
     """
-    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
+    mqtt_mock = await mqtt_mock_entry()
 
     # Fake that the client is connected
     mqtt_mock().connected = True

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1358,7 +1358,7 @@ async def test_replaying_payload_same_topic(
     async_fire_mqtt_message(
         hass, "test/state", "online", qos=0, retain=False
     )  # Simulate new message played back on new subscriptions
-    # After connecting the retain f.lag will not be set, even if the
+    # After connecting the retain flag will not be set, even if the
     # payload published was retained, we cannot see that
     await hass.async_block_till_done()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -129,8 +129,8 @@ def help_assert_message(
         match &= msg.payload == payload
     if qos is not None:
         match &= msg.qos == qos
-    if topic is not None:
-        retain &= msg.retain == retain
+    if retain is not None:
+        match &= msg.retain == retain
     return match
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The handling of MQTT messages with the `retain` flag has changed with this PR. 

Each time a new subscription is created to a shared topic, existing subscriptions that already received a retained payload will no longer receive the replayed retained payload except when re-connecting to the broker.

A retain flag is added to a received message when we are (re)subscribing to the broker and (some) retained payload(s) available. The broker will replay these payloads directly after (re)subscribing—also, the same behavior occurs when the connection is lost, and we are reconnecting. When multiple subscriptions subscribe to the same topic, all shared subscriptions receive retained messages. Till this point, the behavior does not change.

When another subscription with `shared` topic(s) is added, we will subscribe to the broker to ensure we receive any retained messages for that new subscription, existing subscriptions (that already received a retained payload and were initialized earlier) will no longer receive the replayed retained payload triggered by the new subscribes.

For wildcards this works different, as there might be more than one payload. for the same subscription.
Basically the change effects shared subscriptions that receive a retained payload on a specific topic. When another shared subscription is added, we resubscribe to make sure any retained payloads are replayed. We only want to receive a retained payload once for a subscription per topic, so we filter out retained payloads when a new subscription is added. When reconnecting we allow replaying retained payloads for all subscriptions once again. I think we should filter out retained payloads for existing subscriptions to avoid the unexpected side effect on current subscriptions to receive a retained payload while that is not expected.

----

This part is communicated via a developers blogpost: https://github.com/home-assistant/developers.home-assistant/pull/1775

The way how MQTT messages with a `retain` flag are handled has changed. Basically a retain flag is added to a received message when we are (re)subscribing to the broker and retained messages are available. The broker will replay these payloads directly after (re)subscribing. Also when the connection was lost, and we are reconnecting, the same behavior is seen. When there are multiple subscriptions that subscribe to the same topic, all shared subscriptions are receiving the retained messages. Up until this point the behavior has not changed.
When another subscription with `shared` topic(s) is added, we will resubscribe to the broker to ensure we receive any retained messages for that new subscription. Existing subscriptions (that already received a retained payload and were initialized earlier) will no longer receive the replayed retained payload triggered by the new subscribes. This will improve performance.

> After replaying retained message the broker will send updates without a `retain` flag even when the remote client published with a `retain` flag, hence we cannot tell if that update was `retained`. See OASIS MQTT Version 3.1.1 spec ([on how the RETAIN flag is used](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349265)) and Normative Statement Number [MQTT-3.3.1-9](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718134).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
