### PR TITLE
Add Landis+Gyr poll on restart

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/__init__.py
+++ b/homeassistant/components/landisgyr_heat_meter/__init__.py
@@ -29,6 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
+    await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -1,14 +1,16 @@
 """Platform for sensor integration."""
 from __future__ import annotations
 
-from dataclasses import asdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
 import logging
 
 from ultraheat_api.response import HeatMeterResponse
 
 from homeassistant.components.sensor import (
-    RestoreSensor,
     SensorDeviceClass,
+    SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
@@ -25,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -36,177 +39,235 @@ from . import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class HeatMeterSensorEntityDescription(SensorEntityDescription):
+    """Heat Meter sensor description."""
+
+    value_fn: Callable | None = None
+    response_key: str | None = None
+
+
 HEAT_METER_SENSOR_TYPES = (
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="volume_usage_m3",
         icon="mdi:fire",
         name="Volume usage",
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda value: value,
+        response_key="volume_usage_m3",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="heat_usage_gj",
         icon="mdi:fire",
         name="Heat usage GJ",
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda value: value,
+        response_key="heat_usage_gj",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="heat_previous_year_gj",
         icon="mdi:fire",
         name="Heat previous year GJ",
-        native_unit_of_measurement="GJ",
+        native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="heat_previous_year_gj",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="volume_previous_year_m3",
         icon="mdi:fire",
         name="Volume usage previous year",
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="volume_previous_year_m3",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="ownership_number",
         name="Ownership number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="ownership_number",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="error_number",
         name="Error number",
         icon="mdi:home-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="error_number",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="device_number",
         name="Device number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="device_number",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="measurement_period_minutes",
         name="Measurement period minutes",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="measurement_period_minutes",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="power_max_kw",
         name="Power max",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="power_max_kw",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="power_max_previous_year_kw",
         name="Power max previous year",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="power_max_previous_year_kw",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="flowrate_max_m3ph",
         name="Flowrate max",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="flowrate_max_m3ph",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="flowrate_max_previous_year_m3ph",
         name="Flowrate max previous year",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="flowrate_max_previous_year_m3ph",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="return_temperature_max_c",
         name="Return temperature max",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="return_temperature_max_c",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="return_temperature_max_previous_year_c",
         name="Return temperature max previous year",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="return_temperature_max_previous_year_c",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="flow_temperature_max_c",
         name="Flow temperature max",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="flow_temperature_max_c",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="flow_temperature_max_previous_year_c",
         name="Flow temperature max previous year",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="flow_temperature_max_previous_year_c",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="operating_hours",
         name="Operating hours",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="operating_hours",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="flow_hours",
         name="Flow hours",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="flow_hours",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="fault_hours",
         name="Fault hours",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="fault_hours",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="fault_hours_previous_year",
         name="Fault hours previous year",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="fault_hours_previous_year",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="yearly_set_day",
         name="Yearly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="yearly_set_day",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="monthly_set_day",
         name="Monthly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="monthly_set_day",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="meter_date_time",
         name="Meter date time",
         icon="mdi:clock-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=dt_util.as_utc,
+        response_key="meter_date_time",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="measuring_range_m3ph",
         name="Measuring range",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="measuring_range_m3ph",
     ),
-    SensorEntityDescription(
+    HeatMeterSensorEntityDescription(
         key="settings_and_firmware",
         name="Settings and firmware",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda value: value,
+        response_key="settings_and_firmware",
     ),
 )
 
@@ -238,7 +299,8 @@ async def async_setup_entry(
 
 
 class HeatMeterSensor(
-    CoordinatorEntity[DataUpdateCoordinator[HeatMeterResponse]], RestoreSensor
+    CoordinatorEntity[DataUpdateCoordinator[HeatMeterResponse]],
+    SensorEntity,
 ):
     """Representation of a Sensor."""
 
@@ -254,25 +316,12 @@ class HeatMeterSensor(
         self._attr_unique_id = f"{coordinator.config_entry.data['device_number']}_{description.key}"  # type: ignore[union-attr]
         self._attr_name = f"Heat Meter {description.name}"
         self.entity_description = description
-
         self._attr_device_info = device
-        self._attr_should_poll = bool(self.key in ("heat_usage", "heat_previous_year"))
 
-    async def async_added_to_hass(self) -> None:
-        """Call when entity about to be added to hass."""
-        await super().async_added_to_hass()
-        state = await self.async_get_last_sensor_data()
-        if state:
-            self._attr_native_value = state.native_value
+    @property
+    def native_value(self) -> StateType | datetime:
+        """Return the state of the sensor."""
 
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        if self.key in asdict(self.coordinator.data):
-            if self.device_class == SensorDeviceClass.TIMESTAMP:
-                self._attr_native_value = dt_util.as_utc(
-                    asdict(self.coordinator.data)[self.key]
-                )
-            else:
-                self._attr_native_value = asdict(self.coordinator.data)[self.key]
-
-        self.async_write_ha_state()
+        return self.entity_description.value_fn(  # type: ignore[attr-defined]
+            getattr(self.coordinator.data, self.entity_description.response_key, None)  # type: ignore[attr-defined]
+        )

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -43,7 +43,6 @@ _LOGGER = logging.getLogger(__name__)
 class HeatMeterSensorEntityDescriptionMixin:
     """Mixin for additional Heat Meter sensor description attributes ."""
 
-    response_key: str
     value_fn: Callable[[HeatMeterResponse], StateType | datetime]
 
 
@@ -62,7 +61,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
-        response_key="volume_usage_m3",
         value_fn=lambda res: getattr(res, "volume_usage_m3", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -72,7 +70,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
-        response_key="heat_usage_gj",
         value_fn=lambda res: getattr(res, "heat_usage_gj", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -81,7 +78,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Heat previous year GJ",
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="heat_previous_year_gj",
         value_fn=lambda res: getattr(res, "heat_previous_year_gj", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -91,7 +87,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="volume_previous_year_m3",
         value_fn=lambda res: getattr(res, "volume_previous_year_m3", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -99,7 +94,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Ownership number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="ownership_number",
         value_fn=lambda res: getattr(res, "ownership_number", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -107,7 +101,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Error number",
         icon="mdi:home-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="error_number",
         value_fn=lambda res: getattr(res, "error_number", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -115,7 +108,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Device number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="device_number",
         value_fn=lambda res: getattr(res, "device_number", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -124,7 +116,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="measurement_period_minutes",
         value_fn=lambda res: getattr(res, "measurement_period_minutes", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -133,7 +124,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="power_max_kw",
         value_fn=lambda res: getattr(res, "power_max_kw", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -142,7 +132,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="power_max_previous_year_kw",
         value_fn=lambda res: getattr(res, "power_max_previous_year_kw", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -151,7 +140,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="flowrate_max_m3ph",
         value_fn=lambda res: getattr(res, "flowrate_max_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -160,7 +148,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="flowrate_max_previous_year_m3ph",
         value_fn=lambda res: getattr(res, "flowrate_max_previous_year_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -169,7 +156,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="return_temperature_max_c",
         value_fn=lambda res: getattr(res, "return_temperature_max_c", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -178,7 +164,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="return_temperature_max_previous_year_c",
         value_fn=lambda res: getattr(
             res, "return_temperature_max_previous_year_c", None
         ),
@@ -189,7 +174,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="flow_temperature_max_c",
         value_fn=lambda res: getattr(res, "flow_temperature_max_c", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -198,7 +182,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="flow_temperature_max_previous_year_c",
         value_fn=lambda res: getattr(res, "flow_temperature_max_previous_year_c", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -207,7 +190,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="operating_hours",
         value_fn=lambda res: getattr(res, "operating_hours", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -216,7 +198,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="flow_hours",
         value_fn=lambda res: getattr(res, "flow_hours", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -225,7 +206,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="fault_hours",
         value_fn=lambda res: getattr(res, "fault_hours", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -234,7 +214,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="fault_hours_previous_year",
         value_fn=lambda res: getattr(res, "fault_hours_previous_year", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -242,7 +221,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Yearly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="yearly_set_day",
         value_fn=lambda res: getattr(res, "yearly_set_day", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -250,7 +228,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Monthly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="monthly_set_day",
         value_fn=lambda res: getattr(res, "monthly_set_day", None),
     ),
     HeatMeterSensorEntityDescription(
@@ -259,7 +236,6 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:clock-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="meter_date_time",
         value_fn=lambda res: dt_util.as_utc(res.meter_date_time)
         if res.meter_date_time
         else None,
@@ -270,14 +246,12 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="measuring_range_m3ph",
         value_fn=lambda res: getattr(res, "measuring_range_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
         key="settings_and_firmware",
         name="Settings and firmware",
         entity_category=EntityCategory.DIAGNOSTIC,
-        response_key="settings_and_firmware",
         value_fn=lambda res: getattr(res, "settings_and_firmware", None),
     ),
 )

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -44,6 +44,7 @@ class HeatMeterSensorEntityDescriptionMixin:
     """Mixin for additional Heat Meter sensor description attributes ."""
 
     response_key: str
+    value_fn: Callable[[HeatMeterResponse], StateType | datetime]
 
 
 @dataclass
@@ -51,8 +52,6 @@ class HeatMeterSensorEntityDescription(
     SensorEntityDescription, HeatMeterSensorEntityDescriptionMixin
 ):
     """Heat Meter sensor description."""
-
-    value_fn: Callable = lambda value: value
 
 
 HEAT_METER_SENSOR_TYPES = (
@@ -64,6 +63,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
         response_key="volume_usage_m3",
+        value_fn=lambda res: getattr(res, "volume_usage_m3", None),
     ),
     HeatMeterSensorEntityDescription(
         key="heat_usage_gj",
@@ -73,6 +73,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
         response_key="heat_usage_gj",
+        value_fn=lambda res: getattr(res, "heat_usage_gj", None),
     ),
     HeatMeterSensorEntityDescription(
         key="heat_previous_year_gj",
@@ -81,6 +82,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="heat_previous_year_gj",
+        value_fn=lambda res: getattr(res, "heat_previous_year_gj", None),
     ),
     HeatMeterSensorEntityDescription(
         key="volume_previous_year_m3",
@@ -90,6 +92,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="volume_previous_year_m3",
+        value_fn=lambda res: getattr(res, "volume_previous_year_m3", None),
     ),
     HeatMeterSensorEntityDescription(
         key="ownership_number",
@@ -97,6 +100,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="ownership_number",
+        value_fn=lambda res: getattr(res, "ownership_number", None),
     ),
     HeatMeterSensorEntityDescription(
         key="error_number",
@@ -104,6 +108,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:home-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="error_number",
+        value_fn=lambda res: getattr(res, "error_number", None),
     ),
     HeatMeterSensorEntityDescription(
         key="device_number",
@@ -111,6 +116,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="device_number",
+        value_fn=lambda res: getattr(res, "device_number", None),
     ),
     HeatMeterSensorEntityDescription(
         key="measurement_period_minutes",
@@ -119,6 +125,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="measurement_period_minutes",
+        value_fn=lambda res: getattr(res, "measurement_period_minutes", None),
     ),
     HeatMeterSensorEntityDescription(
         key="power_max_kw",
@@ -127,6 +134,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="power_max_kw",
+        value_fn=lambda res: getattr(res, "power_max_kw", None),
     ),
     HeatMeterSensorEntityDescription(
         key="power_max_previous_year_kw",
@@ -135,6 +143,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="power_max_previous_year_kw",
+        value_fn=lambda res: getattr(res, "power_max_previous_year_kw", None),
     ),
     HeatMeterSensorEntityDescription(
         key="flowrate_max_m3ph",
@@ -143,6 +152,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="flowrate_max_m3ph",
+        value_fn=lambda res: getattr(res, "flowrate_max_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
         key="flowrate_max_previous_year_m3ph",
@@ -151,6 +161,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="flowrate_max_previous_year_m3ph",
+        value_fn=lambda res: getattr(res, "flowrate_max_previous_year_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
         key="return_temperature_max_c",
@@ -159,6 +170,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="return_temperature_max_c",
+        value_fn=lambda res: getattr(res, "return_temperature_max_c", None),
     ),
     HeatMeterSensorEntityDescription(
         key="return_temperature_max_previous_year_c",
@@ -167,6 +179,9 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="return_temperature_max_previous_year_c",
+        value_fn=lambda res: getattr(
+            res, "return_temperature_max_previous_year_c", None
+        ),
     ),
     HeatMeterSensorEntityDescription(
         key="flow_temperature_max_c",
@@ -175,6 +190,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="flow_temperature_max_c",
+        value_fn=lambda res: getattr(res, "flow_temperature_max_c", None),
     ),
     HeatMeterSensorEntityDescription(
         key="flow_temperature_max_previous_year_c",
@@ -183,6 +199,7 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="flow_temperature_max_previous_year_c",
+        value_fn=lambda res: getattr(res, "flow_temperature_max_previous_year_c", None),
     ),
     HeatMeterSensorEntityDescription(
         key="operating_hours",
@@ -191,6 +208,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="operating_hours",
+        value_fn=lambda res: getattr(res, "operating_hours", None),
     ),
     HeatMeterSensorEntityDescription(
         key="flow_hours",
@@ -199,6 +217,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="flow_hours",
+        value_fn=lambda res: getattr(res, "flow_hours", None),
     ),
     HeatMeterSensorEntityDescription(
         key="fault_hours",
@@ -207,6 +226,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="fault_hours",
+        value_fn=lambda res: getattr(res, "fault_hours", None),
     ),
     HeatMeterSensorEntityDescription(
         key="fault_hours_previous_year",
@@ -215,6 +235,7 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="fault_hours_previous_year",
+        value_fn=lambda res: getattr(res, "fault_hours_previous_year", None),
     ),
     HeatMeterSensorEntityDescription(
         key="yearly_set_day",
@@ -222,6 +243,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="yearly_set_day",
+        value_fn=lambda res: getattr(res, "yearly_set_day", None),
     ),
     HeatMeterSensorEntityDescription(
         key="monthly_set_day",
@@ -229,6 +251,7 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="monthly_set_day",
+        value_fn=lambda res: getattr(res, "monthly_set_day", None),
     ),
     HeatMeterSensorEntityDescription(
         key="meter_date_time",
@@ -236,8 +259,10 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:clock-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=dt_util.as_utc,
         response_key="meter_date_time",
+        value_fn=lambda res: dt_util.as_utc(res.meter_date_time)
+        if res.meter_date_time
+        else None,
     ),
     HeatMeterSensorEntityDescription(
         key="measuring_range_m3ph",
@@ -246,12 +271,14 @@ HEAT_METER_SENSOR_TYPES = (
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="measuring_range_m3ph",
+        value_fn=lambda res: getattr(res, "measuring_range_m3ph", None),
     ),
     HeatMeterSensorEntityDescription(
         key="settings_and_firmware",
         name="Settings and firmware",
         entity_category=EntityCategory.DIAGNOSTIC,
         response_key="settings_and_firmware",
+        value_fn=lambda res: getattr(res, "settings_and_firmware", None),
     ),
 )
 
@@ -307,6 +334,4 @@ class HeatMeterSensor(
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(
-            getattr(self.coordinator.data, self.entity_description.response_key, None)
-        )
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -43,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 class HeatMeterSensorEntityDescription(SensorEntityDescription):
     """Heat Meter sensor description."""
 
-    value_fn: Callable | None = None
+    value_fn: Callable = lambda value: value
     response_key: str | None = None
 
 
@@ -55,7 +55,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         state_class=SensorStateClass.TOTAL,
-        value_fn=lambda value: value,
         response_key="volume_usage_m3",
     ),
     HeatMeterSensorEntityDescription(
@@ -65,7 +64,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
-        value_fn=lambda value: value,
         response_key="heat_usage_gj",
     ),
     HeatMeterSensorEntityDescription(
@@ -74,7 +72,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Heat previous year GJ",
         native_unit_of_measurement=UnitOfEnergy.GIGA_JOULE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="heat_previous_year_gj",
     ),
     HeatMeterSensorEntityDescription(
@@ -84,7 +81,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.VOLUME,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="volume_previous_year_m3",
     ),
     HeatMeterSensorEntityDescription(
@@ -92,7 +88,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Ownership number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="ownership_number",
     ),
     HeatMeterSensorEntityDescription(
@@ -100,7 +95,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Error number",
         icon="mdi:home-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="error_number",
     ),
     HeatMeterSensorEntityDescription(
@@ -108,7 +102,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Device number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="device_number",
     ),
     HeatMeterSensorEntityDescription(
@@ -117,7 +110,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="measurement_period_minutes",
     ),
     HeatMeterSensorEntityDescription(
@@ -126,7 +118,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="power_max_kw",
     ),
     HeatMeterSensorEntityDescription(
@@ -135,7 +126,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="power_max_previous_year_kw",
     ),
     HeatMeterSensorEntityDescription(
@@ -144,7 +134,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="flowrate_max_m3ph",
     ),
     HeatMeterSensorEntityDescription(
@@ -153,7 +142,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="flowrate_max_previous_year_m3ph",
     ),
     HeatMeterSensorEntityDescription(
@@ -162,7 +150,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="return_temperature_max_c",
     ),
     HeatMeterSensorEntityDescription(
@@ -171,7 +158,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="return_temperature_max_previous_year_c",
     ),
     HeatMeterSensorEntityDescription(
@@ -180,7 +166,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="flow_temperature_max_c",
     ),
     HeatMeterSensorEntityDescription(
@@ -189,7 +174,6 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="flow_temperature_max_previous_year_c",
     ),
     HeatMeterSensorEntityDescription(
@@ -198,7 +182,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="operating_hours",
     ),
     HeatMeterSensorEntityDescription(
@@ -207,7 +190,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="flow_hours",
     ),
     HeatMeterSensorEntityDescription(
@@ -216,7 +198,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="fault_hours",
     ),
     HeatMeterSensorEntityDescription(
@@ -225,7 +206,6 @@ HEAT_METER_SENSOR_TYPES = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="fault_hours_previous_year",
     ),
     HeatMeterSensorEntityDescription(
@@ -233,7 +213,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Yearly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="yearly_set_day",
     ),
     HeatMeterSensorEntityDescription(
@@ -241,7 +220,6 @@ HEAT_METER_SENSOR_TYPES = (
         name="Monthly set day",
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="monthly_set_day",
     ),
     HeatMeterSensorEntityDescription(
@@ -259,14 +237,12 @@ HEAT_METER_SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         icon="mdi:water-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="measuring_range_m3ph",
     ),
     HeatMeterSensorEntityDescription(
         key="settings_and_firmware",
         name="Settings and firmware",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda value: value,
         response_key="settings_and_firmware",
     ),
 )
@@ -304,10 +280,12 @@ class HeatMeterSensor(
 ):
     """Representation of a Sensor."""
 
+    entity_description: HeatMeterSensorEntityDescription
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[HeatMeterResponse],
-        description: SensorEntityDescription,
+        description: HeatMeterSensorEntityDescription,
         device: DeviceInfo,
     ) -> None:
         """Set up the sensor with the initial values."""
@@ -321,7 +299,10 @@ class HeatMeterSensor(
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
-
-        return self.entity_description.value_fn(  # type: ignore[attr-defined]
-            getattr(self.coordinator.data, self.entity_description.response_key, None)  # type: ignore[attr-defined]
-        )
+        if self.entity_description.response_key:
+            return self.entity_description.value_fn(
+                getattr(
+                    self.coordinator.data, self.entity_description.response_key, None
+                )
+            )
+        return None

--- a/homeassistant/components/landisgyr_heat_meter/sensor.py
+++ b/homeassistant/components/landisgyr_heat_meter/sensor.py
@@ -40,11 +40,19 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class HeatMeterSensorEntityDescription(SensorEntityDescription):
+class HeatMeterSensorEntityDescriptionMixin:
+    """Mixin for additional Heat Meter sensor description attributes ."""
+
+    response_key: str
+
+
+@dataclass
+class HeatMeterSensorEntityDescription(
+    SensorEntityDescription, HeatMeterSensorEntityDescriptionMixin
+):
     """Heat Meter sensor description."""
 
     value_fn: Callable = lambda value: value
-    response_key: str | None = None
 
 
 HEAT_METER_SENSOR_TYPES = (
@@ -299,10 +307,6 @@ class HeatMeterSensor(
     @property
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
-        if self.entity_description.response_key:
-            return self.entity_description.value_fn(
-                getattr(
-                    self.coordinator.data, self.entity_description.response_key, None
-                )
-            )
-        return None
+        return self.entity_description.value_fn(
+            getattr(self.coordinator.data, self.entity_description.response_key, None)
+        )

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -85,13 +85,9 @@ async def test_create_sensors(
 
     # check if 26 attributes have been created
     assert len(hass.states.async_all()) == 25
-    assert len(hass.states.async_all()) == 25
 
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
-    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
-    assert state.state == "123.0"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.state == "123.0"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -5,10 +5,7 @@ from unittest.mock import patch
 
 import serial
 
-from homeassistant.components.homeassistant import (
-    DOMAIN as HA_DOMAIN,
-    SERVICE_UPDATE_ENTITY,
-)
+from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
 from homeassistant.components.landisgyr_heat_meter.const import DOMAIN, POLLING_INTERVAL
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
@@ -17,7 +14,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
-    ATTR_ENTITY_ID,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     STATE_UNAVAILABLE,
@@ -74,13 +70,6 @@ async def test_create_sensors(
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await async_setup_component(hass, HA_DOMAIN, {})
-    await hass.async_block_till_done()
-    await hass.services.async_call(
-        HA_DOMAIN,
-        SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage_gj"},
-        blocking=True,
-    )
     await hass.async_block_till_done()
 
     # check if 26 attributes have been created
@@ -140,13 +129,6 @@ async def test_exception_on_polling(mock_heat_meter, hass: HomeAssistant) -> Non
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await async_setup_component(hass, HA_DOMAIN, {})
-    await hass.async_block_till_done()
-    await hass.services.async_call(
-        HA_DOMAIN,
-        SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: "sensor.heat_meter_heat_usage_gj"},
-        blocking=True,
-    )
     await hass.async_block_till_done()
 
     # check if initial setup succeeded

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.components.landisgyr_heat_meter.const import DOMAIN, POLLING_INTERVAL
 from homeassistant.components.sensor import (
-    ATTR_LAST_RESET,
     ATTR_STATE_CLASS,
     SensorDeviceClass,
     SensorStateClass,
@@ -26,16 +25,12 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfVolume,
 )
-from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import (
-    MockConfigEntry,
-    async_fire_time_changed,
-    mock_restore_cache_with_extra_data,
-)
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 API_HEAT_METER_SERVICE = (
     "homeassistant.components.landisgyr_heat_meter.ultraheat_api.HeatMeterService"
@@ -90,9 +85,13 @@ async def test_create_sensors(
 
     # check if 26 attributes have been created
     assert len(hass.states.async_all()) == 25
+    assert len(hass.states.async_all()) == 25
 
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
+    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state
+    assert state.state == "123.0"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.state == "123.0"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
@@ -119,97 +118,6 @@ async def test_create_sensors(
         "sensor.heat_meter_meter_date_time"
     )
     assert entity_registry_entry.entity_category == EntityCategory.DIAGNOSTIC
-
-
-@patch(API_HEAT_METER_SERVICE)
-async def test_restore_state(mock_heat_meter, hass: HomeAssistant) -> None:
-    """Test sensor restore state."""
-    # Home assistant is not running yet
-    hass.state = CoreState.not_running
-    last_reset = "2022-07-01T00:00:00.000000+00:00"
-    mock_restore_cache_with_extra_data(
-        hass,
-        [
-            (
-                State(
-                    "sensor.heat_meter_heat_usage_gj",
-                    "34167",
-                    attributes={
-                        ATTR_LAST_RESET: last_reset,
-                        ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.GIGA_JOULE,
-                        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
-                    },
-                ),
-                {
-                    "native_value": 34167,
-                    "native_unit_of_measurement": UnitOfEnergy.GIGA_JOULE,
-                    "icon": "mdi:fire",
-                    "last_reset": last_reset,
-                },
-            ),
-            (
-                State(
-                    "sensor.heat_meter_volume_usage",
-                    "456",
-                    attributes={
-                        ATTR_LAST_RESET: last_reset,
-                        ATTR_UNIT_OF_MEASUREMENT: UnitOfVolume.CUBIC_METERS,
-                        ATTR_STATE_CLASS: SensorStateClass.TOTAL,
-                    },
-                ),
-                {
-                    "native_value": 456,
-                    "native_unit_of_measurement": UnitOfVolume.CUBIC_METERS,
-                    "icon": "mdi:fire",
-                    "last_reset": last_reset,
-                },
-            ),
-            (
-                State(
-                    "sensor.heat_meter_device_number",
-                    "devicenr_789",
-                    attributes={
-                        ATTR_LAST_RESET: last_reset,
-                    },
-                ),
-                {
-                    "native_value": "devicenr_789",
-                    "native_unit_of_measurement": None,
-                    "last_reset": last_reset,
-                },
-            ),
-        ],
-    )
-    entry_data = {
-        "device": "/dev/USB0",
-        "model": "LUGCUH50",
-        "device_number": "123456789",
-    }
-
-    # create and add entry
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # restore from cache
-    state = hass.states.get("sensor.heat_meter_heat_usage_gj")
-    assert state
-    assert state.state == "34167"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.GIGA_JOULE
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
-
-    state = hass.states.get("sensor.heat_meter_volume_usage")
-    assert state
-    assert state.state == "456"
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfVolume.CUBIC_METERS
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
-
-    state = hass.states.get("sensor.heat_meter_device_number")
-    assert state
-    assert state.state == "devicenr_789"
-    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
 
 @patch(API_HEAT_METER_SERVICE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users have reported issues with the integration not polling on init and restart. This was originally done by design to preserve battery, but the discussion has led to a decision to introduce polling on init/restart after all. This is also more consistent with generally expected HA-behavior. This is therefore seen as a bug fix.
For fixing this, some code improvements have had to te be made, based on suggestions in previous PR-reviews.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84130
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
