### PR TITLE
Partial Test always run on integration change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,7 @@ jobs:
       postgresql_groups: ${{ steps.info.outputs.postgresql_groups }}
       python_versions: ${{ steps.info.outputs.python_versions }}
       test_full_suite: ${{ steps.info.outputs.test_full_suite }}
+      test_partial_suite: ${{ steps.info.outputs.test_partial_suite }}
       test_group_count: ${{ steps.info.outputs.test_group_count }}
       test_groups: ${{ steps.info.outputs.test_groups }}
       tests_glob: ${{ steps.info.outputs.tests_glob }}
@@ -120,9 +121,10 @@ jobs:
           mariadb_groups=${MARIADB_VERSIONS}
           postgresql_groups=${POSTGRESQL_VERSIONS}
           test_full_suite="true"
+          test_partial_suite="false"
           test_groups="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
           test_group_count=10
-          tests="[]"
+          tests="[integration]"
           tests_glob=""
 
           if [[ "${{ steps.integrations.outputs.changes }}" != "[]" ]];
@@ -155,6 +157,7 @@ jobs:
             mariadb_groups="[]"
             postgresql_groups="[]"
             test_full_suite="false"
+            test_partial_suite="true"
           fi
 
           # We need to run the full suite on certain branches.
@@ -182,6 +185,8 @@ jobs:
           echo "python_versions=${ALL_PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
           echo "test_full_suite: ${test_full_suite}"
           echo "test_full_suite=${test_full_suite}" >> $GITHUB_OUTPUT
+          echo "test_partial_suite: ${test_partial_suite}"
+          echo "test_partial_suite=${test_partial_suite}" >> $GITHUB_OUTPUT
           echo "integrations_glob: ${integrations_glob}"
           echo "integrations_glob=${integrations_glob}" >> $GITHUB_OUTPUT
           echo "test_group_count: ${test_group_count}"
@@ -273,18 +278,18 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
               needs.info.outputs.pre-commit_cache_key }}
-      - name: Run black (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual black --all-files --show-diff-on-failure
       - name: Run black (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
+        if: needs.info.outputs.test_partial_suite == 'true'
         shell: bash
         run: |
           . venv/bin/activate
           shopt -s globstar
           pre-commit run --hook-stage manual black --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
+      - name: Run black (fully)
+        if: needs.info.outputs.test_full_suite == 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual black --all-files --show-diff-on-failure
 
   lint-flake8:
     name: Check flake8
@@ -322,18 +327,18 @@ jobs:
       - name: Register flake8 problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/flake8.json"
-      - name: Run flake8 (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual flake8 --all-files
       - name: Run flake8 (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
+        if: needs.info.outputs.test_partial_suite == 'true'
         shell: bash
         run: |
           . venv/bin/activate
           shopt -s globstar
           pre-commit run --hook-stage manual flake8 --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*}
+      - name: Run flake8 (fully)
+        if: needs.info.outputs.test_full_suite == 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual flake8 --all-files
 
   lint-ruff:
     name: Check ruff
@@ -371,18 +376,18 @@ jobs:
       - name: Register ruff problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
-      - name: Run ruff (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual ruff --all-files --show-diff-on-failure
       - name: Run ruff (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
+        if: needs.info.outputs.test_partial_suite == 'true'
         shell: bash
         run: |
           . venv/bin/activate
           shopt -s globstar
           pre-commit run --hook-stage manual ruff --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
+      - name: Run ruff (fully)
+        if: needs.info.outputs.test_full_suite == 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual ruff --all-files --show-diff-on-failure
 
   lint-isort:
     name: Check isort
@@ -456,18 +461,18 @@ jobs:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
               needs.info.outputs.pre-commit_cache_key }}
 
-      - name: Run pyupgrade (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual pyupgrade --all-files --show-diff-on-failure
       - name: Run pyupgrade (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
+        if: needs.info.outputs.test_partial_suite == 'true'
         shell: bash
         run: |
           . venv/bin/activate
           shopt -s globstar
           pre-commit run --hook-stage manual pyupgrade --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
+      - name: Run pyupgrade (fully)
+        if: needs.info.outputs.test_full_suite == 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual pyupgrade --all-files --show-diff-on-failure
 
       - name: Register yamllint problem matcher
         run: |
@@ -485,18 +490,17 @@ jobs:
           . venv/bin/activate
           pre-commit run --hook-stage manual check-json --all-files
 
+      - name: Run prettier (partially)
+        if: needs.info.outputs.test_partial_suite == 'true'
+        shell: bash
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual prettier --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*}
       - name: Run prettier (fully)
         if: needs.info.outputs.test_full_suite == 'true'
         run: |
           . venv/bin/activate
           pre-commit run --hook-stage manual prettier --all-files
-
-      - name: Run prettier (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
-        shell: bash
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual prettier --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*}
 
       - name: Register check executables problem matcher
         run: |
@@ -526,18 +530,18 @@ jobs:
         with:
           args: hadolint Dockerfile.dev
 
-      - name: Run bandit (fully)
-        if: needs.info.outputs.test_full_suite == 'true'
-        run: |
-          . venv/bin/activate
-          pre-commit run --hook-stage manual bandit --all-files --show-diff-on-failure
       - name: Run bandit (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
+        if: needs.info.outputs.test_partial_suite == 'true'
         shell: bash
         run: |
           . venv/bin/activate
           shopt -s globstar
           pre-commit run --hook-stage manual bandit --files {homeassistant,tests}/components/${{ needs.info.outputs.integrations_glob }}/{*,**/*} --show-diff-on-failure
+      - name: Run bandit (fully)
+        if: needs.info.outputs.test_full_suite == 'true'
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual bandit --all-files --show-diff-on-failure
 
   base:
     name: Prepare dependencies
@@ -701,19 +705,19 @@ jobs:
       - name: Register pylint problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
+      - name: Run pylint (partially)
+        if: needs.info.outputs.test_partial_suite == 'true'
+        shell: bash
+        run: |
+          . venv/bin/activate
+          python --version
+          pylint --ignore-missing-annotations=y homeassistant/components/${{ needs.info.outputs.integrations_glob }}
       - name: Run pylint (fully)
         if: needs.info.outputs.test_full_suite == 'true'
         run: |
           . venv/bin/activate
           python --version
           pylint --ignore-missing-annotations=y homeassistant
-      - name: Run pylint (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
-        shell: bash
-        run: |
-          . venv/bin/activate
-          python --version
-          pylint --ignore-missing-annotations=y homeassistant/components/${{ needs.info.outputs.integrations_glob }}
 
   mypy:
     name: Check mypy
@@ -763,19 +767,19 @@ jobs:
       - name: Register mypy problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/mypy.json"
+      - name: Run mypy (partially)
+        if: needs.info.outputs.test_partial_suite == 'true'
+        shell: bash
+        run: |
+          . venv/bin/activate
+          python --version
+          mypy homeassistant/components/${{ needs.info.outputs.integrations_glob }}
       - name: Run mypy (fully)
         if: needs.info.outputs.test_full_suite == 'true'
         run: |
           . venv/bin/activate
           python --version
           mypy homeassistant pylint
-      - name: Run mypy (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
-        shell: bash
-        run: |
-          . venv/bin/activate
-          python --version
-          mypy homeassistant/components/${{ needs.info.outputs.integrations_glob }}
 
   pip-check:
     runs-on: ubuntu-22.04
@@ -813,14 +817,14 @@ jobs:
           . venv/bin/activate
           ./script/pip_check $PIP_CACHE
 
-  pytest:
+  pytest-partial:
     runs-on: ubuntu-22.04
     if: |
       (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
       && github.event.inputs.lint-only != 'true'
       && github.event.inputs.pylint-only != 'true'
       && github.event.inputs.mypy-only != 'true'
-      && (needs.info.outputs.test_full_suite == 'true' || needs.info.outputs.tests_glob)
+      && needs.info.outputs.test_partial_suite =='true'
     needs:
       - info
       - base
@@ -830,6 +834,110 @@ jobs:
       - lint-other
       - lint-ruff
       - mypy
+    strategy:
+      fail-fast: false
+      matrix:
+        integration: ${{ fromJson(needs.info.outputs.tests) }}
+        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
+    name: >-
+      Run tests Python ${{ matrix.python-version }} (${{ matrix.integration }})
+    steps:
+      - name: Install additional OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install \
+            bluez \
+            ffmpeg
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.3.0
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v4.5.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+      - name: Restore full Python ${{ matrix.python-version }} virtual environment
+        id: cache-venv
+        uses: actions/cache/restore@v3.3.0
+        with:
+          path: venv
+          fail-on-cache-miss: true
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            needs.info.outputs.python_cache_key }}
+      - name: Register Python problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/python.json"
+      - name: Install Pytest Annotation plugin
+        run: |
+          . venv/bin/activate
+          # Ideally this should be part of our dependencies
+          # However this plugin is fairly new and doesn't run correctly
+          # on a non-GitHub environment.
+          pip install pytest-github-actions-annotate-failures==0.1.3
+      - name: Register pytest slow test problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/pytest-slow.json"
+      - name: Compile English translations
+        run: |
+          . venv/bin/activate
+          if [[ ! -f "homeassistant/components/${{ matrix.integration }}/strings.json" ]]; then
+            echo "::warning:: missing file tests/components/${{ matrix.integration }}/sensors.py"
+          else
+            python3 -m script.translations develop --integration ${{ matrix.integration }}
+          fi
+      - name: Run pytest (partially)
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          . venv/bin/activate
+          python --version
+
+          if [[ ! -f "tests/components/${{ matrix.integration }}/__init__.py" ]]; then
+            echo "::error:: missing file tests/components/${{ matrix.integration }}/__init__.py"
+            exit 1
+          fi
+
+          python3 -X dev -m pytest \
+            -qq \
+            --timeout=9 \
+            -n auto \
+            --cov="homeassistant.components.${{ matrix.integration }}" \
+            --cov-report=xml \
+            --cov-report=term-missing \
+            -o console_output_style=count \
+            --durations=0 \
+            --durations-min=1 \
+            -p no:sugar \
+            tests/components/${{ matrix.integration }}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: coverage-${{ matrix.python-version }}-${{ matrix.integration }}
+          path: coverage.xml
+      - name: Check dirty
+        run: |
+          ./script/check_dirty
+
+  pytest:
+    runs-on: ubuntu-22.04
+    if: |
+      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
+      && github.event.inputs.lint-only != 'true'
+      && github.event.inputs.pylint-only != 'true'
+      && github.event.inputs.mypy-only != 'true'
+      && (needs.info.outputs.test_full_suite == 'true' || needs.info.outputs.tests_glob)
+      && !failure('pytest-partial')
+
+    needs:
+      - info
+      - base
+      - gen-requirements-all
+      - hassfest
+      - lint-isort
+      - lint-other
+      - lint-ruff
+      - mypy
+      - pytest-partial
     strategy:
       fail-fast: false
       matrix:
@@ -896,31 +1004,6 @@ jobs:
             -o console_output_style=count \
             -p no:sugar \
             tests
-      - name: Run pytest (partially)
-        if: needs.info.outputs.test_full_suite == 'false'
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          . venv/bin/activate
-          python --version
-
-          if [[ ! -f "tests/components/${{ matrix.group }}/__init__.py" ]]; then
-            echo "::error:: missing file tests/components/${{ matrix.group }}/__init__.py"
-            exit 1
-          fi
-
-          python3 -X dev -m pytest \
-            -qq \
-            --timeout=9 \
-            -n auto \
-            --cov="homeassistant.components.${{ matrix.group }}" \
-            --cov-report=xml \
-            --cov-report=term-missing \
-            -o console_output_style=count \
-            --durations=0 \
-            --durations-min=1 \
-            -p no:sugar \
-            tests/components/${{ matrix.group }}
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -1054,6 +1137,7 @@ jobs:
       && github.event.inputs.pylint-only != 'true'
       && github.event.inputs.mypy-only != 'true'
       && needs.info.outputs.postgresql_groups != '[]'
+      && !failure('pytest-partial')
     needs:
       - info
       - base
@@ -1063,6 +1147,7 @@ jobs:
       - lint-other
       - lint-ruff
       - mypy
+      - pytest-partial
     strategy:
       fail-fast: false
       matrix:
@@ -1153,6 +1238,14 @@ jobs:
     needs:
       - info
       - pytest
+      - pytest-partial
+      - pytest-postgres
+      - pytest-mariadb
+    if: |
+      !failure('pytest')
+      || !failure('0ytest-partial')
+      || !failure('pytest-mariadb')
+      || !failure('pytest-postgres')
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.3.0
@@ -1164,5 +1257,4 @@ jobs:
         with:
           flags: full-suite
       - name: Upload coverage to Codecov (partial coverage)
-        if: needs.info.outputs.test_full_suite == 'false'
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1147,7 +1147,6 @@ jobs:
       - lint-other
       - lint-ruff
       - mypy
-      - pytest-partial
     strategy:
       fail-fast: false
       matrix:
@@ -1243,7 +1242,7 @@ jobs:
       - pytest-mariadb
     if: |
       !failure('pytest')
-      || !failure('0ytest-partial')
+      || !failure('pytest-partial')
       || !failure('pytest-mariadb')
       || !failure('pytest-postgres')
     steps:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Core maintainers, feel free to let me know if this is not something you are interested in at all - or if you would like me to modify it/ break it up into smaller PRS.

As of right now, when ci runs, it only runs partial test if core files are not affected. This is great as when you make a small change for an integration, the ci pipeline will be smaller and faster.

However, if I make a change to an integration that also affects core files, i.e. a new integration or bumping the version in my integration, partial does not run, only full does. This is okay, as everything will get tested that needs to, but in terms of debugging, it can be a fair bit slower, as you have to wait for all of the other code in core to get tested before you learn if your integration caused any issues.

But with partial always running before full runs, it means if you have a formatting issue, or a failed test, your ci pipeline will see that quicker and fail, and you will only continue to the more extreme checks as long as your integration changes are good.

As 95% of the time when you are working on a integration, the partial test will catch any issues you have.

There is currently one issue: pytest-partial has no name if there are no integrations to run so it just has the $${{}} in it. If someone knows a solution, please let me know. 

Again, core maintainers, let me know if this isn't something you want, I just saw it and figured I would create this PR and see.\

Uploading to codecov also now waits for all pytest to finish and will upload as long as one of them succeeds

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
