### PR TITLE
Add config flow to pioneer and change the way sources are selected

### DIFF
--- a/homeassistant/components/pioneer/__init__.py
+++ b/homeassistant/components/pioneer/__init__.py
@@ -1,1 +1,18 @@
 """The pioneer component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = [Platform.MEDIA_PLAYER]
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up Pioneer integration from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/pioneer/config_flow.py
+++ b/homeassistant/components/pioneer/config_flow.py
@@ -1,0 +1,82 @@
+"""Config flow for the Pioneer AVR component."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TIMEOUT
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import (
+    CONF_SOURCES,
+    CONF_ZONES,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SOURCES,
+    DEFAULT_TIMEOUT,
+    DEFAULT_ZONE,
+    DOMAIN,
+)
+
+apps_list = {k: f"{v} ({k})" if v else k for k, v in DEFAULT_SOURCES.items()}
+apps = [SelectOptionDict(value="sources", label="Add source")] + [
+    SelectOptionDict(value=k, label=v) for k, v in apps_list.items()
+]
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_SOURCES): SelectSelector(
+            SelectSelectorConfig(
+                options=apps,
+                mode=SelectSelectorMode.DROPDOWN,
+                multiple=True,
+            )
+        ),
+        vol.Optional(CONF_ZONES, default=DEFAULT_ZONE): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=2)
+        ),
+    }
+)
+
+
+class PioneerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Pioneer config flow."""
+
+    VERSION = 1
+
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
+        """Import a config entry from configuration.yaml."""
+
+        self._async_abort_entries_match({CONF_HOST: import_config[CONF_HOST]})
+        return self.async_create_entry(
+            title=import_config[CONF_NAME] or DEFAULT_NAME,
+            data=import_config,
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Handle the user setup step."""
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+
+            return self.async_create_entry(
+                title=DEFAULT_NAME,
+                data=user_input,
+            )
+
+        data_schema = self.add_suggested_values_to_schema(DATA_SCHEMA, user_input)
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/homeassistant/components/pioneer/const.py
+++ b/homeassistant/components/pioneer/const.py
@@ -1,0 +1,77 @@
+"""Consts used by pioneer."""
+from typing import Final
+
+DEFAULT_ZONE = 1
+
+CONF_SOURCES = "sources"
+CONF_ZONES = "zones"
+DOMAIN = "pioneer"
+DEFAULT_NAME = "Pioneer AVR"
+DEFAULT_PORT = 23  # telnet default. Some Pioneer AVRs use 8102
+DEFAULT_TIMEOUT: Final = 500
+DEFAULT_SOURCES: dict[str, str] = {
+    "Phono": "00",
+    "CD": "01",
+    "Tuner": "02",
+    "CD-R/Tape": "03",
+    "DVD": "04",
+    "TV/Sat": "05",
+    "Sat/Cbl": "06",
+    "Video 1": "10",
+    "Multi Channel In": "12",
+    "Video 2": "14",
+    "DVR/BDR": "15",
+    "iPod/USB": "17",
+    "XM Radio": "18",
+    "HDMI 1": "19",
+    "HDMI 2": "20",
+    "HDMI 3": "21",
+    "HDMI 4": "22",
+    "HDMI 5": "23",
+    "HDMI 6": "24",
+    "Blu-Ray": "25",
+    "Home Media Gallery (Internet Radio)": "26",
+    "Sirius": "27",
+    "Adapter Port": "33",
+    "Netradio": "38",
+    "Media Server": "44",
+    "Favorites": "45",
+    "Game": "49",
+}
+
+MAX_VOLUME = 185
+MAX_SOURCE_NUMBERS = 60
+
+
+ZONE_COMMANDS: dict[int, dict[str, dict[str, str]]] = {
+    1: {
+        "POWER": {"COMMAND": "?P", "PREFIX": "PWR"},
+        "VOL": {"COMMAND": "?V", "PREFIX": "VOL"},
+        "MUTE": {"COMMAND": "?M", "PREFIX": "MUT"},
+        "SOURCE_NUM": {"COMMAND": "?F", "PREFIX": "FN"},
+        "TURN_OFF": {"COMMAND": "PF", "PREFIX": ""},
+        "VOL_UP": {"COMMAND": "VU", "PREFIX": ""},
+        "VOL_DOWN": {"COMMAND": "VD", "PREFIX": ""},
+        "VOL_LEVEL": {"COMMAND": "VL", "PREFIX": ""},
+        "MUTE_VOL": {"COMMAND": "MF", "PREFIX": ""},
+        "UNMUTE_VOL": {"COMMAND": "MO", "PREFIX": ""},
+        "TURN_ON": {"COMMAND": "PO", "PREFIX": ""},
+        "SELECT_SOURCE": {"COMMAND": "FN", "PREFIX": ""},
+        "MUTED_VALUE": {"COMMAND": "MUT0", "PREFIX": ""},
+    },
+    2: {
+        "POWER": {"COMMAND": "?AP", "PREFIX": "APR"},
+        "VOL": {"COMMAND": "?ZV", "PREFIX": "ZV"},
+        "MUTE": {"COMMAND": "?Z2M", "PREFIX": "Z2MUT"},
+        "SOURCE_NUM": {"COMMAND": "?ZS", "PREFIX": "Z2F"},
+        "TURN_OFF": {"COMMAND": "APF", "PREFIX": ""},
+        "VOL_UP": {"COMMAND": "ZU", "PREFIX": ""},
+        "VOL_DOWN": {"COMMAND": "ZD", "PREFIX": ""},
+        "VOL_LEVEL": {"COMMAND": "ZV", "PREFIX": ""},
+        "MUTE_VOL": {"COMMAND": "Z2MF", "PREFIX": ""},
+        "UNMUTE_VOL": {"COMMAND": "Z2MO", "PREFIX": ""},
+        "TURN_ON": {"COMMAND": "APO", "PREFIX": ""},
+        "SELECT_SOURCE": {"COMMAND": "ZS", "PREFIX": ""},
+        "MUTED_VALUE": {"COMMAND": "Z2MUT0", "PREFIX": ""},
+    },
+}

--- a/homeassistant/components/pioneer/manifest.json
+++ b/homeassistant/components/pioneer/manifest.json
@@ -2,6 +2,7 @@
   "domain": "pioneer",
   "name": "Pioneer",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/pioneer",
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -2,69 +2,68 @@
 from __future__ import annotations
 
 import logging
+import socket
 import telnetlib
-from typing import Final
-
-import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA,
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(__name__)
-
-CONF_SOURCES = "sources"
-
-DEFAULT_NAME = "Pioneer AVR"
-DEFAULT_PORT = 23  # telnet default. Some Pioneer AVRs use 8102
-DEFAULT_TIMEOUT: Final = None
-DEFAULT_SOURCES: dict[str, str] = {}
-
-
-MAX_VOLUME = 185
-MAX_SOURCE_NUMBERS = 60
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.socket_timeout,
-        vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES): {cv.string: cv.string},
-    }
+from .const import (
+    CONF_SOURCES,
+    CONF_ZONES,
+    DEFAULT_SOURCES,
+    DEFAULT_ZONE,
+    MAX_SOURCE_NUMBERS,
+    MAX_VOLUME,
+    ZONE_COMMANDS,
 )
 
+_LOGGER = logging.getLogger(__name__)
 
-def setup_platform(
+
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Pioneer platform."""
-    pioneer = PioneerDevice(
-        config[CONF_NAME],
-        config[CONF_HOST],
-        config[CONF_PORT],
-        config[CONF_TIMEOUT],
-        config[CONF_SOURCES],
-    )
+    """Set up the pioneer device."""
+    _LOGGER.warning("Configuration of the Pioneer platform in YAML is deprecated; ")
 
-    if pioneer.update():
-        add_entities([pioneer])
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Pioneer platform."""
+    pioneer = [
+        PioneerDevice(
+            entry.data[CONF_NAME],
+            entry.data[CONF_HOST],
+            entry.data[CONF_PORT],
+            entry.data[CONF_TIMEOUT],
+            entry.data[CONF_SOURCES],
+            zone,
+        )
+        for zone in range(1, entry.data[CONF_ZONES] + 1)
+    ]
+    async_add_entities(pioneer, True)
 
 
 class PioneerDevice(MediaPlayerEntity):
     """Representation of a Pioneer device."""
 
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
     _attr_supported_features = (
         MediaPlayerEntityFeature.PAUSE
         | MediaPlayerEntityFeature.VOLUME_SET
@@ -76,25 +75,41 @@ class PioneerDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.PLAY
     )
 
-    def __init__(self, name, host, port, timeout, sources):
+    def __init__(
+        self, name, host, port, timeout, sources: list, zone=DEFAULT_ZONE
+    ) -> None:
         """Initialize the Pioneer device."""
+
+        def filter_sources(pair):
+            key, _ = pair
+            return bool(key in sources)
+
+        source_list = dict(
+            filter(
+                filter_sources,
+                DEFAULT_SOURCES.items(),
+            )
+        )
         self._name = name
         self._host = host
         self._port = port
         self._timeout = timeout
         self._pwstate = "PWR1"
-        self._volume = 0
+        self._volume = float(0)
         self._muted = False
-        self._selected_source = ""
-        self._source_name_to_number = sources
-        self._source_number_to_name = {v: k for k, v in sources.items()}
+        self._selected_source: str | None = None
+        self._source_name_to_number = source_list
+        self._source_number_to_name = {v: k for k, v in source_list.items()}
+        self._zone = zone
+
+        self._attr_unique_id = f"pioneer_{zone}"
 
     @classmethod
-    def telnet_request(cls, telnet, command, expected_prefix):
+    def telnet_request(cls, telnet, command, expected_prefix) -> None | str:
         """Execute `command` and return the response."""
         try:
             telnet.write(command.encode("ASCII") + b"\r")
-        except telnetlib.socket.timeout:
+        except socket.timeout:
             _LOGGER.debug("Pioneer command %s timed out", command)
             return None
 
@@ -104,10 +119,9 @@ class PioneerDevice(MediaPlayerEntity):
             result = telnet.read_until(b"\r\n", timeout=0.2).decode("ASCII").strip()
             if result.startswith(expected_prefix):
                 return result
-
         return None
 
-    def telnet_command(self, command):
+    def telnet_command(self, command) -> None:
         """Establish a telnet connection and sends command."""
         try:
             try:
@@ -118,26 +132,43 @@ class PioneerDevice(MediaPlayerEntity):
             telnet.write(command.encode("ASCII") + b"\r")
             telnet.read_very_eager()  # skip response
             telnet.close()
-        except telnetlib.socket.timeout:
+        except socket.timeout:
             _LOGGER.debug("Pioneer %s command %s timed out", self._name, command)
 
-    def update(self):
+    def update(self) -> None:
         """Get the latest details from the device."""
         try:
             telnet = telnetlib.Telnet(self._host, self._port, self._timeout)
         except OSError:
             _LOGGER.warning("Pioneer %s refused connection", self._name)
-            return False
-
-        pwstate = self.telnet_request(telnet, "?P", "PWR")
+            return
+        zone_commands = ZONE_COMMANDS.get(self._zone)
+        pwstate = self.telnet_request(
+            telnet,
+            zone_commands.get("POWER").get("COMMAND"),  # type: ignore[union-attr]
+            zone_commands.get("POWER").get("PREFIX"),  # type: ignore[union-attr]
+        )
         if pwstate:
             self._pwstate = pwstate
 
-        volume_str = self.telnet_request(telnet, "?V", "VOL")
-        self._volume = int(volume_str[3:]) / MAX_VOLUME if volume_str else None
+        volume_str = self.telnet_request(
+            telnet,
+            zone_commands.get("VOL").get("COMMAND"),  # type: ignore[union-attr]
+            zone_commands.get("VOL").get("PREFIX"),  # type: ignore[union-attr]
+        )
+        self._volume = float(volume_str[3:]) / MAX_VOLUME if volume_str else float(0)
 
-        muted_value = self.telnet_request(telnet, "?M", "MUT")
-        self._muted = (muted_value == "MUT0") if muted_value else None
+        muted_value = self.telnet_request(
+            telnet,
+            zone_commands.get("MUTE").get("COMMAND"),  # type: ignore[union-attr]
+            zone_commands.get("MUTE").get("PREFIX"),  # type: ignore[union-attr]
+        )
+
+        self._muted = (
+            (muted_value == zone_commands.get("MUTED_VALUE").get("COMMAND"))  # type: ignore[union-attr]
+            if muted_value
+            else False
+        )
 
         # Build the source name dictionaries if necessary
         if not self._source_name_to_number:
@@ -153,18 +184,21 @@ class PioneerDevice(MediaPlayerEntity):
                 self._source_name_to_number[source_name] = source_number
                 self._source_number_to_name[source_number] = source_name
 
-        source_number = self.telnet_request(telnet, "?F", "FN")
+        source_result = self.telnet_request(
+            telnet,
+            zone_commands.get("SOURCE_NUM").get("COMMAND"),  # type: ignore[union-attr]
+            zone_commands.get("SOURCE_NUM").get("PREFIX"),  # type: ignore[union-attr]
+        )
 
-        if source_number:
-            self._selected_source = self._source_number_to_name.get(source_number[2:])
+        if source_result:
+            self._selected_source = self._source_number_to_name.get(source_result[2:])
         else:
             self._selected_source = None
 
         telnet.close()
-        return True
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the device."""
         return self._name
 
@@ -181,55 +215,69 @@ class PioneerDevice(MediaPlayerEntity):
         return None
 
     @property
-    def volume_level(self):
+    def volume_level(self) -> float:
         """Volume level of the media player (0..1)."""
         return self._volume
 
     @property
-    def is_volume_muted(self):
+    def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
         return self._muted
 
     @property
-    def source(self):
+    def source(self) -> str | None:
         """Return the current input source."""
         return self._selected_source
 
     @property
-    def source_list(self):
+    def source_list(self) -> list[str] | None:
         """List of available input sources."""
         return list(self._source_name_to_number)
 
     @property
-    def media_title(self):
+    def media_title(self) -> str | None:
         """Title of current playing media."""
         return self._selected_source
 
     def turn_off(self) -> None:
         """Turn off media player."""
-        self.telnet_command("PF")
+        self.telnet_command(
+            ZONE_COMMANDS.get(self._zone).get("TURN_OFF").get("COMMAND")  # type: ignore[union-attr]
+        )
 
     def volume_up(self) -> None:
         """Volume up media player."""
-        self.telnet_command("VU")
+        self.telnet_command(ZONE_COMMANDS.get(self._zone).get("VOL_UP").get("COMMAND"))  # type: ignore[union-attr]
 
     def volume_down(self) -> None:
         """Volume down media player."""
-        self.telnet_command("VD")
+        self.telnet_command(
+            ZONE_COMMANDS.get(self._zone).get("VOL_DOWN").get("COMMAND")  # type: ignore[union-attr]
+        )
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         # 60dB max
-        self.telnet_command(f"{round(volume * MAX_VOLUME):03}VL")
+        vol_command = ZONE_COMMANDS.get(self._zone).get("VOL_LEVEL").get("COMMAND")  # type: ignore[union-attr]
+        self.telnet_command(f"{round(volume * MAX_VOLUME):03}{vol_command}")
 
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
-        self.telnet_command("MO" if mute else "MF")
+        self.telnet_command(
+            ZONE_COMMANDS.get(self._zone).get("UNMUTE_VOL").get("COMMAND")  # type: ignore[union-attr]
+            if mute
+            else ZONE_COMMANDS.get(self._zone).get("MUTE_VOL").get("COMMAND")  # type: ignore[union-attr]
+        )
 
     def turn_on(self) -> None:
         """Turn the media player on."""
-        self.telnet_command("PO")
+        self.telnet_command(ZONE_COMMANDS.get(self._zone).get("TURN_ON").get("COMMAND"))  # type: ignore[union-attr]
 
     def select_source(self, source: str) -> None:
         """Select input source."""
-        self.telnet_command(f"{self._source_name_to_number.get(source)}FN")
+        source_command = (
+            ZONE_COMMANDS.get(self._zone).get("SELECT_SOURCE").get("COMMAND")  # type: ignore[union-attr]
+        )
+        self.telnet_command(
+            f"{self._source_name_to_number.get(source)}{source_command}"
+        )

--- a/homeassistant/components/pioneer/strings.json
+++ b/homeassistant/components/pioneer/strings.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Fill in your Pioneer network and source details",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "timeout": "Telnet request timeout",
+          "sources": "Sources for your Pioneer AVR"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/pioneer/strings.json
+++ b/homeassistant/components/pioneer/strings.json
@@ -8,7 +8,8 @@
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
           "timeout": "Telnet request timeout",
-          "sources": "Sources for your Pioneer AVR"
+          "sources": "Sources for your Pioneer AVR",
+          "zones": "Number of zones supported"
         }
       }
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -317,6 +317,7 @@ FLOWS = {
         "philips_js",
         "pi_hole",
         "picnic",
+        "pioneer",
         "plaato",
         "plex",
         "plugwise",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4125,7 +4125,7 @@
     "pioneer": {
       "name": "Pioneer",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "pjlink": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've added support for additional zones (2 so far), had to change the way sources are done so users can select which sources their players have, this avoids having to list out each and every model.

Also added config flow so it can be done from the UI now. I'm unfamiliar with migrating from yml to config so input is appreciated. I don't own a receiver but I have a friend who is testing it out for me via HACS

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
