### PR TITLE
Envisalink Config Flow Support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -290,7 +290,6 @@ omit =
     homeassistant/components/environment_canada/camera.py
     homeassistant/components/environment_canada/sensor.py
     homeassistant/components/environment_canada/weather.py
-    homeassistant/components/envisalink/*
     homeassistant/components/ephember/climate.py
     homeassistant/components/epson/__init__.py
     homeassistant/components/epson/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -330,6 +330,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/environment_canada/ @gwww @michaeldavie
 /tests/components/environment_canada/ @gwww @michaeldavie
 /homeassistant/components/envisalink/ @ufodone
+/tests/components/envisalink/ @ufodone
 /homeassistant/components/ephember/ @ttroy50
 /homeassistant/components/epson/ @pszafer
 /tests/components/epson/ @pszafer

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -195,7 +195,7 @@ def _transform_yaml_to_config_entry(yaml: dict[str, Any]) -> dict[str, Any]:
     zones = yaml.get(CONF_ZONES)
     if zones:
         zone_set = set()
-        for zone_num in zones.keys():
+        for zone_num in zones:
             zone_set.add(int(zone_num))
         zone_spec = generate_range_string(zone_set)
         if zone_spec is not None:
@@ -208,7 +208,7 @@ def _transform_yaml_to_config_entry(yaml: dict[str, Any]) -> dict[str, Any]:
     partitions = yaml.get(CONF_PARTITIONS)
     if partitions:
         partition_set = set()
-        for part_num in partitions.keys():
+        for part_num in partitions:
             partition_set.add(int(part_num))
         partition_spec = generate_range_string(partition_set)
         if partition_spec is not None:
@@ -227,7 +227,6 @@ def _transform_yaml_to_config_entry(yaml: dict[str, Any]) -> dict[str, Any]:
     for key in (
         CONF_PANIC,
         CONF_EVL_KEEPALIVE,
-        CONF_ZONEDUMP_INTERVAL,
         CONF_TIMEOUT,
         CONF_CREATE_ZONE_BYPASS_SWITCHES,
     ):
@@ -270,7 +269,6 @@ def _async_import_options_from_data_if_missing(
     for importable_option in (
         CONF_PANIC,
         CONF_EVL_KEEPALIVE,
-        CONF_ZONEDUMP_INTERVAL,
         CONF_TIMEOUT,
         CONF_CREATE_ZONE_BYPASS_SWITCHES,
     ):

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -64,9 +64,9 @@ async def async_setup_entry(
     code = entry.data.get(CONF_CODE)
     panic_type = entry.options.get(CONF_PANIC)
     partition_info = entry.data.get(CONF_PARTITIONS)
-    partition_spec = entry.data.get(CONF_PARTITION_SET, DEFAULT_PARTITION_SET)
+    partition_spec: str = entry.data.get(CONF_PARTITION_SET, DEFAULT_PARTITION_SET)
     partition_set = parse_range_string(
-        str(partition_spec), min_val=1, max_val=controller.controller.max_partitions
+        partition_spec, min_val=1, max_val=controller.controller.max_partitions
     )
 
     arm_night_mode = None

--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -33,9 +33,9 @@ async def async_setup_entry(
     """Set up the zone binary sensors based on a config entry."""
     controller = hass.data[DOMAIN][entry.entry_id]
 
-    zone_spec = entry.data.get(CONF_ZONE_SET)
+    zone_spec: str = entry.data.get(CONF_ZONE_SET, "")
     zone_set = parse_range_string(
-        str(zone_spec), min_val=1, max_val=controller.controller.max_zones
+        zone_spec, min_val=1, max_val=controller.controller.max_zones
     )
 
     zone_info = entry.data.get(CONF_ZONES)

--- a/homeassistant/components/envisalink/config_flow.py
+++ b/homeassistant/components/envisalink/config_flow.py
@@ -300,12 +300,12 @@ async def _validate_input(
 
     max_zones = EnvisalinkAlarmPanel.get_max_zones_by_version(panel.envisalink_version)
 
-    zone_set = data.get(CONF_ZONE_SET)
-    partition_set = data.get(CONF_PARTITION_SET)
-    if not parse_range_string(str(zone_set), 1, max_zones):
+    zone_set: str = data.get(CONF_ZONE_SET, "")
+    partition_set: str = data.get(CONF_PARTITION_SET, "")
+    if not parse_range_string(zone_set, 1, max_zones):
         raise PanelError("invalid_zone_spec")
     if not parse_range_string(
-        str(partition_set), 1, EnvisalinkAlarmPanel.get_max_partitions()
+        partition_set, 1, EnvisalinkAlarmPanel.get_max_partitions()
     ):
         raise PanelError("invalid_partition_spec")
 

--- a/homeassistant/components/envisalink/config_flow.py
+++ b/homeassistant/components/envisalink/config_flow.py
@@ -1,0 +1,358 @@
+"""Config flow for Envisalink integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+from pyenvisalink.const import PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_CODE, CONF_HOST, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import (
+    CONF_ALARM_NAME,
+    CONF_CREATE_ZONE_BYPASS_SWITCHES,
+    CONF_EVL_DISCOVERY_PORT,
+    CONF_EVL_KEEPALIVE,
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_HONEYWELL_ARM_NIGHT_MODE,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITION_SET,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONE_SET,
+    CONF_ZONEDUMP_INTERVAL,
+    DEFAULT_ALARM_NAME,
+    DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
+    DEFAULT_DISCOVERY_PORT,
+    DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
+    DEFAULT_KEEPALIVE,
+    DEFAULT_PANIC,
+    DEFAULT_PARTITION_SET,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DEFAULT_USERNAME,
+    DEFAULT_ZONEDUMP_INTERVAL,
+    DOMAIN,
+    HONEYWELL_ARM_MODE_INSTANT_LABEL,
+    HONEYWELL_ARM_MODE_INSTANT_VALUE,
+    HONEYWELL_ARM_MODE_NIGHT_LABEL,
+    HONEYWELL_ARM_MODE_NIGHT_VALUE,
+    LOGGER,
+)
+from .helpers import parse_range_string
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Envisalink."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors = {}
+
+        config_defaults = _get_user_data_defaults()
+
+        if user_input is not None:
+            try:
+                panel = await _validate_input(self.hass, user_input, is_creation=True)
+
+                unique_id = format_mac(panel.mac_address)
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
+
+                title = user_input[CONF_ALARM_NAME]
+                user_input.pop(CONF_ALARM_NAME)
+            except HomeAssistantError as err:
+                errors["base"] = str(err)
+            except Exception as ex:  # pylint: disable=broad-except
+                LOGGER.exception("Unexpected exception: %r", ex)
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=title, data=user_input)
+
+            # Validation errors so update the form defaults with what the user
+            # has entered.
+            config_keys = config_defaults.keys()
+            for key in config_keys:
+                if key in user_input:
+                    config_defaults[key] = user_input[key]
+
+        user_data_schema = _get_user_data_schema(config_defaults, is_creation=True)
+
+        return self.async_show_form(
+            step_id="user", data_schema=user_data_schema, errors=errors
+        )
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle import."""
+        return await self.async_step_user(user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create the options flow."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Envisalink options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+
+        return self.async_show_menu(
+            step_id="user",
+            menu_options={
+                "basic": "Basic",
+                "advanced": "Advanced",
+            },
+        )
+
+    async def async_step_basic(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        errors = {}
+
+        config_defaults = _get_user_data_defaults(self.config_entry.data)
+
+        if user_input is not None:
+            # This flow is for the main config items so update the config_entry with the
+            # values that have been set
+            data = dict(self.config_entry.data)
+            for key, value in user_input.items():
+                data[key] = value
+                config_defaults[key] = value
+
+            try:
+                # Validate that the new settings are okay
+                await _validate_input(self.hass, data)
+            except HomeAssistantError as err:
+                errors["base"] = str(err)
+            except Exception as ex:  # pylint: disable=broad-except
+                LOGGER.exception("Unexpected exception: %r", ex)
+                errors["base"] = "unknown"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=data
+                )
+
+                return self.async_create_entry(title="", data=self.config_entry.options)
+
+        user_data_schema = _get_user_data_schema(config_defaults)
+
+        return self.async_show_form(
+            step_id="basic",
+            data_schema=user_data_schema,
+            errors=errors,
+        )
+
+    async def async_step_advanced(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Make sure all the options are here
+            return self.async_create_entry(title="", data=user_input)
+
+        options_schema = {
+            vol.Optional(
+                CONF_PANIC,
+                default=self.config_entry.options.get(CONF_PANIC, DEFAULT_PANIC),
+            ): cv.string,
+            vol.Optional(
+                CONF_EVL_KEEPALIVE,
+                default=self.config_entry.options.get(
+                    CONF_EVL_KEEPALIVE, DEFAULT_KEEPALIVE
+                ),
+            ): vol.All(vol.Coerce(int), vol.Range(min=15)),
+            vol.Optional(
+                CONF_ZONEDUMP_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_ZONEDUMP_INTERVAL, DEFAULT_ZONEDUMP_INTERVAL
+                ),
+            ): vol.Coerce(int),
+            vol.Optional(
+                CONF_TIMEOUT,
+                default=self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            ): vol.Coerce(int),
+        }
+
+        # Add DSC-only options
+        if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_DSC:
+            # Zone bypass switches are only available on DSC panels
+            options_schema[
+                vol.Optional(
+                    CONF_CREATE_ZONE_BYPASS_SWITCHES,
+                    default=self.config_entry.options.get(
+                        CONF_CREATE_ZONE_BYPASS_SWITCHES,
+                        DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
+                    ),
+                )
+            ] = selector.BooleanSelector()
+
+        # Add Honeywell-only options
+        if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_HONEYWELL:
+            # Allow selection of which keypress to use for Arm Night mode
+            arm_modes = [
+                selector.SelectOptionDict(
+                    value=HONEYWELL_ARM_MODE_NIGHT_VALUE,
+                    label=HONEYWELL_ARM_MODE_NIGHT_LABEL,
+                ),
+                selector.SelectOptionDict(
+                    value=HONEYWELL_ARM_MODE_INSTANT_VALUE,
+                    label=HONEYWELL_ARM_MODE_INSTANT_LABEL,
+                ),
+            ]
+            options_schema[
+                vol.Optional(
+                    CONF_HONEYWELL_ARM_NIGHT_MODE,
+                    default=self.config_entry.options.get(
+                        CONF_HONEYWELL_ARM_NIGHT_MODE, DEFAULT_HONEYWELL_ARM_NIGHT_MODE
+                    ),
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(options=arm_modes)
+            )
+
+        return self.async_show_form(
+            step_id="advanced",
+            data_schema=vol.Schema(options_schema),
+            errors=errors,
+        )
+
+
+class DiscoveryError(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+    def __init__(self, result):
+        """Initialize the exception with the provided reason."""
+        msg = "unknown"
+        if result == EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED:
+            msg = "cannot_connect"
+        elif result == EnvisalinkAlarmPanel.ConnectionResult.INVALID_AUTHORIZATION:
+            msg = "invalid_auth"
+        else:
+            LOGGER.error("Unexpected error: %s", result)
+        super().__init__(msg)
+
+
+class PanelError(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+    def __init__(self, reason):
+        """Initialize the exception with the provided reason."""
+        super().__init__(reason)
+
+
+async def _validate_input(
+    hass: HomeAssistant, data: dict[str, Any], is_creation: bool = False
+) -> EnvisalinkAlarmPanel:
+    """Validate the user input allows us to connect."""
+
+    # Check that we're able to successfully connect and auth with the envisalink
+    panel = EnvisalinkAlarmPanel(
+        data[CONF_HOST],
+        port=data.get(CONF_EVL_PORT, DEFAULT_PORT),
+        userName=data[CONF_USERNAME],
+        password=data[CONF_PASS],
+        httpPort=data.get(CONF_EVL_DISCOVERY_PORT, DEFAULT_DISCOVERY_PORT),
+    )
+
+    result = await panel.discover()
+    if result != EnvisalinkAlarmPanel.ConnectionResult.SUCCESS:
+        raise DiscoveryError(result)
+
+    # Update version and panel from from the discovery information if it's not already
+    # present.  The presence check is to account for the possibility that the config
+    # had previously been imported from configuration.yaml
+    if CONF_EVL_VERSION not in data:
+        data[CONF_EVL_VERSION] = panel.envisalink_version
+    if CONF_PANEL_TYPE not in data:
+        if is_creation:
+            # Only try this during initial setup of the device as it will fail if this
+            # is # called from the options flow because the EVL only allows a single
+            # concurrent connection.
+            await panel.discover_panel_type()
+        data[CONF_PANEL_TYPE] = panel.panel_type
+
+    max_zones = EnvisalinkAlarmPanel.get_max_zones_by_version(panel.envisalink_version)
+
+    zone_set = data.get(CONF_ZONE_SET)
+    partition_set = data.get(CONF_PARTITION_SET)
+    if not parse_range_string(str(zone_set), 1, max_zones):
+        raise PanelError("invalid_zone_spec")
+    if not parse_range_string(
+        str(partition_set), 1, EnvisalinkAlarmPanel.get_max_partitions()
+    ):
+        raise PanelError("invalid_partition_spec")
+
+    return panel
+
+
+def _get_user_data_schema(defaults: dict[str, Any], is_creation: bool = False):
+    schema = {}
+    if is_creation:
+        schema = {
+            vol.Required(CONF_ALARM_NAME, default=defaults[CONF_ALARM_NAME]): cv.string,
+        }
+
+    schema = schema | {
+        vol.Required(CONF_HOST, default=defaults[CONF_HOST]): cv.string,
+        vol.Required(CONF_USERNAME, default=defaults[CONF_USERNAME]): cv.string,
+        vol.Required(CONF_PASS, default=defaults[CONF_PASS]): cv.string,
+        vol.Required(
+            CONF_PARTITION_SET, default=defaults[CONF_PARTITION_SET]
+        ): cv.string,
+        vol.Required(CONF_ZONE_SET, default=defaults[CONF_ZONE_SET]): cv.string,
+        vol.Optional(
+            CONF_CODE, description={"suggested_value": defaults[CONF_CODE]}
+        ): cv.string,
+        vol.Required(CONF_EVL_PORT, default=defaults[CONF_EVL_PORT]): cv.port,
+        vol.Required(
+            CONF_EVL_DISCOVERY_PORT, default=defaults[CONF_EVL_DISCOVERY_PORT]
+        ): cv.port,
+    }
+    return vol.Schema(schema)
+
+
+def _get_user_data_defaults(data=None):
+    if not data:
+        data = {}
+
+    config_defaults = {
+        CONF_ALARM_NAME: data.get(CONF_ALARM_NAME, DEFAULT_ALARM_NAME),
+        CONF_HOST: data.get(CONF_HOST, ""),
+        CONF_USERNAME: data.get(CONF_USERNAME, DEFAULT_USERNAME),
+        CONF_PASS: data.get(CONF_PASS, ""),
+        CONF_ZONE_SET: data.get(CONF_ZONE_SET, ""),
+        CONF_PARTITION_SET: data.get(CONF_PARTITION_SET, DEFAULT_PARTITION_SET),
+        CONF_CODE: data.get(CONF_CODE, ""),
+        CONF_EVL_PORT: data.get(CONF_EVL_PORT, DEFAULT_PORT),
+        CONF_EVL_DISCOVERY_PORT: data.get(
+            CONF_EVL_DISCOVERY_PORT, DEFAULT_DISCOVERY_PORT
+        ),
+    }
+    return config_defaults

--- a/homeassistant/components/envisalink/config_flow.py
+++ b/homeassistant/components/envisalink/config_flow.py
@@ -29,7 +29,6 @@ from .const import (
     CONF_PASS,
     CONF_USERNAME,
     CONF_ZONE_SET,
-    CONF_ZONEDUMP_INTERVAL,
     DEFAULT_ALARM_NAME,
     DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
     DEFAULT_DISCOVERY_PORT,
@@ -40,7 +39,6 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DEFAULT_USERNAME,
-    DEFAULT_ZONEDUMP_INTERVAL,
     DOMAIN,
     HONEYWELL_ARM_MODE_INSTANT_LABEL,
     HONEYWELL_ARM_MODE_INSTANT_VALUE,
@@ -188,12 +186,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_EVL_KEEPALIVE, DEFAULT_KEEPALIVE
                 ),
             ): vol.All(vol.Coerce(int), vol.Range(min=15)),
-            vol.Optional(
-                CONF_ZONEDUMP_INTERVAL,
-                default=self.config_entry.options.get(
-                    CONF_ZONEDUMP_INTERVAL, DEFAULT_ZONEDUMP_INTERVAL
-                ),
-            ): vol.Coerce(int),
             vol.Optional(
                 CONF_TIMEOUT,
                 default=self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),

--- a/homeassistant/components/envisalink/const.py
+++ b/homeassistant/components/envisalink/const.py
@@ -12,17 +12,17 @@ CONF_ALARM_NAME = "alarm_name"
 CONF_ZONE_SET = "zone_set"
 CONF_PARTITION_SET = "partition_set"
 
-CONF_EVL_KEEPALIVE = "keepalive_interval"  # OPTION
+CONF_EVL_KEEPALIVE = "keepalive_interval"
 CONF_EVL_PORT = "port"
 CONF_EVL_DISCOVERY_PORT = "discovery_port"
 CONF_EVL_VERSION = "evl_version"
 CONF_PANEL_TYPE = "panel_type"
-CONF_PANIC = "panic_type"  # OPTION
+CONF_PANIC = "panic_type"
 CONF_PASS = "password"
 CONF_USERNAME = "user_name"
-CONF_ZONEDUMP_INTERVAL = "zonedump_interval"  # OPTION
-CONF_CREATE_ZONE_BYPASS_SWITCHES = "create_zone_bypass_switches"  # OPTION
-CONF_HONEYWELL_ARM_NIGHT_MODE = "honeywell_arm_night_mode"  # OPTION
+CONF_ZONEDUMP_INTERVAL = "zonedump_interval"
+CONF_CREATE_ZONE_BYPASS_SWITCHES = "create_zone_bypass_switches"
+CONF_HONEYWELL_ARM_NIGHT_MODE = "honeywell_arm_night_mode"
 
 
 # Config items used only in the YAML config

--- a/homeassistant/components/envisalink/const.py
+++ b/homeassistant/components/envisalink/const.py
@@ -1,0 +1,57 @@
+"""Constants for the Envisalink integration."""
+
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+DOMAIN = "envisalink"
+
+LOGGER = logging.getLogger(__package__)
+
+CONF_ALARM_NAME = "alarm_name"
+CONF_ZONE_SET = "zone_set"
+CONF_PARTITION_SET = "partition_set"
+
+CONF_EVL_KEEPALIVE = "keepalive_interval"  # OPTION
+CONF_EVL_PORT = "port"
+CONF_EVL_DISCOVERY_PORT = "discovery_port"
+CONF_EVL_VERSION = "evl_version"
+CONF_PANEL_TYPE = "panel_type"
+CONF_PANIC = "panic_type"  # OPTION
+CONF_PASS = "password"
+CONF_USERNAME = "user_name"
+CONF_ZONEDUMP_INTERVAL = "zonedump_interval"  # OPTION
+CONF_CREATE_ZONE_BYPASS_SWITCHES = "create_zone_bypass_switches"  # OPTION
+CONF_HONEYWELL_ARM_NIGHT_MODE = "honeywell_arm_night_mode"  # OPTION
+
+
+# Config items used only in the YAML config
+CONF_ZONENAME = "name"
+CONF_ZONES = "zones"
+CONF_ZONETYPE = "type"
+CONF_PARTITIONNAME = "name"
+CONF_PARTITIONS = "partitions"
+
+# Temporary config entry key used to store values from the YAML config that will
+# transition into the ConfigEntry options
+CONF_YAML_OPTIONS = "yaml_options"
+
+HONEYWELL_ARM_MODE_INSTANT_LABEL = "Instant"
+HONEYWELL_ARM_MODE_INSTANT_VALUE = "7"
+HONEYWELL_ARM_MODE_NIGHT_LABEL = "Night Stay"
+HONEYWELL_ARM_MODE_NIGHT_VALUE = "33"
+
+DEFAULT_ALARM_NAME = "Alarm"
+DEFAULT_CREATE_ZONE_BYPASS_SWITCHES = False
+DEFAULT_EVL_VERSION = 4
+DEFAULT_KEEPALIVE = 60
+DEFAULT_ZONE_SET = ""
+DEFAULT_PARTITION_SET = "1"
+DEFAULT_PANIC = "Police"
+DEFAULT_PORT = 4025
+DEFAULT_DISCOVERY_PORT = 80
+DEFAULT_TIMEOUT = 10
+DEFAULT_USERNAME = "user"
+DEFAULT_ZONEDUMP_INTERVAL = 30
+DEFAULT_ZONETYPE = BinarySensorDeviceClass.OPENING
+DEFAULT_HONEYWELL_ARM_NIGHT_MODE = HONEYWELL_ARM_MODE_NIGHT_VALUE

--- a/homeassistant/components/envisalink/controller.py
+++ b/homeassistant/components/envisalink/controller.py
@@ -21,13 +21,11 @@ from .const import (
     CONF_EVL_PORT,
     CONF_PASS,
     CONF_USERNAME,
-    CONF_ZONEDUMP_INTERVAL,
     DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
     DEFAULT_DISCOVERY_PORT,
     DEFAULT_KEEPALIVE,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
-    DEFAULT_ZONEDUMP_INTERVAL,
     LOGGER,
 )
 
@@ -53,7 +51,6 @@ class EnvisalinkController:
 
         # Options
         keep_alive = entry.options.get(CONF_EVL_KEEPALIVE, DEFAULT_KEEPALIVE)
-        zone_dump = entry.options.get(CONF_ZONEDUMP_INTERVAL, DEFAULT_ZONEDUMP_INTERVAL)
         create_zone_bypass_switches = entry.options.get(
             CONF_CREATE_ZONE_BYPASS_SWITCHES, DEFAULT_CREATE_ZONE_BYPASS_SWITCHES
         )
@@ -66,7 +63,7 @@ class EnvisalinkController:
             port,
             user,
             password,
-            zone_dump,
+            0,  # Disable zone timer dumps
             keep_alive,
             connection_timeout,
             create_zone_bypass_switches,

--- a/homeassistant/components/envisalink/controller.py
+++ b/homeassistant/components/envisalink/controller.py
@@ -1,0 +1,263 @@
+"""Support for Envisalink devices."""
+from collections.abc import Callable
+
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+from pyenvisalink.const import (
+    STATE_CHANGE_PARTITION,
+    STATE_CHANGE_ZONE,
+    STATE_CHANGE_ZONE_BYPASS,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import (
+    CONF_CREATE_ZONE_BYPASS_SWITCHES,
+    CONF_EVL_DISCOVERY_PORT,
+    CONF_EVL_KEEPALIVE,
+    CONF_EVL_PORT,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_ZONEDUMP_INTERVAL,
+    DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
+    DEFAULT_DISCOVERY_PORT,
+    DEFAULT_KEEPALIVE,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DEFAULT_ZONEDUMP_INTERVAL,
+    LOGGER,
+)
+
+
+class EnvisalinkController:
+    """Controller class for managing interactions with the underlying Envisalink device."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the controller for the Envisalink device."""
+        self._unique_id = entry.unique_id
+
+        # Config
+        self.alarm_name = entry.title
+        host = entry.data.get(CONF_HOST)
+        port = entry.data.get(CONF_EVL_PORT, DEFAULT_PORT)
+        discovery_port = entry.data.get(CONF_EVL_DISCOVERY_PORT, DEFAULT_DISCOVERY_PORT)
+        user = entry.data.get(CONF_USERNAME)
+        password = str(entry.data.get(CONF_PASS))
+
+        # Options
+        keep_alive = entry.options.get(CONF_EVL_KEEPALIVE, DEFAULT_KEEPALIVE)
+        zone_dump = entry.options.get(CONF_ZONEDUMP_INTERVAL, DEFAULT_ZONEDUMP_INTERVAL)
+        create_zone_bypass_switches = entry.options.get(
+            CONF_CREATE_ZONE_BYPASS_SWITCHES, DEFAULT_CREATE_ZONE_BYPASS_SWITCHES
+        )
+        connection_timeout = entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+
+        self.hass = hass
+
+        self.controller = EnvisalinkAlarmPanel(
+            host,
+            port,
+            user,
+            password,
+            zone_dump,
+            keep_alive,
+            connection_timeout,
+            create_zone_bypass_switches,
+            httpPort=discovery_port,
+        )
+
+        self._listeners: dict[str, dict] = {
+            STATE_CHANGE_PARTITION: {},
+            STATE_CHANGE_ZONE: {},
+            STATE_CHANGE_ZONE_BYPASS: {},
+        }
+
+        self.controller.callback_connection_status = (
+            self.async_connection_status_callback
+        )
+        self.controller.callback_login_failure = self.async_login_fail_callback
+        self.controller.callback_login_timeout = self.async_login_timeout_callback
+        self.controller.callback_login_success = self.async_login_success_callback
+
+        self.controller.callback_keypad_update = self.async_keypad_updated_callback
+        self.controller.callback_zone_state_change = self.async_zones_updated_callback
+        self.controller.callback_zone_bypass_state_change = (
+            self.async_zone_bypass_update
+        )
+        self.controller.callback_partition_state_change = (
+            self.async_partition_updated_callback
+        )
+
+        LOGGER.debug(
+            "Created EnvisalinkController for %s (host=%s port=%r)",
+            self.alarm_name,
+            host,
+            port,
+        )
+
+    def add_state_change_listener(
+        self, state_type, state_key, update_callback
+    ) -> Callable[[], None]:
+        """Register an entity to have a state update triggered when it's underlying data is changed."""
+
+        def remove_listener() -> None:
+            for state_types in self._listeners.values():
+                for key_list in state_types.values():
+                    for idx, listener in enumerate(key_list):
+                        # pylint: disable-next=comparison-with-callable
+                        if listener[0] == remove_listener:
+                            key_list.pop(idx)
+                            break
+
+        state_info = self._listeners[state_type]
+        if state_key not in state_info:
+            state_info[state_key] = []
+        state_info[state_key].append((remove_listener, update_callback))
+        return remove_listener
+
+    def _process_state_change(self, update_type: str, update_keys: list):
+        state_info = self._listeners[update_type]
+        for key in update_keys:
+            if key in state_info:
+                for listener in state_info[key]:
+                    listener[1]()
+
+    def _update_entity_states(self):
+        """Trigger a state update for all entities."""
+        for state_info in self._listeners.values():
+            for key_list in state_info.values():
+                for listener in key_list:
+                    listener[1]()
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the underlying device."""
+        return self._unique_id
+
+    async def start(self) -> bool:
+        """Start and connection to the underlying Envisalink alarm panel device."""
+        LOGGER.info("Start envisalink")
+        await self.controller.discover()
+
+        if self.controller.mac_address:
+            mac = format_mac(self.controller.mac_address)
+            if mac != self._unique_id:
+                LOGGER.warning(
+                    (
+                        "MAC address (%s) of EVL device (%s) does not match "
+                        "unique ID (%s)"
+                    ),
+                    mac,
+                    self.alarm_name,
+                    self._unique_id,
+                )
+
+        result = await self.controller.start()
+        if result != self.controller.ConnectionResult.SUCCESS:
+            raise ConfigEntryNotReady(
+                self._get_exception_message(
+                    result, f"{self.controller.host}:{self.controller.port}"
+                )
+            )
+
+        return True
+
+    async def stop(self):
+        """Stop the underlying Envisalink alarm panel."""
+
+        if self.controller:
+            await self.controller.stop()
+
+    def _get_exception_message(self, error, location) -> str:
+        if error == EnvisalinkAlarmPanel.ConnectionResult.INVALID_AUTHORIZATION:
+            msg = "Unable to authenticate with Envisalink"
+        elif error == EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED:
+            msg = "Unable to connect to Envisalink"
+        elif error == EnvisalinkAlarmPanel.ConnectionResult.INVALID_PANEL_TYPE:
+            msg = "Unrecognized/undetermined panel type"
+        elif error == EnvisalinkAlarmPanel.ConnectionResult.INVALID_EVL_VERSION:
+            msg = "Unrecognized/undetermined Envisalink version"
+        elif error == EnvisalinkAlarmPanel.ConnectionResult.DISCOVERY_NOT_COMPLETE:
+            msg = "Unable to complete discovery of Envisalink"
+        else:
+            msg = f"Unknown error: {error}"
+        return f"{msg} at {location}"
+
+    @property
+    def available(self) -> bool:
+        """Return if the Envisalink device is available or not."""
+        return self.controller.is_online()
+
+    @callback
+    def async_login_fail_callback(self):
+        """Handle when the evl rejects our login."""
+        LOGGER.error("The Envisalink rejected your credentials")
+        self._update_entity_states()
+
+    @callback
+    def async_login_timeout_callback(self):
+        """Handle a login timeout."""
+        LOGGER.error("Timed out trying to login to the Envisalink- retrying")
+        self._update_entity_states()
+
+    @callback
+    def async_login_success_callback(self):
+        """Handle a successful login."""
+        LOGGER.info("Established a connection and logged into the Envisalink")
+        self._update_entity_states()
+
+    @callback
+    def async_connection_status_callback(self, connected):
+        """Handle when the evl rejects our login."""
+        if not connected:
+            # Trigger a state update for all the entities so they appear as unavailable
+            self._update_entity_states()
+        else:
+            LOGGER.info("Connected to the envisalink device")
+
+    @callback
+    def async_zones_updated_callback(self, data: list):
+        """Handle zone state updates."""
+        LOGGER.debug(
+            "Envisalink sent a '%s' zone update event. Updating zones: %r",
+            self.alarm_name,
+            data,
+        )
+        self._process_state_change(STATE_CHANGE_ZONE, data)
+
+    @callback
+    def async_keypad_updated_callback(self, data: list):
+        """Handle non-alarm based info updates."""
+        LOGGER.debug(
+            "Envisalink sent '%s' new alarm info. Updating alarms: %r",
+            self.alarm_name,
+            data,
+        )
+        self._process_state_change(STATE_CHANGE_PARTITION, data)
+
+    @callback
+    def async_partition_updated_callback(self, data: list):
+        """Handle partition changes thrown by evl (including alarms)."""
+        LOGGER.debug(
+            "The envisalink '%s' sent a partition update event: %r",
+            self.alarm_name,
+            data,
+        )
+        self._process_state_change(STATE_CHANGE_PARTITION, data)
+
+    @callback
+    def async_zone_bypass_update(self, data: list):
+        """Handle zone bypass status updates."""
+        LOGGER.debug(
+            "Envisalink '%s' sent a zone bypass update event. Updating zones: %r",
+            self.alarm_name,
+            data,
+        )
+        self._process_state_change(STATE_CHANGE_ZONE_BYPASS, data)

--- a/homeassistant/components/envisalink/helpers.py
+++ b/homeassistant/components/envisalink/helpers.py
@@ -1,0 +1,79 @@
+"""Helper functions for the Envisalink integration."""
+
+
+def find_yaml_info(entry_number: int, info) -> map | None:
+    """Locate the given entry from a dict whose keys may be strings."""
+    if info is None:
+        return None
+
+    for key, entry in info.items():
+        if int(key) == entry_number:
+            return entry
+    return None
+
+
+def parse_range_string(sequence: str, min_val: int, max_val: int) -> list | None:
+    """Parse a string into a set of zones/partitions."""
+
+    # Empty strings are not valid
+    if sequence is None or len(sequence) == 0:
+        return None
+
+    # Make sure there are only valid characters
+    valid_chars = "1234567890,- "
+    stripped = sequence.strip(valid_chars)
+    if len(stripped) != 0:
+        return None
+
+    # Strip whitespace
+    sequence = sequence.strip(" ")
+
+    range_list = []
+    for seg in sequence.split(","):
+        nums = seg.split("-")
+        for num_str in nums:
+            if len(num_str) == 0:
+                return None
+            value = int(num_str)
+            if value < min_val or value > max_val:
+                return None
+        if len(nums) == 1:
+            range_list.append(int(nums[0]))
+        elif len(nums) == 2:
+            for i in range(int(nums[0]), int(nums[1]) + 1):
+                range_list.append(i)
+        else:
+            return None
+
+    if len(range_list) == 0:
+        return None
+
+    return sorted(set(range_list))
+
+
+def generate_range_string(seq: set) -> str | None:
+    """Generate a string representation of a range of zones/partitions."""
+    if len(seq) == 0:
+        return None
+    lst = list(seq)
+    if len(seq) == 1:
+        return str(lst[0])
+
+    result = ""
+    lst.sort()
+    end = start = lst[0]
+    for i in lst[1:]:
+        if i == (end + 1):
+            end = i
+        else:
+            if start == end:
+                result += f"{start},"
+            else:
+                result += f"{start}-{end},"
+            start = end = i
+
+    if start == end:
+        result += f"{start}"
+    else:
+        result += f"{start}-{end}"
+    return result

--- a/homeassistant/components/envisalink/manifest.json
+++ b/homeassistant/components/envisalink/manifest.json
@@ -2,8 +2,13 @@
   "domain": "envisalink",
   "name": "Envisalink",
   "codeowners": ["@ufodone"],
+  "config_flow": true,
+  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/envisalink",
+  "homekit": {},
   "iot_class": "local_push",
   "loggers": ["pyenvisalink"],
-  "requirements": ["pyenvisalink==4.6"]
+  "requirements": ["pyenvisalink==5.0.0b1"],
+  "ssdp": [],
+  "zeroconf": []
 }

--- a/homeassistant/components/envisalink/models.py
+++ b/homeassistant/components/envisalink/models.py
@@ -1,0 +1,50 @@
+"""Models for Envisalink."""
+from homeassistant.helpers.entity import DeviceInfo, Entity
+
+from .const import DOMAIN, LOGGER
+
+
+class EnvisalinkDevice(Entity):
+    """Representation of an Envisalink device."""
+
+    def __init__(self, name, controller, state_update_type, state_update_key):
+        """Initialize the device."""
+        self._controller = controller
+        self._attr_should_poll = False
+        self._attr_name = name
+        self._state_update_type = state_update_type
+        self._state_update_key = state_update_key
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity to receive state change updates from the underly device."""
+
+        def state_updated():
+            LOGGER.debug("state_updated for '%s'", self._attr_name)
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            self._controller.add_state_change_listener(
+                self._state_update_type, self._state_update_key, state_updated
+            )
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this WLED device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._controller.unique_id)},
+            name=self._controller.alarm_name,
+            manufacturer="eyezon",
+            model=(
+                f"Envisalink {self._controller.controller.envisalink_version}: "
+                "{self._controller.controller.panel_type}"
+            ),
+            sw_version=self._controller.controller.firmware_version,
+            hw_version=self._controller.controller.envisalink_version,
+            configuration_url=f"http://{self._controller.controller.host}",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if this entity is available or not."""
+        return self._controller.available and super().available

--- a/homeassistant/components/envisalink/models.py
+++ b/homeassistant/components/envisalink/models.py
@@ -16,7 +16,7 @@ class EnvisalinkDevice(Entity):
         self._state_update_key = state_update_key
 
     async def async_added_to_hass(self) -> None:
-        """Register this entity to receive state change updates from the underly device."""
+        """Register this entity to receive state change updates from the underlying device."""
 
         def state_updated():
             LOGGER.debug("state_updated for '%s'", self._attr_name)
@@ -37,7 +37,7 @@ class EnvisalinkDevice(Entity):
             manufacturer="eyezon",
             model=(
                 f"Envisalink {self._controller.controller.envisalink_version}: "
-                "{self._controller.controller.panel_type}"
+                f"{self._controller.controller.panel_type}"
             ),
             sw_version=self._controller.controller.firmware_version,
             hw_version=self._controller.controller.envisalink_version,

--- a/homeassistant/components/envisalink/sensor.py
+++ b/homeassistant/components/envisalink/sensor.py
@@ -27,9 +27,9 @@ async def async_setup_entry(
     """Set up the alarm keypad entity based on a config entry."""
     controller = hass.data[DOMAIN][entry.entry_id]
 
-    partition_spec = entry.data.get(CONF_PARTITION_SET)
+    partition_spec: str = entry.data.get(CONF_PARTITION_SET, "")
     partition_set = parse_range_string(
-        str(partition_spec), min_val=1, max_val=controller.controller.max_partitions
+        partition_spec, min_val=1, max_val=controller.controller.max_partitions
     )
     partition_info = entry.data.get(CONF_PARTITIONS)
     if partition_set is not None:

--- a/homeassistant/components/envisalink/services.yaml
+++ b/homeassistant/components/envisalink/services.yaml
@@ -3,15 +3,11 @@
 alarm_keypress:
   name: Alarm keypress
   description: Send custom keypresses to the alarm.
+  target:
+    entity:
+      integration: envisalink
+      domain: alarm_control_panel
   fields:
-    entity_id:
-      name: Entity
-      description: Name of the alarm control panel to trigger.
-      required: true
-      selector:
-        entity:
-          integration: envisalink
-          domain: alarm_control_panel
     keypress:
       name: Keypress
       description: "String to send to the alarm panel (1-6 characters)."
@@ -24,17 +20,13 @@ invoke_custom_function:
   name: Invoke custom function
   description: >
     Allows users with DSC panels to trigger a PGM output (1-4).
-    Note that you need to specify the alarm panel's "code" parameter for this to work.
+    Note that you need to specify the alarm panel's "code" parameter for
+    this to work.
+  target:
+    entity:
+      integration: envisalink
+      domain: alarm_control_panel
   fields:
-    partition:
-      name: Partition
-      description: >
-        The alarm panel partition to trigger the PGM output on.
-        Typically this is just "1".
-      required: true
-      example: "1"
-      selector:
-        text:
     pgm:
       name: PGM
       description: The PGM number to trigger on the alarm panel.
@@ -43,3 +35,9 @@ invoke_custom_function:
         number:
           min: 1
           max: 4
+    code:
+      name: Alarm Code
+      description: The alarm code for the selected partition
+      required: false
+      selector:
+        text:

--- a/homeassistant/components/envisalink/strings.json
+++ b/homeassistant/components/envisalink/strings.json
@@ -1,0 +1,68 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "alarm_name": "Alarm Name",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "user_name": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "partition_set": "Partition list",
+          "zone_set": "Zone list",
+          "code": "Alarm code",
+          "discovery_port": "Discovery Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_zone_spec": "invalid zone specification",
+      "invalid_partition_spec": "Invalid partition specification",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "Basic": "Basic",
+          "Advanced": "Advanced"
+        }
+      },
+      "basic": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "user_name": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "partition_set": "[%key:component::envisalink::config::step::user::data::partition_set%]",
+          "zone_set": "[%key:component::envisalink::config::step::user::data::zone_set%]",
+          "code": "[%key:component::envisalink::config::step::user::data::code%]",
+          "discovery_port": "[%key:component::envisalink::config::step::user::data::discovery_port%]"
+        }
+      },
+      "advanced": {
+        "data": {
+          "panic_type": "Panic type",
+          "keepalive_interval": "Keep-alive interval",
+          "zonedump_interval": "Zone dump interval",
+          "timeout": "Connection timeout",
+          "create_zone_bypass_switches": "Create zone bypass switches",
+          "honeywell_arm_night_mode": "Arm Night Mode"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_zone_spec": "Invalid zone specification",
+      "invalid_partition_spec": "Invalid partition specification",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
+  }
+}

--- a/homeassistant/components/envisalink/switch.py
+++ b/homeassistant/components/envisalink/switch.py
@@ -30,9 +30,9 @@ async def async_setup_entry(
 
     create_bypass_switches = entry.options.get(CONF_CREATE_ZONE_BYPASS_SWITCHES)
     if create_bypass_switches:
-        zone_spec = entry.data.get(CONF_ZONE_SET)
+        zone_spec: str = entry.data.get(CONF_ZONE_SET, "")
         zone_set = parse_range_string(
-            str(zone_spec), min_val=1, max_val=controller.controller.max_zones
+            zone_spec, min_val=1, max_val=controller.controller.max_zones
         )
         zone_info = entry.data.get(CONF_ZONES)
         if zone_set is not None:

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -119,6 +119,7 @@ FLOWS = {
         "enocean",
         "enphase_envoy",
         "environment_canada",
+        "envisalink",
         "epson",
         "escea",
         "esphome",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1424,7 +1424,7 @@
     "envisalink": {
       "name": "Envisalink",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "ephember": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1606,7 +1606,7 @@ pyeight==0.3.2
 pyemby==1.8
 
 # homeassistant.components.envisalink
-pyenvisalink==4.6
+pyenvisalink==5.0.0b1
 
 # homeassistant.components.ephember
 pyephember==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1151,6 +1151,9 @@ pyefergy==22.1.1
 # homeassistant.components.eight_sleep
 pyeight==0.3.2
 
+# homeassistant.components.envisalink
+pyenvisalink==5.0.0b1
+
 # homeassistant.components.everlights
 pyeverlights==0.1.0
 

--- a/tests/components/envisalink/__init__.py
+++ b/tests/components/envisalink/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Envisalink integration."""

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -1,0 +1,248 @@
+"""Fixtures for Envisalink integration tests."""
+from typing import Any
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.envisalink.const import (
+    CONF_ALARM_NAME,
+    CONF_CODE,
+    CONF_CREATE_ZONE_BYPASS_SWITCHES,
+    CONF_EVL_DISCOVERY_PORT,
+    CONF_EVL_KEEPALIVE,
+    CONF_EVL_PORT,
+    CONF_EVL_VERSION,
+    CONF_HONEYWELL_ARM_NIGHT_MODE,
+    CONF_PANEL_TYPE,
+    CONF_PANIC,
+    CONF_PARTITION_SET,
+    CONF_PASS,
+    CONF_USERNAME,
+    CONF_YAML_OPTIONS,
+    CONF_ZONE_SET,
+    CONF_ZONEDUMP_INTERVAL,
+    DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
+    DOMAIN,
+)
+from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
+    EnvisalinkAlarmPanel,
+)
+from homeassistant.components.envisalink.pyenvisalink.const import PANEL_TYPE_HONEYWELL
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+
+
+@pytest.fixture
+def mock_unique_id() -> str:
+    """Return the default unique ID for the panel."""
+    return "01:02:03:04:05:06"
+
+
+@pytest.fixture
+def mock_envisalink_alarm_panel(mock_unique_id):
+    """Return a mocked EnvisalinkAlarmPanel."""
+    with patch.object(
+        EnvisalinkAlarmPanel,
+        "discover",
+        autospec=True,
+        return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "discover_panel_type",
+        autospec=True,
+        return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "start",
+        autospec=True,
+        return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "mac_address",
+        new_callable=PropertyMock,
+        return_value=mock_unique_id,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "panel_type",
+        new_callable=PropertyMock,
+        return_value="DSC",
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "envisalink_version",
+        new_callable=PropertyMock,
+        return_value=4,
+    ), patch(
+        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.get_max_zones_by_version",
+        return_value=128,
+    ):
+        yield
+
+
+def _build_config_data(for_result: bool) -> dict[str, Any]:
+    in_input = {
+        CONF_ALARM_NAME: "test-alarm-name",
+    }
+    in_both = {
+        CONF_HOST: "1.1.1.1",
+        CONF_USERNAME: "test-username",
+        CONF_PASS: "test-password",
+        CONF_ZONE_SET: "1-16",
+        CONF_PARTITION_SET: "1",
+        CONF_CODE: "1234",
+        CONF_EVL_PORT: 4025,
+        CONF_EVL_DISCOVERY_PORT: 80,
+    }
+    in_result = {
+        CONF_EVL_VERSION: 4,
+        CONF_PANEL_TYPE: "DSC",
+    }
+    if for_result:
+        return in_both | in_result
+    return in_input | in_both
+
+
+@pytest.fixture
+def mock_config_data() -> dict[str, Any]:
+    """Return the default input data for the config flow."""
+    return _build_config_data(False)
+
+
+@pytest.fixture
+def mock_config_data_result() -> dict[str, Any]:
+    """Return the default output data from the config flow."""
+    return _build_config_data(True)
+
+
+@pytest.fixture
+def mock_config_entry(mock_config_data_result, mock_unique_id) -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_data_result,
+        unique_id=mock_unique_id,
+    )
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_envisalink_alarm_panel
+) -> MockConfigEntry:
+    """Set up the Envisalink integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry
+
+
+@pytest.fixture
+def mock_config_entry_honeywell(
+    mock_config_data_result, mock_unique_id
+) -> MockConfigEntry:
+    """Return the default mocked config entry for a Honeywell panel."""
+    mock_config_data_result[CONF_PANEL_TYPE] = PANEL_TYPE_HONEYWELL
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_data_result,
+        unique_id=mock_unique_id,
+    )
+
+
+@pytest.fixture
+def mock_config_entry_yaml_options(
+    mock_config_data_result, mock_unique_id
+) -> MockConfigEntry:
+    """Return the default mocked config entry that contains the imported yaml options."""
+    mock_config_data_result[CONF_YAML_OPTIONS] = {
+        CONF_PANIC: "Polic",
+        CONF_EVL_KEEPALIVE: 60,
+        CONF_ZONEDUMP_INTERVAL: 30,
+        CONF_TIMEOUT: 10,
+    }
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_data_result,
+        unique_id=mock_unique_id,
+        source=config_entries.SOURCE_IMPORT,
+    )
+
+
+@pytest.fixture
+def mock_yaml_import_data() -> dict[str, Any]:
+    """Return yaml configuration for import from configuration.yaml."""
+    return {
+        "host": "envisalink-host",
+        "panel_type": "DSC",
+        "user_name": "USER",
+        "password": "PASSWORD",
+        "code": "1234",
+        "port": 4025,
+        "evl_version": 4,
+        "keepalive_interval": 60,
+        "zonedump_interval": 30,
+        "timeout": 10,
+        "panic_type": "Police",
+        "zones": {
+            1: {"name": "Entry Doors", "type": "opening"},
+            2: {"name": "Motion Detectors", "type": "motion"},
+            3: {"name": "Kid's Bedrooms", "type": "opening"},
+            4: {"name": "Master Bedroom", "type": "opening"},
+            5: {"name": "Kitchen", "type": "opening"},
+            6: {"name": "Living/dining Room", "type": "opening"},
+            7: {"name": "Family Room", "type": "opening"},
+            8: {"name": "Basement", "type": "opening"},
+        },
+        "partitions": {
+            1: {"name": "Home Alarm"},
+        },
+    }
+
+
+@pytest.fixture
+def mock_config_entry_yaml_import(
+    mock_unique_id, mock_yaml_import_data
+) -> MockConfigEntry:
+    """Return the config data from after a configuration.yaml import."""
+    options = {}
+    for key in CONF_PANIC, CONF_EVL_KEEPALIVE, CONF_ZONEDUMP_INTERVAL, CONF_TIMEOUT:
+        options[key] = mock_yaml_import_data[key]
+        mock_yaml_import_data.pop(key)
+    mock_yaml_import_data[CONF_ZONE_SET] = "1-8"
+    mock_yaml_import_data[CONF_PARTITION_SET] = "1"
+    mock_yaml_import_data[CONF_YAML_OPTIONS] = {}
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=mock_unique_id,
+        data=mock_yaml_import_data,
+        options=options,
+    )
+
+
+@pytest.fixture
+def mock_options_data_dsc():
+    """Return default configuration parameters for the options flow for DSC panels."""
+    return {
+        CONF_PANIC: "panic",
+        CONF_EVL_KEEPALIVE: 60,
+        CONF_ZONEDUMP_INTERVAL: 30,
+        CONF_TIMEOUT: 10,
+        CONF_CREATE_ZONE_BYPASS_SWITCHES: True,
+    }
+
+
+@pytest.fixture
+def mock_options_data_honeywell():
+    """Return default configuration parameters for the options flow for Honeywell panels."""
+    return {
+        CONF_PANIC: "panic",
+        CONF_EVL_KEEPALIVE: 60,
+        CONF_ZONEDUMP_INTERVAL: 30,
+        CONF_TIMEOUT: 10,
+        CONF_HONEYWELL_ARM_NIGHT_MODE: DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
+    }

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -28,7 +28,12 @@ from homeassistant.components.envisalink.const import (
 from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
     EnvisalinkAlarmPanel,
 )
-from homeassistant.components.envisalink.pyenvisalink.const import PANEL_TYPE_HONEYWELL
+from homeassistant.components.envisalink.pyenvisalink.alarm_state import AlarmState
+from homeassistant.components.envisalink.pyenvisalink.const import (
+    EVL4_MAX_ZONES,
+    MAX_PARTITIONS,
+    PANEL_TYPE_HONEYWELL,
+)
 from homeassistant.const import CONF_HOST, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 
@@ -62,6 +67,11 @@ def mock_envisalink_alarm_panel(mock_unique_id):
         return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
     ), patch.object(
         EnvisalinkAlarmPanel,
+        "is_online",
+        autospec=True,
+        return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
         "mac_address",
         new_callable=PropertyMock,
         return_value=mock_unique_id,
@@ -75,6 +85,11 @@ def mock_envisalink_alarm_panel(mock_unique_id):
         "envisalink_version",
         new_callable=PropertyMock,
         return_value=4,
+    ), patch.object(
+        EnvisalinkAlarmPanel,
+        "alarm_state",
+        new_callable=PropertyMock,
+        return_value=AlarmState.get_initial_alarm_state(EVL4_MAX_ZONES, MAX_PARTITIONS),
     ), patch(
         "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.get_max_zones_by_version",
         return_value=128,
@@ -84,7 +99,7 @@ def mock_envisalink_alarm_panel(mock_unique_id):
 
 def _build_config_data(for_result: bool) -> dict[str, Any]:
     in_input = {
-        CONF_ALARM_NAME: "test-alarm-name",
+        CONF_ALARM_NAME: "TestAlarmName",
     }
     in_both = {
         CONF_HOST: "1.1.1.1",
@@ -118,12 +133,16 @@ def mock_config_data_result() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_config_entry(mock_config_data_result, mock_unique_id) -> MockConfigEntry:
+def mock_config_entry(
+    mock_config_data_result, mock_unique_id, mock_options_data_dsc
+) -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         data=mock_config_data_result,
         unique_id=mock_unique_id,
+        title="Test Alarm Name",
+        options=mock_options_data_dsc,
     )
 
 

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -66,10 +66,7 @@ def mock_envisalink_alarm_panel(mock_unique_id):
         autospec=True,
         return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
     ), patch.object(
-        EnvisalinkAlarmPanel,
-        "is_online",
-        autospec=True,
-        return_value=EnvisalinkAlarmPanel.ConnectionResult.SUCCESS,
+        EnvisalinkAlarmPanel, "is_online", autospec=True, return_value=True
     ), patch.object(
         EnvisalinkAlarmPanel,
         "mac_address",
@@ -178,10 +175,11 @@ def mock_config_entry_yaml_options(
 ) -> MockConfigEntry:
     """Return the default mocked config entry that contains the imported yaml options."""
     mock_config_data_result[CONF_YAML_OPTIONS] = {
-        CONF_PANIC: "Polic",
+        CONF_PANIC: "Police",
         CONF_EVL_KEEPALIVE: 60,
         CONF_ZONEDUMP_INTERVAL: 30,
         CONF_TIMEOUT: 10,
+        CONF_CREATE_ZONE_BYPASS_SWITCHES: True,
     }
     return MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -2,6 +2,14 @@
 from typing import Any
 from unittest.mock import PropertyMock, patch
 
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+from pyenvisalink.alarm_state import AlarmState
+from pyenvisalink.const import (
+    EVL4_MAX_ZONES,
+    MAX_PARTITIONS,
+    PANEL_TYPE_DSC,
+    PANEL_TYPE_HONEYWELL,
+)
 import pytest
 
 from homeassistant import config_entries
@@ -23,16 +31,6 @@ from homeassistant.components.envisalink.const import (
     CONF_ZONEDUMP_INTERVAL,
     DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
     DOMAIN,
-)
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
-)
-from homeassistant.components.envisalink.pyenvisalink.alarm_state import AlarmState
-from homeassistant.components.envisalink.pyenvisalink.const import (
-    EVL4_MAX_ZONES,
-    MAX_PARTITIONS,
-    PANEL_TYPE_DSC,
-    PANEL_TYPE_HONEYWELL,
 )
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
@@ -88,7 +86,7 @@ def mock_envisalink_alarm_panel(mock_unique_id):
         new_callable=PropertyMock,
         return_value=AlarmState.get_initial_alarm_state(EVL4_MAX_ZONES, MAX_PARTITIONS),
     ), patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.get_max_zones_by_version",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.get_max_zones_by_version",
         return_value=128,
     ):
         yield

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.envisalink.const import (
     CONF_ALARM_NAME,
-    CONF_CODE,
     CONF_CREATE_ZONE_BYPASS_SWITCHES,
     CONF_EVL_DISCOVERY_PORT,
     CONF_EVL_KEEPALIVE,
@@ -35,7 +34,7 @@ from homeassistant.components.envisalink.pyenvisalink.const import (
     PANEL_TYPE_DSC,
     PANEL_TYPE_HONEYWELL,
 )
-from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+from homeassistant.const import CONF_CODE, CONF_HOST, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -196,9 +195,7 @@ def mock_config_entry_yaml_options(
     )
 
 
-@pytest.fixture
-def mock_yaml_import_data() -> dict[str, Any]:
-    """Return yaml configuration for import from configuration.yaml."""
+def _build_yaml_import_data() -> dict[str, Any]:
     return {
         "host": "envisalink-host",
         "panel_type": PANEL_TYPE_DSC,
@@ -228,22 +225,26 @@ def mock_yaml_import_data() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_config_entry_yaml_import(
-    mock_unique_id, mock_yaml_import_data
-) -> MockConfigEntry:
+def mock_yaml_import_data() -> dict[str, Any]:
+    """Return yaml configuration for import from configuration.yaml."""
+    return _build_yaml_import_data()
+
+
+@pytest.fixture
+def mock_config_entry_yaml_import(mock_unique_id) -> MockConfigEntry:
     """Return the config data from after a configuration.yaml import."""
+    data = _build_yaml_import_data()
     options = {}
     for key in CONF_PANIC, CONF_EVL_KEEPALIVE, CONF_ZONEDUMP_INTERVAL, CONF_TIMEOUT:
-        options[key] = mock_yaml_import_data[key]
-        mock_yaml_import_data.pop(key)
-    mock_yaml_import_data[CONF_ZONE_SET] = "1-8"
-    mock_yaml_import_data[CONF_PARTITION_SET] = "1"
-    mock_yaml_import_data[CONF_YAML_OPTIONS] = {}
+        options[key] = data[key]
+        data.pop(key)
+    data[CONF_ZONE_SET] = "1-8"
+    data[CONF_PARTITION_SET] = "1"
 
     return MockConfigEntry(
         domain=DOMAIN,
         unique_id=mock_unique_id,
-        data=mock_yaml_import_data,
+        data=data,
         options=options,
     )
 

--- a/tests/components/envisalink/conftest.py
+++ b/tests/components/envisalink/conftest.py
@@ -233,9 +233,10 @@ def mock_config_entry_yaml_import(mock_unique_id) -> MockConfigEntry:
     """Return the config data from after a configuration.yaml import."""
     data = _build_yaml_import_data()
     options = {}
-    for key in CONF_PANIC, CONF_EVL_KEEPALIVE, CONF_ZONEDUMP_INTERVAL, CONF_TIMEOUT:
+    for key in CONF_PANIC, CONF_EVL_KEEPALIVE, CONF_TIMEOUT:
         options[key] = data[key]
         data.pop(key)
+    data.pop(CONF_ZONEDUMP_INTERVAL)
     data[CONF_ZONE_SET] = "1-8"
     data[CONF_PARTITION_SET] = "1"
 
@@ -253,7 +254,6 @@ def mock_options_data_dsc():
     return {
         CONF_PANIC: "panic",
         CONF_EVL_KEEPALIVE: 60,
-        CONF_ZONEDUMP_INTERVAL: 30,
         CONF_TIMEOUT: 10,
         CONF_CREATE_ZONE_BYPASS_SWITCHES: True,
     }
@@ -265,7 +265,6 @@ def mock_options_data_honeywell():
     return {
         CONF_PANIC: "panic",
         CONF_EVL_KEEPALIVE: 60,
-        CONF_ZONEDUMP_INTERVAL: 30,
         CONF_TIMEOUT: 10,
         CONF_HONEYWELL_ARM_NIGHT_MODE: DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
     }

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -27,10 +27,6 @@ async def test_alarm_control_panel_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
     """Test the createion and values of the Envisalink alarm control panels."""
-    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
-
     er.async_get(hass)
 
     state = hass.states.get("alarm_control_panel.test_alarm_name_partition_1")
@@ -55,8 +51,6 @@ async def test_alarm_control_panel_update(
 ) -> None:
     """Test updating the alarm control panel's state."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
 
     er.async_get(hass)
 
@@ -93,8 +87,6 @@ async def test_arming_modes(
 ) -> None:
     """Test disarming the alarm."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
 
     er.async_get(hass)
 
@@ -175,10 +167,6 @@ async def test_services(
     should_succeed,
 ) -> None:
     """Test sending keypresses to the panel."""
-    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
-
     er.async_get(hass)
 
     with patch.object(

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -2,14 +2,12 @@
 
 from unittest.mock import patch
 
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
 import pytest
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.components.envisalink.const import DOMAIN
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
-)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_ALARM_ARMED_AWAY,

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -1,0 +1,204 @@
+"""Test the Envisalink alarm control panels."""
+
+from unittest.mock import patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
+from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
+    EnvisalinkAlarmPanel,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
+    STATE_ALARM_PENDING,
+    STATE_ALARM_TRIGGERED,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_alarm_control_panel_state(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test the createion and values of the Envisalink alarm control panels."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    state = hass.states.get("alarm_control_panel.test_alarm_name_partition_1")
+    assert state
+    assert state.state == STATE_ALARM_DISARMED
+
+
+@pytest.mark.parametrize(
+    "json_key,alarm_state",
+    [
+        ("alarm", STATE_ALARM_TRIGGERED),
+        ("armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT),
+        ("armed_away", STATE_ALARM_ARMED_AWAY),
+        ("armed_stay", STATE_ALARM_ARMED_HOME),
+        ("exit_delay", STATE_ALARM_PENDING),
+        ("entry_delay", STATE_ALARM_PENDING),
+        ("alpha", STATE_ALARM_DISARMED),
+    ],
+)
+async def test_alarm_control_panel_update(
+    hass: HomeAssistant, mock_config_entry, init_integration, json_key, alarm_state
+) -> None:
+    """Test updating the alarm control panel's state."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    controller.controller.alarm_state["partition"][1]["status"][json_key] = True
+    controller.async_partition_updated_callback([1])
+    await hass.async_block_till_done()
+
+    state = hass.states.get("alarm_control_panel.test_alarm_name_partition_1")
+    assert state
+    assert state.state == alarm_state
+
+
+@pytest.mark.parametrize(
+    "service_call,json_key,alarm_state,code",
+    [
+        ("alarm_trigger", "alarm", STATE_ALARM_TRIGGERED, 1234),
+        ("alarm_trigger", "alarm", STATE_ALARM_TRIGGERED, None),
+        ("alarm_arm_night", "armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT, 1234),
+        ("alarm_arm_night", "armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT, None),
+        ("alarm_arm_away", "armed_away", STATE_ALARM_ARMED_AWAY, 1234),
+        ("alarm_arm_away", "armed_away", STATE_ALARM_ARMED_AWAY, None),
+        ("alarm_arm_home", "armed_stay", STATE_ALARM_ARMED_HOME, 1234),
+        ("alarm_arm_home", "armed_stay", STATE_ALARM_ARMED_HOME, None),
+    ],
+)
+async def test_arming_modes(
+    hass: HomeAssistant,
+    mock_config_entry,
+    init_integration,
+    service_call,
+    json_key,
+    alarm_state,
+    code,
+) -> None:
+    """Test disarming the alarm."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    fields = {ATTR_ENTITY_ID: "alarm_control_panel.test_alarm_name_partition_1"}
+    if code:
+        fields["code"] = code
+
+    with patch.object(
+        EnvisalinkAlarmPanel,
+        "arm_away_partition",
+        autospec=True,
+    ):
+        # Arm alarm
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            service_call,
+            fields,
+            blocking=True,
+        )
+        controller.controller.alarm_state["partition"][1]["status"][json_key] = True
+        controller.async_partition_updated_callback([1])
+        await hass.async_block_till_done()
+
+    state = hass.states.get("alarm_control_panel.test_alarm_name_partition_1")
+    assert state
+    assert state.state == alarm_state
+
+    with patch.object(
+        EnvisalinkAlarmPanel,
+        "disarm_partition",
+        autospec=True,
+    ):
+        # Disarm alarm
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            "alarm_disarm",
+            fields,
+            blocking=True,
+        )
+        controller.controller.alarm_state["partition"][1]["status"][json_key] = False
+        controller.controller.alarm_state["partition"][1]["status"]["alpha"] = True
+        controller.async_partition_updated_callback([1])
+        await hass.async_block_till_done()
+
+    state = hass.states.get("alarm_control_panel.test_alarm_name_partition_1")
+    assert state
+    assert state.state == STATE_ALARM_DISARMED
+
+
+@pytest.mark.parametrize(
+    "service_call,patch_name,fields,should_succeed",
+    [
+        ("alarm_keypress", "keypresses_to_partition", {}, False),
+        ("alarm_keypress", "keypresses_to_partition", {"keypress": "*104#"}, True),
+        (
+            "alarm_keypress",
+            "keypresses_to_partition",
+            {"keypress": "*104#", "extra": "value"},
+            False,
+        ),
+        ("invoke_custom_function", "command_output", {}, False),
+        ("invoke_custom_function", "command_output", {"pgm": 2}, True),
+        (
+            "invoke_custom_function",
+            "command_output",
+            {"pgm": 2, "extra": "value"},
+            False,
+        ),
+    ],
+)
+async def test_services(
+    hass: HomeAssistant,
+    mock_config_entry,
+    init_integration,
+    service_call,
+    patch_name,
+    fields,
+    should_succeed,
+) -> None:
+    """Test sending keypresses to the panel."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    with patch.object(
+        EnvisalinkAlarmPanel,
+        patch_name,
+        autospec=True,
+    ):
+        success = True
+        fields = fields | {
+            ATTR_ENTITY_ID: "alarm_control_panel.test_alarm_name_partition_1"
+        }
+        try:
+            await hass.services.async_call(
+                DOMAIN,
+                service_call,
+                fields,
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+        except vol.error.MultipleInvalid:
+            success = False
+
+        assert should_succeed == success

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -33,7 +33,7 @@ async def test_alarm_control_panel_state(
 
 
 @pytest.mark.parametrize(
-    "json_key,alarm_state",
+    ("json_key", "alarm_state"),
     [
         ("alarm", STATE_ALARM_TRIGGERED),
         ("armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT),
@@ -62,16 +62,52 @@ async def test_alarm_control_panel_update(
 
 
 @pytest.mark.parametrize(
-    "service_call,json_key,alarm_state,code",
+    ("service_call", "patch_name", "json_key", "alarm_state", "code"),
     [
-        ("alarm_trigger", "alarm", STATE_ALARM_TRIGGERED, 1234),
-        ("alarm_trigger", "alarm", STATE_ALARM_TRIGGERED, None),
-        ("alarm_arm_night", "armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT, 1234),
-        ("alarm_arm_night", "armed_zero_entry_delay", STATE_ALARM_ARMED_NIGHT, None),
-        ("alarm_arm_away", "armed_away", STATE_ALARM_ARMED_AWAY, 1234),
-        ("alarm_arm_away", "armed_away", STATE_ALARM_ARMED_AWAY, None),
-        ("alarm_arm_home", "armed_stay", STATE_ALARM_ARMED_HOME, 1234),
-        ("alarm_arm_home", "armed_stay", STATE_ALARM_ARMED_HOME, None),
+        ("alarm_trigger", "panic_alarm", "alarm", STATE_ALARM_TRIGGERED, 1234),
+        ("alarm_trigger", "panic_alarm", "alarm", STATE_ALARM_TRIGGERED, None),
+        (
+            "alarm_arm_night",
+            "arm_night_partition",
+            "armed_zero_entry_delay",
+            STATE_ALARM_ARMED_NIGHT,
+            1234,
+        ),
+        (
+            "alarm_arm_night",
+            "arm_night_partition",
+            "armed_zero_entry_delay",
+            STATE_ALARM_ARMED_NIGHT,
+            None,
+        ),
+        (
+            "alarm_arm_away",
+            "arm_away_partition",
+            "armed_away",
+            STATE_ALARM_ARMED_AWAY,
+            1234,
+        ),
+        (
+            "alarm_arm_away",
+            "arm_away_partition",
+            "armed_away",
+            STATE_ALARM_ARMED_AWAY,
+            None,
+        ),
+        (
+            "alarm_arm_home",
+            "arm_stay_partition",
+            "armed_stay",
+            STATE_ALARM_ARMED_HOME,
+            1234,
+        ),
+        (
+            "alarm_arm_home",
+            "arm_stay_partition",
+            "armed_stay",
+            STATE_ALARM_ARMED_HOME,
+            None,
+        ),
     ],
 )
 async def test_arming_modes(
@@ -79,6 +115,7 @@ async def test_arming_modes(
     mock_config_entry,
     init_integration,
     service_call,
+    patch_name,
     json_key,
     alarm_state,
     code,
@@ -94,7 +131,7 @@ async def test_arming_modes(
 
     with patch.object(
         EnvisalinkAlarmPanel,
-        "arm_away_partition",
+        patch_name,
         autospec=True,
     ):
         # Arm alarm
@@ -135,7 +172,7 @@ async def test_arming_modes(
 
 
 @pytest.mark.parametrize(
-    "service_call,patch_name,fields,should_succeed",
+    ("service_call", "patch_name", "fields", "should_succeed"),
     [
         ("alarm_keypress", "keypresses_to_partition", {}, False),
         ("alarm_keypress", "keypresses_to_partition", {"keypress": "*104#"}, True),

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -19,10 +19,6 @@ async def test_binary_sensor_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
     """Test the createion and values of the Envisalink binary sensors."""
-    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
-
     er.async_get(hass)
 
     state = hass.states.get("binary_sensor.test_alarm_name_zone_1")
@@ -38,8 +34,6 @@ async def test_binary_sensor_update(
 ) -> None:
     """Test updating a zone's state."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
 
     er.async_get(hass)
 

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -1,0 +1,47 @@
+"""Test the Envisalink binary sensors."""
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_binary_sensor_state(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test the createion and values of the Envisalink binary sensors."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    state = hass.states.get("binary_sensor.test_alarm_name_zone_1")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("zone") == 1
+    assert state.attributes.get("last_fault") is None  # TODO
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.OPENING
+
+
+async def test_binary_sensor_update(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test updating a zone's state."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    zones = [1, 3, 7]
+    for zone in zones:
+        controller.controller.alarm_state["zone"][zone]["status"]["open"] = True
+    controller.async_zones_updated_callback(zones)
+    await hass.async_block_till_done()
+
+    for zone in zones:
+        state = hass.states.get(f"binary_sensor.test_alarm_name_zone_{zone}")
+        assert state
+        assert state.state == STATE_ON

--- a/tests/components/envisalink/test_config_flow.py
+++ b/tests/components/envisalink/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Envisalink config flow."""
 from unittest.mock import patch
 
+# from homeassistant.components.envisalink import async_setup
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
 import pytest
 
 from homeassistant import config_entries
@@ -9,11 +11,6 @@ from homeassistant.components.envisalink.const import (
     CONF_PARTITION_SET,
     CONF_ZONE_SET,
     DOMAIN,
-)
-
-# from homeassistant.components.envisalink import async_setup
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -76,7 +73,7 @@ async def test_form_discover_error(
     )
 
     with patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
         return_value=alarm_error,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -131,7 +128,7 @@ async def test_form_unexpected_error(hass: HomeAssistant, mock_config_data) -> N
     )
 
     with patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
         side_effect=KeyError("unexpected"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -233,7 +230,7 @@ async def test_options_basic_form_discovery_error(
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
         return_value=EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED,
     ):
         mock_config_data.pop(CONF_ALARM_NAME)
@@ -272,7 +269,7 @@ async def test_options_basic_form_unexpected_error(
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
         side_effect=KeyError("unexpected"),
     ):
         mock_config_data.pop(CONF_ALARM_NAME)

--- a/tests/components/envisalink/test_config_flow.py
+++ b/tests/components/envisalink/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_form(
         user_input=mock_config_data,
     )
 
-    assert result.get("title") == "test-alarm-name"
+    assert result.get("title") == "TestAlarmName"
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     assert "data" in result
     assert result["data"] == mock_config_data_result
@@ -174,6 +174,7 @@ async def test_options_basic_form(
     mock_config_data_result,
     mock_config_data,
     mock_unique_id,
+    mock_options_data_dsc,
 ) -> None:
     """Test the basic options flow."""
     mock_config_entry.add_to_hass(hass)
@@ -201,7 +202,7 @@ async def test_options_basic_form(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert "data" in result
-    assert result["data"] == {}
+    assert result["data"] == mock_options_data_dsc
     assert "result" in result
     assert entry.data == mock_config_data_result
 

--- a/tests/components/envisalink/test_config_flow.py
+++ b/tests/components/envisalink/test_config_flow.py
@@ -1,0 +1,364 @@
+"""Test the Envisalink config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.envisalink.const import (
+    CONF_ALARM_NAME,
+    CONF_PARTITION_SET,
+    CONF_ZONE_SET,
+    DOMAIN,
+)
+
+# from homeassistant.components.envisalink import async_setup
+from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
+    EnvisalinkAlarmPanel,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+def _get_config_entry_from_unique_id(
+    hass: HomeAssistant, unique_id: str
+) -> config_entries.ConfigEntry | None:
+    for entry in hass.config_entries.async_entries(domain=DOMAIN):
+        if entry.unique_id == unique_id:
+            return entry
+    return None
+
+
+async def test_form(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_data,
+    mock_config_data_result,
+    mock_unique_id,
+) -> None:
+    """Test the full manual user flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result.get("step_id") == "user"
+    assert result.get("type") == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=mock_config_data,
+    )
+
+    assert result.get("title") == "test-alarm-name"
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"] == mock_config_data_result
+    assert "result" in result
+    assert result["result"].unique_id == mock_unique_id
+
+
+@pytest.mark.parametrize(
+    "alarm_error,exception_message",
+    [
+        (EnvisalinkAlarmPanel.ConnectionResult.INVALID_AUTHORIZATION, "invalid_auth"),
+        (EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED, "cannot_connect"),
+        ("unknown", "unknown"),
+    ],
+)
+async def test_form_discover_error(
+    hass: HomeAssistant, mock_config_data, alarm_error, exception_message
+) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        return_value=alarm_error,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=mock_config_data,
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": exception_message}
+
+
+async def test_form_invalid_zone_spec(
+    hass: HomeAssistant, mock_envisalink_alarm_panel, mock_config_data
+) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_config_data[CONF_ZONE_SET] = "garbage"
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=mock_config_data,
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_zone_spec"}
+
+
+async def test_form_invalid_partition_spec(
+    hass: HomeAssistant, mock_envisalink_alarm_panel, mock_config_data
+) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_config_data[CONF_PARTITION_SET] = "garbage"
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=mock_config_data,
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_partition_spec"}
+
+
+async def test_form_unexpected_error(hass: HomeAssistant, mock_config_data) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        side_effect=KeyError("unexpected"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=mock_config_data,
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test options config flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result.get("type") == FlowResultType.MENU
+    assert result.get("step_id") == "user"
+
+
+async def test_options_basic_menu(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test options config flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result.get("type") == FlowResultType.MENU
+    assert result.get("step_id") == "user"
+
+
+async def test_options_basic_form(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_entry,
+    mock_config_data_result,
+    mock_config_data,
+    mock_unique_id,
+) -> None:
+    """Test the basic options flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "basic"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "basic"
+    assert result["errors"] == {}
+
+    mock_config_data.pop(CONF_ALARM_NAME)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=mock_config_data
+    )
+    await hass.async_block_till_done()
+    entry = _get_config_entry_from_unique_id(hass, mock_unique_id)
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"] == {}
+    assert "result" in result
+    assert entry.data == mock_config_data_result
+
+
+async def test_options_basic_form_discovery_error(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_entry,
+    mock_config_data_result,
+    mock_config_data,
+    mock_unique_id,
+) -> None:
+    """Test discover error for the basic options flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "basic"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "basic"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        return_value=EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED,
+    ):
+        mock_config_data.pop(CONF_ALARM_NAME)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input=mock_config_data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_options_basic_form_unexpected_error(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_entry,
+    mock_config_data_result,
+    mock_config_data,
+    mock_unique_id,
+) -> None:
+    """Test unexpected error for the basic options flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "basic"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "basic"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.discover",
+        side_effect=KeyError("unexpected"),
+    ):
+        mock_config_data.pop(CONF_ALARM_NAME)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input=mock_config_data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_options_advanced_form_dsc(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_entry,
+    mock_config_data_result,
+    mock_config_data,
+    mock_unique_id,
+    mock_options_data_dsc,
+) -> None:
+    """Test the advanced options flow for DSC panels."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "advanced"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "advanced"
+    assert result["errors"] == {}
+
+    mock_config_data.pop(CONF_ALARM_NAME)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=mock_options_data_dsc
+    )
+    await hass.async_block_till_done()
+    entry = _get_config_entry_from_unique_id(hass, mock_unique_id)
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"] == mock_options_data_dsc
+    assert "result" in result
+    assert entry.data == mock_config_data_result
+
+
+async def test_options_advanced_form_honeywell(
+    hass: HomeAssistant,
+    mock_envisalink_alarm_panel,
+    mock_config_entry_honeywell,
+    mock_config_data_result,
+    mock_config_data,
+    mock_unique_id,
+    mock_options_data_honeywell,
+) -> None:
+    """Test the advanced options flow for Honeywell panels."""
+    mock_config_entry_honeywell.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_honeywell.entry_id,
+        context={"source": "user"},
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "advanced"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "advanced"
+    assert result["errors"] == {}
+
+    mock_config_data.pop(CONF_ALARM_NAME)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=mock_options_data_honeywell
+    )
+    await hass.async_block_till_done()
+    entry = _get_config_entry_from_unique_id(hass, mock_unique_id)
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"] == mock_options_data_honeywell
+    assert "result" in result
+    assert entry.data == mock_config_data_result

--- a/tests/components/envisalink/test_config_flow.py
+++ b/tests/components/envisalink/test_config_flow.py
@@ -57,7 +57,7 @@ async def test_form(
 
 
 @pytest.mark.parametrize(
-    "alarm_error,exception_message",
+    ("alarm_error", "exception_message"),
     [
         (EnvisalinkAlarmPanel.ConnectionResult.INVALID_AUTHORIZATION, "invalid_auth"),
         (EnvisalinkAlarmPanel.ConnectionResult.CONNECTION_FAILED, "cannot_connect"),

--- a/tests/components/envisalink/test_controller.py
+++ b/tests/components/envisalink/test_controller.py
@@ -3,15 +3,14 @@
 from functools import partial
 from unittest.mock import patch
 
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+
 from homeassistant.components.envisalink.const import (
     CONF_PARTITION_SET,
     CONF_ZONE_SET,
     DOMAIN,
 )
 from homeassistant.components.envisalink.helpers import parse_range_string
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
-)
 from homeassistant.const import STATE_ALARM_DISARMED, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/envisalink/test_controller.py
+++ b/tests/components/envisalink/test_controller.py
@@ -1,4 +1,4 @@
-"""Test the Envisalink config flow."""
+"""Test the Envisalink controller."""
 
 from functools import partial
 from unittest.mock import patch

--- a/tests/components/envisalink/test_controller.py
+++ b/tests/components/envisalink/test_controller.py
@@ -1,0 +1,99 @@
+"""Test the Envisalink config flow."""
+
+from functools import partial
+from unittest.mock import patch
+
+from homeassistant.components.envisalink.const import (
+    CONF_PARTITION_SET,
+    CONF_ZONE_SET,
+    DOMAIN,
+)
+from homeassistant.components.envisalink.helpers import parse_range_string
+from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
+    EnvisalinkAlarmPanel,
+)
+from homeassistant.const import STATE_ALARM_DISARMED, STATE_OFF, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+
+def _validate_states(hass, controller, config_entry, should_be_available):
+    zone_spec = config_entry.data.get(CONF_ZONE_SET)
+    zone_set = parse_range_string(
+        zone_spec, min_val=1, max_val=controller.controller.max_zones
+    )
+
+    partition_spec = config_entry.data.get(CONF_PARTITION_SET)
+    partition_set = parse_range_string(
+        partition_spec, min_val=1, max_val=controller.controller.max_partitions
+    )
+
+    if should_be_available:
+        zone_state = STATE_OFF
+        alarm_state = STATE_ALARM_DISARMED
+        keypad_state = "N/A"
+    else:
+        zone_state = STATE_UNAVAILABLE
+        alarm_state = STATE_UNAVAILABLE
+        keypad_state = STATE_UNAVAILABLE
+
+    for zone in zone_set:
+        state = hass.states.get(f"binary_sensor.test_alarm_name_zone_{zone}")
+        assert state
+        assert state.state == zone_state
+
+        state = hass.states.get(f"switch.test_alarm_name_zone_{zone}_bypass")
+        assert state
+        assert state.state == zone_state
+
+    for partition in partition_set:
+        state = hass.states.get(f"sensor.test_alarm_name_partition_{partition}_keypad")
+        assert state
+        assert state.state == keypad_state
+
+        state = hass.states.get(
+            f"alarm_control_panel.test_alarm_name_partition_{partition}"
+        )
+        assert state
+        assert state.state == alarm_state
+
+
+async def test_connection_errors(hass: HomeAssistant, init_integration) -> None:
+    """Test connection failures to the Envisalink."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+    assert len(entries) == 1
+
+    config_entry = entries[0]
+    controller = hass.data[DOMAIN][config_entry.entry_id]
+    assert controller
+
+    zone_spec = config_entry.data.get(CONF_ZONE_SET)
+    parse_range_string(zone_spec, min_val=1, max_val=controller.controller.max_zones)
+
+    _validate_states(hass, controller, config_entry, True)
+
+    callbacks = [
+        controller.async_login_fail_callback,
+        controller.async_login_timeout_callback,
+        partial(controller.async_connection_status_callback, False),
+    ]
+
+    for callback in callbacks:
+        with patch.object(
+            EnvisalinkAlarmPanel, "is_online", autospec=True, return_value=False
+        ):
+            # Simulate a lost connection
+            callback()
+            await hass.async_block_till_done()
+
+        _validate_states(hass, controller, config_entry, False)
+
+        with patch.object(
+            EnvisalinkAlarmPanel, "is_online", autospec=True, return_value=True
+        ):
+            # Simulate connection restored
+            controller.async_connection_status_callback(True)
+            controller.async_login_success_callback()
+            await hass.async_block_till_done()
+
+        _validate_states(hass, controller, config_entry, True)

--- a/tests/components/envisalink/test_helpers.py
+++ b/tests/components/envisalink/test_helpers.py
@@ -1,0 +1,54 @@
+"""Test the helper functions."""
+
+from homeassistant.components.envisalink.helpers import (
+    find_yaml_info,
+    generate_range_string,
+    parse_range_string,
+)
+
+
+async def test_range_parsing() -> None:
+    """Test zone/partition set parsing functions."""
+    min_val = 1
+    max_val = 128
+
+    test_strings = [
+        ("1-8,16-29", True, "1-8,16-29"),
+        ("1-8", True, "1-8"),
+        ("1-20,25-26,42", True, "1-20,25-26,42"),
+        ("3-9,20-23,1,12-14", True, "1,3-9,12-14,20-23"),
+        (f"1,2,{max_val}", True, f"1-2,{max_val}"),
+        (f"1,{min_val},5", True, "1,5"),
+        ("1-2,g,b", False),
+        ("1,2,3-", False),
+        ("1,-3,4", False),
+        (f"1,2,{max_val+1}", False),
+        (f"1,{min_val-1},5", False),
+        ("1-2-3", False),
+        ("8-2", False),
+        ("", False),
+        ("-", False),
+        (",", False),
+        (",-", False),
+    ]
+
+    for idx, item in enumerate(test_strings):
+        result = parse_range_string(item[0], min_val, max_val)
+        success = result is not None
+        assert success is item[1], f"parse_range_string failed at index {idx}"
+        if item[1]:
+            seq = generate_range_string(result)
+            assert seq == item[2], f"generate_range_string failed at index {idx}"
+
+    result = generate_range_string(set())
+    assert not result
+
+
+async def test_find_yaml_info() -> None:
+    """Test extracting zone/partition info from configuration.yaml-based config."""
+    info = {"01": "Zone 1", 2: "Zone 2"}
+
+    assert find_yaml_info(1, info)
+    assert find_yaml_info(2, info)
+    assert not find_yaml_info(3, info)
+    assert not find_yaml_info(3, None)

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import PropertyMock, patch
 
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+from pyenvisalink.const import PANEL_TYPE_HONEYWELL
 import pytest
 
 from homeassistant.components.envisalink.const import (
@@ -10,10 +12,6 @@ from homeassistant.components.envisalink.const import (
     DEFAULT_HONEYWELL_ARM_NIGHT_MODE,
     DOMAIN,
 )
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
-)
-from homeassistant.components.envisalink.pyenvisalink.const import PANEL_TYPE_HONEYWELL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -123,7 +121,7 @@ async def test_init_fail(
 ) -> None:
     """Test startup failures."""
     with patch(
-        "homeassistant.components.envisalink.pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.start",
+        "pyenvisalink.alarm_panel.EnvisalinkAlarmPanel.start",
         return_value=alarm_error,
     ):
         mock_config_entry.add_to_hass(hass)

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -29,6 +29,12 @@ async def test_load_unload_config_entry(hass: HomeAssistant, init_integration) -
     assert hass.data[DOMAIN][entries[0].entry_id]
     # TODO
 
+    # Test a reload
+    result = hass.config_entries.async_update_entry(init_integration, options={})
+    await hass.async_block_till_done()
+    assert result
+
+    # Unload the integration
     await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
 
@@ -88,7 +94,7 @@ async def test_async_setup_import_update(
     config_entry.add_to_hass(hass)
     options = dict(config_entry.options)
     options[CONF_CREATE_ZONE_BYPASS_SWITCHES] = True
-    hass.config_entries.async_update_entry(config_entry, options=options)
+    assert hass.config_entries.async_update_entry(config_entry, options=options)
 
     # Reload it and make sure the zone bypass switches got created
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -59,7 +59,7 @@ async def test_async_setup_import(
     options = entries[0].options
 
     assert data == mock_config_entry_yaml_import.data
-    assert options == {}
+    assert options == mock_config_entry_yaml_import.options
 
 
 async def test_async_setup_import_update(

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -1,0 +1,69 @@
+"""Test the Envisalink config flow."""
+
+# from homeassistant.components.envisalink import async_setup
+from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def test_load_unload_config_entry(hass: HomeAssistant, init_integration) -> None:
+    """Test loading and unloading the integration."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+    assert len(entries) == 1
+
+    assert hass.data[DOMAIN]
+    assert hass.data[DOMAIN][entries[0].entry_id]
+    # TODO
+
+    await hass.config_entries.async_unload(entries[0].entry_id)
+    await hass.async_block_till_done()
+
+    # Ensure everything is cleaned up nicely and are disconnected
+    assert not hass.data.get(DOMAIN)
+
+
+async def test_async_setup_import(
+    hass: HomeAssistant,
+    mock_yaml_import_data,
+    mock_envisalink_alarm_panel,
+    mock_config_entry_yaml_import,
+) -> None:
+    """Test importing from configuration.yaml."""
+    result = await async_setup_component(hass, DOMAIN, {DOMAIN: mock_yaml_import_data})
+    assert result
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+    assert len(entries) == 1
+    data = entries[0].data
+    options = entries[0].options
+
+    assert data == mock_config_entry_yaml_import.data
+    assert options == {}
+
+
+async def test_async_setup_import_update(
+    hass: HomeAssistant,
+    mock_config_data_result,
+    mock_unique_id,
+    mock_yaml_import_data,
+    mock_envisalink_alarm_panel,
+    mock_config_entry_yaml_options,
+) -> None:
+    """Test importing from configuration.yaml."""
+
+    mock_config_entry_yaml_options.add_to_hass(hass)
+
+    result = await async_setup_component(hass, DOMAIN, {DOMAIN: mock_yaml_import_data})
+    assert result
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+    assert len(entries) == 1
+    entries[0].data
+    entries[0].options
+
+
+#    assert options == {}
+# TODO

--- a/tests/components/envisalink/test_init.py
+++ b/tests/components/envisalink/test_init.py
@@ -4,7 +4,10 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.components.envisalink.const import (
+    CONF_CREATE_ZONE_BYPASS_SWITCHES,
+    DOMAIN,
+)
 from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
     EnvisalinkAlarmPanel,
 )
@@ -68,12 +71,28 @@ async def test_async_setup_import_update(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    entries[0].data
-    entries[0].options
+
+    config_entry = entries[0]
+    #    assert options == {}
+    #    TODO
+
+    # Unload the integration
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert not hass.data.get(DOMAIN)
+
+    # Add the zone bypass switch option
+    config_entry.add_to_hass(hass)
+    options = dict(config_entry.options)
+    options[CONF_CREATE_ZONE_BYPASS_SWITCHES] = True
+    hass.config_entries.async_update_entry(config_entry, options=options)
+
+    # Reload it and make sure the zone bypass switches got created
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
-#    assert options == {}
-#    TODO
+#   TODO check zone bypass switches
 
 
 @pytest.mark.parametrize(

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.helpers import entity_registry as er
 async def test_sensor_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
-    """Test the createion and values of the Envisalink binary sensors."""
+    """Test the creating and values of the Envisalink keypad sensors."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
     controller.async_login_success_callback()
     await hass.async_block_till_done()
@@ -30,10 +30,24 @@ async def test_sensor_update(
 
     er.async_get(hass)
 
-    controller.controller.alarm_state["partition"][1]["status"]["alpha"] = "alpha_state"
+    # State update triggered by a partition update
+    controller.controller.alarm_state["partition"][1]["status"][
+        "alpha"
+    ] = "partition_update"
     controller.async_partition_updated_callback([1])
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
     assert state
-    assert state.state == "alpha_state"
+    assert state.state == "partition_update"
+
+    # State update triggered by a keypad update
+    controller.controller.alarm_state["partition"][1]["status"][
+        "alpha"
+    ] = "keypad_update"
+    controller.async_keypad_updated_callback([1])
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
+    assert state
+    assert state.state == "keypad_update"

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -1,4 +1,4 @@
-"""Test the Envisalink binary sensors."""
+"""Test the Envisalink sensors."""
 
 from homeassistant.components.envisalink.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -14,6 +14,24 @@ async def test_sensor_state(
     state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
     assert state
     assert state.state == "N/A"
+    assert state.attributes["ac_present"] is True
+    assert state.attributes["beep"] is False
+    assert state.attributes["armed_bypass"] is False
+    assert state.attributes["chime"] is False
+    assert state.attributes["entry_delay"] is False
+    assert state.attributes["exit_delay"] is False
+    assert state.attributes["last_armed_by_user"] == ""
+    assert state.attributes["last_disarmed_by_user"] == ""
+    assert state.attributes["ready"] is False
+    assert state.attributes["bat_trouble"] is False
+    assert state.attributes["trouble"] is False
+    assert state.attributes["fire"] is False
+    assert state.attributes["alarm"] is False
+    assert state.attributes["alarm_fire_zone"] is False
+    assert state.attributes["alarm_in_memory"] is False
+    assert state.attributes["armed_away"] is False
+    assert state.attributes["armed_stay"] is False
+    assert state.attributes["armed_zero_entry_delay"] is False
 
 
 async def test_sensor_update(

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -1,0 +1,39 @@
+"""Test the Envisalink binary sensors."""
+
+from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_sensor_state(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test the createion and values of the Envisalink binary sensors."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
+    assert state
+    assert state.state == "N/A"
+
+
+async def test_sensor_update(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test updating the keypad's alpha state."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    controller.controller.alarm_state["partition"][1]["status"]["alpha"] = "alpha_state"
+    controller.async_partition_updated_callback([1])
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
+    assert state
+    assert state.state == "alpha_state"

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -9,10 +9,6 @@ async def test_sensor_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
     """Test the creating and values of the Envisalink keypad sensors."""
-    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
-
     er.async_get(hass)
 
     state = hass.states.get("sensor.test_alarm_name_partition_1_keypad")
@@ -25,8 +21,6 @@ async def test_sensor_update(
 ) -> None:
     """Test updating the keypad's alpha state."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
 
     er.async_get(hass)
 

--- a/tests/components/envisalink/test_switch.py
+++ b/tests/components/envisalink/test_switch.py
@@ -2,11 +2,10 @@
 
 from unittest.mock import patch
 
+from pyenvisalink.alarm_panel import EnvisalinkAlarmPanel
+
 from homeassistant.components.envisalink.const import DOMAIN
 from homeassistant.components.envisalink.controller import EnvisalinkController
-from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
-    EnvisalinkAlarmPanel,
-)
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant

--- a/tests/components/envisalink/test_switch.py
+++ b/tests/components/envisalink/test_switch.py
@@ -1,0 +1,72 @@
+"""Test the Envisalink binary sensors."""
+
+from unittest.mock import patch
+
+from homeassistant.components.envisalink.const import DOMAIN
+from homeassistant.components.envisalink.controller import EnvisalinkController
+from homeassistant.components.envisalink.pyenvisalink.alarm_panel import (
+    EnvisalinkAlarmPanel,
+)
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+
+async def _async_toggle_switch(
+    hass: HomeAssistant, controller: EnvisalinkController, state: bool
+):
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {ATTR_ENTITY_ID: "switch.test_alarm_name_zone_1_bypass"},
+        blocking=True,
+    )
+    controller.controller.alarm_state["zone"][1]["bypassed"] = state
+    controller.async_zone_bypass_update([1])
+    await hass.async_block_till_done()
+
+
+async def test_switch_state(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test the createion and values of the Envisalink binary sensors."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    er.async_get(hass)
+
+    state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
+    assert state
+    assert state.state == STATE_OFF
+
+
+async def test_switch_toggle(
+    hass: HomeAssistant, mock_config_entry, init_integration
+) -> None:
+    """Test toggling the bypass switch."""
+    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
+    controller.async_login_success_callback()
+    await hass.async_block_till_done()
+
+    with patch.object(
+        EnvisalinkAlarmPanel,
+        "toggle_zone_bypass",
+        autospec=True,
+    ):
+        er.async_get(hass)
+
+        # Toggle switch on
+        await _async_toggle_switch(hass, controller, True)
+
+        state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
+        assert state
+        assert state.state == STATE_ON
+
+        # Toggle switch off
+        await _async_toggle_switch(hass, controller, False)
+
+        state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
+        assert state
+        assert state.state == STATE_OFF

--- a/tests/components/envisalink/test_switch.py
+++ b/tests/components/envisalink/test_switch.py
@@ -31,10 +31,6 @@ async def test_switch_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
     """Test the createion and values of the Envisalink binary sensors."""
-    controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
-
     er.async_get(hass)
 
     state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
@@ -47,8 +43,6 @@ async def test_switch_toggle(
 ) -> None:
     """Test toggling the bypass switch."""
     controller = hass.data[DOMAIN][mock_config_entry.entry_id]
-    controller.async_login_success_callback()
-    await hass.async_block_till_done()
 
     with patch.object(
         EnvisalinkAlarmPanel,

--- a/tests/components/envisalink/test_switch.py
+++ b/tests/components/envisalink/test_switch.py
@@ -1,4 +1,4 @@
-"""Test the Envisalink binary sensors."""
+"""Test the Envisalink switches."""
 
 from unittest.mock import patch
 
@@ -29,7 +29,7 @@ async def _async_toggle_switch(
 async def test_switch_state(
     hass: HomeAssistant, mock_config_entry, init_integration
 ) -> None:
-    """Test the createion and values of the Envisalink binary sensors."""
+    """Test the creation and values of the Envisalink switches."""
     er.async_get(hass)
 
     state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
@@ -63,3 +63,10 @@ async def test_switch_toggle(
         state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
         assert state
         assert state.state == STATE_OFF
+
+        # And back on
+        await _async_toggle_switch(hass, controller, True)
+
+        state = hass.states.get("switch.test_alarm_name_zone_1_bypass")
+        assert state
+        assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `invoke_custom_function` service call now requires the entity ID of the alarm control panel that the command will be issued to.  Automations or scripts using this service call will need to be updated to include the `entity_id` parameter.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added config flow support for the `Envisalink` integration.

Because this integration was so old, the changes to update it to properly support config flow were quite substantial.  I have been developing these updates as a HACS custom component over [here](https://github.com/ufodone/envisalink_new) with the help of a number of existing users of the integration to help test to ensure the changes are solid.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
