### PR TITLE
Refactor GIOS sensor platform

### DIFF
--- a/homeassistant/components/gios/const.py
+++ b/homeassistant/components/gios/const.py
@@ -17,7 +17,6 @@ URL = "http://powietrze.gios.gov.pl/pjp/current/station_details/info/{station_id
 API_TIMEOUT: Final = 30
 
 ATTR_INDEX: Final = "index"
-ATTR_STATION: Final = "station"
 
 ATTR_C6H6: Final = "c6h6"
 ATTR_CO: Final = "co"

--- a/homeassistant/components/gios/const.py
+++ b/homeassistant/components/gios/const.py
@@ -16,8 +16,6 @@ URL = "http://powietrze.gios.gov.pl/pjp/current/station_details/info/{station_id
 
 API_TIMEOUT: Final = 30
 
-ATTR_INDEX: Final = "index"
-
 ATTR_C6H6: Final = "c6h6"
 ATTR_CO: Final = "co"
 ATTR_NO2: Final = "no2"

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -34,7 +34,6 @@ from .const import (
     ATTR_PM10,
     ATTR_PM25,
     ATTR_SO2,
-    ATTR_STATION,
     ATTRIBUTION,
     DOMAIN,
     MANUFACTURER,
@@ -171,9 +170,7 @@ class GiosSensor(CoordinatorEntity[GiosDataUpdateCoordinator], SensorEntity):
             configuration_url=URL.format(station_id=coordinator.gios.station_id),
         )
         self._attr_unique_id = f"{coordinator.gios.station_id}-{description.key}"
-        self._attrs: dict[str, Any] = {
-            ATTR_STATION: self.coordinator.gios.station_name,
-        }
+        self._attrs: dict[str, Any] = {}
         self.entity_description = description
 
     @property

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -258,7 +258,8 @@ class GiosSensor(CoordinatorEntity[GiosDataUpdateCoordinator], SensorEntity):
         available = super().available
         sensor_data = getattr(self.coordinator.data, self.entity_description.key)
 
+        # Sometimes the API returns sensor data without indexes
         if self.entity_description.subkey:
-            return available and bool(getattr(sensor_data, "index"))
+            return available and bool(sensor_data.index)
 
         return available and bool(sensor_data)

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -14,11 +14,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_NAME,
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONF_NAME,
-)
+from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -183,9 +179,6 @@ class GiosSensor(CoordinatorEntity[GiosDataUpdateCoordinator], SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        self._attrs[ATTR_NAME] = getattr(
-            self.coordinator.data, self.entity_description.key
-        ).name
         self._attrs[ATTR_INDEX] = getattr(
             self.coordinator.data, self.entity_description.key
         ).index

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -81,6 +81,7 @@ SENSOR_TYPES: tuple[GiosSensorEntityDescription, ...] = (
         name="CO",
         value=lambda sensors: sensors.co.value if sensors.co else None,
         suggested_display_precision=0,
+        icon="mdi:molecule",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -34,6 +34,56 @@
           "good": "Good",
           "very_good": "Very good"
         }
+      },
+      "no2_index": {
+        "state": {
+          "very_bad": "Very bad",
+          "bad": "Bad",
+          "sufficient": "Sufficient",
+          "moderate": "Moderate",
+          "good": "Good",
+          "very_good": "Very good"
+        }
+      },
+      "o3_index": {
+        "state": {
+          "very_bad": "Very bad",
+          "bad": "Bad",
+          "sufficient": "Sufficient",
+          "moderate": "Moderate",
+          "good": "Good",
+          "very_good": "Very good"
+        }
+      },
+      "pm10_index": {
+        "state": {
+          "very_bad": "Very bad",
+          "bad": "Bad",
+          "sufficient": "Sufficient",
+          "moderate": "Moderate",
+          "good": "Good",
+          "very_good": "Very good"
+        }
+      },
+      "pm25_index": {
+        "state": {
+          "very_bad": "Very bad",
+          "bad": "Bad",
+          "sufficient": "Sufficient",
+          "moderate": "Moderate",
+          "good": "Good",
+          "very_good": "Very good"
+        }
+      },
+      "so2_index": {
+        "state": {
+          "very_bad": "Very bad",
+          "bad": "Bad",
+          "sufficient": "Sufficient",
+          "moderate": "Moderate",
+          "good": "Good",
+          "very_good": "Very good"
+        }
       }
     }
   }

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -37,52 +37,52 @@
       },
       "no2_index": {
         "state": {
-          "very_bad": "Very bad",
-          "bad": "Bad",
-          "sufficient": "Sufficient",
-          "moderate": "Moderate",
-          "good": "Good",
-          "very_good": "Very good"
+          "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
+          "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
+          "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
+          "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
+          "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
+          "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
         }
       },
       "o3_index": {
         "state": {
-          "very_bad": "Very bad",
-          "bad": "Bad",
-          "sufficient": "Sufficient",
-          "moderate": "Moderate",
-          "good": "Good",
-          "very_good": "Very good"
+          "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
+          "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
+          "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
+          "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
+          "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
+          "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
         }
       },
       "pm10_index": {
         "state": {
-          "very_bad": "Very bad",
-          "bad": "Bad",
-          "sufficient": "Sufficient",
-          "moderate": "Moderate",
-          "good": "Good",
-          "very_good": "Very good"
+          "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
+          "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
+          "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
+          "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
+          "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
+          "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
         }
       },
       "pm25_index": {
         "state": {
-          "very_bad": "Very bad",
-          "bad": "Bad",
-          "sufficient": "Sufficient",
-          "moderate": "Moderate",
-          "good": "Good",
-          "very_good": "Very good"
+          "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
+          "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
+          "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
+          "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
+          "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
+          "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
         }
       },
       "so2_index": {
         "state": {
-          "very_bad": "Very bad",
-          "bad": "Bad",
-          "sufficient": "Sufficient",
-          "moderate": "Moderate",
-          "good": "Good",
-          "very_good": "Very good"
+          "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
+          "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
+          "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
+          "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
+          "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
+          "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
         }
       }
     }

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -37,7 +37,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_c6h6")
     assert state
-    assert state.state == "0"
+    assert state.state == "0.23789"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -53,7 +53,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_co")
     assert state
-    assert state.state == "252"
+    assert state.state == "251.874"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_DEVICE_CLASS) is None
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -69,7 +69,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_no2")
     assert state
-    assert state.state == "7"
+    assert state.state == "7.13411"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.NITROGEN_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -85,7 +85,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_o3")
     assert state
-    assert state.state == "96"
+    assert state.state == "95.7768"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.OZONE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -101,7 +101,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_pm10")
     assert state
-    assert state.state == "17"
+    assert state.state == "16.8344"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -133,7 +133,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_so2")
     assert state
-    assert state.state == "4"
+    assert state.state == "4.35478"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.SULPHUR_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
@@ -216,7 +216,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_c6h6")
     assert state
-    assert state.state == "0"
+    assert state.state == "0.23789"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -232,7 +232,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_co")
     assert state
-    assert state.state == "252"
+    assert state.state == "251.874"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -247,7 +247,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_no2")
     assert state
-    assert state.state == "7"
+    assert state.state == "7.13411"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -262,7 +262,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_o3")
     assert state
-    assert state.state == "96"
+    assert state.state == "95.7768"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -277,7 +277,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_pm10")
     assert state
-    assert state.state == "17"
+    assert state.state == "16.8344"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -307,7 +307,7 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_so2")
     assert state
-    assert state.state == "4"
+    assert state.state == "4.35478"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from gios import ApiError
 
-from homeassistant.components.gios.const import ATTR_INDEX, ATTRIBUTION, DOMAIN
+from homeassistant.components.gios.const import ATTRIBUTION, DOMAIN
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
@@ -45,7 +45,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
-    assert state.attributes.get(ATTR_INDEX) == "very_good"
 
     entry = registry.async_get("sensor.home_c6h6")
     assert entry
@@ -61,7 +60,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "good"
 
     entry = registry.async_get("sensor.home_co")
     assert entry
@@ -77,7 +75,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "good"
 
     entry = registry.async_get("sensor.home_no2")
     assert entry
@@ -93,7 +90,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "good"
 
     entry = registry.async_get("sensor.home_o3")
     assert entry
@@ -109,7 +105,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "good"
 
     entry = registry.async_get("sensor.home_pm10")
     assert entry
@@ -125,7 +120,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "good"
 
     entry = registry.async_get("sensor.home_pm2_5")
     assert entry
@@ -141,7 +135,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) == "very_good"
 
     entry = registry.async_get("sensor.home_so2")
     assert entry
@@ -224,7 +217,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_c6h6")
     assert entry
@@ -239,7 +231,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_co")
     assert entry
@@ -254,7 +245,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_no2")
     assert entry
@@ -269,7 +259,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_o3")
     assert entry
@@ -284,7 +273,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_pm10")
     assert entry
@@ -299,7 +287,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_pm2_5")
     assert entry
@@ -314,7 +301,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_so2")
     assert entry

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -80,6 +80,24 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "123-no2"
 
+    state = hass.states.get("sensor.home_no2_index")
+    assert state
+    assert state.state == "good"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "very_bad",
+        "bad",
+        "sufficient",
+        "moderate",
+        "good",
+        "very_good",
+    ]
+
+    entry = registry.async_get("sensor.home_no2_index")
+    assert entry
+    assert entry.unique_id == "123-no2-index"
+
     state = hass.states.get("sensor.home_o3")
     assert state
     assert state.state == "95.7768"
@@ -94,6 +112,24 @@ async def test_sensor(hass: HomeAssistant) -> None:
     entry = registry.async_get("sensor.home_o3")
     assert entry
     assert entry.unique_id == "123-o3"
+
+    state = hass.states.get("sensor.home_o3_index")
+    assert state
+    assert state.state == "good"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "very_bad",
+        "bad",
+        "sufficient",
+        "moderate",
+        "good",
+        "very_good",
+    ]
+
+    entry = registry.async_get("sensor.home_o3_index")
+    assert entry
+    assert entry.unique_id == "123-o3-index"
 
     state = hass.states.get("sensor.home_pm10")
     assert state
@@ -110,6 +146,24 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "123-pm10"
 
+    state = hass.states.get("sensor.home_pm10_index")
+    assert state
+    assert state.state == "good"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "very_bad",
+        "bad",
+        "sufficient",
+        "moderate",
+        "good",
+        "very_good",
+    ]
+
+    entry = registry.async_get("sensor.home_pm10_index")
+    assert entry
+    assert entry.unique_id == "123-pm10-index"
+
     state = hass.states.get("sensor.home_pm2_5")
     assert state
     assert state.state == "4"
@@ -125,6 +179,24 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "123-pm25"
 
+    state = hass.states.get("sensor.home_pm2_5_index")
+    assert state
+    assert state.state == "good"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "very_bad",
+        "bad",
+        "sufficient",
+        "moderate",
+        "good",
+        "very_good",
+    ]
+
+    entry = registry.async_get("sensor.home_pm2_5_index")
+    assert entry
+    assert entry.unique_id == "123-pm25-index"
+
     state = hass.states.get("sensor.home_so2")
     assert state
     assert state.state == "4.35478"
@@ -139,6 +211,24 @@ async def test_sensor(hass: HomeAssistant) -> None:
     entry = registry.async_get("sensor.home_so2")
     assert entry
     assert entry.unique_id == "123-so2"
+
+    state = hass.states.get("sensor.home_so2_index")
+    assert state
+    assert state.state == "very_good"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "very_bad",
+        "bad",
+        "sufficient",
+        "moderate",
+        "good",
+        "very_good",
+    ]
+
+    entry = registry.async_get("sensor.home_so2_index")
+    assert entry
+    assert entry.unique_id == "123-so2-index"
 
     state = hass.states.get("sensor.home_aqi")
     assert state

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -5,12 +5,7 @@ from unittest.mock import patch
 
 from gios import ApiError
 
-from homeassistant.components.gios.const import (
-    ATTR_INDEX,
-    ATTR_STATION,
-    ATTRIBUTION,
-    DOMAIN,
-)
+from homeassistant.components.gios.const import ATTR_INDEX, ATTRIBUTION, DOMAIN
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
@@ -44,7 +39,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "0"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -61,7 +55,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "252"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) is None
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -78,7 +71,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "7"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.NITROGEN_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -95,7 +87,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "96"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.OZONE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -112,7 +103,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "17"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -129,7 +119,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -146,7 +135,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.SULPHUR_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
@@ -163,7 +151,6 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "good"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.attributes.get(ATTR_OPTIONS) == [
@@ -231,7 +218,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "0"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -248,7 +234,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "252"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -264,7 +249,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "7"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -280,7 +264,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "96"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -296,7 +279,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "17"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -312,7 +294,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -328,7 +309,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -340,106 +340,26 @@ async def test_availability(hass: HomeAssistant) -> None:
 async def test_invalid_indexes(hass: HomeAssistant) -> None:
     """Test states of the sensor when API returns invalid indexes."""
     await init_integration(hass, invalid_indexes=True)
-    registry = er.async_get(hass)
 
-    state = hass.states.get("sensor.home_c6h6")
+    state = hass.states.get("sensor.home_no2_index")
     assert state
-    assert state.state == "0.23789"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
-    assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
+    assert state.state == STATE_UNAVAILABLE
 
-    entry = registry.async_get("sensor.home_c6h6")
-    assert entry
-    assert entry.unique_id == "123-c6h6"
-
-    state = hass.states.get("sensor.home_co")
+    state = hass.states.get("sensor.home_o3_index")
     assert state
-    assert state.state == "251.874"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
+    assert state.state == STATE_UNAVAILABLE
 
-    entry = registry.async_get("sensor.home_co")
-    assert entry
-    assert entry.unique_id == "123-co"
-
-    state = hass.states.get("sensor.home_no2")
+    state = hass.states.get("sensor.home_pm10_index")
     assert state
-    assert state.state == "7.13411"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
+    assert state.state == STATE_UNAVAILABLE
 
-    entry = registry.async_get("sensor.home_no2")
-    assert entry
-    assert entry.unique_id == "123-no2"
-
-    state = hass.states.get("sensor.home_o3")
+    state = hass.states.get("sensor.home_pm2_5_index")
     assert state
-    assert state.state == "95.7768"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
+    assert state.state == STATE_UNAVAILABLE
 
-    entry = registry.async_get("sensor.home_o3")
-    assert entry
-    assert entry.unique_id == "123-o3"
-
-    state = hass.states.get("sensor.home_pm10")
+    state = hass.states.get("sensor.home_so2_index")
     assert state
-    assert state.state == "16.8344"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
-
-    entry = registry.async_get("sensor.home_pm10")
-    assert entry
-    assert entry.unique_id == "123-pm10"
-
-    state = hass.states.get("sensor.home_pm2_5")
-    assert state
-    assert state.state == "4"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
-
-    entry = registry.async_get("sensor.home_pm2_5")
-    assert entry
-    assert entry.unique_id == "123-pm25"
-
-    state = hass.states.get("sensor.home_so2")
-    assert state
-    assert state.state == "4.35478"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    )
-
-    entry = registry.async_get("sensor.home_so2")
-    assert entry
-    assert entry.unique_id == "123-so2"
+    assert state.state == STATE_UNAVAILABLE
 
     state = hass.states.get("sensor.home_aqi")
     assert state is None

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -445,31 +445,6 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state is None
 
 
-async def test_aqi_sensor_availability(hass: HomeAssistant) -> None:
-    """Ensure that we mark the AQI sensor unavailable correctly when indexes are invalid."""
-    await init_integration(hass)
-
-    state = hass.states.get("sensor.home_aqi")
-    assert state
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "good"
-
-    future = utcnow() + timedelta(minutes=60)
-    with patch(
-        "homeassistant.components.gios.Gios._get_all_sensors",
-        return_value=json.loads(load_fixture("gios/sensors.json")),
-    ), patch(
-        "homeassistant.components.gios.Gios._get_indexes",
-        return_value={},
-    ):
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("sensor.home_aqi")
-        assert state
-        assert state.state == STATE_UNAVAILABLE
-
-
 async def test_unique_id_migration(hass: HomeAssistant) -> None:
     """Test states of the unique_id migration."""
     registry = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `name` and `station` sensor state attributes have been removed due to the fact that they are static data that do not describe the state of the entity.

The `index` sensor state attribute has been migrated to a separate entity, e.g. `sensor.home_no2_index`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change:
- adds support for `suggested_display_precision` (removed rounding of values)
- removes `name` state attribute (this attribute returned the static name of the pollutant in Polish, e.g. dwutlenek siarki)
- removes `station` state attributes (this attribute returned the static name of the measurement station)
- migrates `index` state attributes to the sensor entities, those sensors use `SensorDeviceClass.ENUM`
- adds missing entity icons
- updates tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
