### PR TITLE
Implement config flow for nextcloud

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -778,7 +778,9 @@ omit =
     homeassistant/components/nexia/climate.py
     homeassistant/components/nexia/entity.py
     homeassistant/components/nexia/switch.py
-    homeassistant/components/nextcloud/*
+    homeassistant/components/nextcloud/__init__.py
+    homeassistant/components/nextcloud/binary_sensor.py
+    homeassistant/components/nextcloud/sensor.py
     homeassistant/components/nfandroidtv/__init__.py
     homeassistant/components/nfandroidtv/notify.py
     homeassistant/components/nibe_heatpump/__init__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -780,6 +780,9 @@ omit =
     homeassistant/components/nexia/switch.py
     homeassistant/components/nextcloud/__init__.py
     homeassistant/components/nextcloud/binary_sensor.py
+    homeassistant/components/nextcloud/const.py
+    homeassistant/components/nextcloud/coordinator.py
+    homeassistant/components/nextcloud/entity.py
     homeassistant/components/nextcloud/sensor.py
     homeassistant/components/nfandroidtv/__init__.py
     homeassistant/components/nfandroidtv/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -785,8 +785,8 @@ build.json @home-assistant/supervisor
 /tests/components/nexia/ @bdraco
 /homeassistant/components/nextbus/ @vividboarder
 /tests/components/nextbus/ @vividboarder
-/homeassistant/components/nextcloud/ @meichthys @mib1185
-/tests/components/nextcloud/ @meichthys @mib1185
+/homeassistant/components/nextcloud/ @meichthys
+/tests/components/nextcloud/ @meichthys
 /homeassistant/components/nextdns/ @bieniu
 /tests/components/nextdns/ @bieniu
 /homeassistant/components/nfandroidtv/ @tkdrob

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -785,8 +785,8 @@ build.json @home-assistant/supervisor
 /tests/components/nexia/ @bdraco
 /homeassistant/components/nextbus/ @vividboarder
 /tests/components/nextbus/ @vividboarder
-/homeassistant/components/nextcloud/ @meichthys
-/tests/components/nextcloud/ @meichthys
+/homeassistant/components/nextcloud/ @mib1185
+/tests/components/nextcloud/ @mib1185
 /homeassistant/components/nextdns/ @bieniu
 /tests/components/nextdns/ @bieniu
 /homeassistant/components/nfandroidtv/ @tkdrob

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -785,7 +785,8 @@ build.json @home-assistant/supervisor
 /tests/components/nexia/ @bdraco
 /homeassistant/components/nextbus/ @vividboarder
 /tests/components/nextbus/ @vividboarder
-/homeassistant/components/nextcloud/ @meichthys
+/homeassistant/components/nextcloud/ @meichthys @mib1185
+/tests/components/nextcloud/ @meichthys @mib1185
 /homeassistant/components/nextdns/ @bieniu
 /tests/components/nextdns/ @bieniu
 /homeassistant/components/nfandroidtv/ @tkdrob

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -25,10 +25,10 @@ PLATFORMS = (Platform.SENSOR, Platform.BINARY_SENSOR)
 
 # Validate user configuration
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            vol.All(
-                cv.deprecated(DOMAIN),
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
                 {
                     vol.Required(CONF_URL): cv.url,
                     vol.Required(CONF_USERNAME): cv.string,
@@ -38,26 +38,25 @@ CONFIG_SCHEMA = vol.Schema(
                     ): cv.time_period,
                 },
             )
-        )
-    },
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Nextcloud integration."""
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_yaml",
-        breaks_in_ha_version="2023.6.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-    )
-
     if DOMAIN in config:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_yaml",
+            breaks_in_ha_version="2023.6.0",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_yaml",
+        )
+
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
@@ -65,6 +64,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 data=config[DOMAIN],
             )
         )
+
     return True
 
 

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ncm,
         entry,
     )
-    hass.data[DOMAIN] = coordinator
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -4,6 +4,7 @@ import logging
 from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
@@ -12,28 +13,31 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
 PLATFORMS = (Platform.SENSOR, Platform.BINARY_SENSOR)
 
 # Validate user configuration
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_URL): cv.url,
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(
-                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                ): cv.time_period,
-            }
+            vol.All(
+                cv.deprecated(DOMAIN),
+                {
+                    vol.Required(CONF_URL): cv.url,
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                    ): cv.time_period,
+                },
+            )
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -42,12 +46,38 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Nextcloud integration."""
-    conf = config[DOMAIN]
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_yaml",
+        breaks_in_ha_version="2023.6.0",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+    )
+
+    if DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=config[DOMAIN],
+            )
+        )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the Nextcloud integration."""
+
+    def _connect_nc():
+        return NextcloudMonitor(
+            entry.data[CONF_URL], entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+        )
 
     try:
-        ncm = await hass.async_add_executor_job(
-            NextcloudMonitor, conf[CONF_URL], conf[CONF_USERNAME], conf[CONF_PASSWORD]
-        )
+        ncm = await hass.async_add_executor_job(_connect_nc)
     except NextcloudMonitorError:
         _LOGGER.error("Nextcloud setup failed - Check configuration")
         return False
@@ -55,13 +85,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     coordinator = NextcloudDataUpdateCoordinator(
         hass,
         ncm,
-        conf,
+        entry,
     )
     hass.data[DOMAIN] = coordinator
 
     await coordinator.async_config_entry_first_refresh()
 
-    for platform in PLATFORMS:
-        discovery.load_platform(hass, platform, DOMAIN, {}, config)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/nextcloud/binary_sensor.py
+++ b/homeassistant/components/nextcloud/binary_sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Nextcloud binary sensors."""
-    coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN]
+    coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
             NextcloudBinarySensor(coordinator, name)

--- a/homeassistant/components/nextcloud/binary_sensor.py
+++ b/homeassistant/components/nextcloud/binary_sensor.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
@@ -18,24 +18,17 @@ BINARY_SENSORS = (
 )
 
 
-def setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Nextcloud sensors."""
-    if discovery_info is None:
-        return
+    """Set up the Nextcloud binary sensors."""
     coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN]
-
-    add_entities(
+    async_add_entities(
         [
             NextcloudBinarySensor(coordinator, name)
             for name in coordinator.data
             if name in BINARY_SENSORS
-        ],
-        True,
+        ]
     )
 
 

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -32,8 +32,8 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
         """Try to connect to nextcloud server."""
         return NextcloudMonitor(
             user_input.get(CONF_URL),
-            user_input.get(CONF_PASSWORD),
             user_input.get(CONF_USERNAME),
+            user_input.get(CONF_PASSWORD),
         )
 
     async def async_step_import(

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -36,19 +36,16 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input[CONF_PASSWORD],
         )
 
-    async def async_step_import(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
         """Handle a flow initiated by configuration file."""
-        if user_input is not None:
-            self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
-            try:
-                await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
-            except NextcloudMonitorError:
-                _LOGGER.error(
-                    "Connection error during import of yaml configuration, import aborted"
-                )
-                return self.async_abort(reason="connection_error_during_import")
+        self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
+        try:
+            await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
+        except NextcloudMonitorError:
+            _LOGGER.error(
+                "Connection error during import of yaml configuration, import aborted"
+            )
+            return self.async_abort(reason="connection_error_during_import")
         return await self.async_step_user(user_input)
 
     async def async_step_user(

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -31,9 +31,9 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
     def _try_connect_nc(self, user_input: dict) -> NextcloudMonitor:
         """Try to connect to nextcloud server."""
         return NextcloudMonitor(
-            user_input.get(CONF_URL),
-            user_input.get(CONF_USERNAME),
-            user_input.get(CONF_PASSWORD),
+            user_input[CONF_URL],
+            user_input[CONF_USERNAME],
+            user_input[CONF_PASSWORD],
         )
 
     async def async_step_import(
@@ -63,8 +63,7 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
             except NextcloudMonitorError:
                 errors["base"] = "connection_error"
-
-            if not errors:
+            else:
                 return self.async_create_entry(
                     title=user_input[CONF_URL],
                     data={

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 
-from . import DOMAIN
+from .const import DOMAIN
 
 DATA_SCHEMA_USER = vol.Schema(
     {

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -74,6 +74,7 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+        data_schema = self.add_suggested_values_to_schema(DATA_SCHEMA_USER, user_input)
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
+            step_id="user", data_schema=data_schema, errors=errors
         )

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -1,0 +1,69 @@
+"""Config flow to configure the Nextcloud integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
+
+from . import DOMAIN
+
+DATA_SCHEMA_USER = vol.Schema(
+    {
+        vol.Required(CONF_URL): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a Nextcloud config flow."""
+
+    VERSION = 1
+
+    async def async_step_import(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initiated by configuration file."""
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        def _connect_nc():
+            return NextcloudMonitor(
+                user_input[CONF_URL],
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
+            try:
+                await self.hass.async_add_executor_job(_connect_nc)
+            except NextcloudMonitorError:
+                errors["base"] = "connection_error"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_URL],
+                    data={
+                        CONF_URL: user_input[CONF_URL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
+        )

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -46,7 +46,13 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
                 "Connection error during import of yaml configuration, import aborted"
             )
             return self.async_abort(reason="connection_error_during_import")
-        return await self.async_step_user(user_input)
+        return await self.async_step_user(
+            {
+                CONF_URL: user_input[CONF_URL],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+            }
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -63,11 +69,7 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_create_entry(
                     title=user_input[CONF_URL],
-                    data={
-                        CONF_URL: user_input[CONF_URL],
-                        CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        CONF_USERNAME: user_input[CONF_USERNAME],
-                    },
+                    data=user_input,
                 )
 
         data_schema = self.add_suggested_values_to_schema(DATA_SCHEMA_USER, user_input)

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure the Nextcloud integration."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
@@ -19,6 +20,7 @@ DATA_SCHEMA_USER = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
     }
 )
+_LOGGER = logging.getLogger(__name__)
 
 
 class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -26,12 +28,27 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def _try_connect_nc(self, user_input: dict) -> NextcloudMonitor:
+        """Try to connect to nextcloud server."""
+        return NextcloudMonitor(
+            user_input.get(CONF_URL),
+            user_input.get(CONF_PASSWORD),
+            user_input.get(CONF_USERNAME),
+        )
+
     async def async_step_import(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initiated by configuration file."""
         if user_input is not None:
             self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
+            try:
+                await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
+            except NextcloudMonitorError:
+                _LOGGER.error(
+                    "Connection error during import of yaml configuration, import aborted"
+                )
+                return self.async_abort(reason="connection_error_during_import")
         return await self.async_step_user(user_input)
 
     async def async_step_user(
@@ -40,17 +57,10 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors = {}
 
-        def _connect_nc():
-            return NextcloudMonitor(
-                user_input[CONF_URL],
-                user_input[CONF_USERNAME],
-                user_input[CONF_PASSWORD],
-            )
-
         if user_input is not None:
             self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
             try:
-                await self.hass.async_add_executor_job(_connect_nc)
+                await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
             except NextcloudMonitorError:
                 errors["base"] = "connection_error"
 

--- a/homeassistant/components/nextcloud/coordinator.py
+++ b/homeassistant/components/nextcloud/coordinator.py
@@ -6,7 +6,7 @@ from typing import Any
 from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL, CONF_URL
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -29,7 +29,7 @@ class NextcloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass,
             _LOGGER,
             name=self.url,
-            update_interval=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            update_interval=DEFAULT_SCAN_INTERVAL,
         )
 
     # Use recursion to create list of sensors & values based on nextcloud api data

--- a/homeassistant/components/nextcloud/coordinator.py
+++ b/homeassistant/components/nextcloud/coordinator.py
@@ -5,9 +5,9 @@ from typing import Any
 
 from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -19,18 +19,17 @@ class NextcloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Nextcloud data update coordinator."""
 
     def __init__(
-        self, hass: HomeAssistant, ncm: NextcloudMonitor, config: ConfigType
+        self, hass: HomeAssistant, ncm: NextcloudMonitor, entry: ConfigEntry
     ) -> None:
         """Initialize the Nextcloud coordinator."""
-        self.config = config
         self.ncm = ncm
-        self.url = config[CONF_URL]
+        self.url = entry.data[CONF_URL]
 
         super().__init__(
             hass,
             _LOGGER,
             name=self.url,
-            update_interval=config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            update_interval=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
         )
 
     # Use recursion to create list of sensors & values based on nextcloud api data

--- a/homeassistant/components/nextcloud/entity.py
+++ b/homeassistant/components/nextcloud/entity.py
@@ -1,10 +1,8 @@
 """Base entity for the Nextcloud integration."""
 
 
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
 
 
@@ -23,14 +21,3 @@ class NextcloudEntity(CoordinatorEntity[NextcloudDataUpdateCoordinator]):
     def unique_id(self) -> str:
         """Return the unique ID for this sensor."""
         return f"{self.coordinator.url}#{self.item}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device specific attributes."""
-        return DeviceInfo(
-            name=self.coordinator.url,
-            identifiers={(DOMAIN, self.coordinator.url)},
-            model="Nextcloud",
-            sw_version=self.coordinator.data.get("nextcloud_system_version"),
-            configuration_url=self.coordinator.url,
-        )

--- a/homeassistant/components/nextcloud/entity.py
+++ b/homeassistant/components/nextcloud/entity.py
@@ -1,8 +1,10 @@
 """Base entity for the Nextcloud integration."""
 
 
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
 
 
@@ -21,3 +23,14 @@ class NextcloudEntity(CoordinatorEntity[NextcloudDataUpdateCoordinator]):
     def unique_id(self) -> str:
         """Return the unique ID for this sensor."""
         return f"{self.coordinator.url}#{self.item}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device specific attributes."""
+        return DeviceInfo(
+            name=self.coordinator.url,
+            identifiers={(DOMAIN, self.coordinator.url)},
+            model="Nextcloud",
+            sw_version=self.coordinator.data.get("nextcloud_system_version"),
+            configuration_url=self.coordinator.url,
+        )

--- a/homeassistant/components/nextcloud/manifest.json
+++ b/homeassistant/components/nextcloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nextcloud",
   "name": "Nextcloud",
-  "codeowners": ["@meichthys"],
+  "codeowners": ["@mib1185"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nextcloud",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/nextcloud/manifest.json
+++ b/homeassistant/components/nextcloud/manifest.json
@@ -2,6 +2,7 @@
   "domain": "nextcloud",
   "name": "Nextcloud",
   "codeowners": ["@meichthys"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nextcloud",
   "iot_class": "cloud_polling",
   "requirements": ["nextcloudmonitor==1.1.0"]

--- a/homeassistant/components/nextcloud/manifest.json
+++ b/homeassistant/components/nextcloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nextcloud",
   "name": "Nextcloud",
-  "codeowners": ["@meichthys", "@mib1185"],
+  "codeowners": ["@meichthys"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nextcloud",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/nextcloud/manifest.json
+++ b/homeassistant/components/nextcloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nextcloud",
   "name": "Nextcloud",
-  "codeowners": ["@meichthys"],
+  "codeowners": ["@meichthys", "@mib1185"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nextcloud",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/nextcloud/sensor.py
+++ b/homeassistant/components/nextcloud/sensor.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
+from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
@@ -57,24 +58,17 @@ SENSORS = (
 )
 
 
-def setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Nextcloud sensors."""
-    if discovery_info is None:
-        return
     coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN]
-
-    add_entities(
+    async_add_entities(
         [
             NextcloudSensor(coordinator, name)
             for name in coordinator.data
             if name in SENSORS
-        ],
-        True,
+        ]
     )
 
 

--- a/homeassistant/components/nextcloud/sensor.py
+++ b/homeassistant/components/nextcloud/sensor.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Nextcloud sensors."""
-    coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN]
+    coordinator: NextcloudDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
             NextcloudSensor(coordinator, name)

--- a/homeassistant/components/nextcloud/strings.json
+++ b/homeassistant/components/nextcloud/strings.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "flow_title": "Nextcloud",
+    "step": {
+      "user": {
+        "description": "Enter your Nextcloud information.",
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "connection_error": "[%key:common::config_flow::error::cannot_connect%]"
+    }
+  },
+  "issues": {
+    "deprecated_yaml": {
+      "title": "The Netxcloud YAML configuration has been deprecated",
+      "description": "Configuring Netxcloud using YAML has been deprecated.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `nextcloud` YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
+  }
+}

--- a/homeassistant/components/nextcloud/strings.json
+++ b/homeassistant/components/nextcloud/strings.json
@@ -12,7 +12,8 @@
       }
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "connection_error_during_import": "Connection error occured during yaml configuration import"
     },
     "error": {
       "connection_error": "[%key:common::config_flow::error::cannot_connect%]"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -282,6 +282,7 @@ FLOWS = {
         "netatmo",
         "netgear",
         "nexia",
+        "nextcloud",
         "nextdns",
         "nfandroidtv",
         "nibe_heatpump",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3622,7 +3622,7 @@
     "nextcloud": {
       "name": "Nextcloud",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "cloud_polling"
     },
     "nextdns": {

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -887,6 +887,9 @@ nettigo-air-monitor==2.1.0
 # homeassistant.components.nexia
 nexia==2.0.6
 
+# homeassistant.components.nextcloud
+nextcloudmonitor==1.1.0
+
 # homeassistant.components.discord
 nextcord==2.0.0a8
 

--- a/tests/components/nextcloud/__init__.py
+++ b/tests/components/nextcloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Nextcloud integration."""

--- a/tests/components/nextcloud/conftest.py
+++ b/tests/components/nextcloud/conftest.py
@@ -1,6 +1,7 @@
 """Tests for the Nextcloud integration."""
 
-from unittest.mock import Mock
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -13,3 +14,12 @@ def mock_nextcloud_monitor() -> Mock:
     )
 
     return ncm
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.nextcloud.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/nextcloud/conftest.py
+++ b/tests/components/nextcloud/conftest.py
@@ -1,0 +1,15 @@
+"""Tests for the Nextcloud integration."""
+
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture(name="mock_nextcloud_monitor")
+def mock_nextcloud_monitor() -> Mock:
+    """Mock of NextcloudMonitor."""
+    ncm = Mock(
+        update=Mock(return_value=True),
+    )
+
+    return ncm

--- a/tests/components/nextcloud/conftest.py
+++ b/tests/components/nextcloud/conftest.py
@@ -1,4 +1,4 @@
-"""Tests for the Nextcloud integration."""
+"""Fixtrues for the Nextcloud integration tests."""
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 
-@pytest.fixture(name="mock_nextcloud_monitor")
+@pytest.fixture
 def mock_nextcloud_monitor() -> Mock:
     """Mock of NextcloudMonitor."""
     ncm = Mock(

--- a/tests/components/nextcloud/snapshots/test_config_flow.ambr
+++ b/tests/components/nextcloud/snapshots/test_config_flow.ambr
@@ -1,0 +1,15 @@
+# serializer version: 1
+# name: test_import
+  dict({
+    'password': 'nc_pass',
+    'url': 'nc_url',
+    'username': 'nc_user',
+  })
+# ---
+# name: test_user_create_entry
+  dict({
+    'password': 'nc_pass',
+    'url': 'nc_url',
+    'username': 'nc_user',
+  })
+# ---

--- a/tests/components/nextcloud/test_config_flow.py
+++ b/tests/components/nextcloud/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 from nextcloudmonitor import NextcloudMonitorError
+import pytest
 
 from homeassistant.components.nextcloud import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -10,6 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_user_create_entry(

--- a/tests/components/nextcloud/test_config_flow.py
+++ b/tests/components/nextcloud/test_config_flow.py
@@ -1,0 +1,121 @@
+"""Tests for the Nextcloud config flow."""
+from unittest.mock import Mock, patch
+
+from nextcloudmonitor import NextcloudMonitorError
+
+from homeassistant.components.nextcloud import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_form_create_entry(
+    hass: HomeAssistant, mock_nextcloud_monitor: Mock
+) -> None:
+    """Test that the user step works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == SOURCE_USER
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
+        return_value=mock_nextcloud_monitor,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: "nc_url", CONF_USERNAME: "nc_user", CONF_PASSWORD: "nc_pass"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "nc_url"
+    assert result["data"][CONF_URL] == "nc_url"
+    assert result["data"][CONF_USERNAME] == "nc_user"
+    assert result["data"][CONF_PASSWORD] == "nc_pass"
+
+
+async def test_form_already_configured(
+    hass: HomeAssistant, mock_nextcloud_monitor: Mock
+) -> None:
+    """Test that errors are shown when duplicates are added."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="nc_url",
+        unique_id="nc_url",
+        data={CONF_URL: "nc_url", CONF_USERNAME: "nc_user", CONF_PASSWORD: "nc_pass"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == SOURCE_USER
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
+        return_value=mock_nextcloud_monitor,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: "nc_url", CONF_USERNAME: "nc_user", CONF_PASSWORD: "nc_pass"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_form_connection_error(
+    hass: HomeAssistant, mock_nextcloud_monitor: Mock
+) -> None:
+    """Test that errors are shown when connection fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == SOURCE_USER
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
+        return_value=mock_nextcloud_monitor,
+    ) as ncm_mock:
+        ncm_mock.side_effect = NextcloudMonitorError
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_URL: "nc_url", CONF_USERNAME: "nc_user", CONF_PASSWORD: "nc_pass"},
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == SOURCE_USER
+    assert result["errors"] == {"base": "connection_error"}
+
+
+async def test_import(hass: HomeAssistant, mock_nextcloud_monitor: Mock) -> None:
+    """Test that the import step works."""
+    with patch(
+        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
+        return_value=mock_nextcloud_monitor,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_URL: "nc_url",
+                CONF_USERNAME: "nc_user",
+                CONF_PASSWORD: "nc_pass",
+            },
+        )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "nc_url"
+    assert result["data"][CONF_URL] == "nc_url"
+    assert result["data"][CONF_USERNAME] == "nc_user"
+    assert result["data"][CONF_PASSWORD] == "nc_pass"

--- a/tests/components/nextcloud/test_config_flow.py
+++ b/tests/components/nextcloud/test_config_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from nextcloudmonitor import NextcloudMonitorError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.nextcloud import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -16,14 +17,14 @@ pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 async def test_user_create_entry(
-    hass: HomeAssistant, mock_nextcloud_monitor: Mock
+    hass: HomeAssistant, mock_nextcloud_monitor: Mock, snapshot: SnapshotAssertion
 ) -> None:
     """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(
@@ -38,9 +39,7 @@ async def test_user_create_entry(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "nc_url"
-    assert result["data"][CONF_URL] == "nc_url"
-    assert result["data"][CONF_USERNAME] == "nc_user"
-    assert result["data"][CONF_PASSWORD] == "nc_pass"
+    assert result["data"] == snapshot
 
 
 async def test_user_already_configured(
@@ -59,7 +58,7 @@ async def test_user_already_configured(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(
@@ -84,7 +83,7 @@ async def test_user_connection_error(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(
@@ -97,11 +96,13 @@ async def test_user_connection_error(
         )
         await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "connection_error"}
 
 
-async def test_import(hass: HomeAssistant, mock_nextcloud_monitor: Mock) -> None:
+async def test_import(
+    hass: HomeAssistant, mock_nextcloud_monitor: Mock, snapshot: SnapshotAssertion
+) -> None:
     """Test that the import step works."""
     with patch(
         "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
@@ -118,9 +119,7 @@ async def test_import(hass: HomeAssistant, mock_nextcloud_monitor: Mock) -> None
         )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "nc_url"
-    assert result["data"][CONF_URL] == "nc_url"
-    assert result["data"][CONF_USERNAME] == "nc_user"
-    assert result["data"][CONF_PASSWORD] == "nc_pass"
+    assert result["data"] == snapshot
 
 
 async def test_import_already_configured(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nextcloud is now configured via the UI, and configuration from YAML has been imported automatically.
Further the option to define an own scan interval has been removed, data are updated every 60 seconds.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will implement the config flow to the nextcloud integration. Further it was needed to rewrite the integration to use a data update coordinator.

Afterwards, additional features could be added, like a `verify_ssl` option (_which needs bumping `nextcloudmonitor` to 1.2.0_) or re-auth flow (_which needs changes in `nextcloudmonitor` to provide proper exceptions_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #87248 #55433
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26503

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
