### PR TITLE
Set default value for some Fronius entities

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from pyfronius import BadStatusError, FroniusError
 
-from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -25,6 +24,7 @@ from .sensor import (
     OHMPILOT_ENTITY_DESCRIPTIONS,
     POWER_FLOW_ENTITY_DESCRIPTIONS,
     STORAGE_ENTITY_DESCRIPTIONS,
+    FroniusSensorEntityDescription,
 )
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ class FroniusCoordinatorBase(
 
     default_interval: timedelta
     error_interval: timedelta
-    valid_descriptions: list[SensorEntityDescription]
+    valid_descriptions: list[FroniusSensorEntityDescription]
 
     MAX_FAILED_UPDATES = 3
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -1,6 +1,7 @@
 """Support for Fronius devices."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
 from homeassistant.components.sensor import (
@@ -25,6 +26,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -77,113 +79,128 @@ async def async_setup_entry(
         )
 
 
-INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+@dataclass
+class FroniusSensorEntityDescription(SensorEntityDescription):
+    """Describes Fronius sensor entity."""
+
+    default_value: StateType | None = None
+
+
+INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="energy_day",
         name="Energy day",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_year",
         name="Energy year",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_total",
         name="Energy total",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="frequency_ac",
         name="Frequency AC",
+        default_value=0,
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_ac",
         name="Current AC",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_dc",
         name="Current DC",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_dc_2",
         name="Current DC 2",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_ac",
         name="Power AC",
+        default_value=0,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac",
         name="Voltage AC",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_dc",
         name="Voltage DC",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_dc_2",
         name="Voltage DC 2",
+        default_value=0,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
     # device status entities
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="inverter_state",
         name="Inverter state",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="error_code",
         name="Error code",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="status_code",
         name="Status code",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="led_state",
         name="LED state",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="led_color",
         name="LED color",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -191,20 +208,20 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
 ]
 
-LOGGER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+LOGGER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="co2_factor",
         name="CO₂ factor",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule-co2",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="cash_factor",
         name="Grid export tariff",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:cash-plus",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="delivery_factor",
         name="Grid import tariff",
         state_class=SensorStateClass.MEASUREMENT,
@@ -212,8 +229,8 @@ LOGGER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
 ]
 
-METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+METER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="current_ac_phase_1",
         name="Current AC phase 1",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -221,7 +238,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_ac_phase_2",
         name="Current AC phase 2",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -229,7 +246,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_ac_phase_3",
         name="Current AC phase 3",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -237,7 +254,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_reactive_ac_consumed",
         name="Energy reactive AC consumed",
         native_unit_of_measurement=ENERGY_VOLT_AMPERE_REACTIVE_HOUR,
@@ -245,7 +262,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:lightning-bolt-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_reactive_ac_produced",
         name="Energy reactive AC produced",
         native_unit_of_measurement=ENERGY_VOLT_AMPERE_REACTIVE_HOUR,
@@ -253,7 +270,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:lightning-bolt-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_real_ac_minus",
         name="Energy real AC minus",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -261,7 +278,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_real_ac_plus",
         name="Energy real AC plus",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -269,33 +286,33 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_real_consumed",
         name="Energy real consumed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_real_produced",
         name="Energy real produced",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="frequency_phase_average",
         name="Frequency phase average",
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="meter_location",
         name="Meter location",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_apparent_phase_1",
         name="Power apparent phase 1",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
@@ -304,7 +321,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_apparent_phase_2",
         name="Power apparent phase 2",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
@@ -313,7 +330,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_apparent_phase_3",
         name="Power apparent phase 3",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
@@ -322,7 +339,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_apparent",
         name="Power apparent",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
@@ -331,34 +348,34 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_factor_phase_1",
         name="Power factor phase 1",
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_factor_phase_2",
         name="Power factor phase 2",
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_factor_phase_3",
         name="Power factor phase 3",
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_factor",
         name="Power factor",
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_reactive_phase_1",
         name="Power reactive phase 1",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
@@ -367,7 +384,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_reactive_phase_2",
         name="Power reactive phase 2",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
@@ -376,7 +393,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_reactive_phase_3",
         name="Power reactive phase 3",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
@@ -385,7 +402,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_reactive",
         name="Power reactive",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
@@ -394,7 +411,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_real_phase_1",
         name="Power real phase 1",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -402,7 +419,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_real_phase_2",
         name="Power real phase 2",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -410,7 +427,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_real_phase_3",
         name="Power real phase 3",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -418,14 +435,14 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_real",
         name="Power real",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_1",
         name="Voltage AC phase 1",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -433,7 +450,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_2",
         name="Voltage AC phase 2",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -441,7 +458,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_3",
         name="Voltage AC phase 3",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -449,7 +466,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_to_phase_12",
         name="Voltage AC phase 1-2",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -457,7 +474,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_to_phase_23",
         name="Voltage AC phase 2-3",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -465,7 +482,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_ac_phase_to_phase_31",
         name="Voltage AC phase 3-1",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -475,47 +492,47 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
 ]
 
-OHMPILOT_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+OHMPILOT_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="energy_real_ac_consumed",
         name="Energy consumed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_real_ac",
         name="Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="temperature_channel_1",
         name="Temperature channel 1",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="error_code",
         name="Error code",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="state_code",
         name="State code",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="state_message",
         name="State message",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 ]
 
-POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="energy_day",
         name="Energy day",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -523,7 +540,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_year",
         name="Energy year",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -531,7 +548,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="energy_total",
         name="Energy total",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -539,69 +556,75 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="meter_mode",
         name="Meter mode",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_battery",
         name="Power battery",
+        default_value=0,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_grid",
         name="Power grid",
+        default_value=0,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_load",
         name="Power load",
+        default_value=0,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="power_photovoltaics",
         name="Power photovoltaics",
+        default_value=0,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="relative_autonomy",
         name="Relative autonomy",
+        default_value=0,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:home-circle-outline",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="relative_self_consumption",
         name="Relative self consumption",
+        default_value=0,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:solar-power",
     ),
 ]
 
-STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
-    SensorEntityDescription(
+STORAGE_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+    FroniusSensorEntityDescription(
         key="capacity_maximum",
         name="Capacity maximum",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="capacity_designed",
         name="Capacity designed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="current_dc",
         name="Current DC",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -609,7 +632,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_dc",
         name="Voltage DC",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -617,7 +640,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-dc",
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_dc_maximum_cell",
         name="Voltage DC maximum cell",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -626,7 +649,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:current-dc",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="voltage_dc_minimum_cell",
         name="Voltage DC minimum cell",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -635,14 +658,14 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         icon="mdi:current-dc",
         entity_registry_enabled_default=False,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="state_of_charge",
         name="State of charge",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    FroniusSensorEntityDescription(
         key="temperature_cell",
         name="Temperature cell",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -655,7 +678,8 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
 class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEntity):
     """Defines a Fronius coordinator entity."""
 
-    entity_descriptions: list[SensorEntityDescription]
+    entity_description: FroniusSensorEntityDescription
+    entity_descriptions: list[FroniusSensorEntityDescription]
 
     _attr_has_entity_name = True
 
@@ -679,9 +703,16 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
 
     def _get_entity_value(self) -> Any:
         """Extract entity value from coordinator. Raises KeyError if not included in latest update."""
-        new_value = self.coordinator.data[self.solar_net_id][
-            self.entity_description.key
-        ]["value"]
+        try:
+            new_value = self.coordinator.data[self.solar_net_id][
+                self.entity_description.key
+            ]["value"]
+        except KeyError:
+            if self.entity_description.default_value is None:
+                raise
+            return self.entity_description.default_value
+        if new_value is None:
+            return self.entity_description.default_value
         return round(new_value, 4) if isinstance(new_value, float) else new_value
 
     @callback

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -718,8 +718,7 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
         try:
             self._attr_native_value = self._get_entity_value()
         except KeyError:
-            if self.entity_description.default_value is None:
-                return
+            # sets state to `None` if no default_value is defined in entity description
             self._attr_native_value = self.entity_description.default_value
         self.async_write_ha_state()
 

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -62,16 +62,16 @@ async def test_symo_inverter(
     assert_state("sensor.symo_20_power_ac", 1190)
     assert_state("sensor.symo_20_voltage_ac", 227.90)
 
-    # Third test at nighttime - additional AC entities aren't changed
+    # Third test at nighttime - additional AC entities default to 0
     mock_responses(aioclient_mock, night=True)
     async_fire_time_changed(
         hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
-    assert_state("sensor.symo_20_current_ac", 5.19)
-    assert_state("sensor.symo_20_frequency_ac", 49.94)
-    assert_state("sensor.symo_20_power_ac", 1190)
-    assert_state("sensor.symo_20_voltage_ac", 227.90)
+    assert_state("sensor.symo_20_current_ac", 0)
+    assert_state("sensor.symo_20_frequency_ac", 0)
+    assert_state("sensor.symo_20_power_ac", 0)
+    assert_state("sensor.symo_20_voltage_ac", 0)
 
 
 async def test_symo_logger(
@@ -189,6 +189,22 @@ async def test_symo_power_flow(
     assert_state("sensor.solarnet_power_photovoltaics", 1111)
     assert_state("sensor.solarnet_relative_autonomy", 39.4708)
     assert_state("sensor.solarnet_relative_self_consumption", 100)
+
+    # Third test at nighttime - default values are used
+    mock_responses(aioclient_mock, night=True)
+    async_fire_time_changed(
+        hass, dt.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert_state("sensor.solarnet_energy_day", 10828)
+    assert_state("sensor.solarnet_energy_total", 44186900)
+    assert_state("sensor.solarnet_energy_year", 25507686)
+    assert_state("sensor.solarnet_power_grid", 975.31)
+    assert_state("sensor.solarnet_power_load", -975.31)
+    assert_state("sensor.solarnet_power_photovoltaics", 0)
+    assert_state("sensor.solarnet_relative_autonomy", 0)
+    assert_state("sensor.solarnet_relative_self_consumption", 0)
 
 
 async def test_gen24(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Fronius values are omitted or set to `null` in API responses eg. at night when no inverter produces.
This results in entity states like Photovoltaic Power to stay at their last seen value (eg. 7 Watts) over night instead of dropping to 0 - which messes eg. with Riemann sum calculation. 
This PR uses a default value of `0` for those entities when omitted from API response or their value was `null`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/26351
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
