### PR TITLE
Improve threshold binary sensor

### DIFF
--- a/tests/components/threshold/test_binary_sensor.py
+++ b/tests/components/threshold/test_binary_sensor.py
@@ -29,8 +29,8 @@ async def test_sensor_upper(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 15)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "below"
+    assert state.state == "off"
 
     hass.states.async_set(
         "sensor.test_monitored",
@@ -63,12 +63,12 @@ async def test_sensor_upper(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 15)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
+    assert state.attributes["position"] == "below"
     assert state.state == "off"
 
 
@@ -89,8 +89,8 @@ async def test_sensor_lower(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 15)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "above"
+    assert state.state == "off"
 
     hass.states.async_set("sensor.test_monitored", 16)
     await hass.async_block_till_done()
@@ -117,12 +117,12 @@ async def test_sensor_lower(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 15)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
+    assert state.attributes["position"] == "above"
     assert state.state == "off"
 
 
@@ -144,15 +144,15 @@ async def test_sensor_upper_hysteresis(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 17.5)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "below"
+    assert state.state == "off"
 
     # Set the monitored sensor's state to the threshold - hysteresis
     hass.states.async_set("sensor.test_monitored", 12.5)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "below"
+    assert state.state == "off"
 
     hass.states.async_set("sensor.test_monitored", 20)
     await hass.async_block_till_done()
@@ -192,7 +192,7 @@ async def test_sensor_upper_hysteresis(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 18)
     await hass.async_block_till_done()
@@ -219,15 +219,15 @@ async def test_sensor_lower_hysteresis(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 17.5)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "above"
+    assert state.state == "off"
 
     # Set the monitored sensor's state to the threshold - hysteresis
     hass.states.async_set("sensor.test_monitored", 12.5)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "above"
+    assert state.state == "off"
 
     hass.states.async_set("sensor.test_monitored", 20)
     await hass.async_block_till_done()
@@ -267,7 +267,7 @@ async def test_sensor_lower_hysteresis(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 18)
     await hass.async_block_till_done()
@@ -294,15 +294,15 @@ async def test_sensor_in_range_no_hysteresis(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 10)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     # Set the monitored sensor's state to the upper threshold
     hass.states.async_set("sensor.test_monitored", 20)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     hass.states.async_set(
         "sensor.test_monitored",
@@ -336,7 +336,7 @@ async def test_sensor_in_range_no_hysteresis(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 21)
     await hass.async_block_till_done()
@@ -364,29 +364,29 @@ async def test_sensor_in_range_with_hysteresis(hass: HomeAssistant) -> None:
     hass.states.async_set("sensor.test_monitored", 8)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     # Set the monitored sensor's state to the lower threshold + hysteresis
     hass.states.async_set("sensor.test_monitored", 12)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     # Set the monitored sensor's state to the upper threshold + hysteresis
     hass.states.async_set("sensor.test_monitored", 22)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     # Set the monitored sensor's state to the upper threshold - hysteresis
     hass.states.async_set("sensor.test_monitored", 18)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.attributes["position"] == "in_range"
+    assert state.state == "on"
 
     hass.states.async_set(
         "sensor.test_monitored",
@@ -460,7 +460,7 @@ async def test_sensor_in_range_with_hysteresis(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", 17)
     await hass.async_block_till_done()
@@ -507,13 +507,13 @@ async def test_sensor_in_range_unknown_state(
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     hass.states.async_set("sensor.test_monitored", STATE_UNAVAILABLE)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "off"
+    assert state.state == "unknown"
 
     assert "State is not numerical" not in caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The behavior of threshold binary sensor has changed:
- The threshold binary sensor's state is reset to "unknown" when the monitored sensor's state is unknown, unavailable or not a valid float
- When the monitored sensor's state is first valid, or when it's valid after being unknown, unavailable or not a valid float:
  - Initialize a threshold sensor with only a lower threshold to state `off`, with the `position` attribute set to `above`
  - Initialize a threshold sensor with only an upperthreshold to state `off`, with the `position` attribute set to `below`
  - Initialize a threshold sensor with only both an upper and a lower threshold to state `on`, with the `position` attribute set to `in_range`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve threshold binary sensor:
- Reset the threshold binary sensor's state to "unknown" when the monitored sensor's state is unknown, unavailable or not a valid float
- When the monitored sensor's state is first valid, or when it's valid after being unknown, unavailable or not a valid float:
  - Initialize a threshold sensor with only a lower threshold to state `off`, with the `position` attribute set to `above`
  - Initialize a threshold sensor with only an upperthreshold to state `off`, with the `position` attribute set to `below`
  - Initialize a threshold sensor with only both an upper and a lower threshold to state `on`, with the `position` attribute set to `in_range`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/83018

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
