### PR TITLE
Refactor ZHA binary sensors to read from zigpy cache

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -76,34 +76,23 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
             self._channel, SIGNAL_ATTR_UPDATED, self.async_set_state
         )
 
-    @callback
-    def async_restore_last_state(self, last_state):
-        """Restore previous state."""
-        super().async_restore_last_state(last_state)
-        self._state = last_state.state == STATE_ON
-
     @property
     def is_on(self) -> bool:
         """Return True if the switch is on based on the state machine."""
-        if self._state is None:
+        raw_state = self._channel.cluster.get(self.SENSOR_ATTR)
+        if raw_state is None:
             return False
-        return self._state
+        return self.parse(raw_state)
 
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
-        if self.SENSOR_ATTR is None or attr_name != self.SENSOR_ATTR:
-            return
-        self._state = bool(value)
         self.async_write_ha_state()
 
-    async def async_update(self) -> None:
-        """Attempt to retrieve on off state from the binary sensor."""
-        await super().async_update()
-        attribute = getattr(self._channel, "value_attribute", "on_off")
-        attr_value = await self._channel.get_attribute_value(attribute)
-        if attr_value is not None:
-            self._state = attr_value
+    @staticmethod
+    def parse(value: bool | int) -> bool:
+        """Parse the raw attribute into a bool state."""
+        return bool(value)
 
 
 @MULTI_MATCH(channel_names=CHANNEL_ACCELEROMETER)
@@ -167,12 +156,10 @@ class IASZone(BinarySensor):
         """Return device class from component DEVICE_CLASSES."""
         return CLASS_MAPPING.get(self._channel.cluster.get("zone_type"))
 
-    async def async_update(self) -> None:
-        """Attempt to retrieve on off state from the binary sensor."""
-        await super().async_update()
-        value = await self._channel.get_attribute_value("zone_status")
-        if value is not None:
-            self._state = value & 3
+    @staticmethod
+    def parse(value: bool | int) -> bool:
+        """Parse the raw attribute into a bool state."""
+        return bool(value & 3)  # only use bit 0 and 1 for determining alarm state
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -159,7 +159,7 @@ class IASZone(BinarySensor):
     @staticmethod
     def parse(value: bool | int) -> bool:
         """Parse the raw attribute into a bool state."""
-        return bool(value & 3)  # only use bit 0 and 1 for determining alarm state
+        return BinarySensor.parse(value & 3)  # use only bit 0 and 1 for alarm state
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -342,12 +342,12 @@ class IASZoneChannel(ZigbeeChannel):
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
         if command_id == 0:
-            state = args[0] & 3
-            # update attribute cache (sends signal)
+            zone_status = args[0]
+            # update attribute cache with new zone status
             self.cluster.update_attribute(
-                IasZone.attributes_by_name["zone_status"].id, state
+                IasZone.attributes_by_name["zone_status"].id, zone_status
             )
-            self.debug("Updated alarm state: %s", state)
+            self.debug("Updated alarm state: %s", zone_status)
         elif command_id == 1:
             self.debug("Enroll requested")
             res = self._cluster.enroll_response(0, 0)
@@ -391,7 +391,6 @@ class IASZoneChannel(ZigbeeChannel):
     def attribute_updated(self, attrid, value):
         """Handle attribute updates on this cluster."""
         if attrid == IasZone.attributes_by_name["zone_status"].id:
-            value = value & 3
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
                 attrid,

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -336,7 +336,7 @@ class IasWd(ZigbeeChannel):
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""
 
-    ZCL_INIT_ATTRS = {"zone_status": True, "zone_state": False, "zone_type": True}
+    ZCL_INIT_ATTRS = {"zone_status": False, "zone_state": True, "zone_type": True}
 
     @callback
     def cluster_command(self, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -332,7 +332,7 @@ class IasWd(ZigbeeChannel):
         )
 
 
-@registries.ZIGBEE_CHANNEL_REGISTRY.register(security.IasZone.cluster_id)
+@registries.ZIGBEE_CHANNEL_REGISTRY.register(IasZone.cluster_id)
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""
 

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -341,15 +341,13 @@ class IASZoneChannel(ZigbeeChannel):
     @callback
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
-        # TODO: zha-quirks has a bug with the "fake motion with reset" stuff where the ZONE_STATE attribute is set (instead of the correct ZONE_STATUS attribute).
+        # Note: zha-quirks has a bug with the "MotionOnEvent" quirk where the ZONE_STATE attribute is set (instead of the correct ZONE_STATUS attribute).
         #   This command is sent properly though, so we use it to update the ZONE_STATUS attribute here for now.
-        #   (This is a workaround -- see: https://github.com/zigpy/zha-device-handlers/pull/2231 for a fix in quirks)
+        #   See: https://github.com/zigpy/zha-device-handlers/pull/2231 for a fix in quirks.
+        # Note: This also allows to remove the explicit "attribute report signal" here
         if command_id == 0:
             state = args[0] & 3
-            self.cluster.update_attribute(2, state)  # update attribute cache on command
-            self.async_send_signal(
-                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 2, "zone_status", state
-            )
+            self.cluster.update_attribute(2, state)  # update cache (sends signal)
             self.debug("Updated alarm state: %s", state)
         elif command_id == 1:
             self.debug("Enroll requested")

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -341,10 +341,6 @@ class IASZoneChannel(ZigbeeChannel):
     @callback
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
-        # Note: zha-quirks has a bug with the "MotionOnEvent" quirk where the ZONE_STATE attribute is set (instead of the correct ZONE_STATUS attribute).
-        #   This command is sent properly though, so we use it to update the ZONE_STATUS attribute here for now.
-        #   See: https://github.com/zigpy/zha-device-handlers/pull/2231 for a fix in quirks.
-        # Note: This also allows to remove the explicit "attribute report signal" here
         if command_id == 0:
             state = args[0] & 3
             self.cluster.update_attribute(2, state)  # update cache (sends signal)

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -75,6 +75,11 @@ async def async_test_iaszone_on_off(hass, cluster, entity_id):
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
+    # check that binary sensor remains off when non-alarm bits change
+    cluster.listener_event("cluster_command", 1, 0, [0b1111111100])
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_OFF
+
 
 @pytest.mark.parametrize(
     ("device", "on_off_test", "cluster_name", "reporting"),

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -85,7 +85,7 @@ async def async_test_iaszone_on_off(hass, cluster, entity_id):
     ("device", "on_off_test", "cluster_name", "reporting"),
     [
         (DEVICE_IAS, async_test_iaszone_on_off, "ias_zone", (0,)),
-        # (DEVICE_OCCUPANCY, async_test_binary_sensor_on_off, "occupancy", (1,)),
+        (DEVICE_OCCUPANCY, async_test_binary_sensor_on_off, "occupancy", (1,)),
     ],
 )
 async def test_binary_sensor(


### PR DESCRIPTION
## Proposed change
Similar to the changes to `sensor.py` in https://github.com/home-assistant/core/pull/43339, this updates ZHA's binary sensors to also just be a representation of zigpy cached attribute values.

#### More info

For sensors which may need to parse the attribute further, the `parse()` method can be overridden.
The `IASZone` binary sensor uses this, as that only needs to "enable the sensor" if either bit 0 or 1 are set. (So the rest needs to be ignored).

These changes align ZHA's binary sensors with how normal sensors are implemented (and probably more).

It also fixes an issue where the custom binary sensors ("Aqara Pet feeder sensors", and so on) did not set their state on pairing (it was correctly read and initialized, but as no attribute report was sent, `async_set_state()` was never called).

I haven't tested it yet, but this might also fix contact sensors having the wrong state when pairing.

The previous implementation of `async_update()` was also somewhat broken, as it relied on the channel having a `value_attribute` or just defaulted to read the `on_off` attribute otherwise.

#### Saving the `zone_status` command data in cache

Since IASZone attributes aren't reportable per spec, ZHA just receives the "zone status change notification" command and now updates the attribute cache based on that command.

#### Old `value_attribute`

The `value_attribute` value/attribute isn't used in the binary sensor class anymore now, but it still seems to be used in some other places. Although it's likely that this can be removed, as all sensors seem to have `SENSOR_ATTR` set correctly.
(If this can be removed, I wouldn't do it in this PR though)

### Only somewhat related to this PR:

#### PR in quirks repo

A fix for a mixup of `STATE` and `STATUS` is here in the quirks repo: https://github.com/zigpy/zha-device-handlers/pull/2231 (will likely change this a bit after this PR)
Currently, that PR changes it to both update the `ZONE_STATUS` attribute and still send the "zone status change notification" command. As the proper attribute is now updated (and sends an attribute report), the command isn't needed (regardless of the changes in ZHA with binary sensor).
Since ZHA now handles caching the attribute, zha-quirks could just send the command.

#### ZONE_STATE vs ZONE_STATUS
Okay, this is getting somewhat off-topic, but the `IASZoneChannel` has `ZCL_INIT_ATTRS` set like this:
```python
ZCL_INIT_ATTRS = {"zone_status": True, "zone_state": False, "zone_type": True}
```
So `status` (alarm or not) and `type` allow cached reads, but `state` (enrolled or not) doesn't.
Is there also a mix-up here or is this intended?

EDIT: This was a mix-up and a fix for that minor issue is also included in this PR.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
