### PR TITLE
Bump aiohue library to version 4.6.2

### DIFF
--- a/homeassistant/components/hue/logbook.py
+++ b/homeassistant/components/hue/logbook.py
@@ -35,6 +35,7 @@ TRIGGER_TYPE = {
     "remote_double_button_long_press": "both {subtype} released after long press",
     "remote_double_button_short_press": "both {subtype} released",
     "initial_press": "{subtype} pressed initially",
+    "long_press": "{subtype} long press",
     "repeat": "{subtype} held down",
     "short_release": "{subtype} released after short press",
     "long_release": "{subtype} released after long press",

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "local_push",
   "loggers": ["aiohue"],
   "quality_scale": "platinum",
-  "requirements": ["aiohue==4.6.1"],
+  "requirements": ["aiohue==4.6.2"],
   "zeroconf": ["_hue._tcp.local."]
 }

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -46,6 +46,7 @@ DEFAULT_BUTTON_EVENT_TYPES = (
     ButtonEvent.INITIAL_PRESS,
     ButtonEvent.REPEAT,
     ButtonEvent.SHORT_RELEASE,
+    ButtonEvent.LONG_PRESS,
     ButtonEvent.LONG_RELEASE,
 )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -181,7 +181,7 @@ aiohomekit==2.6.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==4.6.1
+aiohue==4.6.2
 
 # homeassistant.components.imap
 aioimaplib==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -165,7 +165,7 @@ aiohomekit==2.6.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==4.6.1
+aiohue==4.6.2
 
 # homeassistant.components.imap
 aioimaplib==1.0.1

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -84,6 +84,7 @@ async def test_get_triggers(
             }
             for event_type in (
                 ButtonEvent.INITIAL_PRESS,
+                ButtonEvent.LONG_PRESS,
                 ButtonEvent.LONG_RELEASE,
                 ButtonEvent.REPEAT,
                 ButtonEvent.SHORT_RELEASE,


### PR DESCRIPTION
## Proposed change
Bump aiohue library to version 4.6.2, which contains various bugfixes, especially for value parse errors printed in the log and the missing "long press" event for remotes.

Releasenotes:
https://github.com/home-assistant-libs/aiohue/releases/tag/4.6.2

## Type of change

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
