### PR TITLE
Adjust registry access in openai_conversation

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, TemplateError
-from homeassistant.helpers import area_registry, intent, template
+from homeassistant.helpers import area_registry as ar, intent, template
 from homeassistant.util import ulid
 
 from .const import (
@@ -150,7 +150,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
-                "areas": list(area_registry.async_get(self.hass).areas.values()),
+                "areas": list(ar.async_get(self.hass).areas.values()),
             },
             parse_result=False,
         )

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -5,20 +5,22 @@ from openai import error
 
 from homeassistant.components import conversation
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import area_registry, device_registry, intent
+from homeassistant.helpers import area_registry as ar, device_registry as dr, intent
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
+async def test_default_prompt(
+    hass: HomeAssistant,
+    mock_init_component,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
     """Test that the default prompt works."""
-    device_reg = device_registry.async_get(hass)
-    area_reg = area_registry.async_get(hass)
-
     for i in range(3):
-        area_reg.async_create(f"{i}Empty Area")
+        area_registry.async_create(f"{i}Empty Area")
 
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "1234")},
         name="Test Device",
@@ -27,16 +29,16 @@ async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
         suggested_area="Test Area",
     )
     for i in range(3):
-        device_reg.async_get_or_create(
+        device_registry.async_get_or_create(
             config_entry_id="1234",
             connections={("test", f"{i}abcd")},
             name="Test Service",
             manufacturer="Test Manufacturer",
             model="Test Model",
             suggested_area="Test Area",
-            entry_type=device_registry.DeviceEntryType.SERVICE,
+            entry_type=dr.DeviceEntryType.SERVICE,
         )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "5678")},
         name="Test Device 2",
@@ -44,7 +46,7 @@ async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
         model="Device 2",
         suggested_area="Test Area 2",
     )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "9876")},
         name="Test Device 3",
@@ -52,13 +54,13 @@ async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
         model="Test Model 3A",
         suggested_area="Test Area 2",
     )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "qwer")},
         name="Test Device 4",
         suggested_area="Test Area 2",
     )
-    device = device_reg.async_get_or_create(
+    device = device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "9876-disabled")},
         name="Test Device 3",
@@ -66,17 +68,17 @@ async def test_default_prompt(hass: HomeAssistant, mock_init_component) -> None:
         model="Test Model 3A",
         suggested_area="Test Area 2",
     )
-    device_reg.async_update_device(
-        device.id, disabled_by=device_registry.DeviceEntryDisabler.USER
+    device_registry.async_update_device(
+        device.id, disabled_by=dr.DeviceEntryDisabler.USER
     )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "9876-no-name")},
         manufacturer="Test Manufacturer NoName",
         model="Test Model NoName",
         suggested_area="Test Area 2",
     )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id="1234",
         connections={("test", "9876-integer-values")},
         name=1,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #88875

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
