### PR TITLE
Parse attribute reports for ZHA select entity

### DIFF
--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -26,6 +26,7 @@ from .core.const import (
     CHANNEL_ON_OFF,
     DATA_ZHA,
     SIGNAL_ADD_ENTITIES,
+    SIGNAL_ATTR_UPDATED,
     Strobe,
 )
 from .core.registries import ZHA_ENTITIES
@@ -210,6 +211,18 @@ class ZCLEnumSelectEntity(ZhaEntity, SelectEntity):
         await self._channel.cluster.write_attributes(
             {self._select_attr: self._enum[option.replace(" ", "_")]}
         )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Run when about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_accept_signal(
+            self._channel, SIGNAL_ATTR_UPDATED, self.async_set_state
+        )
+
+    @callback
+    def async_set_state(self, attr_id: int, attr_name: str, value: Any):
+        """Handle state update from channel."""
         self.async_write_ha_state()
 
 

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -2,17 +2,28 @@
 from unittest.mock import call, patch
 
 import pytest
+from zhaquirks import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 from zigpy.const import SIG_EP_PROFILE
 import zigpy.profiles.zha as zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 import zigpy.zcl.clusters.general as general
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.clusters.security as security
 
+from homeassistant.components.zha.select import AqaraMotionSensitivities
 from homeassistant.const import STATE_UNKNOWN, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, restore_state
 from homeassistant.util import dt as dt_util
 
-from .common import find_entity_id
+from .common import async_enable_traffic, find_entity_id, send_attributes_report
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
 
@@ -29,6 +40,7 @@ def select_select_only():
             Platform.NUMBER,
             Platform.SELECT,
             Platform.SENSOR,
+            Platform.SWITCH,
         ),
     ):
         yield
@@ -323,3 +335,79 @@ async def test_on_off_select_unsupported(
         qualifier=select_name.lower(),
     )
     assert entity_id is None
+
+
+class MotionSensitivityQuirk(CustomDevice):
+    """Quirk with motion sensitivity attribute."""
+
+    class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
+        """Aqara manufacturer specific cluster."""
+
+        cluster_id = 0xFCC0
+        ep_attribute = "opple_cluster"
+        attributes = {
+            0x010C: ("motion_sensitivity", t.uint8_t, True),
+        }
+
+        def __init__(self, *args, **kwargs):
+            """Initialize."""
+            super().__init__(*args, **kwargs)
+            # populate cache to create config entity
+            self._attr_cache.update({0x010C: AqaraMotionSensitivities.Medium})
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [general.Basic.cluster_id, OppleCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+        }
+    }
+
+
+@pytest.fixture
+async def zigpy_device_aqara_sensor(hass, zigpy_device_mock, zha_device_joined):
+    """Device tracker zigpy Aqara motion sensor device."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [general.Basic.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+            }
+        },
+        manufacturer="LUMI",
+        model="lumi.motion.ac02",
+        quirk=MotionSensitivityQuirk,
+    )
+
+    zha_device = await zha_device_joined(zigpy_device)
+    zha_device.available = True
+    await hass.async_block_till_done()
+    return zigpy_device
+
+
+async def test_on_off_select_attribute_report(
+    hass: HomeAssistant, light, zha_device_restored, zigpy_device_aqara_sensor
+) -> None:
+    """Test ZHA attribute report parsing for select platform."""
+
+    zha_device = await zha_device_restored(zigpy_device_aqara_sensor)
+    cluster = zigpy_device_aqara_sensor.endpoints.get(1).opple_cluster
+    entity_id = await find_entity_id(Platform.SELECT, zha_device, hass)
+    assert entity_id is not None
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, [zha_device])
+
+    # test that the state is in default medium state
+    assert hass.states.get(entity_id).state == AqaraMotionSensitivities.Medium.name
+
+    # send attribute report from device
+    await send_attributes_report(
+        hass, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
+    )
+    assert hass.states.get(entity_id).state == AqaraMotionSensitivities.Low.name


### PR DESCRIPTION
## Proposed change
This adds attribute report parsing for ZHA select entities, as this was previously missing for those.
(It's already properly implemented for ZHA switch config entities though.)

Tested with Aqara E1 thermostat select entities (not yet PR'ed).

### Tests

Implemented the tests using motion sensitivity select entity for Aqara P1 motion sensors.
I'm not a huge fan of how the test implementation is done (with the quirk and so on), but it's very similar to the one in [`test_switch.py`](https://github.com/home-assistant/core/blob/e5ce8e920dca371c3e16009935184b60276b13ed/tests/components/zha/test_switch.py#L207-L259).

Note 1: `Platform.SWITCH` needs to be loaded in tests now, as the Aqara P1 motion sensor quirk also tries to generate config switches (even though they're not used in these tests and I didn't add those attributes to the "test quirk").

Note 2: I initially tried to implement tests for this using the "start-up behavior" entity (for the `OnOff` cluster), but that doesn't doesn't parse attribute reports because it's blocked here: https://github.com/home-assistant/core/blob/e5ce8e920dca371c3e16009935184b60276b13ed/homeassistant/components/zha/core/channels/general.py#L420-L426
I have some Gledopto Pro controllers that actually have a button for changing the start-up behavior. In the future, I'll see if they send attribute reports when changed and maybe the code mentioned above should be changed then(?)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
