### PR TITLE
Fix lingering tasks in KNX tests

### DIFF
--- a/tests/components/knx/README.md
+++ b/tests/components/knx/README.md
@@ -69,3 +69,4 @@ Receive some telegrams and assert state.
 - For `payload` in `assert_*` and `receive_*` use `int` for DPT 1, 2 and 3 payload values (DPTBinary) and `tuple` for other DPTs (DPTArray).
 - `await self.hass.async_block_till_done()` is called before `KNXTestKit.assert_*` and after `KNXTestKit.receive_*` so you don't have to explicitly call it.
 - Make sure to assert every outgoing telegram that was created in a test. `assert_no_telegram` is automatically called on teardown.
+- Make sure to `knx.receive_response()` for every Read-request sent form StateUpdater, or to pass its timeout, to not have lingering tasks when finishing the tests.

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -10,6 +10,10 @@ from .conftest import KNXTestKit
 
 from tests.common import async_capture_events
 
+RAW_FLOAT_20_0 = (0x07, 0xD0)
+RAW_FLOAT_21_0 = (0x0C, 0x1A)
+RAW_FLOAT_22_0 = (0x0C, 0x4C)
+
 
 async def test_climate_basic_temperature_set(
     hass: HomeAssistant, knx: KNXTestKit
@@ -34,6 +38,10 @@ async def test_climate_basic_temperature_set(
     await knx.assert_read("1/2/3")
     # read target temperature
     await knx.assert_read("1/2/5")
+    # StateUpdater initialize state
+    await knx.receive_response("1/2/3", RAW_FLOAT_21_0)
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
+    events.clear()
 
     # set new temperature
     await hass.services.async_call(
@@ -42,9 +50,8 @@ async def test_climate_basic_temperature_set(
         {"entity_id": "climate.test", "temperature": 20},
         blocking=True,
     )
-    await knx.assert_write("1/2/4", (7, 208))
+    await knx.assert_write("1/2/4", RAW_FLOAT_20_0)
     assert len(events) == 1
-    events.pop()
 
 
 async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -73,11 +80,12 @@ async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_read("1/2/7")
     await knx.assert_read("1/2/3")
     # StateUpdater initialize state
-    await knx.receive_response("1/2/7", True)
-    await knx.receive_response("1/2/3", (0x21,))
+    await knx.receive_response("1/2/7", (0x01,))
+    await knx.receive_response("1/2/3", RAW_FLOAT_20_0)
     # StateUpdater semaphore allows 2 concurrent requests
     # read target temperature state
     await knx.assert_read("1/2/5")
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
 
     # turn hvac off
     await hass.services.async_call(
@@ -125,11 +133,13 @@ async def test_climate_preset_mode(
     await knx.assert_read("1/2/7")
     await knx.assert_read("1/2/3")
     # StateUpdater initialize state
-    await knx.receive_response("1/2/7", True)
-    await knx.receive_response("1/2/3", (0x01,))
+    await knx.receive_response("1/2/7", (0x01,))
+    await knx.receive_response("1/2/3", RAW_FLOAT_21_0)
     # StateUpdater semaphore allows 2 concurrent requests
     # read target temperature state
     await knx.assert_read("1/2/5")
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
+    events.clear()
 
     # set preset mode
     await hass.services.async_call(
@@ -190,10 +200,11 @@ async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_read("1/2/7")
     await knx.assert_read("1/2/3")
     # StateUpdater initialize state
-    await knx.receive_response("1/2/7", True)
-    await knx.receive_response("1/2/3", (0x01,))
+    await knx.receive_response("1/2/7", (0x01,))
+    await knx.receive_response("1/2/3", RAW_FLOAT_21_0)
     # StateUpdater semaphore allows 2 concurrent requests
     await knx.assert_read("1/2/5")
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
 
     # verify update entity retriggers group value reads to the bus
     await hass.services.async_call(
@@ -210,7 +221,6 @@ async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
 async def test_command_value_idle_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate command_value."""
-    events = async_capture_events(hass, "state_changed")
     await knx.setup_integration(
         {
             ClimateSchema.PLATFORM: {
@@ -222,20 +232,17 @@ async def test_command_value_idle_mode(hass: HomeAssistant, knx: KNXTestKit) -> 
             }
         }
     )
-    assert len(hass.states.async_all()) == 1
-    assert len(events) == 1
-    events.pop()
 
     await hass.async_block_till_done()
     # read states state updater
     await knx.assert_read("1/2/3")
     await knx.assert_read("1/2/5")
     # StateUpdater initialize state
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
+    await knx.receive_response("1/2/3", RAW_FLOAT_21_0)
+    # StateUpdater semaphore allows 2 concurrent requests
+    await knx.assert_read("1/2/6")
     await knx.receive_response("1/2/6", (0x32,))
-    await knx.receive_response("1/2/3", (0x0C, 0x1A))
-
-    assert len(events) == 2
-    events.pop()
 
     knx.assert_state("climate.test", HVACMode.HEAT, command_value=20)
 

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -31,6 +31,10 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     # read position state address and angle state address
     await knx.assert_read("1/0/2")
     await knx.assert_read("1/0/4")
+    # StateUpdater initialize state
+    await knx.receive_response("1/0/2", (0x0F,))
+    await knx.receive_response("1/0/4", (0x30,))
+    events.clear()
 
     # open cover
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Read-requests from StateUpdater yield tasks waiting for the timeout. In tests every StateUpdater request should be answered or the timeout should be passed (eg. `async_fire_time_changed`) to finish these tasks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #88905
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
