### PR TITLE
Add additional CalendarEvent validation

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -356,4 +356,10 @@ class WebDavCalendarData:
         else:
             enddate = obj.dtstart.value + timedelta(days=1)
 
+        # End date for an all day event is exclusive. This fixes the case where
+        # an all day event has a start and end values are the same, or the event
+        # has a zero duration.
+        if not isinstance(enddate, datetime) and obj.dtstart.value == enddate:
+            enddate += timedelta(days=1)
+
         return enddate

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -67,6 +67,23 @@ SCAN_INTERVAL = datetime.timedelta(seconds=60)
 VALID_FREQS = {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}
 
 
+def _has_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Assert that all datetime values have a timezone."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Validate that all datetime values have a timezone."""
+        for k in keys:
+            if (
+                (value := obj.get(k))
+                and isinstance(value, datetime.datetime)
+                and value.tzinfo is None
+            ):
+                raise vol.Invalid("Expected all values to have a timezone")
+        return obj
+
+    return validate
+
+
 def _has_consistent_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Verify that all datetime values have a consistent timezone."""
 
@@ -89,7 +106,7 @@ def _as_local_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]
     """Convert all datetime values to the local timezone."""
 
     def validate(obj: dict[str, Any]) -> dict[str, Any]:
-        """Test that all keys that are datetime values have the same timezone."""
+        """Convert all keys that are datetime values to local timezone."""
         for k in keys:
             if (value := obj.get(k)) and isinstance(value, datetime.datetime):
                 obj[k] = dt.as_local(value)
@@ -98,21 +115,57 @@ def _as_local_timezone(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]
     return validate
 
 
-def _is_sorted(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Verify that the specified values are sequential."""
+def _has_duration(
+    start_key: str, end_key: str
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that the time span between start and end is positive."""
 
     def validate(obj: dict[str, Any]) -> dict[str, Any]:
         """Test that all keys in the dict are in order."""
-        values = []
-        for k in keys:
-            if not (value := obj.get(k)):
-                return obj
-            values.append(value)
-        if all(values) and values != sorted(values):
-            raise vol.Invalid(f"Values were not in order: {values}")
+        if (start := obj.get(start_key)) and (end := obj.get(end_key)):
+            duration = end - start
+            if duration.total_seconds() <= 0:
+                raise vol.Invalid(f"Expected positive event duration ({start}, {end})")
         return obj
 
     return validate
+
+
+def _has_same_type(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Verify that all values are of the same type."""
+
+    def validate(obj: dict[str, Any]) -> dict[str, Any]:
+        """Test that all keys in the dict have values of the same type."""
+        uniq_values = groupby(type(obj[k]) for k in keys)
+        if len(list(uniq_values)) > 1:
+            raise vol.Invalid(f"Expected all values to be the same type: {keys}")
+        return obj
+
+    return validate
+
+
+def _validate_rrule(value: Any) -> str:
+    """Validate a recurrence rule string."""
+    if value is None:
+        raise vol.Invalid("rrule value is None")
+
+    if not isinstance(value, str):
+        raise vol.Invalid("rrule value expected a string")
+
+    try:
+        rrulestr(value)
+    except ValueError as err:
+        raise vol.Invalid(f"Invalid rrule: {str(err)}") from err
+
+    # Example format: FREQ=DAILY;UNTIL=...
+    rule_parts = dict(s.split("=", 1) for s in value.split(";"))
+    if not (freq := rule_parts.get("FREQ")):
+        raise vol.Invalid("rrule did not contain FREQ")
+
+    if freq not in VALID_FREQS:
+        raise vol.Invalid(f"Invalid frequency for rule: {value}")
+
+    return str(value)
 
 
 CREATE_EVENT_SERVICE = "create_event"
@@ -149,8 +202,42 @@ CREATE_EVENT_SCHEMA = vol.All(
     ),
     _has_consistent_timezone(EVENT_START_DATETIME, EVENT_END_DATETIME),
     _as_local_timezone(EVENT_START_DATETIME, EVENT_END_DATETIME),
-    _is_sorted(EVENT_START_DATE, EVENT_END_DATE),
-    _is_sorted(EVENT_START_DATETIME, EVENT_END_DATETIME),
+    _has_duration(EVENT_START_DATE, EVENT_END_DATE),
+    _has_duration(EVENT_START_DATETIME, EVENT_END_DATETIME),
+)
+
+WEBSOCKET_EVENT_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            vol.Required(EVENT_START): vol.Any(cv.date, cv.datetime),
+            vol.Required(EVENT_END): vol.Any(cv.date, cv.datetime),
+            vol.Required(EVENT_SUMMARY): cv.string,
+            vol.Optional(EVENT_DESCRIPTION): cv.string,
+            vol.Optional(EVENT_RRULE): _validate_rrule,
+        },
+        _has_same_type(EVENT_START, EVENT_END),
+        _has_consistent_timezone(EVENT_START, EVENT_END),
+        _as_local_timezone(EVENT_START, EVENT_END),
+        _has_duration(EVENT_START, EVENT_END),
+    )
+)
+
+# Validation for the CalendarEvent dataclass
+CALENDAR_EVENT_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            vol.Required("start"): vol.Any(cv.date, cv.datetime),
+            vol.Required("end"): vol.Any(cv.date, cv.datetime),
+            vol.Required(EVENT_SUMMARY): cv.string,
+            vol.Optional(EVENT_RRULE): _validate_rrule,
+        },
+        _has_same_type("start", "end"),
+        _has_timezone("start", "end"),
+        _has_consistent_timezone("start", "end"),
+        _as_local_timezone("start", "end"),
+        _has_duration("start", "end"),
+    ),
+    extra=vol.ALLOW_EXTRA,
 )
 
 
@@ -243,6 +330,19 @@ class CalendarEvent:
             "all_day": self.all_day,
         }
 
+    def __post_init__(self) -> None:
+        """Perform validation on the CalendarEvent."""
+
+        def skip_none(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
+            return {k: v for k, v in obj if v is not None}
+
+        try:
+            CALENDAR_EVENT_SCHEMA(dataclasses.asdict(self, dict_factory=skip_none))
+        except vol.Invalid as err:
+            raise HomeAssistantError(
+                f"Failed to validate CalendarEvent: {err}"
+            ) from err
+
 
 def _event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, str]:
     """Convert CalendarEvent dataclass items to dictionary of attributes."""
@@ -314,30 +414,6 @@ def is_offset_reached(
     if offset_time == datetime.timedelta():
         return False
     return start + offset_time <= dt.now(start.tzinfo)
-
-
-def _validate_rrule(value: Any) -> str:
-    """Validate a recurrence rule string."""
-    if value is None:
-        raise vol.Invalid("rrule value is None")
-
-    if not isinstance(value, str):
-        raise vol.Invalid("rrule value expected a string")
-
-    try:
-        rrulestr(value)
-    except ValueError as err:
-        raise vol.Invalid(f"Invalid rrule: {str(err)}") from err
-
-    # Example format: FREQ=DAILY;UNTIL=...
-    rule_parts = dict(s.split("=", 1) for s in value.split(";"))
-    if not (freq := rule_parts.get("FREQ")):
-        raise vol.Invalid("rrule did not contain FREQ")
-
-    if freq not in VALID_FREQS:
-        raise vol.Invalid(f"Invalid frequency for rule: {value}")
-
-    return str(value)
 
 
 class CalendarEntity(Entity):
@@ -447,6 +523,7 @@ class CalendarEventView(http.HomeAssistantView):
                 request.app["hass"], start_date, end_date
             )
         except HomeAssistantError as err:
+            _LOGGER.debug("Error reading events: %s", err)
             return self.json_message(
                 f"Error reading events: {err}", HTTPStatus.INTERNAL_SERVER_ERROR
             )
@@ -481,38 +558,11 @@ class CalendarListView(http.HomeAssistantView):
         return self.json(sorted(calendar_list, key=lambda x: cast(str, x["name"])))
 
 
-def _has_same_type(*keys: Any) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Verify that all values are of the same type."""
-
-    def validate(obj: dict[str, Any]) -> dict[str, Any]:
-        """Test that all keys in the dict have values of the same type."""
-        uniq_values = groupby(type(obj[k]) for k in keys)
-        if len(list(uniq_values)) > 1:
-            raise vol.Invalid(f"Expected all values to be the same type: {keys}")
-        return obj
-
-    return validate
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "calendar/event/create",
         vol.Required("entity_id"): cv.entity_id,
-        CONF_EVENT: vol.Schema(
-            vol.All(
-                {
-                    vol.Required(EVENT_START): vol.Any(cv.date, cv.datetime),
-                    vol.Required(EVENT_END): vol.Any(cv.date, cv.datetime),
-                    vol.Required(EVENT_SUMMARY): cv.string,
-                    vol.Optional(EVENT_DESCRIPTION): cv.string,
-                    vol.Optional(EVENT_RRULE): _validate_rrule,
-                },
-                _has_same_type(EVENT_START, EVENT_END),
-                _has_consistent_timezone(EVENT_START, EVENT_END),
-                _as_local_timezone(EVENT_START, EVENT_END),
-                _is_sorted(EVENT_START, EVENT_END),
-            )
-        ),
+        CONF_EVENT: WEBSOCKET_EVENT_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -595,21 +645,7 @@ async def handle_calendar_event_delete(
         vol.Required(EVENT_UID): cv.string,
         vol.Optional(EVENT_RECURRENCE_ID): cv.string,
         vol.Optional(EVENT_RECURRENCE_RANGE): cv.string,
-        vol.Required(CONF_EVENT): vol.Schema(
-            vol.All(
-                {
-                    vol.Required(EVENT_START): vol.Any(cv.date, cv.datetime),
-                    vol.Required(EVENT_END): vol.Any(cv.date, cv.datetime),
-                    vol.Required(EVENT_SUMMARY): cv.string,
-                    vol.Optional(EVENT_DESCRIPTION): cv.string,
-                    vol.Optional(EVENT_RRULE): _validate_rrule,
-                },
-                _has_same_type(EVENT_START, EVENT_END),
-                _has_consistent_timezone(EVENT_START, EVENT_END),
-                _as_local_timezone(EVENT_START, EVENT_END),
-                _is_sorted(EVENT_START, EVENT_END),
-            )
-        ),
+        vol.Required(CONF_EVENT): WEBSOCKET_EVENT_SCHEMA,
     }
 )
 @websocket_api.async_response

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -324,7 +324,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
                 "end_date_time": "2022-04-01T06:00:00",
             },
             vol.error.MultipleInvalid,
-            "Values were not in order",
+            "Expected positive event duration",
         ),
         (
             {
@@ -332,7 +332,15 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
                 "end_date": "2022-04-01",
             },
             vol.error.MultipleInvalid,
-            "Values were not in order",
+            "Expected positive event duration",
+        ),
+        (
+            {
+                "start_date": "2022-04-01",
+                "end_date": "2022-04-01",
+            },
+            vol.error.MultipleInvalid,
+            "Expected positive event duration",
         ),
     ],
     ids=[
@@ -351,6 +359,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
         "inconsistent_timezone",
         "incorrect_date_order",
         "incorrect_datetime_order",
+        "dates_not_exclusive",
     ],
 )
 async def test_create_event_service_invalid_params(

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -597,7 +597,7 @@ async def test_add_event_failure(
 
     with pytest.raises(HomeAssistantError):
         await add_event_call_service(
-            {"start_date": "2022-05-01", "end_date": "2022-05-01"}
+            {"start_date": "2022-05-01", "end_date": "2022-05-02"}
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `calendar.create_event` service now enforces that start and end dates are exclusive. This has always been part of the specification, but was not clearly documented and enforced.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add additional CalendarEvent validation to verify the following:
- `CalendarEvent` objects are created with many of the same validation rules as the websocket and service. This uses the config validation to share validation rules between them.
- `CalendarEvent` with a `datetime` must be specified with a timezone, and can be a timezone other than UTC. No floating times are allowed.
- Start and end dates must be exclusive everywhere (websocket, service, and `CalendarEvent` objects. We could decide to allow all day events with the same start/end date, however I think it may prevent bugs to be more strict here. (In the future we could introduce a `duration` if we wanted to make this easier for users). For now, this is just enforcing todays standard. The previously logic only checked if events were sorted correctly, but is now simplified to check the event duration.

This PR includes fixes fore:
- `caldav` behavior which has tests for dates that have the same start and end. To be conservative, these have been coerced in the integration to still work.  I thought it might be worth being more conservative here given the broad set of caldav servers.
- `google` which had a test case that has been updated to use exclusive end dates.

Note that some of the validations of timezones and exclusive dates have been previously adjusted in these PRs:
- https://github.com/home-assistant/core/pull/88650 - Always passes a timezone
- https://github.com/home-assistant/core/pull/84955 - Always passes a timezone
- https://github.com/home-assistant/core/pull/89028 - Always passes exclusive end dates

Related discussion: https://github.com/home-assistant/architecture/discussions/853


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26558 https://github.com/home-assistant/developers.home-assistant/pull/1709

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
