### PR TITLE
Add sensor language option to sma integration

### DIFF
--- a/homeassistant/components/sma/__init__.py
+++ b/homeassistant/components/sma/__init__.py
@@ -142,9 +142,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def update_listener(hass, entry):
     """Handle options update."""
-    _LOGGER.info("Change SMA language to: %s", entry.options.get(CONF_LANGUAGE))
-    ok_result = await async_unload_entry(hass, entry)
-    if ok_result:
+    _LOGGER.debug("Change SMA language to: %s", entry.options.get(CONF_LANGUAGE))
+    ok_result = False
+    unloaded = await async_unload_entry(hass, entry)
+    if unloaded:
         ok_result = await async_setup_entry(hass, entry)
 
     return ok_result

--- a/homeassistant/components/sma/const.py
+++ b/homeassistant/components/sma/const.py
@@ -1,4 +1,6 @@
 """Constants for the sma integration."""
+from pysma.const import DEFAULT_LANG
+
 from homeassistant.const import Platform
 
 DOMAIN = "sma"
@@ -16,3 +18,5 @@ CONF_GROUP = "group"
 DEFAULT_SCAN_INTERVAL = 5
 
 GROUPS = ["user", "installer"]
+
+DEFAULT_LANGUAGE = DEFAULT_LANG

--- a/homeassistant/components/sma/manifest.json
+++ b/homeassistant/components/sma/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sma",
   "iot_class": "local_polling",
   "loggers": ["pysma"],
-  "requirements": ["pysma==0.7.3"]
+  "requirements": ["pysma==0.7.4"]
 }

--- a/homeassistant/components/sma/strings.json
+++ b/homeassistant/components/sma/strings.json
@@ -23,5 +23,15 @@
         "title": "Set up SMA Solar"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure SMA Solar",
+        "data": {
+          "language": "Sensor value language (must exist on device, e.g. en-US)"
+        }
+      }
+    }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1964,7 +1964,7 @@ pysignalclirestapi==0.3.18
 pyskyqhub==0.1.4
 
 # homeassistant.components.sma
-pysma==0.7.3
+pysma==0.7.4
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1420,7 +1420,7 @@ pysiaalarm==3.0.2
 pysignalclirestapi==0.3.18
 
 # homeassistant.components.sma
-pysma==0.7.3
+pysma==0.7.4
 
 # homeassistant.components.smappee
 pysmappee==0.2.29

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -9,6 +9,7 @@ from pysma.exceptions import (
 
 from homeassistant.components.sma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_LANGUAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -137,3 +138,28 @@ async def test_form_already_configured(hass: HomeAssistant, mock_config_entry) -
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_options_flow_lang(hass: HomeAssistant, mock_config_entry) -> None:
+    """Test config flow options."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.sma.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_LANGUAGE: "en-US"}
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert mock_config_entry.options == {CONF_LANGUAGE: "en-US"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added configuration option to SMA Solar integration to choose sensor value language.
If configured language is not supported by device, it fallsback to English.
![sma-lang-option](https://user-images.githubusercontent.com/3511114/223043542-6f5e461f-11b9-4252-b9c0-2b861fa76c63.png)
The change updates dependency pysma from 0.7.3 to 0.7.4 which includes the following change: https://github.com/kellerza/pysma/pull/117.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26544

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
