### PR TITLE
Add WS API for getting an OTBR's extended address

### DIFF
--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -78,6 +78,11 @@ class OTBRData:
         """Create an active operational dataset."""
         return await self.api.create_active_dataset(dataset)
 
+    @_handle_otbr_error
+    async def get_extended_address(self) -> bytes:
+        """Get extended address (EUI-64)."""
+        return await self.api.get_extended_address()
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Open Thread Border Router component."""

--- a/homeassistant/components/otbr/manifest.json
+++ b/homeassistant/components/otbr/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/otbr",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["python-otbr-api==1.0.5"]
+  "requirements": ["python-otbr-api==1.0.8"]
 }

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -104,6 +104,7 @@ async def websocket_create_network(
         "type": "otbr/get_extended_address",
     }
 )
+@websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_get_extended_address(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict

--- a/homeassistant/components/otbr/websocket_api.py
+++ b/homeassistant/components/otbr/websocket_api.py
@@ -18,6 +18,7 @@ def async_setup(hass: HomeAssistant) -> None:
     """Set up the OTBR Websocket API."""
     websocket_api.async_register_command(hass, websocket_info)
     websocket_api.async_register_command(hass, websocket_create_network)
+    websocket_api.async_register_command(hass, websocket_get_extended_address)
 
 
 @websocket_api.websocket_command(
@@ -96,3 +97,28 @@ async def websocket_create_network(
         return
 
     connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {
+        "type": "otbr/get_extended_address",
+    }
+)
+@websocket_api.async_response
+async def websocket_get_extended_address(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Get extended address (EUI-64)."""
+    if DOMAIN not in hass.data:
+        connection.send_error(msg["id"], "not_loaded", "No OTBR API loaded")
+        return
+
+    data: OTBRData = hass.data[DOMAIN]
+
+    try:
+        extended_address = await data.get_extended_address()
+    except HomeAssistantError as exc:
+        connection.send_error(msg["id"], "get_extended_address_failed", str(exc))
+        return
+
+    connection.send_result(msg["id"], {"extended_address": extended_address.hex()})

--- a/homeassistant/components/thread/manifest.json
+++ b/homeassistant/components/thread/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/thread",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["python-otbr-api==1.0.5", "pyroute2==0.7.5"],
+  "requirements": ["python-otbr-api==1.0.8", "pyroute2==0.7.5"],
   "zeroconf": ["_meshcop._udp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2097,7 +2097,7 @@ python-nest==4.2.0
 
 # homeassistant.components.otbr
 # homeassistant.components.thread
-python-otbr-api==1.0.5
+python-otbr-api==1.0.8
 
 # homeassistant.components.picnic
 python-picnic-api==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1496,7 +1496,7 @@ python-nest==4.2.0
 
 # homeassistant.components.otbr
 # homeassistant.components.thread
-python-otbr-api==1.0.5
+python-otbr-api==1.0.8
 
 # homeassistant.components.picnic
 python-picnic-api==1.1.0

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -234,3 +234,75 @@ async def test_get_info_fetch_fails_3(
     assert msg["id"] == 5
     assert not msg["success"]
     assert msg["error"]["code"] == "set_enabled_failed"
+
+
+async def test_get_extended_address(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry,
+    websocket_client,
+) -> None:
+    """Test get extended address."""
+
+    with patch(
+        "python_otbr_api.OTBR.get_extended_address",
+        return_value=bytes.fromhex("4EF6C4F3FF750626"),
+    ):
+        await websocket_client.send_json(
+            {
+                "id": 5,
+                "type": "otbr/get_extended_address",
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["success"]
+    assert msg["result"] == {"extended_address": "4EF6C4F3FF750626".lower()}
+
+
+async def test_get_extended_address_no_entry(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test get extended address."""
+    await async_setup_component(hass, "otbr", {})
+    websocket_client = await hass_ws_client(hass)
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "otbr/get_extended_address",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_loaded"
+
+
+async def test_get_extended_address_fetch_fails(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    otbr_config_entry,
+    websocket_client,
+) -> None:
+    """Test get extended address."""
+    await async_setup_component(hass, "otbr", {})
+
+    with patch(
+        "python_otbr_api.OTBR.get_extended_address",
+        side_effect=python_otbr_api.OTBRError,
+    ):
+        await websocket_client.send_json(
+            {
+                "id": 5,
+                "type": "otbr/get_extended_address",
+            }
+        )
+        msg = await websocket_client.receive_json()
+
+    assert msg["id"] == 5
+    assert not msg["success"]
+    assert msg["error"]["code"] == "get_extended_address_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS API for getting an OTBR's extended address

Bump python-otbr-api from 1.0.5 to 1.0.8

Release notes:
 - https://github.com/home-assistant-libs/python-otbr-api/releases/tag/1.0.8
 - https://github.com/home-assistant-libs/python-otbr-api/releases/tag/1.0.7
 - https://github.com/home-assistant-libs/python-otbr-api/releases/tag/1.0.6 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
