### PR TITLE
Improve reliability of context id migration

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -671,7 +671,6 @@ class Recorder(threading.Thread):
                 # Make sure we cleanly close the run if
                 # we restart before startup finishes
                 self._shutdown()
-                self._activate_and_set_db_ready()
                 return
 
         if not schema_status.valid:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -655,8 +655,9 @@ class Recorder(threading.Thread):
             self.migration_is_live = migration.live_migration(schema_status)
 
         self.hass.add_job(self.async_connection_success)
+        database_was_ready = self.migration_is_live or schema_status.valid
 
-        if self.migration_is_live or schema_status.valid:
+        if database_was_ready:
             # If the migrate is live or the schema is valid, we need to
             # wait for startup to complete. If its not live, we need to continue
             # on.
@@ -692,7 +693,8 @@ class Recorder(threading.Thread):
                 self._shutdown()
                 return
 
-        self._activate_and_set_db_ready()
+        if not database_was_ready:
+            self._activate_and_set_db_ready()
 
         # Catch up with missed statistics
         with session_scope(session=self.get_session()) as session:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1254,8 +1254,41 @@ def _context_id_to_bytes(context_id: str | None) -> bytes | None:
     return None
 
 
-def migrate_context_ids(instance: Recorder) -> bool:
-    """Migrate context_ids to use binary format."""
+def migrate_states_context_ids(instance: Recorder) -> bool:
+    """Migrate states context_ids to use binary format."""
+    _to_bytes = _context_id_to_bytes
+    session_maker = instance.get_session
+    _LOGGER.debug("Migrating states context_ids to binary format")
+    with session_scope(session=session_maker()) as session:
+        if states := session.execute(find_states_context_ids_to_migrate()).all():
+            session.execute(
+                update(States),
+                [
+                    {
+                        "state_id": state_id,
+                        "context_id": None,
+                        "context_id_bin": _to_bytes(context_id) or _EMPTY_CONTEXT_ID,
+                        "context_user_id": None,
+                        "context_user_id_bin": _to_bytes(context_user_id),
+                        "context_parent_id": None,
+                        "context_parent_id_bin": _to_bytes(context_parent_id),
+                    }
+                    for state_id, context_id, context_user_id, context_parent_id in states
+                ],
+            )
+        # If there is more work to do return False
+        # so that we can be called again
+        is_done = not states
+
+    if is_done:
+        _drop_index(session_maker, "states", "ix_states_context_id")
+
+    _LOGGER.debug("Migrating states context_ids to binary format: done=%s", is_done)
+    return is_done
+
+
+def migrate_events_context_ids(instance: Recorder) -> bool:
+    """Migrate events context_ids to use binary format."""
     _to_bytes = _context_id_to_bytes
     session_maker = instance.get_session
     _LOGGER.debug("Migrating context_ids to binary format")
@@ -1276,31 +1309,14 @@ def migrate_context_ids(instance: Recorder) -> bool:
                     for event_id, context_id, context_user_id, context_parent_id in events
                 ],
             )
-        if states := session.execute(find_states_context_ids_to_migrate()).all():
-            session.execute(
-                update(States),
-                [
-                    {
-                        "state_id": state_id,
-                        "context_id": None,
-                        "context_id_bin": _to_bytes(context_id) or _EMPTY_CONTEXT_ID,
-                        "context_user_id": None,
-                        "context_user_id_bin": _to_bytes(context_user_id),
-                        "context_parent_id": None,
-                        "context_parent_id_bin": _to_bytes(context_parent_id),
-                    }
-                    for state_id, context_id, context_user_id, context_parent_id in states
-                ],
-            )
         # If there is more work to do return False
         # so that we can be called again
-        is_done = not (events or states)
+        is_done = not events
 
     if is_done:
-        _drop_index(session_maker, "events", "ix_events_context_id", quiet=True)
-        _drop_index(session_maker, "states", "ix_states_context_id", quiet=True)
+        _drop_index(session_maker, "events", "ix_events_context_id")
 
-    _LOGGER.debug("Migrating context_ids to binary format: done=%s", is_done)
+    _LOGGER.debug("Migrating events context_ids to binary format: done=%s", is_done)
     return is_done
 
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -64,7 +64,7 @@ from .tasks import (
     PostSchemaMigrationTask,
     StatisticsTimestampMigrationCleanupTask,
 )
-from .util import database_job_retry_wrapper, session_scope
+from .util import database_job_retry_wrapper, retryable_database_job, session_scope
 
 if TYPE_CHECKING:
     from . import Recorder
@@ -1254,6 +1254,7 @@ def _context_id_to_bytes(context_id: str | None) -> bytes | None:
     return None
 
 
+@retryable_database_job("migrate states context_ids to binary format")
 def migrate_states_context_ids(instance: Recorder) -> bool:
     """Migrate states context_ids to use binary format."""
     _to_bytes = _context_id_to_bytes
@@ -1287,6 +1288,7 @@ def migrate_states_context_ids(instance: Recorder) -> bool:
     return is_done
 
 
+@retryable_database_job("migrate events context_ids to binary format")
 def migrate_events_context_ids(instance: Recorder) -> bool:
     """Migrate events context_ids to use binary format."""
     _to_bytes = _context_id_to_bytes
@@ -1320,6 +1322,7 @@ def migrate_events_context_ids(instance: Recorder) -> bool:
     return is_done
 
 
+@retryable_database_job("migrate events event_types to event_type_ids")
 def migrate_event_type_ids(instance: Recorder) -> bool:
     """Migrate event_type to event_type_ids."""
     session_maker = instance.get_session
@@ -1376,6 +1379,7 @@ def migrate_event_type_ids(instance: Recorder) -> bool:
     return is_done
 
 
+@retryable_database_job("migrate states entity_ids to states_meta")
 def migrate_entity_ids(instance: Recorder) -> bool:
     """Migrate entity_ids to states_meta.
 
@@ -1437,6 +1441,7 @@ def migrate_entity_ids(instance: Recorder) -> bool:
     return is_done
 
 
+@retryable_database_job("post migrate states entity_ids to states_meta")
 def post_migrate_entity_ids(instance: Recorder) -> bool:
     """Remove old entity_id strings from states.
 

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -346,16 +346,33 @@ class AdjustLRUSizeTask(RecorderTask):
 
 
 @dataclass
-class ContextIDMigrationTask(RecorderTask):
-    """An object to insert into the recorder queue to migrate context ids."""
+class StatesContextIDMigrationTask(RecorderTask):
+    """An object to insert into the recorder queue to migrate states context ids."""
 
     commit_before = False
 
     def run(self, instance: Recorder) -> None:
         """Run context id migration task."""
-        if not instance._migrate_context_ids():  # pylint: disable=[protected-access]
+        if (
+            not instance._migrate_states_context_ids()  # pylint: disable=[protected-access]
+        ):
             # Schedule a new migration task if this one didn't finish
-            instance.queue_task(ContextIDMigrationTask())
+            instance.queue_task(StatesContextIDMigrationTask())
+
+
+@dataclass
+class EventsContextIDMigrationTask(RecorderTask):
+    """An object to insert into the recorder queue to migrate events context ids."""
+
+    commit_before = False
+
+    def run(self, instance: Recorder) -> None:
+        """Run context id migration task."""
+        if (
+            not instance._migrate_events_context_ids()  # pylint: disable=[protected-access]
+        ):
+            # Schedule a new migration task if this one didn't finish
+            instance.queue_task(EventsContextIDMigrationTask())
 
 
 @dataclass

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -86,6 +86,7 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmpdir) -> None:
         EventOrigin.local,
         time_fired=now,
     )
+    number_of_migrations = 5
 
     with patch.object(recorder, "db_schema", old_db_schema), patch.object(
         recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
@@ -107,6 +108,8 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmpdir) -> None:
         "homeassistant.components.recorder.Recorder._migrate_event_type_ids",
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_entity_ids",
+    ), patch(
+        "homeassistant.components.recorder.Recorder._post_migrate_entity_ids"
     ):
         hass = await async_test_home_assistant(asyncio.get_running_loop())
         recorder_helper.async_initialize_recorder(hass)
@@ -124,8 +127,10 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmpdir) -> None:
 
         await recorder.get_instance(hass).async_add_executor_job(_add_data)
         await hass.async_block_till_done()
+        await recorder.get_instance(hass).async_block_till_done()
 
         await hass.async_stop()
+        await hass.async_block_till_done()
 
         dt_util.DEFAULT_TIME_ZONE = ORIG_TZ
 
@@ -139,7 +144,8 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmpdir) -> None:
 
     # We need to wait for all the migration tasks to complete
     # before we can check the database.
-    for _ in range(5):
+    for _ in range(number_of_migrations):
+        await recorder.get_instance(hass).async_block_till_done()
         await async_wait_recording_done(hass)
 
     def _get_test_data_from_db():

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -100,7 +100,9 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmpdir) -> None:
     ), patch(
         CREATE_ENGINE_TARGET, new=_create_engine_test
     ), patch(
-        "homeassistant.components.recorder.Recorder._migrate_context_ids",
+        "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
+    ), patch(
+        "homeassistant.components.recorder.Recorder._migrate_states_context_ids",
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_event_type_ids",
     ), patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1250,8 +1250,15 @@ def hass_recorder(
         if enable_statistics_table_validation
         else itertools.repeat(set())
     )
-    migrate_context_ids = (
-        recorder.Recorder._migrate_context_ids if enable_migrate_context_ids else None
+    migrate_states_context_ids = (
+        recorder.Recorder._migrate_states_context_ids
+        if enable_migrate_context_ids
+        else None
+    )
+    migrate_events_context_ids = (
+        recorder.Recorder._migrate_events_context_ids
+        if enable_migrate_context_ids
+        else None
     )
     migrate_event_type_ids = (
         recorder.Recorder._migrate_event_type_ids
@@ -1274,8 +1281,12 @@ def hass_recorder(
         side_effect=stats_validate,
         autospec=True,
     ), patch(
-        "homeassistant.components.recorder.Recorder._migrate_context_ids",
-        side_effect=migrate_context_ids,
+        "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
+        side_effect=migrate_events_context_ids,
+        autospec=True,
+    ), patch(
+        "homeassistant.components.recorder.Recorder._migrate_states_context_ids",
+        side_effect=migrate_states_context_ids,
         autospec=True,
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_event_type_ids",
@@ -1354,8 +1365,15 @@ async def async_setup_recorder_instance(
         if enable_statistics_table_validation
         else itertools.repeat(set())
     )
-    migrate_context_ids = (
-        recorder.Recorder._migrate_context_ids if enable_migrate_context_ids else None
+    migrate_states_context_ids = (
+        recorder.Recorder._migrate_states_context_ids
+        if enable_migrate_context_ids
+        else None
+    )
+    migrate_events_context_ids = (
+        recorder.Recorder._migrate_events_context_ids
+        if enable_migrate_context_ids
+        else None
     )
     migrate_event_type_ids = (
         recorder.Recorder._migrate_event_type_ids
@@ -1378,8 +1396,12 @@ async def async_setup_recorder_instance(
         side_effect=stats_validate,
         autospec=True,
     ), patch(
-        "homeassistant.components.recorder.Recorder._migrate_context_ids",
-        side_effect=migrate_context_ids,
+        "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
+        side_effect=migrate_events_context_ids,
+        autospec=True,
+    ), patch(
+        "homeassistant.components.recorder.Recorder._migrate_states_context_ids",
+        side_effect=migrate_states_context_ids,
         autospec=True,
     ), patch(
         "homeassistant.components.recorder.Recorder._migrate_event_type_ids",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since migration of context_ids in events can finish much earlier than states we would keep looking at the table because states as not done. Make them separate tasks.

Adds the missing retryable database job decorator in case MariaDB deadlocks during migration.

All the migrations would happen twice because `_activate_and_set_db_ready` could be called twice because we previously called the function twice before it was refactored. In 2023.3.x it didn't show up because there is a guard in the async function to prevent it from being run twice, but now that the migration is tied to it, it was trying to do the migration twice.  The migration is designed to recover but it would cause the test to randomly fail because it was expected to be completed.

https://github.com/home-assistant/core/blob/ddde17606deb8c34293695bfb526192c0e040224/homeassistant/components/recorder/core.py#L659
https://github.com/home-assistant/core/blob/ddde17606deb8c34293695bfb526192c0e040224/homeassistant/components/recorder/core.py#L648

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
