### PR TITLE
Reolink test init 100%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -974,7 +974,6 @@ omit =
     homeassistant/components/rejseplanen/sensor.py
     homeassistant/components/remember_the_milk/__init__.py
     homeassistant/components/remote_rpi_gpio/*
-    homeassistant/components/reolink/__init__.py
     homeassistant/components/reolink/binary_sensor.py
     homeassistant/components/reolink/camera.py
     homeassistant/components/reolink/entity.py

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -25,8 +25,8 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         yield mock_setup_entry
 
 
-@pytest.fixture(name="reolink_connect")
-def reolink_connect_fixture(mock_get_source_ip):
+@pytest.fixture
+def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None]:
     """Mock reolink connection."""
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -62,8 +62,7 @@ def reolink_platforms(mock_get_source_ip: None) -> Generator[None, None, None]:
         yield
 
 
-@pytest.fixture(name="config_entry")
-def reolink_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Add the reolink mock config entry to hass."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,4 +1,4 @@
-"""Test the Reolink config flow."""
+"""Setup the Reolink tests."""
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -53,7 +53,7 @@ def reolink_setup_entry_fixture() -> Generator[AsyncMock, None, None]:
 
 @pytest.fixture(name="reolink_connect")
 def reolink_connect_fixture(mock_get_source_ip):
-    """Mock reolink connection and entry setup."""
+    """Mock reolink connection."""
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",
         return_value=True,
@@ -65,6 +65,6 @@ def reolink_connect_fixture(mock_get_source_ip):
 
 @pytest.fixture(name="reolink_init")
 def reolink_init_fixture(mock_get_source_ip):
-    """Mock reolink connection and entry setup."""
+    """Mock reolink entry setup."""
     with patch("homeassistant.components.reolink.PLATFORMS", return_value=[]):
         yield

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -16,32 +16,6 @@ TEST_NVR_NAME = "test_reolink_name"
 TEST_USE_HTTPS = True
 
 
-def get_mock_info(error=None):
-    """Return a mock gateway info instance."""
-    host_mock = Mock()
-    if error is None:
-        host_mock.get_host_data = AsyncMock(return_value=None)
-    else:
-        host_mock.get_host_data = AsyncMock(side_effect=error)
-    host_mock.get_states = AsyncMock(return_value=None)
-    host_mock.check_new_firmware = AsyncMock(return_value=False)
-    host_mock.unsubscribe = AsyncMock(return_value=True)
-    host_mock.logout = AsyncMock(return_value=True)
-    host_mock.mac_address = TEST_MAC
-    host_mock.onvif_enabled = True
-    host_mock.rtmp_enabled = True
-    host_mock.rtsp_enabled = True
-    host_mock.nvr_name = TEST_NVR_NAME
-    host_mock.port = TEST_PORT
-    host_mock.use_https = TEST_USE_HTTPS
-    host_mock.is_admin = True
-    host_mock.user_level = "admin"
-    host_mock.sw_version_update_required = False
-    host_mock.timeout = 60
-    host_mock.renewtimer = 600
-    return host_mock
-
-
 @pytest.fixture(name="reolink_setup_entry")
 def reolink_setup_entry_fixture() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,6 +1,6 @@
 """Setup the Reolink tests."""
 from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -31,7 +31,9 @@ def reolink_connect_fixture(mock_get_source_ip):
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",
         return_value=True,
-    ), patch("homeassistant.components.reolink.host.Host", autospec=True) as host_mock_class:
+    ), patch(
+        "homeassistant.components.reolink.host.Host", autospec=True
+    ) as host_mock_class:
         host_mock = host_mock_class.return_value
         host_mock.get_host_data = AsyncMock(return_value=None)
         host_mock.get_states = AsyncMock(return_value=None)

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -55,8 +55,8 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
         yield host_mock
 
 
-@pytest.fixture(name="reolink_init")
-def reolink_init_fixture(mock_get_source_ip):
+@pytest.fixture
+def reolink_platforms(mock_get_source_ip: None) -> Generator[None, None, None]:
     """Mock reolink entry setup."""
     with patch("homeassistant.components.reolink.PLATFORMS", return_value=[]):
         yield

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -60,3 +60,25 @@ def reolink_init_fixture(mock_get_source_ip):
     """Mock reolink entry setup."""
     with patch("homeassistant.components.reolink.PLATFORMS", return_value=[]):
         yield
+
+
+@pytest.fixture(name="config_entry")
+def reolink_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
+    """Add the reolink mock config entry to hass."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_PORT: TEST_PORT,
+            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
+        },
+        options={
+            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -16,8 +16,8 @@ TEST_NVR_NAME = "test_reolink_name"
 TEST_USE_HTTPS = True
 
 
-@pytest.fixture(name="reolink_setup_entry")
-def reolink_setup_entry_fixture() -> Generator[AsyncMock, None, None]:
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.reolink.async_setup_entry", return_value=True

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -35,11 +35,11 @@ def reolink_connect_fixture(mock_get_source_ip):
         "homeassistant.components.reolink.host.Host", autospec=True
     ) as host_mock_class:
         host_mock = host_mock_class.return_value
-        host_mock.get_host_data = AsyncMock(return_value=None)
-        host_mock.get_states = AsyncMock(return_value=None)
-        host_mock.check_new_firmware = AsyncMock(return_value=False)
-        host_mock.unsubscribe = AsyncMock(return_value=True)
-        host_mock.logout = AsyncMock(return_value=True)
+        host_mock.get_host_data.return_value = None
+        host_mock.get_states.return_value = None
+        host_mock.check_new_firmware.return_value = False
+        host_mock.unsubscribe.return_value = True
+        host_mock.logout.return_value = True
         host_mock.mac_address = TEST_MAC
         host_mock.onvif_enabled = True
         host_mock.rtmp_enabled = True

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,0 +1,53 @@
+"""Test the Reolink config flow."""
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+TEST_HOST = "1.2.3.4"
+TEST_HOST2 = "4.5.6.7"
+TEST_USERNAME = "admin"
+TEST_USERNAME2 = "username"
+TEST_PASSWORD = "password"
+TEST_PASSWORD2 = "new_password"
+TEST_MAC = "ab:cd:ef:gh:ij:kl"
+TEST_PORT = 1234
+TEST_NVR_NAME = "test_reolink_name"
+TEST_USE_HTTPS = True
+
+
+def get_mock_info(error=None, user_level="admin", sw_required=False):
+    """Return a mock gateway info instance."""
+    host_mock = Mock()
+    if error is None:
+        host_mock.get_host_data = AsyncMock(return_value=None)
+    else:
+        host_mock.get_host_data = AsyncMock(side_effect=error)
+    host_mock.check_new_firmware = AsyncMock(return_value=False)
+    host_mock.unsubscribe = AsyncMock(return_value=True)
+    host_mock.logout = AsyncMock(return_value=True)
+    host_mock.mac_address = TEST_MAC
+    host_mock.onvif_enabled = True
+    host_mock.rtmp_enabled = True
+    host_mock.rtsp_enabled = True
+    host_mock.nvr_name = TEST_NVR_NAME
+    host_mock.port = TEST_PORT
+    host_mock.use_https = TEST_USE_HTTPS
+    host_mock.is_admin = user_level == "admin"
+    host_mock.user_level = user_level
+    host_mock.sw_version_update_required = sw_required
+    host_mock.timeout = 60
+    host_mock.renewtimer = 600
+    host_mock.get_states = AsyncMock(return_value=None)
+    return host_mock
+
+
+@pytest.fixture(name="reolink_connect", autouse=True)
+def reolink_connect_fixture(mock_get_source_ip):
+    """Mock reolink connection and entry setup."""
+    with patch(
+        "homeassistant.components.reolink.host.webhook.async_register",
+        return_value=True,
+    ), patch("homeassistant.components.reolink.PLATFORMS", return_value=[]), patch(
+        "homeassistant.components.reolink.host.Host", return_value=get_mock_info()
+    ):
+        yield

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -57,10 +57,26 @@ def reolink_connect_fixture(mock_get_source_ip):
     with patch(
         "homeassistant.components.reolink.host.webhook.async_register",
         return_value=True,
-    ), patch(
-        "homeassistant.components.reolink.host.Host", return_value=get_mock_info()
-    ):
-        yield
+    ), patch("homeassistant.components.reolink.host.Host", autospec=True) as host_mock_class:
+        host_mock = host_mock_class.return_value
+        host_mock.get_host_data = AsyncMock(return_value=None)
+        host_mock.get_states = AsyncMock(return_value=None)
+        host_mock.check_new_firmware = AsyncMock(return_value=False)
+        host_mock.unsubscribe = AsyncMock(return_value=True)
+        host_mock.logout = AsyncMock(return_value=True)
+        host_mock.mac_address = TEST_MAC
+        host_mock.onvif_enabled = True
+        host_mock.rtmp_enabled = True
+        host_mock.rtsp_enabled = True
+        host_mock.nvr_name = TEST_NVR_NAME
+        host_mock.port = TEST_PORT
+        host_mock.use_https = TEST_USE_HTTPS
+        host_mock.is_admin = True
+        host_mock.user_level = "admin"
+        host_mock.sw_version_update_required = False
+        host_mock.timeout = 60
+        host_mock.renewtimer = 600
+        yield host_mock
 
 
 @pytest.fixture(name="reolink_init")

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,8 +1,16 @@
 """Setup the Reolink tests."""
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from homeassistant.components.reolink import const
+from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+
+from tests.common import MockConfigEntry
 
 TEST_HOST = "1.2.3.4"
 TEST_HOST2 = "4.5.6.7"
@@ -62,6 +70,7 @@ def reolink_platforms(mock_get_source_ip: None) -> Generator[None, None, None]:
         yield
 
 
+@pytest.fixture
 def config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Add the reolink mock config entry to hass."""
     config_entry = MockConfigEntry(

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Reolink config flow."""
 import json
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
@@ -65,7 +65,7 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
     }
 
 
-async def test_config_flow_errors(hass: HomeAssistant) -> None:
+async def test_config_flow_errors(hass: HomeAssistant, reolink_connect) -> None:
     """Successful flow manually initialized by the user after some errors."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -75,16 +75,15 @@ async def test_config_flow_errors(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    host_mock = get_mock_info(error=ReolinkError("Test error"))
-    with patch("homeassistant.components.reolink.host.Host", return_value=host_mock):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-                CONF_HOST: TEST_HOST,
-            },
-        )
+    #reolink_connect.get_host_data = AsyncMock(side_effect=ReolinkError("Test error"))
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_HOST: TEST_HOST,
+        },
+    )
 
     assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,69 +1,32 @@
 """Test the Reolink config flow."""
 import json
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
-import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
 from homeassistant.components.reolink import const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
-from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import format_mac
 
+from .conftest import (
+    TEST_HOST,
+    TEST_HOST2,
+    TEST_MAC,
+    TEST_NVR_NAME,
+    TEST_PASSWORD,
+    TEST_PASSWORD2,
+    TEST_PORT,
+    TEST_USE_HTTPS,
+    TEST_USERNAME,
+    TEST_USERNAME2,
+    get_mock_info,
+)
+
 from tests.common import MockConfigEntry
-
-TEST_HOST = "1.2.3.4"
-TEST_HOST2 = "4.5.6.7"
-TEST_USERNAME = "admin"
-TEST_USERNAME2 = "username"
-TEST_PASSWORD = "password"
-TEST_PASSWORD2 = "new_password"
-TEST_MAC = "ab:cd:ef:gh:ij:kl"
-TEST_PORT = 1234
-TEST_NVR_NAME = "test_reolink_name"
-TEST_USE_HTTPS = True
-
-
-def get_mock_info(error=None, user_level="admin"):
-    """Return a mock gateway info instance."""
-    host_mock = Mock()
-    if error is None:
-        host_mock.get_host_data = AsyncMock(return_value=None)
-    else:
-        host_mock.get_host_data = AsyncMock(side_effect=error)
-    host_mock.check_new_firmware = AsyncMock(return_value=False)
-    host_mock.unsubscribe = AsyncMock(return_value=True)
-    host_mock.logout = AsyncMock(return_value=True)
-    host_mock.mac_address = TEST_MAC
-    host_mock.onvif_enabled = True
-    host_mock.rtmp_enabled = True
-    host_mock.rtsp_enabled = True
-    host_mock.nvr_name = TEST_NVR_NAME
-    host_mock.port = TEST_PORT
-    host_mock.use_https = TEST_USE_HTTPS
-    host_mock.is_admin = user_level == "admin"
-    host_mock.user_level = user_level
-    host_mock.timeout = 60
-    host_mock.renewtimer = 600
-    host_mock.get_states = AsyncMock(return_value=None)
-    return host_mock
-
-
-@pytest.fixture(name="reolink_connect", autouse=True)
-def reolink_connect_fixture(mock_get_source_ip):
-    """Mock reolink connection and entry setup."""
-    with patch(
-        "homeassistant.components.reolink.host.webhook.async_register",
-        return_value=True,
-    ), patch("homeassistant.components.reolink.PLATFORMS", return_value=[]), patch(
-        "homeassistant.components.reolink.host.Host", return_value=get_mock_info()
-    ):
-        yield
 
 
 async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
@@ -422,63 +385,3 @@ async def test_dhcp_abort_flow(hass: HomeAssistant) -> None:
 
     assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-
-
-async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
-    """Test no repairs issue is raised when http local url is used."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
-
-    await async_process_ha_core_config(
-        hass, {"country": "GB", "internal_url": "http://test_homeassistant_address"}
-    )
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)
-    assert len(issue_registry.issues) == 0
-
-
-async def test_https_repair_issue(hass: HomeAssistant) -> None:
-    """Test repairs issue is raised when https local url is used."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
-
-    await async_process_ha_core_config(
-        hass, {"country": "GB", "internal_url": "https://test_homeassistant_address"}
-    )
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)
-    assert len(issue_registry.issues) == 1

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -93,7 +93,7 @@ async def test_config_flow_errors(
 
     reolink_connect.is_admin = True
     reolink_connect.user_level = "admin"
-    reolink_connect.get_host_data = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.get_host_data.side_effect = ReolinkError("Test error")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -107,8 +107,8 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
-    reolink_connect.get_host_data = AsyncMock(
-        side_effect=json.JSONDecodeError("test_error", "test", 1)
+    reolink_connect.get_host_data.side_effect = json.JSONDecodeError(
+        "test_error", "test", 1
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -123,9 +123,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "unknown"}
 
-    reolink_connect.get_host_data = AsyncMock(
-        side_effect=CredentialsInvalidError("Test error")
-    )
+    reolink_connect.get_host_data.side_effect = CredentialsInvalidError("Test error")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -139,7 +137,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "invalid_auth"}
 
-    reolink_connect.get_host_data = AsyncMock(side_effect=ApiError("Test error"))
+    reolink_connect.get_host_data.side_effect = ApiError("Test error")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -153,7 +151,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "api_error"}
 
-    reolink_connect.get_host_data = AsyncMock(return_value=None)
+    reolink_connect.get_host_data.return_value = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Reolink config flow."""
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
@@ -151,7 +151,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "api_error"}
 
-    reolink_connect.get_host_data.return_value = None
+    reolink_connect.get_host_data.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Reolink config flow."""
 import json
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
@@ -64,7 +64,9 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
     }
 
 
-async def test_config_flow_errors(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_config_flow_errors(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Successful flow manually initialized by the user after some errors."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -105,7 +107,9 @@ async def test_config_flow_errors(hass: HomeAssistant, reolink_connect: MagicMoc
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
-    reolink_connect.get_host_data = AsyncMock(side_effect=json.JSONDecodeError("test_error", "test", 1))
+    reolink_connect.get_host_data = AsyncMock(
+        side_effect=json.JSONDecodeError("test_error", "test", 1)
+    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -119,7 +123,9 @@ async def test_config_flow_errors(hass: HomeAssistant, reolink_connect: MagicMoc
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "unknown"}
 
-    reolink_connect.get_host_data = AsyncMock(side_effect=CredentialsInvalidError("Test error"))
+    reolink_connect.get_host_data = AsyncMock(
+        side_effect=CredentialsInvalidError("Test error")
+    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -28,7 +28,7 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
-pytestmark = pytest.mark.usefixtures("reolink_setup_entry", "reolink_connect")
+pytestmark = pytest.mark.usefixtures("mock_setup_entry", "reolink_connect")
 
 
 async def test_config_flow_manual_success(hass: HomeAssistant) -> None:

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -2,6 +2,7 @@
 import json
 from unittest.mock import patch
 
+import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
 
 from homeassistant import config_entries, data_entry_flow
@@ -27,6 +28,8 @@ from .conftest import (
 )
 
 from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("reolink_setup_entry", "reolink_connect")
 
 
 async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
@@ -87,7 +90,9 @@ async def test_config_flow_errors(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
-    host_mock = get_mock_info(user_level="guest")
+    host_mock = get_mock_info()
+    host_mock.is_admin = False
+    host_mock.user_level = "guest"
     with patch("homeassistant.components.reolink.host.Host", return_value=host_mock):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -26,7 +26,7 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
-pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_init")
+pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
 
 
 @pytest.mark.parametrize(

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,0 +1,137 @@
+"""Test the Reolink init."""
+from unittest.mock import patch
+
+from homeassistant.components.reolink import const
+from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
+from homeassistant.config import async_process_ha_core_config
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import format_mac
+
+from .conftest import (
+    TEST_HOST,
+    TEST_MAC,
+    TEST_NVR_NAME,
+    TEST_PASSWORD,
+    TEST_PORT,
+    TEST_USE_HTTPS,
+    TEST_USERNAME,
+    get_mock_info,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
+    """Test no repairs issue is raised when http local url is used."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_PORT: TEST_PORT,
+            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
+        },
+        options={
+            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    await async_process_ha_core_config(
+        hass, {"country": "GB", "internal_url": "http://test_homeassistant_address"}
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    assert (const.DOMAIN, "https_webhook") not in issue_registry.issues
+
+
+async def test_https_repair_issue(hass: HomeAssistant) -> None:
+    """Test repairs issue is raised when https local url is used."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_PORT: TEST_PORT,
+            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
+        },
+        options={
+            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    await async_process_ha_core_config(
+        hass, {"country": "GB", "internal_url": "https://test_homeassistant_address"}
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    assert (const.DOMAIN, "https_webhook") in issue_registry.issues
+
+
+async def test_no_firmware_repair_issue(hass: HomeAssistant) -> None:
+    """Test no firmware issue is raised when firmware is new enough."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_PORT: TEST_PORT,
+            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
+        },
+        options={
+            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    assert (const.DOMAIN, "firmware_update") not in issue_registry.issues
+
+
+async def test_firmware_repair_issue(hass: HomeAssistant) -> None:
+    """Test firmware issue is raised when too old firmware is used."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_PORT: TEST_PORT,
+            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
+        },
+        options={
+            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    host_mock = get_mock_info(sw_required=True)
+    with patch("homeassistant.components.reolink.host.Host", return_value=host_mock):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    assert (const.DOMAIN, "firmware_update") in issue_registry.issues

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -29,28 +29,6 @@ from tests.common import MockConfigEntry
 pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_init")
 
 
-@pytest.fixture(name="config_entry")
-def reolink_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
-    """Add the reolink mock config entry to hass."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
-    return config_entry
-
-
 @pytest.mark.parametrize(
     ("attr", "value", "expected"),
     [
@@ -102,8 +80,6 @@ async def test_failures_parametrized(
     await hass.async_block_till_done()
 
     assert config_entry.state == expected
-    if expected != ConfigEntryState.LOADED:
-        assert not hass.data.get(const.DOMAIN)
 
 
 async def test_update_listener(

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -6,23 +6,10 @@ import pytest
 from reolink_aio.exceptions import ReolinkError
 
 from homeassistant.components.reolink import const
-from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.device_registry import format_mac
-
-from .conftest import (
-    TEST_HOST,
-    TEST_MAC,
-    TEST_NVR_NAME,
-    TEST_PASSWORD,
-    TEST_PORT,
-    TEST_USE_HTTPS,
-    TEST_USERNAME,
-)
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,5 +1,5 @@
 """Test the Reolink init."""
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from reolink_aio.exceptions import ReolinkError
@@ -50,7 +50,9 @@ def reolink_mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     return config_entry
 
 
-async def test_ConfigEntryAuthFailed(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_ConfigEntryAuthFailed(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test a ConfigEntryAuthFailed is raised when credentials are invalid."""
     config_entry = reolink_mock_config_entry(hass)
 
@@ -63,7 +65,9 @@ async def test_ConfigEntryAuthFailed(hass: HomeAssistant, reolink_connect: Magic
     assert not hass.data.get(const.DOMAIN)
 
 
-async def test_ConfigEntryNotReady(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_ConfigEntryNotReady(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test a ConfigEntryNotReady is raised when initial connection fails."""
     config_entry = reolink_mock_config_entry(hass)
 
@@ -75,7 +79,9 @@ async def test_ConfigEntryNotReady(hass: HomeAssistant, reolink_connect: MagicMo
     assert not hass.data.get(const.DOMAIN)
 
 
-async def test_ConfigEntryNotReady_initial_fetch(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_ConfigEntryNotReady_initial_fetch(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test a ConfigEntryNotReady is raised when initial fetch of data fails."""
     config_entry = reolink_mock_config_entry(hass)
 
@@ -87,7 +93,9 @@ async def test_ConfigEntryNotReady_initial_fetch(hass: HomeAssistant, reolink_co
     assert not hass.data.get(const.DOMAIN)
 
 
-async def test_firmware_update_not_supported(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_firmware_update_not_supported(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test successful setup if firmware update is not supported."""
     config_entry = reolink_mock_config_entry(hass)
 
@@ -98,18 +106,24 @@ async def test_firmware_update_not_supported(hass: HomeAssistant, reolink_connec
     assert config_entry.state == ConfigEntryState.LOADED
 
 
-async def test_firmware_update_error(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_firmware_update_error(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test error during firmware update does not block setup."""
     config_entry = reolink_mock_config_entry(hass)
 
-    reolink_connect.check_new_firmware = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.check_new_firmware = AsyncMock(
+        side_effect=ReolinkError("Test error")
+    )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert config_entry.state == ConfigEntryState.LOADED
 
 
-async def test_unexpected_error(hass: HomeAssistant, reolink_connect: MagicMock) -> None:
+async def test_unexpected_error(
+    hass: HomeAssistant, reolink_connect: MagicMock
+) -> None:
     """Test a unexpected error during initial connection."""
     config_entry = reolink_mock_config_entry(hass)
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -69,18 +69,20 @@ async def test_failures_parametrized(
     assert config_entry.state == expected
 
 
-async def test_async_update_entry(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+async def test_entry_reloading(
+    hass: HomeAssistant, config_entry: MockConfigEntry, reolink_connect: MagicMock
 ) -> None:
-    """Test the update entry function."""
+    """Test the entry is reloaded correctly when settings change."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    assert reolink_connect.logout.call_count == 0
     assert config_entry.title == "test_reolink_name"
 
     hass.config_entries.async_update_entry(config_entry, title="New Name")
     await hass.async_block_till_done()
 
+    assert reolink_connect.logout.call_count == 1
     assert config_entry.title == "New Name"
 
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -69,10 +69,10 @@ async def test_failures_parametrized(
     assert config_entry.state == expected
 
 
-async def test_update_listener(
+async def test_async_update_entry(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test the update listener."""
+    """Test the update entry function."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,9 +1,13 @@
 """Test the Reolink init."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from reolink_aio.exceptions import ReolinkError
 
 from homeassistant.components.reolink import const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -22,9 +26,11 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
+pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_init")
 
-async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
-    """Test no repairs issue is raised when http local url is used."""
+
+def reolink_mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Add the reolink mock config entry to hass."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=format_mac(TEST_MAC),
@@ -41,6 +47,115 @@ async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
         title=TEST_NVR_NAME,
     )
     config_entry.add_to_hass(hass)
+
+    return config_entry
+
+
+async def test_ConfigEntryAuthFailed(hass: HomeAssistant) -> None:
+    """Test a ConfigEntryAuthFailed is raised when credentials are invalid."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info()
+    mock_info.is_admin = False
+    mock_info.user_level = "guest"
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert not hass.data.get(const.DOMAIN)
+
+
+async def test_ConfigEntryNotReady(hass: HomeAssistant) -> None:
+    """Test a ConfigEntryNotReady is raised when initial connection fails."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info(error=ReolinkError("Test error"))
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert not hass.data.get(const.DOMAIN)
+
+
+async def test_ConfigEntryNotReady_initial_fetch(hass: HomeAssistant) -> None:
+    """Test a ConfigEntryNotReady is raised when initial fetch of data fails."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info()
+    mock_info.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert not hass.data.get(const.DOMAIN)
+
+
+async def test_firmware_update_not_supported(hass: HomeAssistant) -> None:
+    """Test successful setup if firmware update is not supported."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info()
+    mock_info.supported = Mock(return_value=False)
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+
+async def test_firmware_update_error(hass: HomeAssistant) -> None:
+    """Test error during firmware update does not block setup."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info()
+    mock_info.check_new_firmware = AsyncMock(side_effect=ReolinkError("Test error"))
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+
+async def test_unexpected_error(hass: HomeAssistant) -> None:
+    """Test a unexpected error during initial connection."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    mock_info = get_mock_info(error=ValueError("Test error"))
+    with patch("homeassistant.components.reolink.host.Host", return_value=mock_info):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert not hass.data.get(const.DOMAIN)
+
+
+async def test_update_listener(hass: HomeAssistant) -> None:
+    """Test the update listener."""
+    config_entry = reolink_mock_config_entry(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.title == "test_reolink_name"
+
+    hass.config_entries.async_update_entry(config_entry, title="New Name")
+    await hass.async_block_till_done()
+
+    assert config_entry.title == "New Name"
+
+
+async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
+    """Test no repairs issue is raised when http local url is used."""
+    config_entry = reolink_mock_config_entry(hass)
 
     await async_process_ha_core_config(
         hass, {"country": "GB", "internal_url": "http://test_homeassistant_address"}
@@ -55,22 +170,7 @@ async def test_http_no_repair_issue(hass: HomeAssistant) -> None:
 
 async def test_https_repair_issue(hass: HomeAssistant) -> None:
     """Test repairs issue is raised when https local url is used."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
+    config_entry = reolink_mock_config_entry(hass)
 
     await async_process_ha_core_config(
         hass, {"country": "GB", "internal_url": "https://test_homeassistant_address"}
@@ -81,57 +181,3 @@ async def test_https_repair_issue(hass: HomeAssistant) -> None:
 
     issue_registry = ir.async_get(hass)
     assert (const.DOMAIN, "https_webhook") in issue_registry.issues
-
-
-async def test_no_firmware_repair_issue(hass: HomeAssistant) -> None:
-    """Test no firmware issue is raised when firmware is new enough."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)
-    assert (const.DOMAIN, "firmware_update") not in issue_registry.issues
-
-
-async def test_firmware_repair_issue(hass: HomeAssistant) -> None:
-    """Test firmware issue is raised when too old firmware is used."""
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
-            const.CONF_USE_HTTPS: TEST_USE_HTTPS,
-        },
-        options={
-            const.CONF_PROTOCOL: DEFAULT_PROTOCOL,
-        },
-        title=TEST_NVR_NAME,
-    )
-    config_entry.add_to_hass(hass)
-
-    host_mock = get_mock_info(sw_required=True)
-    with patch("homeassistant.components.reolink.host.Host", return_value=host_mock):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)
-    assert (const.DOMAIN, "firmware_update") in issue_registry.issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up reolink tests and fixtures.
Bring test coverage for the __init__.py file to 100% for the Reolink integration.

Requested by @epenet in this PR: https://github.com/home-assistant/core/pull/88903#discussion_r1124457591

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
