### PR TITLE
Raise ValueError on date parsing of MQTT sensor with invalid date format

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -286,10 +286,7 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 return
             try:
                 if (payload_datetime := dt_util.parse_datetime(new_value)) is None:
-                    _LOGGER.warning(
-                        "Invalid state message '%s' from '%s'", msg.payload, msg.topic
-                    )
-                    return
+                    raise ValueError
             except ValueError:
                 _LOGGER.warning(
                     "Invalid state message '%s' from '%s'", msg.payload, msg.topic

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -293,7 +293,6 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 )
                 self._attr_native_value = None
                 return
-
             if self.device_class == SensorDeviceClass.DATE:
                 self._attr_native_value = payload_datetime.date()
                 return

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -284,12 +284,23 @@ class MqttSensor(MqttEntity, RestoreSensor):
             if self.device_class is None:
                 self._attr_native_value = new_value
                 return
-            if (payload_datetime := dt_util.parse_datetime(new_value)) is None:
+            try:
+                if (payload_datetime := dt_util.parse_datetime(new_value)) is None:
+                    _LOGGER.warning(
+                        "Invalid state message '%s' from '%s'", msg.payload, msg.topic
+                    )
+                    self._attr_native_value = None
+                    return
+            except ValueError as value_error:
                 _LOGGER.warning(
-                    "Invalid state message '%s' from '%s'", msg.payload, msg.topic
+                    "Invalid state message '%s' from '%s': %s",
+                    msg.payload,
+                    msg.topic,
+                    value_error.args,
                 )
                 self._attr_native_value = None
                 return
+
             if self.device_class == SensorDeviceClass.DATE:
                 self._attr_native_value = payload_datetime.date()
                 return

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -289,16 +289,11 @@ class MqttSensor(MqttEntity, RestoreSensor):
                     _LOGGER.warning(
                         "Invalid state message '%s' from '%s'", msg.payload, msg.topic
                     )
-                    self._attr_native_value = None
                     return
-            except ValueError as value_error:
+            except ValueError:
                 _LOGGER.warning(
-                    "Invalid state message '%s' from '%s': %s",
-                    msg.payload,
-                    msg.topic,
-                    value_error.args,
+                    "Invalid state message '%s' from '%s'", msg.payload, msg.topic
                 )
-                self._attr_native_value = None
                 return
 
             if self.device_class == SensorDeviceClass.DATE:

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -291,6 +291,7 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 _LOGGER.warning(
                     "Invalid state message '%s' from '%s'", msg.payload, msg.topic
                 )
+                self._attr_native_value = None
                 return
 
             if self.device_class == SensorDeviceClass.DATE:

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -134,6 +134,12 @@ async def test_setting_sensor_value_via_mqtt_message(
             "2021-11-18T19:25:00+00:00",
             False,
         ),
+        (
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "2021-13-18T35:25:00+00:00",
+            STATE_UNKNOWN,
+            True,
+        ),
         (sensor.SensorDeviceClass.TIMESTAMP, "invalid", STATE_UNKNOWN, True),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When parsing dates `dt_util.parse_datetime()` is used. This could raise an exception we would to log information about the context.
The way of logging is now similar to the logging when parsing a `last_reset` update,

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
