### PR TITLE
Migrate integration_platform helper to use async_get_integrations

### DIFF
--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -87,12 +87,12 @@ async def async_process_integration_platform_for_component(
     ]
     integrations = await async_get_integrations(hass, (component_name,))
     await asyncio.gather(
-        *[
+        *(
             _async_process_single_integration_platform_component(
                 hass, component_name, integrations[component_name], integration_platform
             )
             for integration_platform in integration_platforms
-        ]
+        )
     )
 
 
@@ -125,10 +125,10 @@ async def async_process_integration_platforms(
     ]:
         integrations = await async_get_integrations(hass, top_level_components)
         await asyncio.gather(
-            *[
+            *(
                 _async_process_single_integration_platform_component(
                     hass, comp, integrations[comp], integration_platform
                 )
                 for comp in top_level_components
-            ]
+            )
         )

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -28,7 +28,7 @@ class IntegrationPlatform:
 async def _async_process_single_integration_platform_component(
     hass: HomeAssistant,
     component_name: str,
-    integrations: dict[str, Integration | Exception],
+    integration: Integration | Exception,
     integration_platform: IntegrationPlatform,
 ) -> None:
     """Process a single integration platform."""
@@ -36,7 +36,6 @@ async def _async_process_single_integration_platform_component(
         return
     integration_platform.seen_components.add(component_name)
 
-    integration = integrations[component_name]
     if isinstance(integration, Exception):
         _LOGGER.exception(
             "Error importing integration %s for %s",
@@ -90,7 +89,7 @@ async def async_process_integration_platform_for_component(
     await asyncio.gather(
         *[
             _async_process_single_integration_platform_component(
-                hass, component_name, integrations, integration_platform
+                hass, component_name, integrations[component_name], integration_platform
             )
             for integration_platform in integration_platforms
         ]
@@ -128,7 +127,7 @@ async def async_process_integration_platforms(
         await asyncio.gather(
             *[
                 _async_process_single_integration_platform_component(
-                    hass, comp, integrations, integration_platform
+                    hass, comp, integrations[comp], integration_platform
                 )
                 for comp in top_level_components
             ]

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -88,8 +88,14 @@ async def async_process_integration_platform_for_component(
     integrations = await async_get_integrations(hass, (component_name,))
     await asyncio.gather(
         *(
-            _async_process_single_integration_platform_component(
-                hass, component_name, integrations[component_name], integration_platform
+            asyncio.create_task(
+                _async_process_single_integration_platform_component(
+                    hass,
+                    component_name,
+                    integrations[component_name],
+                    integration_platform,
+                ),
+                name=f"process integration platform {integration_platform.platform_name} for {component_name}",
             )
             for integration_platform in integration_platforms
         )
@@ -126,8 +132,11 @@ async def async_process_integration_platforms(
         integrations = await async_get_integrations(hass, top_level_components)
         await asyncio.gather(
             *(
-                _async_process_single_integration_platform_component(
-                    hass, comp, integrations[comp], integration_platform
+                asyncio.create_task(
+                    _async_process_single_integration_platform_component(
+                        hass, comp, integrations[comp], integration_platform
+                    ),
+                    name=f"process integration platform {platform_name} for {comp}",
                 )
                 for comp in top_level_components
             )

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -1,6 +1,8 @@
 """Test integration platform helpers."""
 from unittest.mock import Mock
 
+import pytest
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platform_for_component,
@@ -51,3 +53,27 @@ async def test_process_integration_platforms_none_loaded(hass: HomeAssistant) ->
     # Verify we can call async_process_integration_platform_for_component
     # when there are none loaded and it does not throw
     await async_process_integration_platform_for_component(hass, "any")
+
+
+async def test_broken_integration(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test handling an integration with a broken or missing manifest."""
+    Mock()
+    hass.config.components.add("loaded")
+
+    event_platform = Mock()
+    mock_platform(hass, "event.platform_to_check", event_platform)
+
+    processed = []
+
+    async def _process_platform(hass, domain, platform):
+        """Process platform."""
+        processed.append((domain, platform))
+
+    await async_process_integration_platforms(
+        hass, "platform_to_check", _process_platform
+    )
+
+    assert len(processed) == 0
+    assert "Error importing integration loaded for platform_to_check" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We were fetching integrations inside the gather one at a time when its much more efficient to fetch them all at once and pass them to each task.

I did a bit of cleanup to reject running the integration platforms a bit sooner with a filter

Noticed why I was looking for event loop blocks
`2023-03-07 19:01:33.475 WARNING (MainThread) [asyncio] Executing <Task finished name='process integration platform diagnostics for thread' coro=<_async_process_single_integration_platform_component() done, defined at /usr/src/homeassistant/homeassistant/helpers/integration_platform.py:28> result=None created at /usr/local/lib/python3.10/asyncio/tasks.py:337> took 0.678 seconds`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
