### PR TITLE
Fix lingering task in debounce tests

### DIFF
--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -1,8 +1,12 @@
 """Tests for debounce."""
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import debounce
+from homeassistant.util.dt import utcnow
+
+from ..common import async_fire_time_changed
 
 
 async def test_immediate_works(hass: HomeAssistant) -> None:
@@ -41,9 +45,8 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 2
-    # Cancel the TimerHandle to avoid lingering tasks
-    debouncer._timer_task.cancel()
-    await debouncer._handle_timer_finish()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
     assert len(calls) == 2
     assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
@@ -91,9 +94,8 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 0
-    # Cancel the TimerHandle to avoid lingering tasks
-    debouncer._timer_task.cancel()
-    await debouncer._handle_timer_finish()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is False
@@ -154,9 +156,8 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     await debouncer.async_call()
     assert len(calls) == 2
     assert calls == [1, 2]
-    # Cancel the TimerHandle to avoid lingering tasks
-    debouncer._timer_task.cancel()
-    await debouncer._handle_timer_finish()
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls == [1, 2]
     assert debouncer._timer_task is None

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -57,6 +57,9 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
 
+    # Cleanup debouncer to avoid lingering tasks
+    debouncer.async_cancel()
+
 
 async def test_not_immediate_works(hass: HomeAssistant) -> None:
     """Test immediate works."""
@@ -106,6 +109,9 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
+
+    # Cleanup debouncer to avoid lingering tasks
+    debouncer.async_cancel()
 
 
 async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> None:
@@ -167,3 +173,6 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
+
+    # Cleanup debouncer to avoid lingering tasks
+    debouncer.async_cancel()

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -41,6 +41,8 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 2
+    # Cancel the TimerHandle to avoid lingering tasks
+    debouncer._timer_task.cancel()
     await debouncer._handle_timer_finish()
     assert len(calls) == 2
     assert debouncer._timer_task is None
@@ -56,9 +58,6 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
-
-    # Cleanup debouncer to avoid lingering tasks
-    debouncer.async_cancel()
 
 
 async def test_not_immediate_works(hass: HomeAssistant) -> None:
@@ -92,6 +91,8 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     # Call and let timer run out
     await debouncer.async_call()
     assert len(calls) == 0
+    # Cancel the TimerHandle to avoid lingering tasks
+    debouncer._timer_task.cancel()
     await debouncer._handle_timer_finish()
     assert len(calls) == 1
     assert debouncer._timer_task is not None
@@ -109,9 +110,6 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
-
-    # Cleanup debouncer to avoid lingering tasks
-    debouncer.async_cancel()
 
 
 async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> None:
@@ -156,6 +154,8 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     await debouncer.async_call()
     assert len(calls) == 2
     assert calls == [1, 2]
+    # Cancel the TimerHandle to avoid lingering tasks
+    debouncer._timer_task.cancel()
     await debouncer._handle_timer_finish()
     assert len(calls) == 2
     assert calls == [1, 2]
@@ -173,6 +173,3 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
-
-    # Cleanup debouncer to avoid lingering tasks
-    debouncer.async_cancel()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #88905
```console
=========================== short test summary info ============================
ERROR tests/helpers/test_debounce.py::test_immediate_works - Failed: Linger task after test <Task pending name='Task-8925' coro=<Debouncer._handle_timer_finish() running at /home/runner/work/core/core/homeassistant/helpers/debounce.py:86> cb=[set.remove()] created at /home/runner/work/core/core/homeassistant/core.py:523>
```
 and
https://github.com/home-assistant/core/actions/runs/4305497813/jobs/7521057966
```console
=========================== short test summary info ============================
ERROR tests/helpers/test_debounce.py::test_immediate_works_with_function_swapped - Failed: Linger task after test <Task pending name='Task-8913' coro=<Debouncer._handle_timer_finish() running at /home/runner/work/core/core/homeassistant/helpers/debounce.py:86> cb=[set.remove()] created at /home/runner/work/core/core/homeassistant/core.py:523>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
