### PR TITLE
Small improvements to middleware filter

### DIFF
--- a/tests/components/http/test_security_filter.py
+++ b/tests/components/http/test_security_filter.py
@@ -49,7 +49,17 @@ async def test_ok_requests(
         ("/", {"test": "test/../../api"}, True),
         ("/", {"test": "/test/%2E%2E%2f%2E%2E%2fapi"}, True),
         ("/", {"test": "test/%2E%2E%2f%2E%2E%2fapi"}, True),
+        ("/", {"test": "test/%252E%252E/api"}, True),
+        ("/", {"test": "test/%252E%252E%2fapi"}, True),
+        (
+            "/",
+            {"test": "test/%2525252E%2525252E%2525252f%2525252E%2525252E%2525252fapi"},
+            True,
+        ),
+        ("/test/.%252E/api", {}, False),
+        ("/test/%252E%252E/api", {}, False),
         ("/test/%2E%2E%2f%2E%2E%2fapi", {}, False),
+        ("/test/%2525252E%2525252E%2525252f%2525252E%2525252E/api", {}, False),
         ("/", {"sql": ";UNION SELECT (a, b"}, True),
         ("/", {"sql": "UNION%20SELECT%20%28a%2C%20b"}, True),
         ("/UNION%20SELECT%20%28a%2C%20b", {}, False),
@@ -87,7 +97,7 @@ async def test_bad_requests(
         None,
         http.request,
         "GET",
-        f"http://{mock_api_client.host}:{mock_api_client.port}/{request_path}{man_params}",
+        f"http://{mock_api_client.host}:{mock_api_client.port}{request_path}{man_params}",
         request_params,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some small improvements to our middleware filter. This PR builds on top of f047d04 (no PR) and #45179.

Improvements include:
- Catch encoded paths/query_strings that have been encoded multiple times
- Superfluous slash in the tested URL sneaked into the tests, basically affecting all tests to have an additional slash in their path (`//`, instead of `/`)
- Stupid typo in a doc string `tblock` -> `block` 🙈 

Considering the small impact, it might be nice to include this into the current beta. I've added tests to ensure it is working as intended.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
