### PR TITLE
Add missing mock in axis config flow tests

### DIFF
--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -1,8 +1,9 @@
 """Axis conftest."""
 from __future__ import annotations
 
+from collections.abc import Generator
 from copy import deepcopy
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from axis.rtsp import Signal, State
 import pytest
@@ -40,6 +41,16 @@ from .const import (
 
 from tests.common import MockConfigEntry
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.axis.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
 
 # Config entry fixtures
 

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -38,16 +38,15 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_config_entry")
-async def mock_config_entry_fixture(hass, config_entry):
+async def mock_config_entry_fixture(hass, config_entry, mock_setup_entry):
     """Mock config entry and setup entry."""
-    with patch("homeassistant.components.axis.async_setup_entry", return_value=True):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        yield config_entry
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return config_entry
 
 
 async def test_flow_manual_configuration(
-    hass: HomeAssistant, setup_default_vapix_requests
+    hass: HomeAssistant, setup_default_vapix_requests, mock_setup_entry
 ) -> None:
     """Test that config flow works."""
     MockConfigEntry(domain=AXIS_DOMAIN, source=SOURCE_IGNORE).add_to_hass(hass)
@@ -164,7 +163,7 @@ async def test_flow_fails_cannot_connect(hass: HomeAssistant) -> None:
 
 
 async def test_flow_create_entry_multiple_existing_entries_of_same_model(
-    hass: HomeAssistant, setup_default_vapix_requests
+    hass: HomeAssistant, setup_default_vapix_requests, mock_setup_entry
 ) -> None:
     """Test that create entry can generate a name with other entries."""
     entry = MockConfigEntry(
@@ -310,7 +309,11 @@ async def test_reauth_flow_update_configuration(
     ],
 )
 async def test_discovery_flow(
-    hass: HomeAssistant, setup_default_vapix_requests, source: str, discovery_info: dict
+    hass: HomeAssistant,
+    setup_default_vapix_requests,
+    source: str,
+    discovery_info: dict,
+    mock_setup_entry,
 ) -> None:
     """Test the different discovery flows for new devices work."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in #89292

Note: there is still a lingering timer on `test_option_flow`, which I am not sure how to fix, but I think it's still worth fixing these.
```console
================================================================================== short test summary info ===================================================================================
ERROR tests/components/axis/test_config_flow.py::test_option_flow - Failed: Lingering timer after test <TimerHandle when=6928.159338017187 async_track_point_in_utc_time.<locals>.run_action(<Job track ti...7f22a4f5a0e0>>) at /workspaces/home-assistant-co...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
