### PR TITLE
Fix flux_led set time to not happen during DST switch

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -209,7 +209,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await device.async_set_time()
 
     await _async_sync_time()  # set at startup
-    entry.async_on_unload(async_track_time_change(hass, _async_sync_time, 2, 40, 30))
+    entry.async_on_unload(async_track_time_change(hass, _async_sync_time, 3, 40, 30))
 
     # There must not be any awaits between here and the return
     # to avoid a race condition where the add_update_listener is not

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -236,7 +236,7 @@ async def test_time_sync_startup_and_next_day(hass: HomeAssistant) -> None:
         assert config_entry.state == ConfigEntryState.LOADED
 
     assert len(bulb.async_set_time.mock_calls) == 1
-    async_fire_time_changed(hass, utcnow() + timedelta(hours=48))
+    async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
     await hass.async_block_till_done()
     assert len(bulb.async_set_time.mock_calls) == 2
 

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -236,7 +236,7 @@ async def test_time_sync_startup_and_next_day(hass: HomeAssistant) -> None:
         assert config_entry.state == ConfigEntryState.LOADED
 
     assert len(bulb.async_set_time.mock_calls) == 1
-    async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
+    async_fire_time_changed(hass, utcnow() + timedelta(hours=48))
     await hass.async_block_till_done()
     assert len(bulb.async_set_time.mock_calls) == 2
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
flux_led will now sync time at 03:40:20 instead of 02:40:20 to ensure its always doing so at a time that exists due to DST

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
