### PR TITLE
Template light - Allow brightness to be updated at the same time as other attributes

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -376,6 +376,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             optimistic_set = True
 
         common_params = {}
+        script_called = False
 
         if ATTR_BRIGHTNESS in kwargs:
             common_params["brightness"] = kwargs[ATTR_BRIGHTNESS]
@@ -385,6 +386,7 @@ class LightTemplate(TemplateEntity, LightEntity):
 
         if ATTR_COLOR_TEMP in kwargs and self._temperature_script:
             common_params["color_temp"] = kwargs[ATTR_COLOR_TEMP]
+            script_called = True
 
             await self.async_run_script(
                 self._temperature_script,
@@ -403,6 +405,7 @@ class LightTemplate(TemplateEntity, LightEntity):
                 )
 
             common_params["effect"] = effect
+            script_called = True
 
             await self.async_run_script(
                 self._effect_script, run_variables=common_params, context=self._context
@@ -412,15 +415,19 @@ class LightTemplate(TemplateEntity, LightEntity):
             common_params["hs"] = hs_value
             common_params["h"] = int(hs_value[0])
             common_params["s"] = int(hs_value[1])
+            script_called = True
 
             await self.async_run_script(
                 self._color_script, run_variables=common_params, context=self._context
             )
-        elif ATTR_BRIGHTNESS in kwargs and self._level_script:
+
+        if ATTR_BRIGHTNESS in kwargs and self._level_script:
+            script_called = True
             await self.async_run_script(
                 self._level_script, run_variables=common_params, context=self._context
             )
-        else:
+
+        if not script_called:
             await self.async_run_script(
                 self._on_script, run_variables=common_params, context=self._context
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a proposed fix to to allow template lights to update the brightness attribute in a service call which also updates color, color temperature or effect.

For example, if you call the light_on service to change both the color temperature and brightness, only the color temperature will be updated, this fixes that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34915 (this is an old issue which went stale and closed. I could not find any open issues)
- This PR is related to issue: #34915
- Link to documentation pull request: I don't _think_ that any documentation needs to be updated for this, but happy to be challenged on this.

I found an old PR which aimed to fix the same issue in a different way (#36353). However, that pull request went stale and was closed. The solution in that PR was perhaps more elegant than this one, but was a breaking change. This PR aims to not be a breaking change.

Currently, the code which sets the brightness is inside an `elif` clause which is not reached if any of color, color temperature or effect is set. This pull request moves this into its own `if` statement so that it is always checked.

Currently, if no data attributes are set, there is an `else` statement which turns the light on without calling any other script. However, since I split the if statement into multiple statements, this approach no longer works. To resolve this, I created a variable called `script_called` which keeps track if we need to call the turn on light script.

Finally, I added some tests which fail with the live code and pass with the proposed code.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

_**Note: This is my first PR and I couldn't figure out how to run the black test command. I read the guidelines and attempted to follow them though.**_

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
