### PR TITLE
Fix MQTT rgb light brightness scaling

### DIFF
--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -495,10 +495,12 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 self._attr_color_mode = color_mode
             if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
                 rgb = convert_color(*color)
-                percent_bright = max(rgb) / 255.0
-                self._attr_brightness = min(round(percent_bright * 255), 255)
+                brightness = max(rgb)
+                self._attr_brightness = min(round(brightness), 255)
                 # Normalize the color to 100% brightness
-                color = tuple(round(channel / percent_bright) for channel in color)
+                color = tuple(
+                    min(round(channel / brightness * 255), 255) for channel in color
+                )
             return color
 
         @callback

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -495,10 +495,10 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 self._attr_color_mode = color_mode
             if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
                 rgb = convert_color(*color)
-                percent_bright = float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
+                percent_bright = max(rgb) / 255.0
                 self._attr_brightness = min(round(percent_bright * 255), 255)
                 # Normalize the color to 100% brightness
-                color = tuple(int(channel / percent_bright) for channel in color)
+                color = tuple(round(channel / percent_bright) for channel in color)
             return color
 
         @callback

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -497,6 +497,8 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 rgb = convert_color(*color)
                 percent_bright = float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
                 self._attr_brightness = min(round(percent_bright * 255), 255)
+                # Normalize the color to 100% brightness
+                color = tuple(int(channel / percent_bright) for channel in color)
             return color
 
         @callback

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -496,7 +496,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
                 rgb = convert_color(*color)
                 brightness = max(rgb)
-                self._attr_brightness = min(round(brightness), 255)
+                self._attr_brightness = brightness
                 # Normalize the color to 100% brightness
                 color = tuple(
                     min(round(channel / brightness * 255), 255) for channel in color

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -654,6 +654,7 @@ async def test_brightness_from_rgb_controlling_scale(
 
     state = hass.states.get("light.test")
     assert state.attributes.get("brightness") == 128
+    assert state.attributes.get("rgb_color") == (255, 127, 63)
 
     mqtt_mock.async_publish.reset_mock()
     await common.async_turn_on(hass, "light.test", brightness=191)
@@ -671,6 +672,7 @@ async def test_brightness_from_rgb_controlling_scale(
 
     state = hass.states.get("light.test")
     assert state.attributes.get("brightness") == 191
+    assert state.attributes.get("rgb_color") == (254, 126, 62)
 
 
 async def test_controlling_state_via_topic_with_templates(

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -636,8 +636,8 @@ async def test_brightness_from_rgb_controlling_scale(
             }
         },
     )
+    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
     await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
 
     state = hass.states.get("light.test")
     assert state.state == STATE_UNKNOWN
@@ -650,10 +650,27 @@ async def test_brightness_from_rgb_controlling_scale(
     state = hass.states.get("light.test")
     assert state.attributes.get("brightness") == 255
 
-    async_fire_mqtt_message(hass, "test_scale_rgb/rgb/status", "127,0,0")
+    async_fire_mqtt_message(hass, "test_scale_rgb/rgb/status", "128,64,32")
 
     state = hass.states.get("light.test")
-    assert state.attributes.get("brightness") == 127
+    assert state.attributes.get("brightness") == 128
+
+    mqtt_mock.async_publish.reset_mock()
+    await common.async_turn_on(hass, "light.test", brightness=191)
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_has_calls(
+        [
+            call("test_scale_rgb/set", "on", 0, False),
+            call("test_scale_rgb/rgb/set", "191,95,47", 0, False),
+        ],
+        any_order=True,
+    )
+    async_fire_mqtt_message(hass, "test_scale_rgb/rgb/status", "191,95,47")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.test")
+    assert state.attributes.get("brightness") == 191
 
 
 async def test_controlling_state_via_topic_with_templates(

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -654,7 +654,7 @@ async def test_brightness_from_rgb_controlling_scale(
 
     state = hass.states.get("light.test")
     assert state.attributes.get("brightness") == 128
-    assert state.attributes.get("rgb_color") == (255, 127, 63)
+    assert state.attributes.get("rgb_color") == (255, 128, 64)
 
     mqtt_mock.async_publish.reset_mock()
     await common.async_turn_on(hass, "light.test", brightness=191)
@@ -672,7 +672,7 @@ async def test_brightness_from_rgb_controlling_scale(
 
     state = hass.states.get("light.test")
     assert state.attributes.get("brightness") == 191
-    assert state.attributes.get("rgb_color") == (254, 126, 62)
+    assert state.attributes.get("rgb_color") == (255, 127, 63)
 
 
 async def test_controlling_state_via_topic_with_templates(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the brightness of MQTT rgb light is scaled and, the current brightness calculated from the rgb status, this should be taken into account when setting a new brightness.

Example: When the brightness is first set to 128 (50%) on a rgb of (255,0,0) the result is (128,0,0). If then the brightness is set to 191 (75 %) we should know that the current RGB values are related to the current brightness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89151
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
