### PR TITLE
Cleanup plex config flow tests

### DIFF
--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
 from .helpers import trigger_plex_update, wait_for_debouncer
@@ -55,7 +56,7 @@ async def test_bad_credentials(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -66,14 +67,14 @@ async def test_bad_credentials(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result["type"] == "form"
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"][CONF_TOKEN] == "faulty_credentials"
 
@@ -85,7 +86,7 @@ async def test_bad_hostname(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch(
@@ -97,14 +98,14 @@ async def test_bad_hostname(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        assert result["type"] == "form"
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"][CONF_HOST] == "not_found"
 
@@ -116,7 +117,7 @@ async def test_unknown_exception(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexapi.myplex.MyPlexAccount", side_effect=Exception), patch(
@@ -125,13 +126,13 @@ async def test_unknown_exception(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "abort"
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "unknown"
 
 
@@ -148,7 +149,7 @@ async def test_no_servers_found(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
@@ -157,13 +158,13 @@ async def test_no_servers_found(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "form"
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "no_servers"
 
@@ -175,7 +176,7 @@ async def test_single_available_server(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
@@ -184,25 +185,22 @@ async def test_single_available_server(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "create_entry"
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
-        server_id = result["data"][CONF_SERVER_IDENTIFIER]
-        mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
-
-        assert result["title"] == mock_plex_server.url_in_use
-        assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
-            result["data"][CONF_SERVER_IDENTIFIER]
-            == mock_plex_server.machine_identifier
+            result["title"] == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
+        assert result["data"][CONF_SERVER] == "Plex Server 1"
+        assert result["data"][CONF_SERVER_IDENTIFIER] == "unique_id_123"
         assert (
-            result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use
+            result["data"][PLEX_SERVER_CONFIG][CONF_URL]
+            == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
         assert result["data"][PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
@@ -220,7 +218,7 @@ async def test_multiple_servers_with_selection(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     requests_mock.get(
@@ -233,13 +231,13 @@ async def test_multiple_servers_with_selection(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "form"
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "select_server"
 
         result = await hass.config_entries.flow.async_configure(
@@ -248,19 +246,16 @@ async def test_multiple_servers_with_selection(
                 CONF_SERVER_IDENTIFIER: MOCK_SERVERS[0][CONF_SERVER_IDENTIFIER]
             },
         )
-        assert result["type"] == "create_entry"
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
-        server_id = result["data"][CONF_SERVER_IDENTIFIER]
-        mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
-
-        assert result["title"] == mock_plex_server.url_in_use
-        assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
-            result["data"][CONF_SERVER_IDENTIFIER]
-            == mock_plex_server.machine_identifier
+            result["title"] == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
+        assert result["data"][CONF_SERVER] == "Plex Server 1"
+        assert result["data"][CONF_SERVER_IDENTIFIER] == "unique_id_123"
         assert (
-            result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use
+            result["data"][PLEX_SERVER_CONFIG][CONF_URL]
+            == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
         assert result["data"][PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
@@ -286,7 +281,7 @@ async def test_adding_last_unconfigured_server(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     requests_mock.get(
@@ -300,25 +295,22 @@ async def test_adding_last_unconfigured_server(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "create_entry"
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
-        server_id = result["data"][CONF_SERVER_IDENTIFIER]
-        mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
-
-        assert result["title"] == mock_plex_server.url_in_use
-        assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
-            result["data"][CONF_SERVER_IDENTIFIER]
-            == mock_plex_server.machine_identifier
+            result["title"] == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
+        assert result["data"][CONF_SERVER] == "Plex Server 1"
+        assert result["data"][CONF_SERVER_IDENTIFIER] == "unique_id_123"
         assert (
-            result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use
+            result["data"][PLEX_SERVER_CONFIG][CONF_URL]
+            == "https://1-2-3-4.123456789001234567890.plex.direct:32400"
         )
         assert result["data"][PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
@@ -347,7 +339,7 @@ async def test_all_available_servers_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     requests_mock.get("https://plex.tv/users/account", text=plextv_account)
@@ -362,13 +354,13 @@ async def test_all_available_servers_configured(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "abort"
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "all_configured"
 
 
@@ -380,7 +372,7 @@ async def test_option_flow(hass: HomeAssistant, entry, mock_plex_server) -> None
     result = await hass.config_entries.options.async_init(
         entry.entry_id, context={"source": "test"}, data=None
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "plex_mp_settings"
 
     result = await hass.config_entries.options.async_configure(
@@ -391,7 +383,7 @@ async def test_option_flow(hass: HomeAssistant, entry, mock_plex_server) -> None
             CONF_MONITORED_USERS: list(mock_plex_server.accounts),
         },
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         Platform.MEDIA_PLAYER: {
             CONF_USE_EPISODE_ART: True,
@@ -414,7 +406,7 @@ async def test_missing_option_flow(
     result = await hass.config_entries.options.async_init(
         entry.entry_id, context={"source": "test"}, data=None
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "plex_mp_settings"
 
     result = await hass.config_entries.options.async_configure(
@@ -425,7 +417,7 @@ async def test_missing_option_flow(
             CONF_MONITORED_USERS: list(mock_plex_server.accounts),
         },
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         Platform.MEDIA_PLAYER: {
             CONF_USE_EPISODE_ART: True,
@@ -451,7 +443,7 @@ async def test_option_flow_new_users_available(
     mock_plex_server = await setup_plex_server(config_entry=entry)
     await hass.async_block_till_done()
 
-    server_id = mock_plex_server.machine_identifier
+    server_id = "unique_id_123"
     monitored_users = hass.data[DOMAIN][SERVERS][server_id].option_monitored_users
 
     new_users = [x for x in mock_plex_server.accounts if x not in monitored_users]
@@ -461,7 +453,7 @@ async def test_option_flow_new_users_available(
     result = await hass.config_entries.options.async_init(
         entry.entry_id, context={"source": "test"}, data=None
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "plex_mp_settings"
     multiselect_defaults = result["data_schema"].schema["monitored_users"].options
 
@@ -477,7 +469,7 @@ async def test_external_timed_out(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
@@ -486,13 +478,13 @@ async def test_external_timed_out(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "abort"
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "token_request_timeout"
 
 
@@ -505,7 +497,7 @@ async def test_callback_view(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
@@ -514,7 +506,7 @@ async def test_callback_view(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         client = await hass_client_no_auth()
         forward_url = f'{config_flow.AUTH_CALLBACK_PATH}?flow_id={result["flow_id"]}'
@@ -541,7 +533,7 @@ async def test_manual_config(
         config_flow.DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["data_schema"] is None
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -553,7 +545,7 @@ async def test_manual_config(
     )
 
     assert result["data_schema"] is not None
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user_advanced"
 
     with patch("plexauth.PlexAuth.initiate_auth"):
@@ -561,7 +553,7 @@ async def test_manual_config(
             result["flow_id"], user_input={"setup_method": AUTOMATIC_SETUP_STRING}
         )
 
-    assert result["type"] == "external"
+    assert result["type"] == FlowResultType.EXTERNAL_STEP
     hass.config_entries.flow.async_abort(result["flow_id"])
 
     # Advanced manual
@@ -571,14 +563,14 @@ async def test_manual_config(
     )
 
     assert result["data_schema"] is not None
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user_advanced"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"setup_method": MANUAL_SETUP_STRING}
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
 
     MANUAL_SERVER = {
@@ -599,7 +591,7 @@ async def test_manual_config(
         result["flow_id"], user_input=MANUAL_SERVER_NO_HOST_OR_TOKEN
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
     assert result["errors"]["base"] == "host_or_token"
 
@@ -611,7 +603,7 @@ async def test_manual_config(
             result["flow_id"], user_input=MANUAL_SERVER
         )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
     assert result["errors"]["base"] == "ssl_error"
 
@@ -623,7 +615,7 @@ async def test_manual_config(
             result["flow_id"], user_input=MANUAL_SERVER
         )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
     assert result["errors"]["base"] == "ssl_error"
 
@@ -635,7 +627,7 @@ async def test_manual_config(
             result["flow_id"], user_input=MANUAL_SERVER
         )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
     assert result["errors"]["base"] == "ssl_error"
 
@@ -647,15 +639,12 @@ async def test_manual_config(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == "create_entry"
+    assert result["type"] == FlowResultType.CREATE_ENTRY
 
-    server_id = result["data"][CONF_SERVER_IDENTIFIER]
-    mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
-
-    assert result["title"] == mock_plex_server.url_in_use
-    assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
-    assert result["data"][CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
-    assert result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use
+    assert result["title"] == "http://1.2.3.4:32400"
+    assert result["data"][CONF_SERVER] == "Plex Server 1"
+    assert result["data"][CONF_SERVER_IDENTIFIER] == "unique_id_123"
+    assert result["data"][PLEX_SERVER_CONFIG][CONF_URL] == "http://1.2.3.4:32400"
     assert result["data"][PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
 
@@ -673,14 +662,14 @@ async def test_manual_config_with_token(
         context={"source": SOURCE_USER, "show_advanced_options": True},
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user_advanced"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"setup_method": MANUAL_SETUP_STRING}
     )
 
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "manual_setup"
 
     with patch(
@@ -690,15 +679,13 @@ async def test_manual_config_with_token(
             result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
-    assert result["type"] == "create_entry"
+    assert result["type"] == FlowResultType.CREATE_ENTRY
 
-    server_id = result["data"][CONF_SERVER_IDENTIFIER]
-    mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
-    mock_url = mock_plex_server.url_in_use
+    mock_url = "https://1-2-3-4.123456789001234567890.plex.direct:32400"
 
     assert result["title"] == mock_url
-    assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
-    assert result["data"][CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
+    assert result["data"][CONF_SERVER] == "Plex Server 1"
+    assert result["data"][CONF_SERVER_IDENTIFIER] == "unique_id_123"
     assert result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_url
     assert result["data"][PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
@@ -706,26 +693,6 @@ async def test_manual_config_with_token(
     requests_mock.get(f"{mock_url}/library", text=empty_library)
     requests_mock.get(f"{mock_url}/library/sections", text=empty_payload)
     await hass.async_block_till_done()
-
-
-async def test_setup_with_limited_credentials(
-    hass: HomeAssistant, entry, setup_plex_server
-) -> None:
-    """Test setup with a user with limited permissions."""
-    with patch(
-        "plexapi.server.PlexServer.systemAccounts",
-        side_effect=plexapi.exceptions.Unauthorized,
-    ) as mock_accounts:
-        mock_plex_server = await setup_plex_server()
-
-    assert mock_accounts.called
-
-    plex_server = hass.data[DOMAIN][SERVERS][mock_plex_server.machine_identifier]
-    assert len(plex_server.accounts) == 0
-    assert plex_server.owner is None
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_integration_discovery(hass: HomeAssistant) -> None:
@@ -781,13 +748,13 @@ async def test_trigger_reauth(
         "plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"
     ):
         result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "abort"
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
         assert result["flow_id"] == flow_id
 
@@ -795,8 +762,8 @@ async def test_trigger_reauth(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.data[CONF_SERVER] == mock_plex_server.friendly_name
-    assert entry.data[CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
+    assert entry.data[CONF_SERVER] == "Plex Server 1"
+    assert entry.data[CONF_SERVER_IDENTIFIER] == "unique_id_123"
     assert entry.data[PLEX_SERVER_CONFIG][CONF_URL] == PLEX_DIRECT_URL
     assert entry.data[PLEX_SERVER_CONFIG][CONF_TOKEN] == "BRAND_NEW_TOKEN"
 
@@ -837,13 +804,13 @@ async def test_trigger_reauth_multiple_servers_available(
         "plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"
     ):
         result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
-        assert result["type"] == "external"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "external_done"
+        assert result["type"] == FlowResultType.EXTERNAL_STEP_DONE
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result["type"] == "abort"
+        assert result["type"] == FlowResultType.ABORT
         assert result["flow_id"] == flow_id
         assert result["reason"] == "reauth_successful"
 
@@ -851,8 +818,8 @@ async def test_trigger_reauth_multiple_servers_available(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.data[CONF_SERVER] == mock_plex_server.friendly_name
-    assert entry.data[CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
+    assert entry.data[CONF_SERVER] == "Plex Server 1"
+    assert entry.data[CONF_SERVER_IDENTIFIER] == "unique_id_123"
     assert entry.data[PLEX_SERVER_CONFIG][CONF_URL] == PLEX_DIRECT_URL
     assert entry.data[PLEX_SERVER_CONFIG][CONF_TOKEN] == "BRAND_NEW_TOKEN"
 
@@ -862,7 +829,7 @@ async def test_client_request_missing(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
@@ -884,7 +851,7 @@ async def test_client_header_issues(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleaunup config flow tests prior to refactoring (see #88905 / #88980)
- Move `test_setup_with_limited_credentials` to `test_init` module as it has nothing to do with config flow.
- Use `FlowResultType` when asserting `result["type"]`
- Avoid reading data from `hass.data[DOMAIN][SERVERS]` when asserting results

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
