### PR TITLE
Add names to the config entry setup and shutdown tasks

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1134,7 +1134,7 @@ class ConfigEntries:
             *(
                 asyncio.create_task(
                     entry.async_shutdown(),
-                    name=f"shutdown config entry {entry.title} {entry.domain} {entry.entry_id}",
+                    name=f"config entry shutdown {entry.title} {entry.domain} {entry.entry_id}",
                 )
                 for entry in self._entries.values()
             )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1131,7 +1131,13 @@ class ConfigEntries:
     async def _async_shutdown(self, event: Event) -> None:
         """Call when Home Assistant is stopping."""
         await asyncio.gather(
-            *(entry.async_shutdown() for entry in self._entries.values())
+            *(
+                asyncio.create_task(
+                    entry.async_shutdown(),
+                    name=f"shutdown config entry {entry.title} {entry.domain} {entry.entry_id}",
+                )
+                for entry in self._entries.values()
+            )
         )
         await self.flow.async_shutdown()
 
@@ -1390,7 +1396,13 @@ class ConfigEntries:
     ) -> None:
         """Forward the setup of an entry to platforms."""
         await asyncio.gather(
-            *(self.async_forward_entry_setup(entry, platform) for platform in platforms)
+            *(
+                asyncio.create_task(
+                    self.async_forward_entry_setup(entry, platform),
+                    name=f"config entry forward setup {entry.title} {entry.domain} {entry.entry_id} {platform}",
+                )
+                for platform in platforms
+            )
         )
 
     async def async_forward_entry_setup(
@@ -1421,7 +1433,10 @@ class ConfigEntries:
         return all(
             await asyncio.gather(
                 *(
-                    self.async_forward_entry_unload(entry, platform)
+                    asyncio.create_task(
+                        self.async_forward_entry_unload(entry, platform),
+                        name=f"config entry forward unload {entry.title} {entry.domain} {entry.entry_id} {platform}",
+                    )
                     for platform in platforms
                 )
             )
@@ -1952,7 +1967,13 @@ class EntityRegistryDisabledHandler:
         )
 
         await asyncio.gather(
-            *(self.hass.config_entries.async_reload(entry_id) for entry_id in to_reload)
+            *(
+                asyncio.create_task(
+                    self.hass.config_entries.async_reload(entry_id),
+                    name="config entry reload {entry.title} {entry.domain} {entry.entry_id}",
+                )
+                for entry_id in to_reload
+            )
         )
 
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -295,7 +295,10 @@ async def _async_setup_component(
 
         await asyncio.gather(
             *(
-                entry.async_setup(hass, integration=integration)
+                asyncio.create_task(
+                    entry.async_setup(hass, integration=integration),
+                    name=f"setup entry {entry.title} {entry.domain} {entry.entry_id}",
+                )
                 for entry in hass.config_entries.async_entries(domain)
             )
         )

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -297,7 +297,7 @@ async def _async_setup_component(
             *(
                 asyncio.create_task(
                     entry.async_setup(hass, integration=integration),
-                    name=f"setup entry {entry.title} {entry.domain} {entry.entry_id}",
+                    name=f"config entry setup {entry.title} {entry.domain} {entry.entry_id}",
                 )
                 for entry in hass.config_entries.async_entries(domain)
             )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add names to the config entry setup and shutdown tasks

`2023-03-07 19:48:08.108 WARNING (MainThread) [asyncio] Executing <Task pending name='config entry forward setup Sonos sonos 93dadd691bfd36c53dc4013cd69b9c42 media_player' coro=<ConfigEntries.async_forward_entry_setup() running at /usr/src/homeassistant/homeassistant/config_entries.py:1426> wait_for=<Future pending cb=[shield.<locals>._outer_done_callback() at /usr/local/lib/python3.10/asyncio/tasks.py:857, Task.task_wakeup()] created at /usr/local/lib/python3.10/asyncio/base_events.py:429> cb=[gather.<locals>._done_callback() at /usr/local/lib/python3.10/asyncio/tasks.py:720] created at /usr/local/lib/python3.10/asyncio/tasks.py:337> took 0.170 seconds
`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
