### PR TITLE
Await block till done inside patched config entry in tests

### DIFF
--- a/tests/components/advantage_air/test_config_flow.py
+++ b/tests/components/advantage_air/test_config_flow.py
@@ -33,12 +33,12 @@ async def test_form(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) ->
             result1["flow_id"],
             USER_INPUT,
         )
+        await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 1
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result2["title"] == "testname"
     assert result2["data"] == USER_INPUT
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
     # Test Duplicate Config Flow

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -187,11 +187,11 @@ async def test_user_form_one_entry_per_device_allowed(hass: HomeAssistant) -> No
             result["flow_id"],
             {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "already_configured"
 
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 0
 
 

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -33,11 +33,11 @@ async def test_form(hass: HomeAssistant) -> None:
             result["flow_id"],
             {CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-epson"
     assert result2["data"] == {CONF_HOST: "1.1.1.1"}
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/faa_delays/test_config_flow.py
+++ b/tests/components/faa_delays/test_config_flow.py
@@ -37,13 +37,13 @@ async def test_form(hass: HomeAssistant) -> None:
                 "id": "test",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Test airport"
     assert result2["data"] == {
         "id": "test",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -37,6 +37,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
                 "password": "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "1.1.1.1"
@@ -45,7 +46,6 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -47,6 +47,7 @@ async def test_formx(hass: HomeAssistant) -> None:
                 "password": "test-password",
             },
         )
+        await hass.async_block_till_done()
 
         mock_api_class.assert_called_once_with(ANY, "1.1.1.1")
         mock_api.__aenter__.assert_called_once()
@@ -60,7 +61,6 @@ async def test_formx(hass: HomeAssistant) -> None:
         "host": "1.1.1.1",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/kulersky/test_config_flow.py
+++ b/tests/components/kulersky/test_config_flow.py
@@ -60,10 +60,10 @@ async def test_flow_no_devices_found(hass: HomeAssistant) -> None:
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -87,8 +87,8 @@ async def test_flow_exceptions_caught(hass: HomeAssistant) -> None:
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -67,13 +67,13 @@ async def test_bridge_import_flow(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_IMPORT},
             data=entry_mock_data,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == CasetaConfigFlow.ENTRY_DEFAULT_TITLE
     assert result["data"] == entry_mock_data
     assert result["result"].unique_id == "000004d2"
 
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -381,6 +381,8 @@ async def test_import_discovery_integration(
                 type=type_in_discovery,
             ),
         )
+        await hass.async_block_till_done()
+
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_NAME
     assert result["data"] == {
@@ -395,7 +397,6 @@ async def test_import_discovery_integration(
         mock_save_json.assert_called_once()
         mock_remove.assert_not_called()
 
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -431,6 +432,7 @@ async def test_ssdp_discovery(hass: HomeAssistant) -> None:
         assert result["step_id"] == "link"
 
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_NAME
@@ -439,5 +441,4 @@ async def test_ssdp_discovery(hass: HomeAssistant) -> None:
         CONF_TOKEN: TEST_TOKEN,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/nws/test_config_flow.py
+++ b/tests/components/nws/test_config_flow.py
@@ -108,7 +108,8 @@ async def test_form_already_configured(
             result["flow_id"],
             {"api_key": "test"},
         )
+        await hass.async_block_till_done()
+
     assert result2["type"] == "abort"
     assert result2["reason"] == "already_configured"
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -76,7 +76,8 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
         }
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -102,8 +103,6 @@ async def test_user_duplicate(
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.usefixtures("filled_device_registry")

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -119,10 +119,10 @@ async def test_success(
             context={"source": config_entries.SOURCE_USER},
             data=FIXTURE_USER_INPUT,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_URL] == FIXTURE_USER_INPUT[CONF_URL]
-    await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Was reviewing some PRs from @epenet and noticed that the PRs in question all are not waiting until the side-effect from creating a config entry are done inside the patch statement. The side effect is setting up the new config entry. This PR addresses the ones that I could find with a quick search.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
