### PR TITLE
Bump pyfritzhome to 0.6.8 and add support for Non-Color-Bulbs

### DIFF
--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -72,8 +72,10 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
         """Initialize the FritzboxLight entity."""
         super().__init__(coordinator, ain, None)
 
-        self._attr_max_color_temp_kelvin = int(max(supported_color_temps))
-        self._attr_min_color_temp_kelvin = int(min(supported_color_temps))
+        if supported_color_temps:
+            # only available for color bulbs
+            self._attr_max_color_temp_kelvin = int(max(supported_color_temps))
+            self._attr_min_color_temp_kelvin = int(min(supported_color_temps))
 
         # Fritz!DECT 500 only supports 12 values for hue, with 3 saturations each.
         # Map supported colors to dict {hue: [sat1, sat2, sat3]} for easier lookup
@@ -125,7 +127,11 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
     @property
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
-        return SUPPORTED_COLOR_MODES
+        if self.data.has_color:
+            return SUPPORTED_COLOR_MODES
+        if self.data.has_level:
+            return {ColorMode.BRIGHTNESS}
+        return {ColorMode.ONOFF}
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/homeassistant/components/fritzbox/manifest.json
+++ b/homeassistant/components/fritzbox/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyfritzhome"],
-  "requirements": ["pyfritzhome==0.6.7"],
+  "requirements": ["pyfritzhome==0.6.8"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:fritzbox:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1645,7 +1645,7 @@ pyforked-daapd==0.1.14
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.7
+pyfritzhome==0.6.8
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1182,7 +1182,7 @@ pyforked-daapd==0.1.14
 pyfreedompro==1.1.0
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.6.7
+pyfritzhome==0.6.8
 
 # homeassistant.components.fronius
 pyfronius==0.7.1

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -151,6 +151,8 @@ class FritzDeviceLightMock(FritzEntityBaseMock):
     has_alarm = False
     has_powermeter = False
     has_lightbulb = True
+    has_color = True
+    has_level = True
     has_switch = False
     has_temperature_sensor = False
     has_thermostat = False

--- a/tests/components/fritzbox/test_light.py
+++ b/tests/components/fritzbox/test_light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
     ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_MIN_COLOR_TEMP_KELVIN,
+    ATTR_SUPPORTED_COLOR_MODES,
     DOMAIN,
 )
 from homeassistant.const import (
@@ -57,6 +58,46 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     assert state.attributes[ATTR_COLOR_TEMP_KELVIN] == 2700
     assert state.attributes[ATTR_MIN_COLOR_TEMP_KELVIN] == 2700
     assert state.attributes[ATTR_MAX_COLOR_TEMP_KELVIN] == 6500
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
+
+
+async def test_setup_non_color(hass: HomeAssistant, fritz: Mock) -> None:
+    """Test setup of platform of non color bulb."""
+    device = FritzDeviceLightMock()
+    device.has_color = False
+    device.get_color_temps.return_value = []
+    device.get_colors.return_value = {}
+
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_BRIGHTNESS] == 100
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness"]
+
+
+async def test_setup_non_color_non_level(hass: HomeAssistant, fritz: Mock) -> None:
+    """Test setup of platform of non color and non level bulb."""
+    device = FritzDeviceLightMock()
+    device.has_color = False
+    device.has_level = False
+    device.get_color_temps.return_value = []
+    device.get_colors.return_value = {}
+
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_BRIGHTNESS] == 100
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["onoff"]
 
 
 async def test_setup_color(hass: HomeAssistant, fritz: Mock) -> None:
@@ -80,6 +121,7 @@ async def test_setup_color(hass: HomeAssistant, fritz: Mock) -> None:
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
     assert state.attributes[ATTR_BRIGHTNESS] == 100
     assert state.attributes[ATTR_HS_COLOR] == (100, 70)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
 
 
 async def test_turn_on(hass: HomeAssistant, fritz: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pyfritzhome to new version 0.6.8 and enable the displaying of Non-Color-Bulbs which were not supported until now

diff: https://github.com/hthiery/python-fritzhome/compare/0.6.7...0.6.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/hthiery/python-fritzhome/issues/80
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26494

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] -> 



If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
