### PR TITLE
Nuki: show actual device model in device registry

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -215,7 +215,7 @@ class NukiEntity(CoordinatorEntity[NukiCoordinator], Generic[_NukiDeviceT]):
             "identifiers": {(DOMAIN, parse_id(self._nuki_device.nuki_id))},
             "name": self._nuki_device.name,
             "manufacturer": "Nuki Home Solutions GmbH",
-            "model": self._nuki_device.device_type_str.capitalize(),
+            "model": self._nuki_device.device_model_str.capitalize(),
             "sw_version": self._nuki_device.firmware_version,
             "via_device": (DOMAIN, self.coordinator.bridge_id),
         }

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nuki",
   "iot_class": "local_polling",
   "loggers": ["pynuki"],
-  "requirements": ["pynuki==1.6.0"]
+  "requirements": ["pynuki==1.6.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1816,7 +1816,7 @@ pynina==0.2.0
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.6.0
+pynuki==1.6.1
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1308,7 +1308,7 @@ pynina==0.2.0
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.6.0
+pynuki==1.6.1
 
 # homeassistant.components.nut
 pynut2==2.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1. Bumping pynuki to v1.6.1 ([changelog](https://github.com/pschmitt/pynuki/compare/1.6.0...1.6.1))

Thanks to this update we can:

2. Use the actual device model name for the device registry. Previously, it was only showing  "lock" or "opener". Now it will show actual model names like: "Nuki Smart Lock Pro 3.0", "Nuki Opener", ...

Hope it's okay to combine both changes in a single PR. If not, I'm happy to split them, but then they should be merged together.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
