### PR TITLE
Add window open mode for fritz climate

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -27,6 +27,7 @@ from .const import (
     ATTR_STATE_HOLIDAY_MODE,
     ATTR_STATE_SUMMER_MODE,
     ATTR_STATE_WINDOW_OPEN,
+    ATTR_STATE_WINDOW_OPEN_ENDTIME,
     CONF_COORDINATOR,
     DOMAIN as FRITZBOX_DOMAIN,
 )
@@ -37,7 +38,7 @@ OPERATION_LIST = [HVACMode.HEAT, HVACMode.OFF]
 MIN_TEMPERATURE = 8
 MAX_TEMPERATURE = 28
 
-PRESET_MANUAL = "manual"
+PRESET_WINDOW_OPEN = "Window open"
 
 # special temperatures for on/off in Fritz!Box API (modified by pyfritzhome)
 ON_API_TEMPERATURE = 127.0
@@ -100,6 +101,16 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             )
         await self.coordinator.async_refresh()
 
+    async def async_set_window_open(self, window_open: bool) -> None:
+        """Set the thermostate to off (window open) for a pre defined time."""
+        if window_open:
+            timeout = 60 * 15
+        else:
+            timeout = 0
+
+        await self.hass.async_add_executor_job(self.data.set_window_open, timeout)
+        await self.coordinator.async_refresh()
+
     @property
     def hvac_mode(self) -> HVACMode:
         """Return the current operation mode."""
@@ -126,6 +137,8 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return current preset mode."""
+        if self.data.window_open:
+            return PRESET_WINDOW_OPEN
         if self.data.target_temperature == self.data.comfort_temperature:
             return PRESET_COMFORT
         if self.data.target_temperature == self.data.eco_temperature:
@@ -135,7 +148,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
     @property
     def preset_modes(self) -> list[str]:
         """Return supported preset modes."""
-        return [PRESET_ECO, PRESET_COMFORT]
+        return [PRESET_ECO, PRESET_COMFORT, PRESET_WINDOW_OPEN]
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode."""
@@ -143,6 +156,11 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             await self.async_set_temperature(temperature=self.data.comfort_temperature)
         elif preset_mode == PRESET_ECO:
             await self.async_set_temperature(temperature=self.data.eco_temperature)
+
+        if preset_mode == PRESET_WINDOW_OPEN:
+            await self.async_set_window_open(True)
+        else:
+            await self.async_set_window_open(False)
 
     @property
     def min_temp(self) -> int:
@@ -170,5 +188,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             attrs[ATTR_STATE_SUMMER_MODE] = self.data.summer_active
         if self.data.window_open is not None:
             attrs[ATTR_STATE_WINDOW_OPEN] = self.data.window_open
+        if self.data.window_open_endtime is not None:
+            attrs[ATTR_STATE_WINDOW_OPEN_ENDTIME] = self.data.window_open_endtime
 
         return attrs

--- a/homeassistant/components/fritzbox/const.py
+++ b/homeassistant/components/fritzbox/const.py
@@ -10,6 +10,7 @@ ATTR_STATE_BATTERY_LOW: Final = "battery_low"
 ATTR_STATE_HOLIDAY_MODE: Final = "holiday_mode"
 ATTR_STATE_SUMMER_MODE: Final = "summer_mode"
 ATTR_STATE_WINDOW_OPEN: Final = "window_open"
+ATTR_STATE_WINDOW_OPEN_ENDTIME: Final = "window_open_endtime"
 
 COLOR_MODE: Final = "1"
 COLOR_TEMP_MODE: Final = "4"

--- a/homeassistant/components/fritzbox/model.py
+++ b/homeassistant/components/fritzbox/model.py
@@ -16,6 +16,7 @@ class ClimateExtraAttributes(TypedDict, total=False):
     holiday_mode: bool
     summer_mode: bool
     window_open: bool
+    window_open_endtime: float
 
 
 @dataclass

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -96,7 +96,7 @@ class FritzDeviceClimateMock(FritzEntityBaseMock):
     present = True
     summer_active = "fake_summer"
     target_temperature = 19.5
-    window_open = "fake_window"
+    window_open = False
     nextchange_temperature = 22.0
     nextchange_endperiod = 0
     nextchange_preset = PRESET_COMFORT

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -20,6 +20,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
+from homeassistant.components.fritzbox.climate import PRESET_WINDOW_OPEN
 from homeassistant.components.fritzbox.const import (
     ATTR_STATE_BATTERY_LOW,
     ATTR_STATE_HOLIDAY_MODE,
@@ -65,11 +66,15 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     assert state.attributes[ATTR_MAX_TEMP] == 28
     assert state.attributes[ATTR_MIN_TEMP] == 8
     assert state.attributes[ATTR_PRESET_MODE] is None
-    assert state.attributes[ATTR_PRESET_MODES] == [PRESET_ECO, PRESET_COMFORT]
+    assert state.attributes[ATTR_PRESET_MODES] == [
+        PRESET_ECO,
+        PRESET_COMFORT,
+        PRESET_WINDOW_OPEN,
+    ]
     assert state.attributes[ATTR_STATE_BATTERY_LOW] is True
     assert state.attributes[ATTR_STATE_HOLIDAY_MODE] == "fake_holiday"
     assert state.attributes[ATTR_STATE_SUMMER_MODE] == "fake_summer"
-    assert state.attributes[ATTR_STATE_WINDOW_OPEN] == "fake_window"
+    assert state.attributes[ATTR_STATE_WINDOW_OPEN] is False
     assert state.attributes[ATTR_TEMPERATURE] == 19.5
     assert ATTR_STATE_CLASS not in state.attributes
     assert state.state == HVACMode.HEAT
@@ -366,6 +371,22 @@ async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock) -> None:
         True,
     )
     assert device.set_target_temperature.call_args_list == [call(16)]
+
+
+async def test_set_preset_mode_window_open(hass: HomeAssistant, fritz: Mock) -> None:
+    """Test setting preset mode."""
+    device = FritzDeviceClimateMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_PRESET_MODE: PRESET_WINDOW_OPEN},
+        True,
+    )
+    assert device.set_window_open.call_args_list == [call(900)]
 
 
 async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This enables setting window open mode for fritz home via home assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other in this repository.

Yes: See #89150, #89152

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
