### PR TITLE
Bump ruff to 0.0.253

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.247
+    rev: v0.0.253
     hooks:
       - id: ruff
         args:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -177,7 +177,10 @@ class PS4Device(MediaPlayerEntity):
                         self._attr_source = self._attr_media_title
                         self._attr_media_content_type = None
                         # Get data from PS Store.
-                        asyncio.ensure_future(self.async_get_title_data(title_id, name))
+                        self.hass.async_create_background_task(
+                            self.async_get_title_data(title_id, name),
+                            "ps4.media_player-get_title_data",
+                        )
                 else:
                     if self.state != MediaPlayerState.IDLE:
                         self.idle()

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -393,7 +393,10 @@ class ZHAGateway:
             device_info = zha_device.zha_device_info
             zha_device.async_cleanup_handles()
             async_dispatcher_send(self._hass, f"{SIGNAL_REMOVE}_{str(zha_device.ieee)}")
-            asyncio.ensure_future(self._async_remove_device(zha_device, entity_refs))
+            self._hass.async_create_task(
+                self._async_remove_device(zha_device, entity_refs),
+                "ZHAGateway._async_remove_device",
+            )
             if device_info is not None:
                 async_dispatcher_send(
                     self._hass,

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -14,5 +14,5 @@ pycodestyle==2.10.0
 pydocstyle==6.2.3
 pyflakes==3.0.1
 pyupgrade==3.3.1
-ruff==0.0.247
+ruff==0.0.253
 yamllint==1.28.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for `ensure_future` for `RUF006` https://github.com/charliermarsh/ruff/pull/2943
- [x] PS4
   ```console
   homeassistant/components/ps4/media_player.py:180:25: RUF006 Store a reference to the return value of `asyncio.ensure_future`
   ```
- [x] ZHA
   ```console
   homeassistant/components/zha/core/gateway.py:396:13: RUF006 Store a reference to the return value of `asyncio.ensure_future`
   ```
- [x] tests/test_runner.py
   ```console
   tests/test_runner.py:104:9: RUF006 Store a reference to the return value of `asyncio.ensure_future`
   tests/test_runner.py:105:9: RUF006 Store a reference to the return value of `asyncio.ensure_future`
   tests/test_runner.py:106:9: RUF006 Store a reference to the return value of `asyncio.ensure_future`
   ```

https://github.com/charliermarsh/ruff/releases/tag/v0.0.253
https://github.com/charliermarsh/ruff/releases/tag/v0.0.252
https://github.com/charliermarsh/ruff/releases/tag/v0.0.251
https://github.com/charliermarsh/ruff/releases/tag/v0.0.250
https://github.com/charliermarsh/ruff/releases/tag/v0.0.249
https://github.com/charliermarsh/ruff/releases/tag/v0.0.248

https://github.com/charliermarsh/ruff/compare/v0.0.247...v0.0.253

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
