### PR TITLE
Bump `brother` and `pysnmplib` backend libraries

### DIFF
--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["brother", "pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "platinum",
-  "requirements": ["brother==2.2.0"],
+  "requirements": ["brother==2.3.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["pysnmplib==5.0.20"]
+  "requirements": ["pysnmplib==5.0.21"]
 }

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -145,7 +145,7 @@ async def async_setup_platform(
             ContextData(),
         ]
     get_result = await getCmd(*request_args, ObjectType(ObjectIdentity(baseoid)))
-    errindication, _, _, _ = await get_result
+    errindication, _, _, _ = get_result
 
     if errindication and not accept_errors:
         _LOGGER.error("Please check the details in the configuration file")
@@ -207,7 +207,7 @@ class SnmpData:
         get_result = await getCmd(
             *self._request_args, ObjectType(ObjectIdentity(self._baseoid))
         )
-        errindication, errstatus, errindex, restable = await get_result
+        errindication, errstatus, errindex, restable = get_result
 
         if errindication and not self._accept_errors:
             _LOGGER.error("SNMP error: %s", errindication)

--- a/homeassistant/components/snmp/switch.py
+++ b/homeassistant/components/snmp/switch.py
@@ -261,7 +261,7 @@ class SnmpSwitch(SwitchEntity):
         get_result = await getCmd(
             *self._request_args, ObjectType(ObjectIdentity(self._baseoid))
         )
-        errindication, errstatus, errindex, restable = await get_result
+        errindication, errstatus, errindex, restable = get_result
 
         if errindication:
             _LOGGER.error("SNMP error: %s", errindication)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -480,7 +480,7 @@ boto3==1.20.24
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.2.0
+brother==2.3.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1
@@ -1982,7 +1982,7 @@ pysmarty==0.8
 pysml==0.0.8
 
 # homeassistant.components.snmp
-pysnmplib==5.0.20
+pysnmplib==5.0.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -393,7 +393,7 @@ boschshcpy==0.2.35
 broadlink==0.18.3
 
 # homeassistant.components.brother
-brother==2.2.0
+brother==2.3.0
 
 # homeassistant.components.brunt
 brunt==1.2.0
@@ -1435,7 +1435,7 @@ pysmartthings==0.7.6
 pysml==0.0.8
 
 # homeassistant.components.snmp
-pysnmplib==5.0.20
+pysnmplib==5.0.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.3

--- a/tests/components/snmp/test_sensor.py
+++ b/tests/components/snmp/test_sensor.py
@@ -1,6 +1,5 @@
 """SNMP sensor tests."""
 
-import asyncio
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -16,11 +15,9 @@ def hlapi_mock():
     """Mock out 3rd party API."""
     mock_data = MagicMock()
     mock_data.prettyPrint = Mock(return_value="13.5")
-    future = asyncio.get_event_loop().create_future()
-    future.set_result((None, None, None, [[mock_data]]))
     with patch(
         "homeassistant.components.snmp.sensor.getCmd",
-        return_value=future,
+        return_value=(None, None, None, [[mock_data]]),
     ):
         yield
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- bumps `pysnmplib` library to version 5.0.21
- bumps `brother` library to version 2.3.0 (`brother` uses `pynsmplib`)
- updates `snmp` integration and tests to make them compatible with the new `pysnmplib`

Changelogs:
https://github.com/bieniu/brother/compare/2.2.0...2.3.0
https://github.com/pysnmp/pysnmp/compare/v5.0.20...v5.0.21

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
