### PR TITLE
Fix imap_email_content unknown status and replaying stale states

### DIFF
--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -101,12 +101,12 @@ class EmailReader:
 
     @property
     def last_id(self) -> int | None:
-        """The last email uid that was processed."""
+        """Return last email uid that was processed."""
         return self._last_id
 
     @property
     def last_unread_id(self) -> int | None:
-        """The last email uid received."""
+        """Return last email uid received."""
         if self._unread_ids:
             return max(int(uid) for uid in self._unread_ids)
         return self._last_id

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -95,8 +95,21 @@ class EmailReader:
         self._folder = folder
         self._verify_ssl = verify_ssl
         self._last_id = None
+        self._last_message = None
         self._unread_ids = deque([])
         self.connection = None
+
+    @property
+    def last_id(self) -> int | None:
+        """The last email uid that was processed."""
+        return self._last_id
+
+    @property
+    def last_unread_id(self) -> int | None:
+        """The last email uid received."""
+        if self._unread_ids:
+            return max(int(uid) for uid in self._unread_ids)
+        return self._last_id
 
     def connect(self):
         """Login and setup the connection."""
@@ -128,21 +141,21 @@ class EmailReader:
         try:
             self.connection.select(self._folder, readonly=True)
 
-            if not self._unread_ids:
-                search = f"SINCE {datetime.date.today():%d-%b-%Y}"
-                if self._last_id is not None:
-                    search = f"UID {self._last_id}:*"
+            if self._last_id is None:
+                # search for today and yesterday
+                time_from = datetime.datetime.now() - datetime.timedelta(days=1)
+                search = f"SINCE {time_from:%d-%b-%Y}"
+            else:
+                search = f"UID {self._last_id}:*"
 
-                _, data = self.connection.uid("search", None, search)
-                self._unread_ids = deque(data[0].split())
-
+            _, data = self.connection.uid("search", None, search)
+            self._unread_ids = deque(data[0].split())
             while self._unread_ids:
                 message_uid = self._unread_ids.popleft()
                 if self._last_id is None or int(message_uid) > self._last_id:
                     self._last_id = int(message_uid)
-                    return self._fetch_message(message_uid)
-
-            return self._fetch_message(str(self._last_id))
+                    self._last_message = self._fetch_message(message_uid)
+                    return self._last_message
 
         except imaplib.IMAP4.error:
             _LOGGER.info("Connection to %s lost, attempting to reconnect", self._server)
@@ -254,22 +267,30 @@ class EmailContentSensor(SensorEntity):
     def update(self) -> None:
         """Read emails and publish state change."""
         email_message = self._email_reader.read_next()
+        while (
+            self._last_id is None or self._last_id != self._email_reader.last_unread_id
+        ):
+            if email_message is None:
+                self._message = None
+                self._state_attributes = {}
+                return
 
-        if email_message is None:
-            self._message = None
-            self._state_attributes = {}
-            return
+            self._last_id = self._email_reader.last_id
 
-        if self.sender_allowed(email_message):
-            message = EmailContentSensor.get_msg_subject(email_message)
+            if self.sender_allowed(email_message):
+                message = EmailContentSensor.get_msg_subject(email_message)
 
-            if self._value_template is not None:
-                message = self.render_template(email_message)
+                if self._value_template is not None:
+                    message = self.render_template(email_message)
 
-            self._message = message
-            self._state_attributes = {
-                ATTR_FROM: EmailContentSensor.get_msg_sender(email_message),
-                ATTR_SUBJECT: EmailContentSensor.get_msg_subject(email_message),
-                ATTR_DATE: email_message["Date"],
-                ATTR_BODY: EmailContentSensor.get_msg_text(email_message),
-            }
+                self._message = message
+                self._state_attributes = {
+                    ATTR_FROM: EmailContentSensor.get_msg_sender(email_message),
+                    ATTR_SUBJECT: EmailContentSensor.get_msg_subject(email_message),
+                    ATTR_DATE: email_message["Date"],
+                    ATTR_BODY: EmailContentSensor.get_msg_text(email_message),
+                }
+
+            if self._last_id == self._email_reader.last_unread_id:
+                break
+            email_message = self._email_reader.read_next()

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -107,8 +107,11 @@ class EmailReader:
     @property
     def last_unread_id(self) -> int | None:
         """Return last email uid received."""
+        # We assume the last id in the list is the last unread id
+        # We cannot know if that is the newest one, because it could arrive later
+        # https://stackoverflow.com/questions/12409862/python-imap-the-order-of-uids
         if self._unread_ids:
-            return max(int(uid) for uid in self._unread_ids)
+            return int(self._unread_ids[-1])
         return self._last_id
 
     def connect(self):

--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -14,9 +14,16 @@ from homeassistant.helpers.template import Template
 class FakeEMailReader:
     """A test class for sending test emails."""
 
-    def __init__(self, messages):
+    def __init__(self, messages) -> None:
         """Set up the fake email reader."""
         self._messages = messages
+        self.last_id = 0
+        self.last_unread_id = len(messages)
+
+    def add_test_message(self, message):
+        """Add a new message."""
+        self.last_unread_id += 1
+        self._messages.append(message)
 
     def connect(self):
         """Stay always Connected."""
@@ -26,6 +33,7 @@ class FakeEMailReader:
         """Get the next email."""
         if len(self._messages) == 0:
             return None
+        self.last_id += 1
         return self._messages.popleft()
 
 
@@ -146,7 +154,7 @@ async def test_multi_part_only_other_text(hass: HomeAssistant) -> None:
 
 
 async def test_multiple_emails(hass: HomeAssistant) -> None:
-    """Test multiple emails."""
+    """Test multiple emails, discarding stale states."""
     states = []
 
     test_message1 = email.message.Message()
@@ -158,8 +166,14 @@ async def test_multiple_emails(hass: HomeAssistant) -> None:
     test_message2 = email.message.Message()
     test_message2["From"] = "sender@test.com"
     test_message2["Subject"] = "Test 2"
-    test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 58)
     test_message2.set_payload("Test Message 2")
+
+    test_message3 = email.message.Message()
+    test_message3["From"] = "sender@test.com"
+    test_message3["Subject"] = "Test 3"
+    test_message3["Date"] = datetime.datetime(2016, 1, 1, 12, 50, 1)
+    test_message3.set_payload("Test Message 2")
 
     def state_changed_listener(entity_id, from_s, to_s):
         states.append(to_s)
@@ -178,11 +192,13 @@ async def test_multiple_emails(hass: HomeAssistant) -> None:
 
     sensor.async_schedule_update_ha_state(True)
     await hass.async_block_till_done()
+    # Fake a new received message
+    sensor._email_reader.add_test_message(test_message3)
     sensor.async_schedule_update_ha_state(True)
     await hass.async_block_till_done()
 
-    assert states[0].state == "Test"
-    assert states[1].state == "Test 2"
+    assert states[0].state == "Test 2"
+    assert states[1].state == "Test 3"
 
     assert sensor.extra_state_attributes["body"] == "Test Message 2"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Only for the last valid mail the state is updated at startup.
During startup emails received since `yesterday` are examined, this was since `today`.
The state will not become `unknown` if no new messages are received after a previous valid state, unless home_assistant is restarted.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes the startup behaviour for the `imap_email_content` sensor platform.
- Emails are examined for `today` and `yesterday`, this avoids `unknown` states when the date is changing and there is not an update email to process yet.
- Only for the last valid received mail the sensor state is updated.

### Note
The `imap_email_content` sensor misses an option that allows to set wat retain period the last state message should have. Now this is min 1 day, and max 2 days.
To allow further improvements this integration should be updated to be set up using config flow. A PR was opened for this :  #89707.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86388
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
