### PR TITLE
Cache remote app list for vizio TVs

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -128,8 +128,9 @@ class VizioAppsDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]
             # Reset the fail count and threshold when the data is successfully retrieved
             self.fail_count = 0
             self.fail_threshold = 10
-            # Store the new data so we have it for the next restart
-            await self.store.async_save(data)
+            # Store the new data if it has changed so we have it for the next restart
+            if data != self.data:
+                await self.store.async_save(data)
             return data
         # For every failure, increase the fail count until we reach the threshold.
         # We then log a warning, increase the threshold, and reset the fail count.

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -337,6 +337,8 @@ class VizioDevice(MediaPlayerEntity):
         @callback
         def apps_list_update() -> None:
             """Update list of all apps."""
+            if not self._apps_coordinator:
+                return
             self._all_apps = self._apps_coordinator.data
             self.async_write_ha_state()
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -337,12 +337,6 @@ class VizioDevice(MediaPlayerEntity):
         @callback
         def apps_list_update() -> None:
             """Update list of all apps."""
-            # If the data hasn't changed we don't need to do a state update
-            if (
-                not self._apps_coordinator
-                or self._all_apps == self._apps_coordinator.data
-            ):
-                return
             self._all_apps = self._apps_coordinator.data
             self.async_write_ha_state()
 

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -137,7 +137,7 @@ class VizioDevice(MediaPlayerEntity):
         device: VizioAsync,
         name: str,
         device_class: MediaPlayerDeviceClass,
-        apps_coordinator: VizioAppsDataUpdateCoordinator,
+        apps_coordinator: VizioAppsDataUpdateCoordinator | None,
     ) -> None:
         """Initialize Vizio device."""
         self._config_entry = config_entry
@@ -330,17 +330,25 @@ class VizioDevice(MediaPlayerEntity):
             )
         )
 
+        if not self._apps_coordinator:
+            return
+
         # Register callback for app list updates if device is a TV
         @callback
-        def apps_list_update():
+        def apps_list_update() -> None:
             """Update list of all apps."""
+            # If the data hasn't changed we don't need to do a state update
+            if (
+                not self._apps_coordinator
+                or self._all_apps == self._apps_coordinator.data
+            ):
+                return
             self._all_apps = self._apps_coordinator.data
             self.async_write_ha_state()
 
-        if self._attr_device_class == MediaPlayerDeviceClass.TV:
-            self.async_on_remove(
-                self._apps_coordinator.async_add_listener(apps_list_update)
-            )
+        self.async_on_remove(
+            self._apps_coordinator.async_add_listener(apps_list_update)
+        )
 
     @property
     def source(self) -> str | None:


### PR DESCRIPTION
## Proposed change
The `pyvizio` library contains a static list of app configurations that can be used to generate a source list for the media player entity. There is also a set of remote endpoints that can be queried to get the latest list. Over time, the static list has gotten stale but the remote endpoints have continued to be updated. These remote endpoints changed, and as a result, the integration reverted to the original static list which at this point was well out of date. This new approach stores the latest list of apps so that if this were to happen again, user's source lists wouldn't suddenly change on a reboot.

Did some slight refactoring as well for typing and to outdent some stuff


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
