### PR TITLE
Allow reloading iZone config entry

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -3,7 +3,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EXCLUDE, Platform
+from homeassistant.const import CONF_EXCLUDE, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -48,6 +48,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
     await async_start_discovery_service(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    async def shutdown_event(event):
+        await async_stop_discovery_service(hass)
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_event)
+    )
+
     return True
 
 

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -1,7 +1,6 @@
 """Platform for the iZone AC."""
 import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
@@ -29,37 +28,28 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Register the iZone component config."""
-    if not (conf := config.get(IZONE)):
-        return True
 
-    hass.data[DATA_CONFIG] = conf
+    # Check for manually added config, this may exclude some devices
+    if conf := config.get(IZONE):
+        hass.data[DATA_CONFIG] = conf
 
-    # Explicitly added in the config file, create a config entry.
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            IZONE, context={"source": config_entries.SOURCE_IMPORT}
-        )
-    )
+    # Start the discovery service
+    await async_start_discovery_service(hass)
+
+    async def shutdown_event(event):
+        await async_stop_discovery_service(hass)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_event)
 
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
-    await async_start_discovery_service(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    async def shutdown_event(event):
-        await async_stop_discovery_service(hass)
-
-    entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_event)
-    )
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the config entry and stop discovery process."""
-    await async_stop_discovery_service(hass)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -1,6 +1,7 @@
 """Platform for the iZone AC."""
 import voluptuous as vol
 
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
@@ -32,6 +33,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Check for manually added config, this may exclude some devices
     if conf := config.get(IZONE):
         hass.data[DATA_CONFIG] = conf
+
+        # Explicitly added in the config file, create a config entry.
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                IZONE, context={"source": config_entries.SOURCE_IMPORT}
+            )
+        )
 
     # Start the discovery service
     await async_start_discovery_service(hass)

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -95,7 +95,9 @@ async def async_setup_entry(
         init_controller(controller)
 
     # connect to register any further components
-    async_dispatcher_connect(hass, DISPATCH_CONTROLLER_DISCOVERED, init_controller)
+    config.async_on_unload(
+        async_dispatcher_connect(hass, DISPATCH_CONTROLLER_DISCOVERED, init_controller)
+    )
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -1,7 +1,8 @@
 """Internal discovery service for  iZone AC."""
+import logging
+
 import pizone
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -15,15 +16,17 @@ from .const import (
     DISPATCH_ZONE_UPDATE,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class DiscoveryService(pizone.Listener):
     """Discovery data and interfacing with pizone library."""
 
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialise discovery service."""
         super().__init__()
         self.hass = hass
-        self.pi_disco = None
+        self.pi_disco = None  # type: pizone.DiscoveryService | None
 
     # Listener interface
     def controller_discovered(self, ctrl: pizone.Controller) -> None:
@@ -52,6 +55,7 @@ async def async_start_discovery_service(hass: HomeAssistant):
     if disco := hass.data.get(DATA_DISCOVERY_SERVICE):
         # Already started
         return disco
+    _LOGGER.debug("Starting iZone Discovery Service")
 
     # discovery local services
     disco = DiscoveryService(hass)
@@ -61,11 +65,6 @@ async def async_start_discovery_service(hass: HomeAssistant):
     session = aiohttp_client.async_get_clientsession(hass)
     disco.pi_disco = pizone.discovery(disco, session=session)
     await disco.pi_disco.start_discovery()
-
-    async def shutdown_event(event):
-        await async_stop_discovery_service(hass)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_event)
 
     return disco
 
@@ -77,3 +76,5 @@ async def async_stop_discovery_service(hass: HomeAssistant):
 
     await disco.pi_disco.close()
     del hass.data[DATA_DISCOVERY_SERVICE]
+
+    _LOGGER.debug("Stopped iZone Discovery Service")

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -26,7 +26,7 @@ class DiscoveryService(pizone.Listener):
         """Initialise discovery service."""
         super().__init__()
         self.hass = hass
-        self.pi_disco = None  # type: pizone.DiscoveryService | None
+        self.pi_disco: pizone.DiscoveryService | None = None
 
     # Listener interface
     def controller_discovered(self, ctrl: pizone.Controller) -> None:


### PR DESCRIPTION

## Proposed change
Allows reloading of iZone config entry.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
