### PR TITLE
Bump auroranoaa to 0.0.3

### DIFF
--- a/homeassistant/components/aurora/manifest.json
+++ b/homeassistant/components/aurora/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/aurora",
   "iot_class": "cloud_polling",
   "loggers": ["auroranoaa"],
-  "requirements": ["auroranoaa==0.0.2"]
+  "requirements": ["auroranoaa==0.0.3"]
 }

--- a/homeassistant/components/aurora/sensor.py
+++ b/homeassistant/components/aurora/sensor.py
@@ -1,5 +1,5 @@
 """Support for Aurora Forecast sensor."""
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
@@ -33,3 +33,8 @@ class AuroraSensor(AuroraEntity, SensorEntity):
     def native_value(self):
         """Return % chance the aurora is visible."""
         return self.coordinator.data
+
+    @property
+    def state_class(self):
+        """Return state class for measurement."""
+        return SensorStateClass.MEASUREMENT

--- a/homeassistant/components/aurora/sensor.py
+++ b/homeassistant/components/aurora/sensor.py
@@ -1,5 +1,5 @@
 """Support for Aurora Forecast sensor."""
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
@@ -33,8 +33,3 @@ class AuroraSensor(AuroraEntity, SensorEntity):
     def native_value(self):
         """Return % chance the aurora is visible."""
         return self.coordinator.data
-
-    @property
-    def state_class(self):
-        """Return state class for measurement."""
-        return SensorStateClass.MEASUREMENT

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ asyncsleepiq==1.2.3
 atenpdu==0.3.2
 
 # homeassistant.components.aurora
-auroranoaa==0.0.2
+auroranoaa==0.0.3
 
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -334,7 +334,7 @@ async-upnp-client==0.33.1
 asyncsleepiq==1.2.3
 
 # homeassistant.components.aurora
-auroranoaa==0.0.2
+auroranoaa==0.0.3
 
 # homeassistant.components.aurora_abb_powerone
 aurorapy==0.2.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Bumps version of aurora api to fix issues with NOAA value conversion to fix #82587 
Aurora API Changes Diff: https://github.com/djtimca/aurora-api/compare/2b79c03..94f8583
Add state_class to aurora sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #82587 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
