### PR TITLE
Avoid unnecessary Task in debouncer

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -124,6 +124,7 @@ class Debouncer(Generic[_R_co]):
 
         self._execute_at_end_of_timer = False
 
+    @callback
     def _on_debounce(self) -> None:
         """Create job task, but only if pending."""
         self._timer_task = None

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -117,8 +117,6 @@ class Debouncer(Generic[_R_co]):
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("Unexpected exception from %s", self.function)
 
-            self._schedule_timer()
-
     @callback
     def async_cancel(self) -> None:
         """Cancel any scheduled call."""

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -117,6 +117,9 @@ class Debouncer(Generic[_R_co]):
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("Unexpected exception from %s", self.function)
 
+            # Schedule a new timer to prevent new runs during cooldown
+            self._schedule_timer()
+
     @callback
     def async_cancel(self) -> None:
         """Cancel any scheduled call."""

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -129,13 +129,14 @@ class Debouncer(Generic[_R_co]):
 
         self._execute_at_end_of_timer = False
 
+    def _create_task(self) -> None:
+        if self._execute_at_end_of_timer:
+            self.hass.async_create_task(
+                self._handle_timer_finish(),
+                f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}",
+            )
+
     @callback
     def _schedule_timer(self) -> None:
         """Schedule a timer."""
-        self._timer_task = self.hass.loop.call_later(
-            self.cooldown,
-            lambda: self.hass.async_create_task(
-                self._handle_timer_finish(),
-                f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}",
-            ),
-        )
+        self._timer_task = self.hass.loop.call_later(self.cooldown, self._create_task)

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -129,7 +129,8 @@ class Debouncer(Generic[_R_co]):
 
         self._execute_at_end_of_timer = False
 
-    def _create_task(self) -> None:
+    def _on_debounce(self) -> None:
+        """Create job task, but only if pending."""
         if self._execute_at_end_of_timer:
             self.hass.async_create_task(
                 self._handle_timer_finish(),
@@ -141,4 +142,4 @@ class Debouncer(Generic[_R_co]):
     @callback
     def _schedule_timer(self) -> None:
         """Schedule a timer."""
-        self._timer_task = self.hass.loop.call_later(self.cooldown, self._create_task)
+        self._timer_task = self.hass.loop.call_later(self.cooldown, self._on_debounce)

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -94,9 +94,6 @@ class Debouncer(Generic[_R_co]):
         """Handle a finished timer."""
         assert self._job is not None
 
-        if not self._execute_at_end_of_timer:
-            return
-
         self._execute_at_end_of_timer = False
 
         # Locked means a call is in progress. Any call is good, so abort.

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -135,6 +135,8 @@ class Debouncer(Generic[_R_co]):
                 self._handle_timer_finish(),
                 f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}",
             )
+        else:
+            self._timer_task = None
 
     @callback
     def _schedule_timer(self) -> None:

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -97,12 +97,9 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert debouncer._timer_task is not None
+    assert debouncer._timer_task is None
     assert debouncer._execute_at_end_of_timer is False
     assert debouncer._job.target == debouncer.function
-
-    # Reset debouncer
-    debouncer.async_cancel()
 
     # Test calling doesn't schedule if currently executing.
     await debouncer._execute_lock.acquire()

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -97,9 +97,12 @@ async def test_not_immediate_works(hass: HomeAssistant) -> None:
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert debouncer._timer_task is None
+    assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is False
     assert debouncer._job.target == debouncer.function
+
+    # Reset debouncer
+    debouncer.async_cancel()
 
     # Test calling doesn't schedule if currently executing.
     await debouncer._execute_lock.acquire()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #89292
Original PR #32161

Avoid creating a Task after debouncer cooldown if the job is not pending.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
