### PR TITLE
Adjust entity registry access in homekit tests

### DIFF
--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -10,7 +10,7 @@ from homeassistant.components.homekit.accessories import HomeDriver
 from homeassistant.components.homekit.const import BRIDGE_NAME, EVENT_HOMEKIT_CHANGED
 from homeassistant.components.homekit.iidmanager import AccessoryIIDStorage
 
-from tests.common import async_capture_events, mock_device_registry, mock_registry
+from tests.common import async_capture_events
 
 
 @pytest.fixture
@@ -101,18 +101,6 @@ def mock_hap(hass, event_loop, iid_storage, mock_zeroconf):
 def events(hass):
     """Yield caught homekit_changed events."""
     return async_capture_events(hass, EVENT_HOMEKIT_CHANGED)
-
-
-@pytest.fixture(name="device_reg")
-def device_reg_fixture(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture(name="entity_reg")
-def entity_reg_fixture(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 @pytest.fixture

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.homekit.const import (
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import RegistryEntry, RegistryEntryHider
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entityfilter import CONF_INCLUDE_DOMAINS
 from homeassistant.setup import async_setup_component
 
@@ -398,8 +398,8 @@ async def test_options_flow_devices(
     port_mock,
     hass: HomeAssistant,
     demo_cleanup,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     mock_get_source_ip,
     mock_async_zeroconf: None,
 ) -> None:
@@ -451,7 +451,7 @@ async def test_options_flow_devices(
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "exclude"
 
-    entry = entity_reg.async_get("light.ceiling_lights")
+    entry = entity_registry.async_get("light.ceiling_lights")
     assert entry is not None
     device_id = entry.device_id
 
@@ -1379,7 +1379,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
     mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
-    entity_reg,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure exclude mode does not offer category entities."""
     config_entry = _mock_config_entry_with_options_populated()
@@ -1389,7 +1389,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
     hass.states.async_set("media_player.sonos", "off")
     hass.states.async_set("switch.other", "off")
 
-    sonos_config_switch: RegistryEntry = entity_reg.async_get_or_create(
+    sonos_config_switch = entity_registry.async_get_or_create(
         "switch",
         "sonos",
         "config",
@@ -1398,7 +1398,7 @@ async def test_options_flow_exclude_mode_skips_category_entities(
     )
     hass.states.async_set(sonos_config_switch.entity_id, "off")
 
-    sonos_notconfig_switch: RegistryEntry = entity_reg.async_get_or_create(
+    sonos_notconfig_switch = entity_registry.async_get_or_create(
         "switch",
         "sonos",
         "notconfig",
@@ -1484,7 +1484,7 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
     mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
-    entity_reg,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure exclude mode does not offer hidden entities."""
     config_entry = _mock_config_entry_with_options_populated()
@@ -1494,12 +1494,12 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
     hass.states.async_set("media_player.sonos", "off")
     hass.states.async_set("switch.other", "off")
 
-    sonos_hidden_switch: RegistryEntry = entity_reg.async_get_or_create(
+    sonos_hidden_switch = entity_registry.async_get_or_create(
         "switch",
         "sonos",
         "config",
         device_id="1234",
-        hidden_by=RegistryEntryHider.INTEGRATION,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
     )
     hass.states.async_set(sonos_hidden_switch.entity_id, "off")
     await hass.async_block_till_done()
@@ -1569,7 +1569,7 @@ async def test_options_flow_include_mode_allows_hidden_entities(
     mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
-    entity_reg,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure include mode does not offer hidden entities."""
     config_entry = _mock_config_entry_with_options_populated()
@@ -1579,12 +1579,12 @@ async def test_options_flow_include_mode_allows_hidden_entities(
     hass.states.async_set("media_player.sonos", "off")
     hass.states.async_set("switch.other", "off")
 
-    sonos_hidden_switch: RegistryEntry = entity_reg.async_get_or_create(
+    sonos_hidden_switch = entity_registry.async_get_or_create(
         "switch",
         "sonos",
         "config",
         device_id="1234",
-        hidden_by=RegistryEntryHider.INTEGRATION,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
     )
     hass.states.async_set(sonos_hidden_switch.entity_id, "off")
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_diagnostics.py
+++ b/tests/components/homekit/test_diagnostics.py
@@ -9,6 +9,7 @@ from homeassistant.components.homekit.const import (
 )
 from homeassistant.const import CONF_NAME, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .util import async_init_integration
@@ -314,8 +315,8 @@ async def test_config_entry_with_trigger_accessory(
     mock_async_zeroconf: None,
     events,
     demo_cleanup,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test generating diagnostics for a bridge config entry with a trigger accessory."""
     assert await async_setup_component(hass, "demo", {"demo": {}})
@@ -326,7 +327,7 @@ async def test_config_entry_with_trigger_accessory(
     assert await async_setup_component(hass, "demo", {"demo": {}})
     await hass.async_block_till_done()
 
-    entry = entity_reg.async_get("light.ceiling_lights")
+    entry = entity_registry.async_get("light.ceiling_lights")
     assert entry is not None
     device_id = entry.device_id
 

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .util import PATH_HOMEKIT
@@ -71,7 +72,7 @@ async def test_bridge_with_triggers(
     hass: HomeAssistant,
     hk_driver,
     mock_async_zeroconf: None,
-    entity_reg,
+    entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we can setup a bridge with triggers and we ignore numeric states.
@@ -83,7 +84,7 @@ async def test_bridge_with_triggers(
     assert await async_setup_component(hass, "demo", {"demo": {}})
     await hass.async_block_till_done()
 
-    entry = entity_reg.async_get("cover.living_room_window")
+    entry = entity_registry.async_get("cover.living_room_window")
     assert entry is not None
     device_id = entry.device_id
 

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -6,13 +6,19 @@ from homeassistant.components.homekit.const import CHAR_PROGRAMMABLE_SWITCH_EVEN
 from homeassistant.components.homekit.type_triggers import DeviceTriggerAccessory
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_programmable_switch_button_fires_on_trigger(
-    hass: HomeAssistant, hk_driver, events, demo_cleanup, device_reg, entity_reg
+    hass: HomeAssistant,
+    hk_driver,
+    events,
+    demo_cleanup,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""
     hk_driver.publish = MagicMock()
@@ -24,7 +30,7 @@ async def test_programmable_switch_button_fires_on_trigger(
     hass.states.async_set("light.ceiling_lights", STATE_OFF)
     await hass.async_block_till_done()
 
-    entry = entity_reg.async_get("light.ceiling_lights")
+    entry = entity_registry.async_get("light.ceiling_lights")
     assert entry is not None
     device_id = entry.device_id
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #88875
I have also adjusted to use registry fixtures where applicable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
