### PR TITLE
Fix check on non numeric custom sensor device classes

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -272,7 +272,7 @@ class SensorEntity(Entity):
     def _numeric_state_expected(self) -> bool:
         """Return true if the sensor must be numeric."""
         device_class = try_parse_enum(SensorDeviceClass, self.device_class)
-        if device_class in {*NON_NUMERIC_DEVICE_CLASSES}:
+        if device_class in NON_NUMERIC_DEVICE_CLASSES:
             return False
         if (
             self.state_class is not None

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -271,6 +271,8 @@ class SensorEntity(Entity):
     @property
     def _numeric_state_expected(self) -> bool:
         """Return true if the sensor must be numeric."""
+        # Note: the order of the checks needs to be kept aligned
+        # with the checks in `state` property.
         device_class = try_parse_enum(SensorDeviceClass, self.device_class)
         if device_class in NON_NUMERIC_DEVICE_CLASSES:
             return False

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -271,15 +271,18 @@ class SensorEntity(Entity):
     @property
     def _numeric_state_expected(self) -> bool:
         """Return true if the sensor must be numeric."""
+        device_class = try_parse_enum(SensorDeviceClass, self.device_class)
+        if device_class in {*NON_NUMERIC_DEVICE_CLASSES}:
+            return False
         if (
             self.state_class is not None
             or self.native_unit_of_measurement is not None
             or self.suggested_display_precision is not None
         ):
             return True
-        # Sensors with custom device classes are not considered numeric
-        device_class = try_parse_enum(SensorDeviceClass, self.device_class)
-        return device_class not in {None, *NON_NUMERIC_DEVICE_CLASSES}
+        # Sensors with custom device classes will have the device class
+        # converted to None and are not considered numeric
+        return device_class is not None
 
     @property
     def options(self) -> list[str] | None:

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -205,6 +205,47 @@ async def test_datetime_conversion(
     assert state.state == test_timestamp.isoformat()
 
 
+async def test_a_sensor_with_a_non_numeric_device_class(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
+    """Test that a sensor with a non numeric device class will be non numeric.
+
+    A non numeric sensor with a valid device class should never be
+    handled as numeric because it has a device class.
+    """
+    test_timestamp = datetime(2017, 12, 19, 18, 29, 42, tzinfo=timezone.utc)
+    test_local_timestamp = test_timestamp.astimezone(
+        dt_util.get_time_zone("Europe/Amsterdam")
+    )
+
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test",
+        native_value=test_local_timestamp,
+        native_unit_of_measurement="",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    )
+
+    platform.ENTITIES["1"] = platform.MockSensor(
+        name="Test",
+        native_value=test_local_timestamp,
+        state_class="",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    )
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(platform.ENTITIES["0"].entity_id)
+    assert state.state == test_timestamp.isoformat()
+
+    state = hass.states.get(platform.ENTITIES["1"].entity_id)
+    assert state.state == test_timestamp.isoformat()
+
+
 @pytest.mark.parametrize(
     ("device_class", "state_value", "provides"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `SensorEntity._numeric_state_expected` to match `SensorEntity.state`

This fixes an issue a where an invalid `native_unit_of_measurement` setting, `state_class` or `suggested_display_precision` has priority over a valid device class which is not numeric.
If for example a sensor has a `timestamp` device class and a custom UOM (or "") the sensor should be treated as not numeric.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
