### PR TITLE
Abort Hue config flow if bridge can not be reached

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -152,7 +152,6 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({"host": user_input["host"]})
         bridge = await self._get_bridge(user_input[CONF_HOST])
         if bridge is None:
-            LOGGER.error("Error connecting to the Hue bridge at %s", user_input["host"])
             return self.async_abort(reason="cannot_connect")
         self.bridge = bridge
         return await self.async_step_link()
@@ -235,9 +234,6 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             discovery_info.host, discovery_info.properties["bridgeid"]
         )
         if bridge is None:
-            LOGGER.error(
-                "Error connecting to the Hue bridge at %s", discovery_info.host
-            )
             return self.async_abort(reason="cannot_connect")
         self.bridge = bridge
         return await self.async_step_link()
@@ -253,9 +249,6 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """
         bridge = await self._get_bridge(discovery_info.host)
         if bridge is None:
-            LOGGER.error(
-                "Error connecting to the Hue bridge at %s", discovery_info.host
-            )
             return self.async_abort(reason="cannot_connect")
         self.bridge = bridge
         await self._async_handle_discovery_without_unique_id()
@@ -275,9 +268,6 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         bridge = await self._get_bridge(import_info["host"])
         if bridge is None:
-            LOGGER.error(
-                "Error connecting to the Hue bridge at %s", import_info["host"]
-            )
             return self.async_abort(reason="cannot_connect")
         self.bridge = bridge
         return await self.async_step_link()

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -75,7 +75,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             bridge = await discover_bridge(
                 host, websession=aiohttp_client.async_get_clientsession(self.hass)
             )
-        except aiohttp.ClientError:
+        except aiohttp.ClientError as err:
+            LOGGER.warning(
+                "Error while attempting to retrieve discovery information, "
+                "is there a bridge alive on IP %s ?",
+                host,
+                exc_info=err,
+            )
             return None
         if bridge_id is not None:
             bridge_id = normalize_bridge_id(bridge_id)
@@ -144,7 +150,11 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._async_abort_entries_match({"host": user_input["host"]})
-        self.bridge = await self._get_bridge(user_input[CONF_HOST])
+        bridge = await self._get_bridge(user_input[CONF_HOST])
+        if bridge is None:
+            LOGGER.error("Error connecting to the Hue bridge at %s", user_input["host"])
+            return self.async_abort(reason="cannot_connect")
+        self.bridge = bridge
         return await self.async_step_link()
 
     async def async_step_link(
@@ -221,9 +231,15 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         # we need to query the other capabilities too
-        self.bridge = await self._get_bridge(
+        bridge = await self._get_bridge(
             discovery_info.host, discovery_info.properties["bridgeid"]
         )
+        if bridge is None:
+            LOGGER.error(
+                "Error connecting to the Hue bridge at %s", discovery_info.host
+            )
+            return self.async_abort(reason="cannot_connect")
+        self.bridge = bridge
         return await self.async_step_link()
 
     async def async_step_homekit(
@@ -235,7 +251,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         as the unique identifier. Therefore, this method uses discovery without
         a unique ID.
         """
-        self.bridge = await self._get_bridge(discovery_info.host)
+        bridge = await self._get_bridge(discovery_info.host)
+        if bridge is None:
+            LOGGER.error(
+                "Error connecting to the Hue bridge at %s", discovery_info.host
+            )
+            return self.async_abort(reason="cannot_connect")
+        self.bridge = bridge
         await self._async_handle_discovery_without_unique_id()
         return await self.async_step_link()
 
@@ -251,7 +273,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Check if host exists, abort if so.
         self._async_abort_entries_match({"host": import_info["host"]})
 
-        self.bridge = await self._get_bridge(import_info["host"])
+        bridge = await self._get_bridge(import_info["host"])
+        if bridge is None:
+            LOGGER.error(
+                "Error connecting to the Hue bridge at %s", import_info["host"]
+            )
+            return self.async_abort(reason="cannot_connect")
+        self.bridge = bridge
         return await self.async_step_link()
 
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -150,8 +150,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._async_abort_entries_match({"host": user_input["host"]})
-        bridge = await self._get_bridge(user_input[CONF_HOST])
-        if bridge is None:
+        if (bridge := await self._get_bridge(user_input[CONF_HOST])) is None:
             return self.async_abort(reason="cannot_connect")
         self.bridge = bridge
         return await self.async_step_link()

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
-from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.test_util.aiohttp import AiohttpClientMocker, ClientError
 
 
 @pytest.fixture(name="hue_setup", autouse=True)
@@ -645,3 +645,67 @@ async def test_bridge_zeroconf_ipv6(hass: HomeAssistant) -> None:
 
     assert result["type"] == "abort"
     assert result["reason"] == "invalid_host"
+
+
+async def test_bridge_connection_failed(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that connection errors to the bridge are handled."""
+    create_mock_api_discovery(aioclient_mock, [])
+
+    with patch(
+        "homeassistant.components.hue.config_flow.discover_bridge",
+        side_effect=ClientError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"host": "blah"}
+        )
+
+        # a warning message should have been logged that the bridge could not be reached
+        assert "Error while attempting to retrieve discovery information" in caplog.text
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"
+
+        # test again with zeroconf discovered wrong bridge IP
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=zeroconf.ZeroconfServiceInfo(
+                host="blah",
+                addresses=["1.2.3.4"],
+                port=443,
+                hostname="Philips-hue.local",
+                type="_hue._tcp.local.",
+                name="Philips Hue - ABCABC._hue._tcp.local.",
+                properties={
+                    "_raw": {"bridgeid": b"ecb5fafffeabcabc", "modelid": b"BSB002"},
+                    "bridgeid": "ecb5fafffeabcabc",
+                    "modelid": "BSB002",
+                },
+            ),
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"
+
+        # test again with homekit discovered wrong bridge IP
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN,
+            context={"source": config_entries.SOURCE_HOMEKIT},
+            data=zeroconf.ZeroconfServiceInfo(
+                host="0.0.0.0",
+                addresses=["0.0.0.0"],
+                hostname="mock_hostname",
+                name="mock_name",
+                port=None,
+                properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+                type="mock_type",
+            ),
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -709,3 +709,12 @@ async def test_bridge_connection_failed(
         )
         assert result["type"] == "abort"
         assert result["reason"] == "cannot_connect"
+
+        # repeat test with import flow
+        result = await hass.config_entries.flow.async_init(
+            const.DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": "blah"},
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
## Proposed change
It seems that sometimes the wrong ip reaches the discovery flow causing the setup to fail unexpectedly. Add some guards and logging in the code for when that happens.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #85909
- This PR is related to issue: #86872
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
