### PR TITLE
Add device class for Landis+Gyr GJ energy sensor

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -32,20 +32,11 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
-from .const import GJ_TO_MWH
 
 _LOGGER = logging.getLogger(__name__)
 
 
 HEAT_METER_SENSOR_TYPES = (
-    SensorEntityDescription(
-        key="heat_usage",
-        icon="mdi:fire",
-        name="Heat usage",
-        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
-    ),
     SensorEntityDescription(
         key="volume_usage_m3",
         icon="mdi:fire",
@@ -61,14 +52,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
-    ),
-    SensorEntityDescription(
-        key="heat_previous_year",
-        icon="mdi:fire",
-        name="Heat usage previous year",
-        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="heat_previous_year_gj",
@@ -292,19 +275,4 @@ class HeatMeterSensor(
             else:
                 self._attr_native_value = asdict(self.coordinator.data)[self.key]
 
-        if self.key == "heat_usage":
-            self._attr_native_value = convert_gj_to_mwh(
-                self.coordinator.data.heat_usage_gj
-            )
-
-        if self.key == "heat_previous_year":
-            self._attr_native_value = convert_gj_to_mwh(
-                self.coordinator.data.heat_previous_year_gj
-            )
-
         self.async_write_ha_state()
-
-
-def convert_gj_to_mwh(gigajoule) -> float:
-    """Convert GJ to MWh using the conversion value."""
-    return round(gigajoule * GJ_TO_MWH, 5)

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -32,20 +32,11 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
-from .const import GJ_TO_MWH
 
 _LOGGER = logging.getLogger(__name__)
 
 
 HEAT_METER_SENSOR_TYPES = (
-    SensorEntityDescription(
-        key="heat_usage",
-        icon="mdi:fire",
-        name="Heat usage",
-        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL,
-    ),
     SensorEntityDescription(
         key="volume_usage_m3",
         icon="mdi:fire",
@@ -54,23 +45,14 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
     ),
-    # Diagnostic entity for debugging, this will match the value in GJ indicated on the meter's display
     SensorEntityDescription(
         key="heat_usage_gj",
         icon="mdi:fire",
         name="Heat usage GJ",
-        native_unit_of_measurement="GJ",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key="heat_previous_year",
-        icon="mdi:fire",
-        name="Heat usage previous year",
-        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.TOTAL,
     ),
-    # Diagnostic entity for debugging, this will match the value in GJ of previous year indicated on the meter's display
     SensorEntityDescription(
         key="heat_previous_year_gj",
         icon="mdi:fire",
@@ -293,19 +275,4 @@ class HeatMeterSensor(
             else:
                 self._attr_native_value = asdict(self.coordinator.data)[self.key]
 
-        if self.key == "heat_usage":
-            self._attr_native_value = convert_gj_to_mwh(
-                self.coordinator.data.heat_usage_gj
-            )
-
-        if self.key == "heat_previous_year":
-            self._attr_native_value = convert_gj_to_mwh(
-                self.coordinator.data.heat_previous_year_gj
-            )
-
         self.async_write_ha_state()
-
-
-def convert_gj_to_mwh(gigajoule) -> float:
-    """Convert GJ to MWh using the conversion value."""
-    return round(gigajoule * GJ_TO_MWH, 5)

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -32,11 +32,20 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
+from .const import GJ_TO_MWH
 
 _LOGGER = logging.getLogger(__name__)
 
 
 HEAT_METER_SENSOR_TYPES = (
+    SensorEntityDescription(
+        key="heat_usage",
+        icon="mdi:fire",
+        name="Heat usage",
+        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+    ),
     SensorEntityDescription(
         key="volume_usage_m3",
         icon="mdi:fire",
@@ -52,6 +61,14 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+    ),
+    SensorEntityDescription(
+        key="heat_previous_year",
+        icon="mdi:fire",
+        name="Heat usage previous year",
+        native_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="heat_previous_year_gj",
@@ -275,4 +292,19 @@ class HeatMeterSensor(
             else:
                 self._attr_native_value = asdict(self.coordinator.data)[self.key]
 
+        if self.key == "heat_usage":
+            self._attr_native_value = convert_gj_to_mwh(
+                self.coordinator.data.heat_usage_gj
+            )
+
+        if self.key == "heat_previous_year":
+            self._attr_native_value = convert_gj_to_mwh(
+                self.coordinator.data.heat_previous_year_gj
+            )
+
         self.async_write_ha_state()
+
+
+def convert_gj_to_mwh(gigajoule) -> float:
+    """Convert GJ to MWh using the conversion value."""
+    return round(gigajoule * GJ_TO_MWH, 5)

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -83,18 +83,18 @@ async def test_create_sensors(
     await hass.services.async_call(
         HA_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage"},
+        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage_gj"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
     # check if 26 attributes have been created
-    assert len(hass.states.async_all()) == 27
+    assert len(hass.states.async_all()) == 25
 
-    state = hass.states.get("sensor.heat_meter_heat_usage")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
-    assert state.state == "34.16669"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.MEGA_WATT_HOUR
+    assert state.state == "123.0"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
 
@@ -132,17 +132,17 @@ async def test_restore_state(mock_heat_meter, hass: HomeAssistant) -> None:
         [
             (
                 State(
-                    "sensor.heat_meter_heat_usage",
+                    "sensor.heat_meter_heat_usage_gj",
                     "34167",
                     attributes={
                         ATTR_LAST_RESET: last_reset,
-                        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.MEGA_WATT_HOUR,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.GIGA_JOULE,
                         ATTR_STATE_CLASS: SensorStateClass.TOTAL,
                     },
                 ),
                 {
                     "native_value": 34167,
-                    "native_unit_of_measurement": UnitOfEnergy.MEGA_WATT_HOUR,
+                    "native_unit_of_measurement": UnitOfEnergy.GIGA_JOULE,
                     "icon": "mdi:fire",
                     "last_reset": last_reset,
                 },
@@ -194,10 +194,10 @@ async def test_restore_state(mock_heat_meter, hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # restore from cache
-    state = hass.states.get("sensor.heat_meter_heat_usage")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
     assert state.state == "34167"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.MEGA_WATT_HOUR
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
 
     state = hass.states.get("sensor.heat_meter_volume_usage")
@@ -240,21 +240,21 @@ async def test_exception_on_polling(mock_heat_meter, hass: HomeAssistant) -> Non
     await hass.services.async_call(
         HA_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage"},
+        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage_gj"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
     # check if initial setup succeeded
-    state = hass.states.get("sensor.heat_meter_heat_usage")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
-    assert state.state == "34.16669"
+    assert state.state == "123.0"
 
     # Now 'disable' the connection and wait for polling and see if it fails
     mock_heat_meter().read.side_effect = serial.serialutil.SerialException
     async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL)
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.heat_meter_heat_usage")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state.state == STATE_UNAVAILABLE
 
     # Now 'enable' and see if next poll succeeds
@@ -270,6 +270,6 @@ async def test_exception_on_polling(mock_heat_meter, hass: HomeAssistant) -> Non
     mock_heat_meter().read.side_effect = None
     async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL)
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.heat_meter_heat_usage")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
-    assert state.state == "34.44447"
+    assert state.state == "124.0"

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -89,7 +89,7 @@ async def test_create_sensors(
     await hass.async_block_till_done()
 
     # check if 26 attributes have been created
-    assert len(hass.states.async_all()) == 25
+    assert len(hass.states.async_all()) == 27
 
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -89,7 +89,7 @@ async def test_create_sensors(
     await hass.async_block_till_done()
 
     # check if 26 attributes have been created
-    assert len(hass.states.async_all()) == 27
+    assert len(hass.states.async_all()) == 25
 
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The conversion to MWh and the corresponding MWh-entities are removed. 

To resolve the breaking change:
- Users that make use of any of _sensor.heat_meter_heat_usage_ or _sensor.heat_meter_heat_previous_year_ for automations, scripts, etc., can replace these with the GJ-entities _sensor.heat_meter_heat_usage_gj_ and _sensor.heat_meter_heat_previous_year_gj_.
- If applicable, in the energy dashboard replace sensor.heat_meter_heat_usage with sensor.heat_meter_heat_usage_gj. Note that the energy dashboard will still convert to MWh or kWh, therefore resulting in the same values as before. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since release 2022.11 GigaJoule is an supported unit. 
The conversion to MWh is therefore removed. Users are kindly asked to use the available GJ entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
