### PR TITLE
Revert "Add day to event end to correct TwenteMilieu event timespan"

### DIFF
--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -1,7 +1,7 @@
 """Support for Twente Milieu Calendar."""
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 from twentemilieu import WasteType
 
@@ -58,7 +58,7 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
                 CalendarEvent(
                     summary=WASTE_TYPE_TO_DESCRIPTION[waste_type],
                     start=waste_date,
-                    end=waste_date + timedelta(days=1),
+                    end=waste_date,
                 )
                 for waste_date in waste_dates
                 if start_date.date() <= waste_date <= end_date.date()
@@ -89,7 +89,7 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
             self._event = CalendarEvent(
                 summary=WASTE_TYPE_TO_DESCRIPTION[next_waste_pickup_type],
                 start=next_waste_pickup_date,
-                end=next_waste_pickup_date + timedelta(days=1),
+                end=next_waste_pickup_date,
             )
 
         super()._handle_coordinator_update()

--- a/tests/components/twentemilieu/snapshots/test_calendar.ambr
+++ b/tests/components/twentemilieu/snapshots/test_calendar.ambr
@@ -12,7 +12,7 @@
     dict({
       'description': None,
       'end': dict({
-        'date': '2022-01-07',
+        'date': '2022-01-06',
       }),
       'location': None,
       'recurrence_id': None,
@@ -30,7 +30,7 @@
     'attributes': ReadOnlyDict({
       'all_day': True,
       'description': '',
-      'end_time': '2022-01-07 00:00:00',
+      'end_time': '2022-01-06 00:00:00',
       'friendly_name': 'Twente Milieu',
       'icon': 'mdi:delete-empty',
       'location': '',


### PR DESCRIPTION
Reverts home-assistant/core#89028

This has been merged, but is a workaround, not an actual fix.
For details, see:

https://github.com/home-assistant/core/pull/89028#issuecomment-1454685204

/CC @allenporter 