### PR TITLE
TP-Link Omada update entities code review feedback

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Unexpected error connecting to Omada controller: {ex}"
         ) from ex
 
-    site_client = await client.get_site_client(OmadaSite(None, entry.data[CONF_SITE]))
+    site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
     controller = OmadaSiteController(hass, site_client)
     hass.data[DOMAIN][entry.entry_id] = controller
 

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -1,7 +1,5 @@
 """Controller for sharing Omada API coordinators between platforms."""
 
-from functools import partial
-
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
 from tplink_omada_client.omadasiteclient import OmadaSiteClient
 
@@ -9,13 +7,28 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import OmadaCoordinator
 
+POLL_SWITCH_PORT = 300
 
-async def _poll_switch_state(
-    client: OmadaSiteClient, network_switch: OmadaSwitch
-) -> dict[str, OmadaSwitchPortDetails]:
-    """Poll a switch's current state."""
-    ports = await client.get_switch_ports(network_switch)
-    return {p.port_id: p for p in ports}
+
+class OmadaSwitchPortCoordinator(OmadaCoordinator[OmadaSwitchPortDetails]):
+    """Coordinator for getting details about ports on a switch."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        omada_client: OmadaSiteClient,
+        network_switch: OmadaSwitch,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass, omada_client, f"{network_switch.name} Ports", POLL_SWITCH_PORT
+        )
+        self._network_switch = network_switch
+
+    async def poll_update(self) -> dict[str, OmadaSwitchPortDetails]:
+        """Poll a switch's current state."""
+        ports = await self.omada_client.get_switch_ports(self._network_switch)
+        return {p.port_id: p for p in ports}
 
 
 class OmadaSiteController:
@@ -26,9 +39,7 @@ class OmadaSiteController:
         self._hass = hass
         self._omada_client = omada_client
 
-        self._switch_port_coordinators: dict[
-            str, OmadaCoordinator[OmadaSwitchPortDetails]
-        ] = {}
+        self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
 
     @property
     def omada_client(self) -> OmadaSiteClient:
@@ -37,16 +48,11 @@ class OmadaSiteController:
 
     def get_switch_port_coordinator(
         self, switch: OmadaSwitch
-    ) -> OmadaCoordinator[OmadaSwitchPortDetails]:
+    ) -> OmadaSwitchPortCoordinator:
         """Get coordinator for network port information of a given switch."""
         if switch.mac not in self._switch_port_coordinators:
-            self._switch_port_coordinators[switch.mac] = OmadaCoordinator[
-                OmadaSwitchPortDetails
-            ](
-                self._hass,
-                self._omada_client,
-                f"{switch.name} Ports",
-                partial(_poll_switch_state, network_switch=switch),
+            self._switch_port_coordinators[switch.mac] = OmadaSwitchPortCoordinator(
+                self._hass, self._omada_client, switch
             )
 
         return self._switch_port_coordinators[switch.mac]

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -1,5 +1,4 @@
 """Generic Omada API coordinator."""
-from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
 from typing import Generic, TypeVar
@@ -24,7 +23,6 @@ class OmadaCoordinator(DataUpdateCoordinator[dict[str, T]], Generic[T]):
         hass: HomeAssistant,
         omada_client: OmadaSiteClient,
         name: str,
-        update_func: Callable[[OmadaSiteClient], Awaitable[dict[str, T]]],
         poll_delay: int = 300,
     ) -> None:
         """Initialize my coordinator."""
@@ -35,12 +33,15 @@ class OmadaCoordinator(DataUpdateCoordinator[dict[str, T]], Generic[T]):
             update_interval=timedelta(seconds=poll_delay),
         )
         self.omada_client = omada_client
-        self._update_func = update_func
 
     async def _async_update_data(self) -> dict[str, T]:
         """Fetch data from API endpoint."""
         try:
             async with async_timeout.timeout(10):
-                return await self._update_func(self.omada_client)
+                return await self.poll_update()
         except OmadaClientException as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+    async def poll_update(self) -> dict[str, T]:
+        """Poll the current data from the controller."""
+        raise NotImplementedError("Update method not implemented")

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["tplink-omada-client==1.1.3"]
+  "requirements": ["tplink-omada-client==1.1.4"]
 }

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -14,8 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .controller import OmadaSiteController
-from .coordinator import OmadaCoordinator
+from .controller import OmadaSiteController, OmadaSwitchPortCoordinator
 from .entity import OmadaDeviceEntity
 
 POE_SWITCH_ICON = "mdi:ethernet"
@@ -68,7 +67,7 @@ class OmadaNetworkSwitchPortPoEControl(
 
     def __init__(
         self,
-        coordinator: OmadaCoordinator[OmadaSwitchPortDetails],
+        coordinator: OmadaSwitchPortCoordinator,
         device: OmadaSwitch,
         port_id: str,
     ) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2524,7 +2524,7 @@ total_connect_client==2023.2
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.1.3
+tplink-omada-client==1.1.4
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1785,7 +1785,7 @@ toonapi==0.2.1
 total_connect_client==2023.2
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.1.3
+tplink-omada-client==1.1.4
 
 # homeassistant.components.transmission
 transmission-rpc==3.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
 
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates requested in post-merge review of PR #89562.
Mostly just a code tidy, no functional changes.

Dependency: [tp-link library updated](https://github.com/MarkGodwin/tplink-omada-api/compare/release/v1.1.3...release/v1.1.4) to flag typing information


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #89562
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
