### PR TITLE
Adjust xiaomi_ble tests

### DIFF
--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -152,8 +152,11 @@ async def test_xiaomi_battery_voltage(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01(hass: HomeAssistant) -> None:
-    """This device has multiple advertisements before all sensors are visible. Test that this works."""
+async def test_xiaomi_hhccjcy01(hass: HomeAssistant) -> None:
+    """Test HHCCJCY01 multiple advertisements.
+
+    This device has multiple advertisements before all sensors are visible.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="C4:7C:8D:6A:3E:7A",
@@ -230,8 +233,11 @@ async def test_xiaomi_HHCCJCY01(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01_not_connectable(hass: HomeAssistant) -> None:
-    """This device has multiple advertisements before all sensors are visible but not connectable."""
+async def test_xiaomi_hhccjcy01_not_connectable(hass: HomeAssistant) -> None:
+    """Test HHCCJCY01 when sensors are not connectable.
+
+    This device has multiple advertisements before all sensors are visible but not connectable.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="C4:7C:8D:6A:3E:7A",
@@ -311,10 +317,14 @@ async def test_xiaomi_HHCCJCY01_not_connectable(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(
+async def test_xiaomi_hhccjcy01_only_some_sources_connectable(
     hass: HomeAssistant,
 ) -> None:
-    """This device has multiple advertisements before all sensors are visible and some sources are connectable."""
+    """Test HHCCJCY01 partial sources.
+
+    This device has multiple advertisements before all sensors are visible
+    and some sources are connectable.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="C4:7C:8D:6A:3E:7A",
@@ -399,8 +409,12 @@ async def test_xiaomi_HHCCJCY01_only_some_sources_connectable(
     await hass.async_block_till_done()
 
 
-async def test_xiaomi_CGDK2(hass: HomeAssistant) -> None:
-    """This device has encrypion so we need to retrieve its bindkey from the configentry."""
+async def test_xiaomi_cgdk2_bind_key(hass: HomeAssistant) -> None:
+    """Test CGDK2 bind key.
+
+    This device has encryption so we need to retrieve its bind key
+    from the config entry.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="58:2D:34:12:20:89",
@@ -436,8 +450,11 @@ async def test_xiaomi_CGDK2(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_hhcc_HHCCJCY10(hass: HomeAssistant) -> None:
-    """This device used a different UUID compared to the other Xiaomi sensors."""
+async def test_hhccjcy10_uuid(hass: HomeAssistant) -> None:
+    """Test HHCCJCY10 UUID.
+
+    This device uses a different UUID compared to the other Xiaomi sensors.
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="DC:23:4D:E5:5B:FC",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename tests and adjust docstrings

Linked to #89077

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
