### PR TITLE
Split reauth tests in plex

### DIFF
--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for Plex tests."""
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -16,6 +17,15 @@ from tests.common import MockConfigEntry, load_fixture
 def plex_server_url(entry):
     """Return a protocol-less URL from a config entry."""
     return entry.data[PLEX_SERVER_CONFIG][CONF_URL].split(":", 1)[-1]
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.plex.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture(name="album", scope="session")

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -2,7 +2,7 @@
 import copy
 from http import HTTPStatus
 import ssl
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import plexapi.exceptions
 import pytest
@@ -42,7 +42,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
-from .helpers import trigger_plex_update, wait_for_debouncer
 from .mock_classes import MockGDM
 
 from tests.common import MockConfigEntry
@@ -718,31 +717,22 @@ async def test_integration_discovery(hass: HomeAssistant) -> None:
     assert flow["step_id"] == "user"
 
 
-async def test_trigger_reauth(
+async def test_reauth(
     hass: HomeAssistant,
-    entry,
-    mock_plex_server,
-    mock_websocket,
+    entry: MockConfigEntry,
+    mock_plex_calls: None,
     current_request_with_host: None,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test setup and reauthorization of a Plex token."""
+    entry.add_to_hass(hass)
 
-    assert entry.state is ConfigEntryState.LOADED
-
-    with patch(
-        "plexapi.server.PlexServer.clients", side_effect=plexapi.exceptions.Unauthorized
-    ), patch("plexapi.server.PlexServer", side_effect=plexapi.exceptions.Unauthorized):
-        trigger_plex_update(mock_websocket)
-        await wait_for_debouncer(hass)
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state is not ConfigEntryState.LOADED
-
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
-
-    flow_id = flows[0]["flow_id"]
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH},
+        data=entry.data,
+    )
+    flow_id = result["flow_id"]
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
         "plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"
@@ -767,38 +757,33 @@ async def test_trigger_reauth(
     assert entry.data[PLEX_SERVER_CONFIG][CONF_URL] == PLEX_DIRECT_URL
     assert entry.data[PLEX_SERVER_CONFIG][CONF_TOKEN] == "BRAND_NEW_TOKEN"
 
+    mock_setup_entry.assert_called_once()
 
-async def test_trigger_reauth_multiple_servers_available(
+
+async def test_reauth_multiple_servers_available(
     hass: HomeAssistant,
-    entry,
-    mock_plex_server,
-    mock_websocket,
+    entry: MockConfigEntry,
+    mock_plex_calls: None,
     current_request_with_host: None,
     requests_mock: requests_mock.Mocker,
-    plextv_resources_two_servers,
+    plextv_resources_two_servers: str,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test setup and reauthorization of a Plex token when multiple servers are available."""
-    assert entry.state is ConfigEntryState.LOADED
-
     requests_mock.get(
         "https://plex.tv/api/resources",
         text=plextv_resources_two_servers,
     )
 
-    with patch(
-        "plexapi.server.PlexServer.clients", side_effect=plexapi.exceptions.Unauthorized
-    ), patch("plexapi.server.PlexServer", side_effect=plexapi.exceptions.Unauthorized):
-        trigger_plex_update(mock_websocket)
-        await wait_for_debouncer(hass)
+    entry.add_to_hass(hass)
 
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state is not ConfigEntryState.LOADED
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH},
+        data=entry.data,
+    )
 
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
-
-    flow_id = flows[0]["flow_id"]
+    flow_id = result["flow_id"]
 
     with patch("plexauth.PlexAuth.initiate_auth"), patch(
         "plexauth.PlexAuth.token", return_value="BRAND_NEW_TOKEN"
@@ -822,6 +807,8 @@ async def test_trigger_reauth_multiple_servers_available(
     assert entry.data[CONF_SERVER_IDENTIFIER] == "unique_id_123"
     assert entry.data[PLEX_SERVER_CONFIG][CONF_URL] == PLEX_DIRECT_URL
     assert entry.data[PLEX_SERVER_CONFIG][CONF_TOKEN] == "BRAND_NEW_TOKEN"
+
+    mock_setup_entry.assert_called_once()
 
 
 async def test_client_request_missing(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out "trigger reauth" and "do reauth" processes, and ensure that `async_setup_entry` is correctly patched during the reauth process.

Linked to #88905

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
