### PR TITLE
Use repair issue when port enable fails in Reolink

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -128,7 +128,7 @@ class ReolinkHost:
                     translation_placeholders={
                         "name": self._api.nvr_name,
                         "ports": ports,
-                        "info_link": "https://support.reolink.com/hc/en-us/articles/900004435763-How-to-Set-up-Reolink-Ports-Settings-via-Reolink-Client-New-Client-"
+                        "info_link": "https://support.reolink.com/hc/en-us/articles/900004435763-How-to-Set-up-Reolink-Ports-Settings-via-Reolink-Client-New-Client-",
                     },
                 )
         else:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -109,23 +109,30 @@ class ReolinkHost:
                     enable_rtsp=enable_rtsp,
                 )
             except ReolinkError:
+                ports = ""
                 if enable_onvif:
-                    _LOGGER.error(
-                        "Failed to enable ONVIF on %s. "
-                        "Set it to ON to receive notifications",
-                        self._api.nvr_name,
-                    )
+                    ports += "ONVIF "
 
                 if enable_rtmp:
-                    _LOGGER.error(
-                        "Failed to enable RTMP on %s. Set it to ON",
-                        self._api.nvr_name,
-                    )
+                    ports += "RTMP "
                 elif enable_rtsp:
-                    _LOGGER.error(
-                        "Failed to enable RTSP on %s. Set it to ON",
-                        self._api.nvr_name,
-                    )
+                    ports += "RTSP "
+
+                ir.async_create_issue(
+                    self._hass,
+                    DOMAIN,
+                    "enable_port",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="enable_port",
+                    translation_placeholders={
+                        "name": self._api.nvr_name,
+                        "ports": ports,
+                        "info_link": "https://support.reolink.com/hc/en-us/articles/900004435763-How-to-Set-up-Reolink-Ports-Settings-via-Reolink-Client-New-Client-"
+                    },
+                )
+        else:
+            ir.async_delete_issue(self._hass, DOMAIN, "enable_port")
 
         self._unique_id = format_mac(self._api.mac_address)
 

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -42,7 +42,7 @@
     "https_webhook": {
       "title": "Reolink webhook URL uses HTTPS (SSL)",
       "description": "Reolink products can not push motion events to an HTTPS address (SSL), please configure a (local) HTTP address under \"Home Assistant URL\" in the [network settings]({network_link}). The current (local) address is: `{base_url}`"
-    }
+    },
     "enable_port": {
       "title": "Reolink port not enabled",
       "description": "Failed to automatically enable {ports}port(s) on {name}. Set it to ON [manually using the Reolink client]({info_link})"

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -43,6 +43,10 @@
       "title": "Reolink webhook URL uses HTTPS (SSL)",
       "description": "Reolink products can not push motion events to an HTTPS address (SSL), please configure a (local) HTTP address under \"Home Assistant URL\" in the [network settings]({network_link}). The current (local) address is: `{base_url}`"
     }
+    "enable_port": {
+      "title": "Reolink port not enabled",
+      "description": "Failed to automatically enable {ports}port(s) on {name}. Set it to ON [manually using the Reolink client]({info_link})"
+    }
   },
   "entity": {
     "select": {

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -45,7 +45,7 @@
     },
     "enable_port": {
       "title": "Reolink port not enabled",
-      "description": "Failed to automatically enable {ports}port(s) on {name}. Set it to ON [manually using the Reolink client]({info_link})"
+      "description": "Failed to automatically enable {ports}port(s) on {name}. Use the [Reolink client]({info_link}) to manually set it to ON"
     }
   },
   "entity": {

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -86,7 +86,7 @@ async def test_entry_reloading(
     assert config_entry.title == "New Name"
 
 
-async def test_http_no_repair_issue(
+async def test_no_repair_issue(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test no repairs issue is raised when http local url is used."""
@@ -99,6 +99,7 @@ async def test_http_no_repair_issue(
 
     issue_registry = ir.async_get(hass)
     assert (const.DOMAIN, "https_webhook") not in issue_registry.issues
+    assert (const.DOMAIN, "enable_port") not in issue_registry.issues
 
 
 async def test_https_repair_issue(
@@ -114,3 +115,23 @@ async def test_https_repair_issue(
 
     issue_registry = ir.async_get(hass)
     assert (const.DOMAIN, "https_webhook") in issue_registry.issues
+
+
+@pytest.mark.parametrize("protocol", ["rtsp", "rtmp"])
+async def test_port_repair_issue(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    protocol: str,
+) -> None:
+    """Test repairs issue is raised when auto enable of ports fails."""
+    reolink_connect.set_net_port = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.onvif_enabled = False
+    reolink_connect.rtsp_enabled = False
+    reolink_connect.rtmp_enabled = False
+    reolink_connect.protocol = protocol
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+    assert (const.DOMAIN, "enable_port") in issue_registry.issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When automatic enabeling of the ONVIF/RTSP/RTMP ports in the reolink device fails, issue a repairs issue with instructions on how to manually enable those ports, instead of only logging a error.

![afbeelding](https://user-images.githubusercontent.com/14811189/224560933-d5b59dfd-4fee-4395-93fb-ee04ba8f7db4.png)
![afbeelding](https://user-images.githubusercontent.com/14811189/224560976-e42534f1-303d-43ad-807a-bce9874400bd.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
