### PR TITLE
Add ability to disable/snooze alert notifications

### DIFF
--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -17,3 +17,9 @@ CONF_DATA = "data"
 
 DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False
+
+NOTIFICATION_SNOOZE = "snooze"
+SERVICE_NOTIFICATION_CONTROL = "notification_control"
+ATTR_SNOOZE_UNTIL = "snooze_until"
+SNOOZE_NOTIFICATIONS_ENABLED = "notifications-enabled"
+SNOOZE_NOTIFICATIONS_DISABLED = "notifications-disabled"

--- a/homeassistant/components/alert/services.yaml
+++ b/homeassistant/components/alert/services.yaml
@@ -18,3 +18,33 @@ turn_on:
   target:
     entity:
       domain: alert
+
+notification_control:
+  name: Notification Control
+  description: Enable/Disable/Snooze notifications (for current and future alerts).
+  target:
+    entity:
+      domain: alert
+  fields:
+    enable:
+      name: Notifications
+      description: Enable, disable or snooze notifications
+      example: true
+      required: true
+      selector:
+        select:
+          options:
+            - label: "On"
+              value: "on"
+            - label: "Off"
+              value: "off"
+            - label: "Snooze"
+              value: "snooze"
+    snooze_hours:
+      name: Snooze for (hours)
+      description: Notifications will only be sent for alerts that fire after this many hours from now.  Should only be set if Notifications is set to "Snooze"
+      required: false
+      selector:
+        number:
+          min: 0
+          mode: box

--- a/homeassistant/components/alert/services.yaml
+++ b/homeassistant/components/alert/services.yaml
@@ -7,21 +7,21 @@ toggle:
 
 turn_off:
   name: Turn off
-  description: Silence alert's notifications.
+  description: Silence alert's notifications. Affects only current firing, not future firings of the alert.
   target:
     entity:
       domain: alert
 
 turn_on:
   name: Turn on
-  description: Reset alert's notifications.
+  description: Reset alert's notifications. Affects only current firing, not future firings of the alert.
   target:
     entity:
       domain: alert
 
 notification_control:
   name: Notification Control
-  description: Enable/Disable/Snooze notifications (for current and future alerts).
+  description: Enable/Disable/Snooze notifications. Affects current and future alert firings.
   target:
     entity:
       domain: alert
@@ -34,17 +34,15 @@ notification_control:
       selector:
         select:
           options:
-            - label: "On"
+            - label: "Enable"
               value: "on"
-            - label: "Off"
+            - label: "Disable"
               value: "off"
             - label: "Snooze"
               value: "snooze"
-    snooze_hours:
-      name: Snooze for (hours)
-      description: Notifications will only be sent for alerts that fire after this many hours from now.  Should only be set if Notifications is set to "Snooze"
+    snooze_until:
+      name: Snooze until
+      description: Notifications will only be sent for alerts that fire after this time.  Should only be set if Notifications is set to "Snooze". Format can be "2000-01-20 04:23:00". Time is parsed as GMT.
       required: false
       selector:
-        number:
-          min: 0
-          mode: box
+        text:

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -1,11 +1,13 @@
 """The tests for the Alert component."""
 
 from copy import deepcopy
+from datetime import datetime, timedelta
 
 import pytest
 
 import homeassistant.components.alert as alert
 from homeassistant.components.alert.const import (
+    ATTR_SNOOZE_UNTIL,
     CONF_ALERT_MESSAGE,
     CONF_DATA,
     CONF_DONE_MESSAGE,
@@ -13,6 +15,10 @@ from homeassistant.components.alert.const import (
     CONF_SKIP_FIRST,
     CONF_TITLE,
     DOMAIN,
+    NOTIFICATION_SNOOZE,
+    SERVICE_NOTIFICATION_CONTROL,
+    SNOOZE_NOTIFICATIONS_DISABLED,
+    SNOOZE_NOTIFICATIONS_ENABLED,
 )
 import homeassistant.components.notify as notify
 from homeassistant.const import (
@@ -28,10 +34,11 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import CoreState, HomeAssistant, ServiceCall, State
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import now
 
-from tests.common import async_mock_service
+from tests.common import async_mock_service, mock_restore_cache
 
 NAME = "alert_test"
 DONE_MESSAGE = "alert_gone"
@@ -76,6 +83,7 @@ ENTITY_ID = f"{DOMAIN}.{NAME}"
 @pytest.fixture
 def mock_notifier(hass: HomeAssistant) -> list[ServiceCall]:
     """Mock for notifier."""
+
     return async_mock_service(hass, notify.DOMAIN, NOTIFIER)
 
 
@@ -83,6 +91,8 @@ async def test_setup(hass: HomeAssistant) -> None:
     """Test setup method."""
     assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     assert hass.states.get(ENTITY_ID).state == STATE_IDLE
+    snooze_until = hass.states.get(ENTITY_ID).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_ENABLED
 
 
 async def test_fire(hass: HomeAssistant, mock_notifier: list[ServiceCall]) -> None:
@@ -324,3 +334,149 @@ async def test_done_message_state_tracker_reset_on_cancel(hass: HomeAssistant) -
     hass.async_add_job(entity.end_alerting)
     await hass.async_block_till_done()
     assert entity._send_done_message is False
+
+
+async def test_ignore_notification(
+    hass: HomeAssistant, mock_notifier: list[ServiceCall]
+) -> None:
+    """Test notifications."""
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
+    assert len(mock_notifier) == 0
+
+    # Disable notifications. No notifications should be sent
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NOTIFICATION_CONTROL,
+        {ATTR_ENTITY_ID: ENTITY_ID, "enable": STATE_OFF},
+        blocking=True,
+    )
+    snooze_until = hass.states.get(ENTITY_ID).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_DISABLED
+
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 0
+
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 0
+
+    # Re-enable notifications. Now notifications should be sent.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NOTIFICATION_CONTROL,
+        {ATTR_ENTITY_ID: ENTITY_ID, "enable": STATE_ON},
+        blocking=True,
+    )
+    snooze_until = hass.states.get(ENTITY_ID).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_ENABLED
+
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 1
+
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 2
+
+
+async def test_snooze_notification(
+    hass: HomeAssistant, mock_notifier: list[ServiceCall]
+) -> None:
+    """Test snoozing notifications."""
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
+    assert len(mock_notifier) == 0
+
+    # Snooze notifications for an hour
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NOTIFICATION_CONTROL,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            "enable": NOTIFICATION_SNOOZE,
+            "snooze_hours": 1,
+        },
+        blocking=True,
+    )
+    snooze_until = hass.states.get(ENTITY_ID).attributes[ATTR_SNOOZE_UNTIL]
+    assert isinstance(snooze_until, datetime)
+    assert snooze_until > now()
+
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 0
+
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(mock_notifier) == 0
+
+    # TODO - it'd be nice to test that if enough time passes, the notifications will start firing,
+    # but I think that'd require somehow mocking out datetime.
+
+
+ENTITY_ID1 = f"{DOMAIN}.{NAME}1"
+ENTITY_ID2 = f"{DOMAIN}.{NAME}2"
+ENTITY_ID3 = f"{DOMAIN}.{NAME}3"
+
+
+async def test_restore_snooze_state(hass: HomeAssistant) -> None:
+    """Test alert snooze state restore on restart."""
+
+    # We test restoring 3 entities. First has notifications disabled. Second has them enabled.
+    # Third has notifications snoozed for the next hour.
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                ENTITY_ID,
+                STATE_IDLE,
+                {ATTR_SNOOZE_UNTIL: SNOOZE_NOTIFICATIONS_DISABLED},
+            ),
+            State(
+                ENTITY_ID1,
+                STATE_IDLE,
+                {ATTR_SNOOZE_UNTIL: SNOOZE_NOTIFICATIONS_ENABLED},
+            ),
+            State(
+                ENTITY_ID2,
+                STATE_IDLE,
+                {ATTR_SNOOZE_UNTIL: str(now() + timedelta(hours=1))},
+            ),
+            State(
+                ENTITY_ID3,
+                STATE_IDLE,
+                {ATTR_SNOOZE_UNTIL: str(now() - timedelta(hours=1))},
+            ),
+        ),
+    )
+    TEST_CONFIG2 = deepcopy(TEST_CONFIG)
+    TEST_CONFIG2[DOMAIN][NAME + "1"] = deepcopy(TEST_CONFIG[DOMAIN][NAME])
+    TEST_CONFIG2[DOMAIN][NAME + "2"] = deepcopy(TEST_CONFIG[DOMAIN][NAME])
+    TEST_CONFIG2[DOMAIN][NAME + "3"] = deepcopy(TEST_CONFIG[DOMAIN][NAME])
+    TEST_CONFIG2[DOMAIN][NAME + "1"][CONF_NAME] = NAME + "1"
+    TEST_CONFIG2[DOMAIN][NAME + "2"][CONF_NAME] = NAME + "2"
+    TEST_CONFIG2[DOMAIN][NAME + "3"][CONF_NAME] = NAME + "3"
+
+    hass.state = CoreState.not_running
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG2)
+
+    hass.states.get(ENTITY_ID)
+    assert hass.states.get(ENTITY_ID).state == STATE_IDLE
+    snooze_until = hass.states.get(ENTITY_ID).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_DISABLED
+
+    hass.states.get(ENTITY_ID1)
+    assert hass.states.get(ENTITY_ID1).state == STATE_IDLE
+    snooze_until = hass.states.get(ENTITY_ID1).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_ENABLED
+
+    hass.states.get(ENTITY_ID2)
+    assert hass.states.get(ENTITY_ID2).state == STATE_IDLE
+    snooze_until = hass.states.get(ENTITY_ID2).attributes[ATTR_SNOOZE_UNTIL]
+    assert isinstance(snooze_until, datetime)
+    assert snooze_until > now()
+
+    hass.states.get(ENTITY_ID3)
+    assert hass.states.get(ENTITY_ID3).state == STATE_IDLE
+    snooze_until = hass.states.get(ENTITY_ID3).attributes[ATTR_SNOOZE_UNTIL]
+    assert snooze_until == SNOOZE_NOTIFICATIONS_ENABLED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add ability to Alert class to disable alert notifications, either until a specified time or indefinitely.
The alert will still fire and can still be ack'd, so alert status and history is preserved for diagnostics.
Alert notification snoozing is preserved across HomeAssistant restarts (via RestoreEntity).

This change allows silencing an alert that is repeatedly turning on & off without loosing alert information or affecting notifications from other alerts. An example would be a water-leak sensor that is a little wet and oscillates above & below the alert threshold. Or a heat sensor similarly near a threshold temperature.

The mechanism is via a new Alert attribute, "snooze_until", that controls notification behavior, and a new service call, alert.notification_control to adjust the attribute. It might make sense to have a follow-on change to Lovelace to change the more-info popup for alerts to make it easier to access the new behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

There are a few threads in which people comment on getting too many alert notifications. I think people sometimes avoid alerts and make do with automations + extra input_xx entities, which isn't ideal. Some threads:
- https://community.home-assistant.io/t/wind-speed-alert-notification/382333
- https://community.home-assistant.io/t/nagging-repeatable-alert-notification-send-to-mobile-and-optional-other-actions/256392
- https://community.home-assistant.io/t/ability-to-disable-an-alert-worth-a-cl/541516

I'm happy to update the Alert documentation - thought I'd wait to see how this pull request is received first.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
