### PR TITLE
Add Statistics "total_area" to calculate consumption over a long time

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -85,6 +85,7 @@ STAT_SUM = "sum"
 STAT_SUM_DIFFERENCES = "sum_differences"
 STAT_SUM_DIFFERENCES_NONNEGATIVE = "sum_differences_nonnegative"
 STAT_TOTAL = "total"
+STAT_TOTAL_AREA = "total_area"
 STAT_VALUE_MAX = "value_max"
 STAT_VALUE_MIN = "value_min"
 STAT_VARIANCE = "variance"
@@ -114,6 +115,7 @@ STATS_NUMERIC_SUPPORT = {
     STAT_SUM_DIFFERENCES,
     STAT_SUM_DIFFERENCES_NONNEGATIVE,
     STAT_TOTAL,
+    STAT_TOTAL_AREA,
     STAT_VALUE_MAX,
     STAT_VALUE_MIN,
     STAT_VARIANCE,
@@ -163,6 +165,7 @@ STATS_NUMERIC_RETAIN_UNIT = {
     STAT_SUM_DIFFERENCES,
     STAT_SUM_DIFFERENCES_NONNEGATIVE,
     STAT_TOTAL,
+    STAT_TOTAL_AREA,
     STAT_VALUE_MAX,
     STAT_VALUE_MIN,
 }
@@ -719,6 +722,23 @@ class StatisticsSensor(SensorEntity):
 
     def _stat_total(self) -> StateType:
         return self._stat_sum()
+
+    def _stat_total_area(self) -> StateType:
+        """
+        Like total, but multiply each datapoint with its duration.
+        Gets the sum of the rectangles.
+        Given an X/second sensor,
+        you can get total X consumption in the last 24h
+        """
+        # Copied from _stat_average_linear
+        if len(self.states) >= 2:
+            area: float = 0
+            for i in range(1, len(self.states)):
+                width = self.states[i] + self.states[i - 1]
+                height = (self.ages[i] - self.ages[i - 1]).total_seconds()
+                area += width * height
+            return area
+        return None
 
     def _stat_value_max(self) -> StateType:
         if len(self.states) > 0:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm interested in calculating the power consumption of my boiler.
I have a sensor that measures the Ampere consumption, and I'd like to use the "statistics" model to sum Amperes over the last 24 hours.
The current "total" or "sum" doesn't take into account the duration of each datapoint. "average_linear" does, but it does extra math to it.

I'm proposing to create "total_area" which calculates the area in the rectangle, which is actually total unit produced / consumed in that time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
    I don't see any testing for existing "area" code

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
