### PR TITLE
Fix removal of non device-bound resources in Hue

### DIFF
--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -55,7 +55,13 @@ class HueBaseEntity(Entity):
         self._attr_unique_id = resource.id
         # device is precreated in main handler
         # this attaches the entity to the precreated device
-        if self.device is not None:
+        if self.device is None:
+            # attach all device-less entities to the bridge itself
+            # e.g. config based sensors like entertainment area
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, bridge.api.config.bridge.bridge_id)},
+            )
+        else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self.device.id)},
             )
@@ -137,17 +143,14 @@ class HueBaseEntity(Entity):
     def _handle_event(self, event_type: EventType, resource: HueResource) -> None:
         """Handle status event for this resource (or it's parent)."""
         if event_type == EventType.RESOURCE_DELETED:
-            # remove any services created for zones/rooms
+            # handle removal of room and zone 'virtual' devices/services
             # regular devices are removed automatically by the logic in device.py.
             if resource.type in (ResourceTypes.ROOM, ResourceTypes.ZONE):
                 dev_reg = async_get_device_registry(self.hass)
                 if device := dev_reg.async_get_device({(DOMAIN, resource.id)}):
                     dev_reg.async_remove_device(device.id)
-            if resource.type in (
-                ResourceTypes.GROUPED_LIGHT,
-                ResourceTypes.SCENE,
-                ResourceTypes.SMART_SCENE,
-            ):
+            # cleanup entities that are not strictly device-bound and have the bridge as parent
+            if self.device is None:
                 ent_reg = async_get_entity_registry(self.hass)
                 ent_reg.async_remove(self.entity_id)
             return


### PR DESCRIPTION
## Proposed change
Fix removal of non device-bound resources (like entertainment areas), otherwise they'd become orphan entities when removed from the bridge.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #88494
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
