### PR TITLE
Fix issues with swisscom router integration

### DIFF
--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 import logging
+import json
 
 import requests
 import voluptuous as vol
@@ -12,23 +13,24 @@ from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_IP = "192.168.1.1"
+DEFAULT_IP = "internetbox.swisscom.ch"
 
 PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
-    {vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string}
+    {
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_HOST, default=DEFAULT_IP): cv.string
+    }
 )
 
 
-def get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> SwisscomDeviceScanner | None:
+def get_scanner(hass: HomeAssistant, config: ConfigType) -> DeviceScanner | None:
     """Return the Swisscom device scanner."""
     scanner = SwisscomDeviceScanner(config[DOMAIN])
 
@@ -36,11 +38,12 @@ def get_scanner(
 
 
 class SwisscomDeviceScanner(DeviceScanner):
-    """Class which queries a router running Swisscom Internet-Box firmware."""
+    """This class queries a router running Swisscom Internet-Box firmware."""
 
     def __init__(self, config):
         """Initialize the scanner."""
         self.host = config[CONF_HOST]
+        self.password = config[CONF_PASSWORD]
         self.last_results = {}
 
         # Test the router is accessible.
@@ -77,31 +80,146 @@ class SwisscomDeviceScanner(DeviceScanner):
         self.last_results = active_clients
         return True
 
-    def get_swisscom_data(self):
-        """Retrieve data from Swisscom and return parsed result."""
-        url = f"http://{self.host}/ws"
-        headers = {"Content-Type": "application/x-sah-ws-4-call+json"}
-        data = """
-        {"service":"Devices", "method":"get",
-        "parameters":{"expression":"lan and not self"}}"""
-
-        devices = {}
-
+    def swisscom_post_request(self, session, headers, data):
+        # Send a POST request to /ws endpoint of the router.
+        # Returns None on failure or the response object
+        url = f"https://{self.host}/ws"
+        _LOGGER.debug(
+            f"Send request to {url}:\nheaders={headers} \ndata={data} \ncookies={session.cookies}"
+        )
         try:
-            request = requests.post(url, headers=headers, data=data, timeout=10)
+            response = session.post(url, headers=headers, data=data, timeout=10)
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             requests.exceptions.ConnectTimeout,
         ):
-            _LOGGER.info("No response from Swisscom Internet Box")
-            return devices
+            _LOGGER.warning("No response from Swisscom Internet Box")
+            return None
 
-        if "status" not in request.json():
-            _LOGGER.info("No status in response from Swisscom Internet Box")
-            return devices
+        _LOGGER.debug(f"Headers: {response.headers}")
+        _LOGGER.debug(f"Response: {response.text}")
 
-        for device in request.json()["status"]:
+        # Check validity
+        if response.status_code != 200:
+            _LOGGER.warning(f"Response status unexpected: {response.status_code}")
+            return None
+        # Check status
+        if "status" not in response.json():
+            _LOGGER.warning("No status in response from Swisscom Internet Box")
+            return None
+        # Check for errors
+        if "errors" in response.json():
+            _LOGGER.warning("Errors in response from Swisscom Internet Box:")
+            _LOGGER.warning(json.dumps(response.json()["errors"]))
+            return None
+        return response
+
+    def get_swisscom_data(self):
+        # Retrieve data from Swisscom router and return parsed result.
+        session = requests.session()
+
+        # Send a request to create a authenticated session 
+        headers = {
+            "Authorization": "X-Sah-Login", 
+            "Content-Type": "application/x-sah-ws-4-call+json"}
+        data = (
+            """{"service": "sah.Device.Information","method": "createContext","parameters": {"applicationName": "webui","username": "admin","password": \""""
+            + self.password
+            + """\"}}"""
+        )
+
+        _LOGGER.debug("Send session request")
+        authentication_response = self.swisscom_post_request(session, headers, data)
+        if authentication_response is None:
+            return {}
+
+        _LOGGER.debug("Got session response:")
+        authentication_data = authentication_response.json()
+        _LOGGER.debug(json.dumps(authentication_data))
+        # response data should have the following content:
+        # {
+        #  "status": 0,
+        #  "data": {
+        #    "contextID": "XXX",
+        #    "username": "admin",
+        #    "groups": "http,admin"
+        #  }
+        # }
+        if authentication_data["status"] != 0:
+            _LOGGER.warn(
+                "Unexpected status in response from Swisscom Internet Box during session setup"
+            )
+            return {}
+        if (
+            "data" not in authentication_data
+            or "contextID" not in authentication_data["data"]
+        ):
+            _LOGGER.warn(
+                "No data/contextID in response from Swisscom Internet Box during session setup"
+            )
+            return {}
+
+        # extract context ID
+        context_id = authentication_data["data"]["contextID"]
+
+        # And it should have a session id in the 'Set-Cookie' header of the response:
+        # DEVICEID/sessid=SESSIONID; 
+        # Note: there might be multiple cookies that contain '/sessid=' but some have no SESSIONID value. 
+        # Assumption is that these try to clear a previous session id first, because the last occurence has the desired value.
+        session_cookies = authentication_response.headers["set-cookie"]
+        session_cookie_list = session_cookies.split(";")
+        # find the last matching the '/sessid=' substring...
+        needle = "/sessid="
+        matching_cookies = [s for s in session_cookie_list if needle in s]
+        if len(matching_cookies) == 0:
+            _LOGGER.warn(
+                "No matches for session id in response header from Swisscom Internet Box during session setup"
+            )
+            return {}
+        # ... and use the last one...
+        matching_cookie = matching_cookies[-1]
+        _LOGGER.info(f"Session ID Cookie: {matching_cookie}")
+        try:
+            match_position = matching_cookie.index(needle)
+        except ValueError:
+            _LOGGER.warn(
+                "No matching session id in response header from Swisscom Internet Box during session setup"
+            )
+            return {}
+
+        # ... to extract the device id ...
+        device_id = matching_cookie[0:match_position:1]
+        # ... and the session id
+        session_id = matching_cookie[
+            match_position + len(needle) : len(matching_cookie) : 1
+        ]
+
+        _LOGGER.debug(
+            f">> Information from handshake: context_id={context_id} / device_id={device_id} / session_id={session_id}"
+        )
+
+        # Now, we can access the router! Send a request to get the devices ...
+        # ... containing the required cookies ...
+        session.cookies.set(f"{device_id}/sessid", session_id, domain="internetbox.swisscom.ch")
+        session.cookies.set(f"swc/deviceID", device_id, domain="internetbox.swisscom.ch")
+        session.cookies.set(f"{device_id}/context", context_id, domain="internetbox.swisscom.ch")
+        session.cookies.set(f"{device_id}/accept-language", "en-US,en", domain="internetbox.swisscom.ch")
+        # ... and headers
+        headers = {
+            "Authorization": f"X-Sah {context_id}",
+            "X-Context": context_id,
+            "Content-Type": "application/x-sah-ws-4-call+json",
+        }
+        # the request wants to get the devices in the LAN
+        data = """{"service": "Devices", "method": "get", "parameters": {"expression": "lan and not self and not interface"}, "flags": "no_actions"}"""
+        device_response = self.swisscom_post_request(session, headers, data)
+        if device_response is None:
+            return {}
+
+        # extract the devices
+        devices = {}
+        for device in device_response.json()["status"]:
             with suppress(KeyError, requests.exceptions.RequestException):
                 devices[device["Key"]] = {
                     "ip": device["IPAddress"],


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing the broken swisscom router integration. See [#87220](https://github.com/home-assistant/core/issues/87220)

- new default ip is "internetbox.swisscom.ch"
- new default protocol is `https` #82789

fixing #87220
- retrieving devices requires router password since firmware update to 13.20.26/13.20.18
- solution is to open a session with the router using a two-step process
  - first, the session is created to authenticate and get a session id and context
  - second, using these values, the list of devices can be retrieved

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
  - fixes #87220 
  - fixes #82789 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
