### PR TITLE
Drop duplicated indices from recorder database schema

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -68,7 +68,7 @@ class Base(DeclarativeBase):
     """Base class for tables."""
 
 
-SCHEMA_VERSION = 39
+SCHEMA_VERSION = 40
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ class Events(Base):
         LargeBinary(CONTEXT_ID_BIN_MAX_LENGTH)
     )
     event_type_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("event_types.event_type_id"), index=True
+        Integer, ForeignKey("event_types.event_type_id")
     )
     event_data_rel: Mapped[EventData | None] = relationship("EventData")
     event_type_rel: Mapped[EventTypes | None] = relationship("EventTypes")
@@ -426,7 +426,7 @@ class States(Base):
         LargeBinary(CONTEXT_ID_BIN_MAX_LENGTH)
     )
     metadata_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("states_meta.metadata_id"), index=True
+        Integer, ForeignKey("states_meta.metadata_id")
     )
     states_meta_rel: Mapped[StatesMeta | None] = relationship("StatesMeta")
 
@@ -617,7 +617,6 @@ class StatisticsBase:
     metadata_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey(f"{TABLE_STATISTICS_META}.id", ondelete="CASCADE"),
-        index=True,
     )
     start: Mapped[datetime | None] = mapped_column(
         DATETIME_TYPE, index=True

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1041,6 +1041,19 @@ def _apply_update(  # noqa: C901
             "ix_statistics_short_term_statistic_id_start",
             quiet=True,
         )
+    elif new_version == 40:
+        # ix_events_event_type_id is a left-prefix of ix_events_event_type_id_time_fired_ts
+        _drop_index(session_maker, "events", "ix_events_event_type_id")
+        # ix_states_metadata_id is a left-prefix of ix_states_metadata_id_last_updated_ts
+        _drop_index(session_maker, "states", "ix_states_metadata_id")
+        # ix_statistics_metadata_id is a left-prefix of ix_statistics_statistic_id_start_ts
+        _drop_index(session_maker, "statistics", "ix_statistics_metadata_id")
+        # ix_statistics_short_term_metadata_id is a left-prefix of ix_statistics_short_term_statistic_id_start_ts
+        _drop_index(
+            session_maker,
+            "statistics_short_term",
+            "ix_statistics_short_term_metadata_id",
+        )
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop duplicated indices from schema. Saves ~10% on most of my test cases.
https://docs.percona.com/percona-toolkit/pt-duplicate-key-checker.html

Before
```
-rwxr-xr-x    1 root     root     732704768 Mar 13 03:38 home-assistant_v2.db
STATES............................................ 36398       20.3% 
STATISTICS........................................ 25579       14.3% 
IX_STATES_CONTEXT_ID_BIN.......................... 14658        8.2% 
STATISTICS_SHORT_TERM............................. 13762        7.7% 
IX_STATES_METADATA_ID_LAST_UPDATED_TS............. 12199        6.8% 
IX_STATES_LAST_UPDATED_TS......................... 10142        5.7% 
IX_STATISTICS_STATISTIC_ID_START_TS............... 8939         5.0% 
IX_STATES_OLD_STATE_ID............................ 7668         4.3% 
IX_STATES_ATTRIBUTES_ID........................... 7364         4.1% 
IX_STATISTICS_START_TS............................ 7139         4.0% 
IX_STATES_METADATA_ID............................. 7007         3.9% 
IX_STATISTICS_METADATA_ID......................... 6190         3.5% 
IX_STATES_EVENT_ID................................ 5644         3.2% 
IX_STATISTICS_SHORT_TERM_STATISTIC_ID_START_TS.... 5235         2.9% 
IX_STATISTICS_SHORT_TERM_START_TS................. 4140         2.3% 
IX_STATISTICS_SHORT_TERM_METADATA_ID.............. 3659         2.0% 
STATE_ATTRIBUTES.................................. 1002         0.56% 
EVENTS............................................ 715          0.40% 
IX_EVENTS_CONTEXT_ID_BIN.......................... 369          0.21% 
IX_EVENTS_EVENT_TYPE_ID_TIME_FIRED_TS............. 281          0.16% 
IX_EVENTS_TIME_FIRED_TS........................... 251          0.14% 
IX_EVENTS_DATA_ID................................. 174          0.097% 
IX_EVENTS_EVENT_TYPE_ID........................... 146          0.082% 
IX_STATE_ATTRIBUTES_HASH.......................... 53           0.030% 
EVENT_DATA........................................ 49           0.027% 
IX_STATISTICS_RUNS_START.......................... 28           0.016% 
STATISTICS_RUNS................................... 28           0.016% 
STATES_META....................................... 24           0.013% 
STATISTICS_META................................... 12           0.007% 
IX_STATISTICS_META_STATISTIC_ID................... 9            0.005% 
IX_EVENT_DATA_HASH................................ 7            0.004% 
RECORDER_RUNS..................................... 4            0.002% 
IX_RECORDER_RUNS_START_END........................ 3            0.002% 
SQLITE_SCHEMA..................................... 3            0.002% 
EVENT_TYPES....................................... 1            0.0% 
SCHEMA_CHANGES.................................... 1            0.0% 
```
After
```
-rwxr-xr-x    1 root     root     656351232 Mar 13 03:39 home-assistant_v2.db
STATES............................................ 36442       22.7% 
STATISTICS........................................ 25579       15.9% 
IX_STATES_CONTEXT_ID_BIN.......................... 14576        9.1% 
STATISTICS_SHORT_TERM............................. 13767        8.6% 
IX_STATES_METADATA_ID_LAST_UPDATED_TS............. 11876        7.4% 
IX_STATES_LAST_UPDATED_TS......................... 10082        6.3% 
IX_STATISTICS_STATISTIC_ID_START_TS............... 8555         5.3% 
IX_STATES_OLD_STATE_ID............................ 7609         4.7% 
IX_STATISTICS_START_TS............................ 7137         4.4% 
IX_STATES_ATTRIBUTES_ID........................... 7131         4.4% 
IX_STATES_EVENT_ID................................ 5611         3.5% 
IX_STATISTICS_SHORT_TERM_STATISTIC_ID_START_TS.... 5299         3.3% 
IX_STATISTICS_SHORT_TERM_START_TS................. 4112         2.6% 
STATE_ATTRIBUTES.................................. 1004         0.62% 
EVENTS............................................ 720          0.45% 
IX_EVENTS_CONTEXT_ID_BIN.......................... 369          0.23% 
IX_EVENTS_EVENT_TYPE_ID_TIME_FIRED_TS............. 274          0.17% 
IX_EVENTS_TIME_FIRED_TS........................... 252          0.16% 
IX_EVENTS_DATA_ID................................. 157          0.098% 
EVENT_DATA........................................ 49           0.030% 
IX_STATE_ATTRIBUTES_HASH.......................... 45           0.028% 
STATISTICS_RUNS................................... 28           0.017% 
IX_STATISTICS_RUNS_START.......................... 27           0.017% 
STATES_META....................................... 24           0.015% 
STATISTICS_META................................... 12           0.007% 
IX_STATISTICS_META_STATISTIC_ID................... 9            0.006% 
IX_EVENT_DATA_HASH................................ 6            0.004% 
RECORDER_RUNS..................................... 4            0.002% 
IX_RECORDER_RUNS_START_END........................ 3            0.002% 
SQLITE_SCHEMA..................................... 3            0.002% 
EVENT_TYPES....................................... 1            0.0% 
SCHEMA_CHANGES.................................... 1            0.0% 

```

```bash
% pt-duplicate-key-checker --databases fresh

# ix_events_event_type_id is a left-prefix of ix_events_event_type_id_time_fired_ts
# Key definitions:
#   KEY `ix_events_event_type_id` (`event_type_id`),
#   KEY `ix_events_event_type_id_time_fired_ts` (`event_type_id`,`time_fired_ts`),
# Column types:
#         `event_type_id` int(11) default null
#         `time_fired_ts` double default null
# To remove this duplicate index, execute:
ALTER TABLE `fresh`.`events` DROP INDEX `ix_events_event_type_id`;

# ########################################################################
# fresh.states
# ########################################################################

# ix_states_metadata_id is a left-prefix of ix_states_metadata_id_last_updated_ts
# Key definitions:
#   KEY `ix_states_metadata_id` (`metadata_id`),
#   KEY `ix_states_metadata_id_last_updated_ts` (`metadata_id`,`last_updated_ts`),
# Column types:
#         `metadata_id` int(11) default null
#         `last_updated_ts` double default null
# To remove this duplicate index, execute:
ALTER TABLE `fresh`.`states` DROP INDEX `ix_states_metadata_id`;

# ########################################################################
# fresh.statistics
# ########################################################################

# ix_statistics_metadata_id is a left-prefix of ix_statistics_statistic_id_start_ts
# Key definitions:
#   KEY `ix_statistics_metadata_id` (`metadata_id`),
#   UNIQUE KEY `ix_statistics_statistic_id_start_ts` (`metadata_id`,`start_ts`),
# Column types:
#         `metadata_id` int(11) default null
#         `start_ts` double default null
# To remove this duplicate index, execute:
ALTER TABLE `fresh`.`statistics` DROP INDEX `ix_statistics_metadata_id`;

# ########################################################################
# fresh.statistics_short_term
# ########################################################################

# ix_statistics_short_term_metadata_id is a left-prefix of ix_statistics_short_term_statistic_id_start_ts
# Key definitions:
#   KEY `ix_statistics_short_term_metadata_id` (`metadata_id`),
#   UNIQUE KEY `ix_statistics_short_term_statistic_id_start_ts` (`metadata_id`,`start_ts`),
# Column types:
#         `metadata_id` int(11) default null
#         `start_ts` double default null
# To remove this duplicate index, execute:
ALTER TABLE `fresh`.`statistics_short_term` DROP INDEX `ix_statistics_short_term_metadata_id`;

# ########################################################################
# Summary of indexes
# ########################################################################

# Size Duplicate Indexes   20
# Total Duplicate Indexes  4
# Total Indexes            47

```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/data.home-assistant/pull/263

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [data.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
