### PR TITLE
Revert "Replace Fitbit weight SensorStateClass measurement with total"

### DIFF
--- a/homeassistant/components/fitbit/const.py
+++ b/homeassistant/components/fitbit/const.py
@@ -220,7 +220,7 @@ FITBIT_RESOURCES_LIST: Final[tuple[FitbitSensorEntityDescription, ...]] = (
         name="Weight",
         unit_type="weight",
         icon="mdi:human",
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WEIGHT,
     ),
     FitbitSensorEntityDescription(


### PR DESCRIPTION
Reverts home-assistant/core#88118

Related to: https://github.com/home-assistant/core/pull/88314

Resolves: https://github.com/home-assistant/core/issues/87241#issuecomment-1452310878