### PR TITLE
Refactor recorder tests to use recorder history API

### DIFF
--- a/tests/components/automation/test_recorder.py
+++ b/tests/components/automation/test_recorder.py
@@ -12,11 +12,11 @@ from homeassistant.components.automation import (
     CONF_ID,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_mock_service
 from tests.components.recorder.common import async_wait_recording_done
@@ -32,6 +32,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, calls
 ) -> None:
     """Test automation registered attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -49,25 +50,13 @@ async def test_exclude_attributes(
     assert ["hello.world"] == calls[0].data.get(ATTR_ENTITY_ID)
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_LAST_TRIGGERED not in state.attributes
-        assert ATTR_MODE not in state.attributes
-        assert ATTR_CUR not in state.attributes
-        assert CONF_ID not in state.attributes
-        assert ATTR_MAX not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) == 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_LAST_TRIGGERED not in state.attributes
+            assert ATTR_MODE not in state.attributes
+            assert ATTR_CUR not in state.attributes
+            assert CONF_ID not in state.attributes
+            assert ATTR_MAX not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/calendar/test_recorder.py
+++ b/tests/components/calendar/test_recorder.py
@@ -2,10 +2,9 @@
 from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -15,6 +14,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test sensor attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
@@ -28,21 +28,9 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert ATTR_FRIENDLY_NAME in state.attributes
-        assert "description" not in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_FRIENDLY_NAME in state.attributes
+            assert "description" not in state.attributes

--- a/tests/components/camera/test_recorder.py
+++ b/tests/components/camera/test_recorder.py
@@ -5,15 +5,14 @@ from datetime import timedelta
 
 from homeassistant.components import camera
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -23,6 +22,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test camera registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
@@ -31,24 +31,12 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_camera_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_camera_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert "access_token" not in state.attributes
-        assert ATTR_ENTITY_PICTURE not in state.attributes
-        assert ATTR_ATTRIBUTION not in state.attributes
-        assert ATTR_SUPPORTED_FEATURES not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert "access_token" not in state.attributes
+            assert ATTR_ENTITY_PICTURE not in state.attributes
+            assert ATTR_ATTRIBUTION not in state.attributes
+            assert ATTR_SUPPORTED_FEATURES not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/climate/test_recorder.py
+++ b/tests/components/climate/test_recorder.py
@@ -16,10 +16,9 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_STEP,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -29,6 +28,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test climate registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, climate.DOMAIN, {climate.DOMAIN: {"platform": "demo"}}
     )
@@ -37,29 +37,17 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert ATTR_PRESET_MODES not in state.attributes
-        assert ATTR_HVAC_MODES not in state.attributes
-        assert ATTR_FAN_MODES not in state.attributes
-        assert ATTR_SWING_MODES not in state.attributes
-        assert ATTR_MIN_TEMP not in state.attributes
-        assert ATTR_MAX_TEMP not in state.attributes
-        assert ATTR_MIN_HUMIDITY not in state.attributes
-        assert ATTR_MAX_HUMIDITY not in state.attributes
-        assert ATTR_TARGET_TEMP_STEP not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_PRESET_MODES not in state.attributes
+            assert ATTR_HVAC_MODES not in state.attributes
+            assert ATTR_FAN_MODES not in state.attributes
+            assert ATTR_SWING_MODES not in state.attributes
+            assert ATTR_MIN_TEMP not in state.attributes
+            assert ATTR_MAX_TEMP not in state.attributes
+            assert ATTR_MIN_HUMIDITY not in state.attributes
+            assert ATTR_MAX_HUMIDITY not in state.attributes
+            assert ATTR_TARGET_TEMP_STEP not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/fan/test_recorder.py
+++ b/tests/components/fan/test_recorder.py
@@ -6,10 +6,9 @@ from datetime import timedelta
 from homeassistant.components import fan
 from homeassistant.components.fan import ATTR_PRESET_MODES
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,27 +18,16 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test fan registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(hass, fan.DOMAIN, {fan.DOMAIN: {"platform": "demo"}})
     await hass.async_block_till_done()
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert ATTR_PRESET_MODES not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_PRESET_MODES not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/group/test_recorder.py
+++ b/tests/components/group/test_recorder.py
@@ -6,10 +6,9 @@ from datetime import timedelta
 from homeassistant.components import group
 from homeassistant.components.group import ATTR_AUTO, ATTR_ENTITY_ID, ATTR_ORDER
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,6 +18,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test number registered attributes to be excluded."""
+    now = dt_util.utcnow()
     hass.states.async_set("light.bowl", STATE_ON)
 
     assert await async_setup_component(hass, "light", {})
@@ -38,27 +38,12 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            attr_ids = {}
-            for db_state_attributes in session.query(StateAttributes):
-                attr_ids[
-                    db_state_attributes.attributes_id
-                ] = db_state_attributes.to_native()
-            for db_state, _ in session.query(States, StateAttributes).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = attr_ids[db_state.attributes_id]
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        if state.domain == group.DOMAIN:
-            assert ATTR_AUTO not in state.attributes
-            assert ATTR_ENTITY_ID not in state.attributes
-            assert ATTR_ORDER not in state.attributes
-            assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            if split_entity_id(state.entity_id)[0] == group.DOMAIN:
+                assert ATTR_AUTO not in state.attributes
+                assert ATTR_ENTITY_ID not in state.attributes
+                assert ATTR_ORDER not in state.attributes
+                assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/humidifier/test_recorder.py
+++ b/tests/components/humidifier/test_recorder.py
@@ -10,10 +10,9 @@ from homeassistant.components.humidifier import (
     ATTR_MIN_HUMIDITY,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -23,6 +22,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test humidifier registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, humidifier.DOMAIN, {humidifier.DOMAIN: {"platform": "demo"}}
     )
@@ -31,23 +31,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert ATTR_MIN_HUMIDITY not in state.attributes
-        assert ATTR_MAX_HUMIDITY not in state.attributes
-        assert ATTR_AVAILABLE_MODES not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_MIN_HUMIDITY not in state.attributes
+            assert ATTR_MAX_HUMIDITY not in state.attributes
+            assert ATTR_AVAILABLE_MODES not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/input_boolean/test_recorder.py
+++ b/tests/components/input_boolean/test_recorder.py
@@ -5,10 +5,9 @@ from datetime import timedelta
 
 from homeassistant.components.input_boolean import DOMAIN
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,6 +19,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 
     state = hass.states.get("input_boolean.test")
@@ -30,20 +30,8 @@ async def test_exclude_attributes(
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
-
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes

--- a/tests/components/input_button/test_recorder.py
+++ b/tests/components/input_button/test_recorder.py
@@ -5,10 +5,9 @@ from datetime import timedelta
 
 from homeassistant.components.input_button import DOMAIN
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,6 +19,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 
     state = hass.states.get("input_button.test")
@@ -31,19 +31,8 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes

--- a/tests/components/input_datetime/test_recorder.py
+++ b/tests/components/input_datetime/test_recorder.py
@@ -5,10 +5,9 @@ from datetime import timedelta
 
 from homeassistant.components.input_datetime import CONF_HAS_DATE, CONF_HAS_TIME, DOMAIN
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,6 +19,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {CONF_HAS_TIME: True}}}
     )
@@ -35,21 +35,10 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
-    assert CONF_HAS_DATE not in states[0].attributes
-    assert CONF_HAS_TIME not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes
+            assert CONF_HAS_DATE not in state.attributes
+            assert CONF_HAS_TIME not in state.attributes

--- a/tests/components/input_number/test_recorder.py
+++ b/tests/components/input_number/test_recorder.py
@@ -11,10 +11,9 @@ from homeassistant.components.input_number import (
     DOMAIN,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -26,6 +25,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {"min": 0, "max": 100}}}
     )
@@ -43,23 +43,12 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_MIN not in states[0].attributes
-    assert ATTR_MAX not in states[0].attributes
-    assert ATTR_STEP not in states[0].attributes
-    assert ATTR_MODE not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes
+            assert ATTR_MIN not in state.attributes
+            assert ATTR_MAX not in state.attributes
+            assert ATTR_STEP not in state.attributes
+            assert ATTR_MODE not in state.attributes

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -5,10 +5,9 @@ from datetime import timedelta
 
 from homeassistant.components.input_select import ATTR_OPTIONS, DOMAIN
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -20,6 +19,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -42,20 +42,9 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_OPTIONS in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes
+            assert ATTR_OPTIONS in state.attributes

--- a/tests/components/input_text/test_recorder.py
+++ b/tests/components/input_text/test_recorder.py
@@ -12,10 +12,9 @@ from homeassistant.components.input_text import (
     MODE_TEXT,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -27,6 +26,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})
 
     state = hass.states.get("input_text.test")
@@ -42,23 +42,12 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_MAX not in states[0].attributes
-    assert ATTR_MIN not in states[0].attributes
-    assert ATTR_MODE not in states[0].attributes
-    assert ATTR_PATTERN not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes
+            assert ATTR_MAX not in state.attributes
+            assert ATTR_MIN not in state.attributes
+            assert ATTR_MODE not in state.attributes
+            assert ATTR_PATTERN not in state.attributes

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -13,10 +13,9 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -26,6 +25,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test light registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {"platform": "demo"}}
     )
@@ -34,26 +34,14 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_MIN_MIREDS not in state.attributes
-        assert ATTR_MAX_MIREDS not in state.attributes
-        assert ATTR_SUPPORTED_COLOR_MODES not in state.attributes
-        assert ATTR_EFFECT not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
-        assert ATTR_MAX_COLOR_TEMP_KELVIN not in state.attributes
-        assert ATTR_MIN_COLOR_TEMP_KELVIN not in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_MIN_MIREDS not in state.attributes
+            assert ATTR_MAX_MIREDS not in state.attributes
+            assert ATTR_SUPPORTED_COLOR_MODES not in state.attributes
+            assert ATTR_EFFECT not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes
+            assert ATTR_MAX_COLOR_TEMP_KELVIN not in state.attributes
+            assert ATTR_MIN_COLOR_TEMP_KELVIN not in state.attributes

--- a/tests/components/media_player/test_recorder.py
+++ b/tests/components/media_player/test_recorder.py
@@ -12,10 +12,9 @@ from homeassistant.components.media_player import (
     ATTR_SOUND_MODE_LIST,
 )
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -25,6 +24,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test media_player registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, media_player.DOMAIN, {media_player.DOMAIN: {"platform": "demo"}}
     )
@@ -33,26 +33,14 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_ENTITY_PICTURE not in state.attributes
-        assert ATTR_ENTITY_PICTURE_LOCAL not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
-        assert ATTR_INPUT_SOURCE_LIST not in state.attributes
-        assert ATTR_MEDIA_POSITION not in state.attributes
-        assert ATTR_MEDIA_POSITION_UPDATED_AT not in state.attributes
-        assert ATTR_SOUND_MODE_LIST not in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_ENTITY_PICTURE not in state.attributes
+            assert ATTR_ENTITY_PICTURE_LOCAL not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes
+            assert ATTR_INPUT_SOURCE_LIST not in state.attributes
+            assert ATTR_MEDIA_POSITION not in state.attributes
+            assert ATTR_MEDIA_POSITION_UPDATED_AT not in state.attributes
+            assert ATTR_SOUND_MODE_LIST not in state.attributes

--- a/tests/components/number/test_recorder.py
+++ b/tests/components/number/test_recorder.py
@@ -6,10 +6,9 @@ from datetime import timedelta
 from homeassistant.components import number
 from homeassistant.components.number import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_STEP
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -23,28 +22,17 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
         hass, number.DOMAIN, {number.DOMAIN: {"platform": "demo"}}
     )
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    now = dt_util.utcnow()
+    async_fire_time_changed(hass, now + timedelta(minutes=5))
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
     assert len(states) > 1
-    for state in states:
-        assert ATTR_MIN not in state.attributes
-        assert ATTR_MAX not in state.attributes
-        assert ATTR_STEP not in state.attributes
-        assert ATTR_MODE not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_MIN not in state.attributes
+            assert ATTR_MAX not in state.attributes
+            assert ATTR_STEP not in state.attributes
+            assert ATTR_MODE not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.schedule.const import ATTR_NEXT_EVENT, DOMAIN
 from homeassistant.const import ATTR_EDITABLE, ATTR_FRIENDLY_NAME, ATTR_ICON
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -22,6 +21,7 @@ async def test_exclude_attributes(
     enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
+    now = dt_util.utcnow()
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -54,22 +54,11 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) == 1
-    assert ATTR_EDITABLE not in states[0].attributes
-    assert ATTR_FRIENDLY_NAME in states[0].attributes
-    assert ATTR_ICON in states[0].attributes
-    assert ATTR_NEXT_EVENT not in states[0].attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EDITABLE not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes
+            assert ATTR_ICON in state.attributes
+            assert ATTR_NEXT_EVENT not in state.attributes

--- a/tests/components/script/test_recorder.py
+++ b/tests/components/script/test_recorder.py
@@ -5,8 +5,7 @@ import pytest
 
 from homeassistant.components import script
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.script import (
     ATTR_CUR,
     ATTR_LAST_ACTION,
@@ -15,8 +14,9 @@ from homeassistant.components.script import (
     ATTR_MODE,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import Context, HomeAssistant, State, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_mock_service
 from tests.components.recorder.common import async_wait_recording_done
@@ -32,6 +32,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, calls
 ) -> None:
     """Test automation registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await hass.async_block_till_done()
     calls = []
     context = Context()
@@ -65,25 +66,13 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
     assert len(calls) == 1
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_LAST_TRIGGERED not in state.attributes
-        assert ATTR_MODE not in state.attributes
-        assert ATTR_CUR not in state.attributes
-        assert ATTR_LAST_ACTION not in state.attributes
-        assert ATTR_MAX not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_LAST_TRIGGERED not in state.attributes
+            assert ATTR_MODE not in state.attributes
+            assert ATTR_CUR not in state.attributes
+            assert ATTR_LAST_ACTION not in state.attributes
+            assert ATTR_MAX not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/select/test_recorder.py
+++ b/tests/components/select/test_recorder.py
@@ -5,11 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components import select
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,6 +18,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test select registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, select.DOMAIN, {select.DOMAIN: {"platform": "demo"}}
     )
@@ -27,21 +27,9 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_OPTIONS not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_OPTIONS not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/siren/test_recorder.py
+++ b/tests/components/siren/test_recorder.py
@@ -5,11 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components import siren
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.siren import ATTR_AVAILABLE_TONES
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,6 +18,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test siren registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, siren.DOMAIN, {siren.DOMAIN: {"platform": "demo"}}
     )
@@ -27,21 +27,9 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_AVAILABLE_TONES not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_AVAILABLE_TONES not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.sun import (
     DOMAIN,
     STATE_ATTR_AZIMUTH,
@@ -19,7 +18,7 @@ from homeassistant.components.sun import (
     STATE_ATTR_RISING,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -29,35 +28,24 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test sun attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_sun_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_sun_states)
-    assert len(states) > 1
-    for state in states:
-        assert STATE_ATTR_AZIMUTH not in state.attributes
-        assert STATE_ATTR_ELEVATION not in state.attributes
-        assert STATE_ATTR_NEXT_DAWN not in state.attributes
-        assert STATE_ATTR_NEXT_DUSK not in state.attributes
-        assert STATE_ATTR_NEXT_MIDNIGHT not in state.attributes
-        assert STATE_ATTR_NEXT_NOON not in state.attributes
-        assert STATE_ATTR_NEXT_RISING not in state.attributes
-        assert STATE_ATTR_NEXT_SETTING not in state.attributes
-        assert STATE_ATTR_RISING not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert STATE_ATTR_AZIMUTH not in state.attributes
+            assert STATE_ATTR_ELEVATION not in state.attributes
+            assert STATE_ATTR_NEXT_DAWN not in state.attributes
+            assert STATE_ATTR_NEXT_DUSK not in state.attributes
+            assert STATE_ATTR_NEXT_MIDNIGHT not in state.attributes
+            assert STATE_ATTR_NEXT_NOON not in state.attributes
+            assert STATE_ATTR_NEXT_RISING not in state.attributes
+            assert STATE_ATTR_NEXT_SETTING not in state.attributes
+            assert STATE_ATTR_RISING not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/text/test_recorder.py
+++ b/tests/components/text/test_recorder.py
@@ -5,11 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components import text
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.text import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_PATTERN
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,28 +18,17 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test siren registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(hass, text.DOMAIN, {text.DOMAIN: {"platform": "demo"}})
     await hass.async_block_till_done()
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        for attr in (ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_PATTERN):
-            assert attr not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            for attr in (ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_PATTERN):
+                assert attr not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -7,8 +7,7 @@ from unittest.mock import Mock
 from pyunifiprotect.data import Camera, Event, EventType
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.unifiprotect.binary_sensor import EVENT_SENSORS
 from homeassistant.components.unifiprotect.const import (
     ATTR_EVENT_ID,
@@ -16,7 +15,7 @@ from homeassistant.components.unifiprotect.const import (
     DEFAULT_ATTRIBUTION,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, STATE_ON, Platform
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 
 from .utils import MockUFPFixture, ids_from_device_description, init_entry
 
@@ -32,7 +31,7 @@ async def test_exclude_attributes(
     fixed_now: datetime,
 ) -> None:
     """Test binary_sensor has event_id and event_score excluded from recording."""
-
+    now = fixed_now
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
 
     _, entity_id = ids_from_device_description(
@@ -70,22 +69,10 @@ async def test_exclude_attributes(
     assert state.attributes[ATTR_EVENT_SCORE] == 100
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_EVENT_SCORE not in state.attributes
-        assert ATTR_EVENT_ID not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_EVENT_SCORE not in state.attributes
+            assert ATTR_EVENT_ID not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.update.const import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -13,7 +12,7 @@ from homeassistant.components.update.const import (
     DOMAIN,
 )
 from homeassistant.const import ATTR_ENTITY_PICTURE, CONF_PLATFORM
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -25,6 +24,7 @@ async def test_exclude_attributes(
     recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
 ) -> None:
     """Test update attributes to be excluded."""
+    now = dt_util.utcnow()
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
@@ -42,23 +42,11 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_ENTITY_PICTURE not in state.attributes
-        assert ATTR_IN_PROGRESS not in state.attributes
-        assert ATTR_RELEASE_SUMMARY not in state.attributes
-        assert ATTR_INSTALLED_VERSION in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_ENTITY_PICTURE not in state.attributes
+            assert ATTR_IN_PROGRESS not in state.attributes
+            assert ATTR_RELEASE_SUMMARY not in state.attributes
+            assert ATTR_INSTALLED_VERSION in state.attributes

--- a/tests/components/vacuum/test_recorder.py
+++ b/tests/components/vacuum/test_recorder.py
@@ -5,11 +5,10 @@ from datetime import timedelta
 
 from homeassistant.components import vacuum
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.vacuum import ATTR_FAN_SPEED_LIST
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -19,6 +18,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test vacuum registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, vacuum.DOMAIN, {vacuum.DOMAIN: {"platform": "demo"}}
     )
@@ -27,21 +27,9 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_FAN_SPEED_LIST not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_FAN_SPEED_LIST not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/water_heater/test_recorder.py
+++ b/tests/components/water_heater/test_recorder.py
@@ -5,15 +5,14 @@ from datetime import timedelta
 
 from homeassistant.components import water_heater
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.water_heater import (
     ATTR_MAX_TEMP,
     ATTR_MIN_TEMP,
     ATTR_OPERATION_LIST,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -23,6 +22,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test water_heater registered attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(
         hass, water_heater.DOMAIN, {water_heater.DOMAIN: {"platform": "demo"}}
     )
@@ -31,23 +31,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_OPERATION_LIST not in state.attributes
-        assert ATTR_MIN_TEMP not in state.attributes
-        assert ATTR_MAX_TEMP not in state.attributes
-        assert ATTR_FRIENDLY_NAME in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_OPERATION_LIST not in state.attributes
+            assert ATTR_MIN_TEMP not in state.attributes
+            assert ATTR_MAX_TEMP not in state.attributes
+            assert ATTR_FRIENDLY_NAME in state.attributes

--- a/tests/components/weather/test_recorder.py
+++ b/tests/components/weather/test_recorder.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import StateAttributes, States
-from homeassistant.components.recorder.util import session_scope
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.weather import ATTR_FORECAST, DOMAIN
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
@@ -18,6 +17,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test weather attributes to be excluded."""
+    now = dt_util.utcnow()
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"platform": "demo"}})
     hass.config.units = METRIC_SYSTEM
     await hass.async_block_till_done()
@@ -30,20 +30,8 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    def _fetch_states() -> list[State]:
-        with session_scope(hass=hass) as session:
-            native_states = []
-            for db_state, db_state_attributes in session.query(
-                States, StateAttributes
-            ).outerjoin(
-                StateAttributes, States.attributes_id == StateAttributes.attributes_id
-            ):
-                state = db_state.to_native()
-                state.attributes = db_state_attributes.to_native()
-                native_states.append(state)
-            return native_states
-
-    states: list[State] = await hass.async_add_executor_job(_fetch_states)
-    assert len(states) > 1
-    for state in states:
-        assert ATTR_FORECAST not in state.attributes
+    states = await hass.async_add_executor_job(get_significant_states, hass, now)
+    assert len(states) >= 1
+    for entity_states in states.values():
+        for state in entity_states:
+            assert ATTR_FORECAST not in state.attributes


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor recorder tests to use recorder history API instead of manually selecting the states from the database

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
