### PR TITLE
Cache transient templates compiles provided via api

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -351,7 +351,9 @@ class APIComponentsView(HomeAssistantView):
         return self.json(request.app["hass"].config.components)
 
 
-_cached_template = lru_cache(template.Template)
+# Hold a reference to the cached template string to prevent it from being
+# garbage collected so the template compile cache can be used.
+_cached_template_str = lru_cache(str)
 
 
 class APITemplateView(HomeAssistantView):
@@ -366,8 +368,9 @@ class APITemplateView(HomeAssistantView):
             raise Unauthorized()
         try:
             data = await request.json()
-            tpl = _cached_template(data["template"])
-            tpl.hass = request.app["hass"]
+            tpl = template.Template(
+                _cached_template_str(data["template"]), request.app["hass"]
+            )
             return tpl.async_render(variables=data.get("variables"), parse_result=False)
         except (ValueError, TemplateError) as ex:
             return self.json_message(

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -365,7 +365,10 @@ async def webhook_stream_camera(
     return webhook_response(resp, registration=config_entry.data)
 
 
-_cached_template = lru_cache(template.Template)
+@lru_cache
+def _cached_template(template_str: str, hass: HomeAssistant) -> template.Template:
+    """Return a cached template."""
+    return template.Template(template_str, hass)
 
 
 @WEBHOOK_COMMANDS.register("render_template")
@@ -384,8 +387,7 @@ async def webhook_render_template(
     resp = {}
     for key, item in data.items():
         try:
-            tpl = _cached_template(item[ATTR_TEMPLATE])
-            tpl.hass = hass
+            tpl = _cached_template(item[ATTR_TEMPLATE], hass)
             resp[key] = tpl.async_render(item.get(ATTR_TEMPLATE_VARIABLES))
         except TemplateError as ex:
             resp[key] = {"error": str(ex)}

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
-from functools import wraps
+from functools import lru_cache, wraps
 from http import HTTPStatus
 import logging
 import secrets
@@ -365,6 +365,9 @@ async def webhook_stream_camera(
     return webhook_response(resp, registration=config_entry.data)
 
 
+_cached_template = lru_cache(template.Template)
+
+
 @WEBHOOK_COMMANDS.register("render_template")
 @validate_schema(
     {
@@ -381,7 +384,8 @@ async def webhook_render_template(
     resp = {}
     for key, item in data.items():
         try:
-            tpl = template.Template(item[ATTR_TEMPLATE], hass)
+            tpl = _cached_template(item[ATTR_TEMPLATE])
+            tpl.hass = hass
             resp[key] = tpl.async_render(item.get(ATTR_TEMPLATE_VARIABLES))
         except TemplateError as ex:
             resp[key] = {"error": str(ex)}

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -425,7 +425,10 @@ def handle_ping(
     connection.send_message(pong_message(msg["id"]))
 
 
-_cached_template = lru_cache(template.Template)
+@lru_cache
+def _cached_template(template_str: str, hass: HomeAssistant) -> template.Template:
+    """Return a cached template."""
+    return template.Template(template_str, hass)
 
 
 @decorators.websocket_command(
@@ -444,8 +447,7 @@ async def handle_render_template(
 ) -> None:
     """Handle render_template command."""
     template_str = msg["template"]
-    template_obj = _cached_template(template_str)
-    template_obj.hass = hass
+    template_obj = _cached_template(template_str, hass)
     variables = msg.get("variables")
     timeout = msg.get("timeout")
     info = None

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -425,9 +425,7 @@ def handle_ping(
     connection.send_message(pong_message(msg["id"]))
 
 
-# Hold a reference to the cached template string to prevent it from being
-# garbage collected so the template compile cache can be used.
-_cached_template_str = lru_cache(str)
+_cached_template = lru_cache(template.Template)
 
 
 @decorators.websocket_command(
@@ -446,7 +444,8 @@ async def handle_render_template(
 ) -> None:
     """Handle render_template command."""
     template_str = msg["template"]
-    template_obj = template.Template(_cached_template_str(template_str), hass)
+    template_obj = _cached_template(template_str)
+    template_obj.hass = hass
     variables = msg.get("variables")
     timeout = msg.get("timeout")
     info = None

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -425,7 +425,9 @@ def handle_ping(
     connection.send_message(pong_message(msg["id"]))
 
 
-_cached_template = lru_cache(template.Template)
+# Hold a reference to the cached template string to prevent it from being
+# garbage collected so the template compile cache can be used.
+_cached_template_str = lru_cache(str)
 
 
 @decorators.websocket_command(
@@ -444,8 +446,7 @@ async def handle_render_template(
 ) -> None:
     """Handle render_template command."""
     template_str = msg["template"]
-    template_obj = _cached_template(template_str)
-    template_obj.hass = hass
+    template_obj = template.Template(_cached_template_str(template_str), hass)
     variables = msg.get("variables")
     timeout = msg.get("timeout")
     info = None

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -359,6 +359,42 @@ async def test_api_template(hass: HomeAssistant, mock_api_client: TestClient) ->
 
     assert body == "20"
 
+    hass.states.async_remove("sensor.temperature")
+    resp = await mock_api_client.post(
+        const.URL_API_TEMPLATE,
+        json={"template": "{{ states.sensor.temperature.state }}"},
+    )
+
+    body = await resp.text()
+
+    assert body == ""
+
+
+async def test_api_template_cached(
+    hass: HomeAssistant, mock_api_client: TestClient
+) -> None:
+    """Test the template API uses the cache."""
+    hass.states.async_set("sensor.temperature", 30)
+
+    resp = await mock_api_client.post(
+        const.URL_API_TEMPLATE,
+        json={"template": "{{ states.sensor.temperature.state }}"},
+    )
+
+    body = await resp.text()
+
+    assert body == "30"
+
+    hass.states.async_set("sensor.temperature", 40)
+    resp = await mock_api_client.post(
+        const.URL_API_TEMPLATE,
+        json={"template": "{{ states.sensor.temperature.state }}"},
+    )
+
+    body = await resp.text()
+
+    assert body == "40"
+
 
 async def test_api_template_error(
     hass: HomeAssistant, mock_api_client: TestClient

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -349,6 +349,16 @@ async def test_api_template(hass: HomeAssistant, mock_api_client: TestClient) ->
 
     assert body == "10"
 
+    hass.states.async_set("sensor.temperature", 20)
+    resp = await mock_api_client.post(
+        const.URL_API_TEMPLATE,
+        json={"template": "{{ states.sensor.temperature.state }}"},
+    )
+
+    body = await resp.text()
+
+    assert body == "20"
+
 
 async def test_api_template_error(
     hass: HomeAssistant, mock_api_client: TestClient


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
partially fixes #89047 (there is more going on here)

While investigating 89047 it was discovered there was no caching of template complies that come in via that api because we don't have a strong reference to hold to the template string which means they get compiled every time which makes it ~100-1000x slower than it could be if we cached the compile.

These were being compiled every time
<img width="1180" alt="Screenshot 2023-03-02 at 9 50 01 AM" src="https://user-images.githubusercontent.com/663432/222546921-5ab9f45f-67ac-4a5f-9aab-86232c99616a.png">
<img width="1177" alt="Screenshot 2023-03-02 at 9 49 45 AM" src="https://user-images.githubusercontent.com/663432/222546927-42bf9585-694b-442e-a684-1d9a728e5169.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
