### PR TITLE
Move local calendar text fixtures to conftest.py

### DIFF
--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for local calendar."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
-from tests.typing import ClientSessionGenerator
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 CALENDAR_NAME = "Light Schedule"
 FRIENDLY_NAME = "Light schedule"
@@ -150,7 +150,7 @@ ClientFixture = Callable[[], Awaitable[Client]]
 @pytest.fixture
 async def ws_client(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> ClientFixture:
     """Fixture for creating the test websocket client."""
 

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -1,0 +1,161 @@
+"""Fixtures for local calendar."""
+
+from collections.abc import Awaitable, Callable
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+import urllib
+
+from aiohttp import ClientWebSocketResponse
+import pytest
+
+from homeassistant.components.local_calendar import LocalCalendarStore
+from homeassistant.components.local_calendar.const import CONF_CALENDAR_NAME, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
+
+CALENDAR_NAME = "Light Schedule"
+FRIENDLY_NAME = "Light schedule"
+TEST_ENTITY = "calendar.light_schedule"
+
+
+class FakeStore(LocalCalendarStore):
+    """Mock storage implementation."""
+
+    def __init__(self, hass: HomeAssistant, path: Path) -> None:
+        """Initialize FakeStore."""
+        super().__init__(hass, path)
+        self._content = ""
+
+    def _load(self) -> str:
+        """Read from calendar storage."""
+        return self._content
+
+    def _store(self, ics_content: str) -> None:
+        """Persist the calendar storage."""
+        self._content = ics_content
+
+
+@pytest.fixture(name="store", autouse=True)
+def mock_store() -> None:
+    """Test cleanup, remove any media storage persisted during the test."""
+
+    stores: dict[Path, FakeStore] = {}
+
+    def new_store(hass: HomeAssistant, path: Path) -> FakeStore:
+        if path not in stores:
+            stores[path] = FakeStore(hass, path)
+        return stores[path]
+
+    with patch(
+        "homeassistant.components.local_calendar.LocalCalendarStore", new=new_store
+    ):
+        yield
+
+
+@pytest.fixture(name="time_zone")
+def mock_time_zone() -> str:
+    """Fixture for time zone to use in tests."""
+    # Set our timezone to CST/Regina so we can check calculations
+    # This keeps UTC-6 all year round
+    return "America/Regina"
+
+
+@pytest.fixture(autouse=True)
+def set_time_zone(hass: HomeAssistant, time_zone: str):
+    """Set the time zone for the tests."""
+    # Set our timezone to CST/Regina so we can check calculations
+    # This keeps UTC-6 all year round
+    hass.config.set_time_zone(time_zone)
+
+
+@pytest.fixture(name="config_entry")
+def mock_config_entry() -> MockConfigEntry:
+    """Fixture for mock configuration entry."""
+    return MockConfigEntry(domain=DOMAIN, data={CONF_CALENDAR_NAME: CALENDAR_NAME})
+
+
+@pytest.fixture(name="setup_integration")
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the integration."""
+    config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+
+GetEventsFn = Callable[[str, str], Awaitable[dict[str, Any]]]
+
+
+@pytest.fixture(name="get_events")
+def get_events_fixture(hass_client: ClientSessionGenerator) -> GetEventsFn:
+    """Fetch calendar events from the HTTP API."""
+
+    async def _fetch(start: str, end: str) -> None:
+        client = await hass_client()
+        response = await client.get(
+            f"/api/calendars/{TEST_ENTITY}?start={urllib.parse.quote(start)}&end={urllib.parse.quote(end)}"
+        )
+        assert response.status == HTTPStatus.OK
+        return await response.json()
+
+    return _fetch
+
+
+def event_fields(data: dict[str, str]) -> dict[str, str]:
+    """Filter event API response to minimum fields."""
+    return {
+        k: data.get(k)
+        for k in ["summary", "start", "end", "recurrence_id"]
+        if data.get(k)
+    }
+
+
+class Client:
+    """Test client with helper methods for calendar websocket."""
+
+    def __init__(self, client):
+        """Initialize Client."""
+        self.client = client
+        self.id = 0
+
+    async def cmd(self, cmd: str, payload: dict[str, Any] = None) -> dict[str, Any]:
+        """Send a command and receive the json result."""
+        self.id += 1
+        await self.client.send_json(
+            {
+                "id": self.id,
+                "type": f"calendar/event/{cmd}",
+                **(payload if payload is not None else {}),
+            }
+        )
+        resp = await self.client.receive_json()
+        assert resp.get("id") == self.id
+        return resp
+
+    async def cmd_result(self, cmd: str, payload: dict[str, Any] = None) -> Any:
+        """Send a command and parse the result."""
+        resp = await self.cmd(cmd, payload)
+        assert resp.get("success")
+        assert resp.get("type") == "result"
+        return resp.get("result")
+
+
+ClientFixture = Callable[[], Awaitable[Client]]
+
+
+@pytest.fixture
+async def ws_client(
+    hass: HomeAssistant,
+    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+) -> ClientFixture:
+    """Fixture for creating the test websocket client."""
+
+    async def create_client() -> Client:
+        ws_client = await hass_ws_client(hass)
+        return Client(ws_client)
+
+    return create_client

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -41,7 +41,7 @@ class FakeStore(LocalCalendarStore):
 
 
 @pytest.fixture(name="store", autouse=True)
-def mock_store() -> None:
+def mock_store() -> Generator[None, None, None]:
     """Test cleanup, remove any media storage persisted during the test."""
 
     stores: dict[Path, FakeStore] = {}
@@ -117,7 +117,7 @@ def event_fields(data: dict[str, str]) -> dict[str, str]:
 class Client:
     """Test client with helper methods for calendar websocket."""
 
-    def __init__(self, client):
+    def __init__(self, client: ClientWebSocketResponse) -> None:
         """Initialize Client."""
         self.client = client
         self.id = 0

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -1,168 +1,23 @@
 """Tests for calendar platform of local calendar."""
 
-from collections.abc import Awaitable, Callable
 import datetime
-from http import HTTPStatus
-from pathlib import Path
-from typing import Any
-from unittest.mock import patch
-import urllib
 
-from aiohttp import ClientWebSocketResponse
 import pytest
 
-from homeassistant.components.local_calendar import LocalCalendarStore
-from homeassistant.components.local_calendar.const import CONF_CALENDAR_NAME, DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import DATE_STR_FORMAT
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from .conftest import (
+    FRIENDLY_NAME,
+    TEST_ENTITY,
+    ClientFixture,
+    GetEventsFn,
+    event_fields,
+)
+
 from tests.common import MockConfigEntry
-from tests.typing import ClientSessionGenerator
-
-CALENDAR_NAME = "Light Schedule"
-FRIENDLY_NAME = "Light schedule"
-TEST_ENTITY = "calendar.light_schedule"
-
-
-class FakeStore(LocalCalendarStore):
-    """Mock storage implementation."""
-
-    def __init__(self, hass: HomeAssistant, path: Path) -> None:
-        """Initialize FakeStore."""
-        super().__init__(hass, path)
-        self._content = ""
-
-    def _load(self) -> str:
-        """Read from calendar storage."""
-        return self._content
-
-    def _store(self, ics_content: str) -> None:
-        """Persist the calendar storage."""
-        self._content = ics_content
-
-
-@pytest.fixture(name="store", autouse=True)
-def mock_store() -> None:
-    """Test cleanup, remove any media storage persisted during the test."""
-
-    stores: dict[Path, FakeStore] = {}
-
-    def new_store(hass: HomeAssistant, path: Path) -> FakeStore:
-        if path not in stores:
-            stores[path] = FakeStore(hass, path)
-        return stores[path]
-
-    with patch(
-        "homeassistant.components.local_calendar.LocalCalendarStore", new=new_store
-    ):
-        yield
-
-
-@pytest.fixture(name="time_zone")
-def mock_time_zone() -> str:
-    """Fixture for time zone to use in tests."""
-    # Set our timezone to CST/Regina so we can check calculations
-    # This keeps UTC-6 all year round
-    return "America/Regina"
-
-
-@pytest.fixture(autouse=True)
-def set_time_zone(hass: HomeAssistant, time_zone: str):
-    """Set the time zone for the tests."""
-    # Set our timezone to CST/Regina so we can check calculations
-    # This keeps UTC-6 all year round
-    hass.config.set_time_zone(time_zone)
-
-
-@pytest.fixture(name="config_entry")
-def mock_config_entry() -> MockConfigEntry:
-    """Fixture for mock configuration entry."""
-    return MockConfigEntry(domain=DOMAIN, data={CONF_CALENDAR_NAME: CALENDAR_NAME})
-
-
-@pytest.fixture(name="setup_integration")
-async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
-    """Set up the integration."""
-    config_entry.add_to_hass(hass)
-    assert await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
-
-
-GetEventsFn = Callable[[str, str], Awaitable[dict[str, Any]]]
-
-
-@pytest.fixture(name="get_events")
-def get_events_fixture(hass_client: ClientSessionGenerator) -> GetEventsFn:
-    """Fetch calendar events from the HTTP API."""
-
-    async def _fetch(start: str, end: str) -> None:
-        client = await hass_client()
-        response = await client.get(
-            f"/api/calendars/{TEST_ENTITY}?start={urllib.parse.quote(start)}&end={urllib.parse.quote(end)}"
-        )
-        assert response.status == HTTPStatus.OK
-        return await response.json()
-
-    return _fetch
-
-
-def event_fields(data: dict[str, str]) -> dict[str, str]:
-    """Filter event API response to minimum fields."""
-    return {
-        k: data.get(k)
-        for k in ["summary", "start", "end", "recurrence_id"]
-        if data.get(k)
-    }
-
-
-class Client:
-    """Test client with helper methods for calendar websocket."""
-
-    def __init__(self, client):
-        """Initialize Client."""
-        self.client = client
-        self.id = 0
-
-    async def cmd(self, cmd: str, payload: dict[str, Any] = None) -> dict[str, Any]:
-        """Send a command and receive the json result."""
-        self.id += 1
-        await self.client.send_json(
-            {
-                "id": self.id,
-                "type": f"calendar/event/{cmd}",
-                **(payload if payload is not None else {}),
-            }
-        )
-        resp = await self.client.receive_json()
-        assert resp.get("id") == self.id
-        return resp
-
-    async def cmd_result(self, cmd: str, payload: dict[str, Any] = None) -> Any:
-        """Send a command and parse the result."""
-        resp = await self.cmd(cmd, payload)
-        assert resp.get("success")
-        assert resp.get("type") == "result"
-        return resp.get("result")
-
-
-ClientFixture = Callable[[], Awaitable[Client]]
-
-
-@pytest.fixture
-async def ws_client(
-    hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
-) -> ClientFixture:
-    """Fixture for creating the test websocket client."""
-
-    async def create_client() -> Client:
-        ws_client = await hass_ws_client(hass)
-        return Client(ws_client)
-
-    return create_client
 
 
 async def test_empty_calendar(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move local calendar text fixtures to conftest.py as a "pre-factoring" before adding another platform. These fixture are all needed to test any calendar functionality since they (1) setup the integration (2) setup a fake store and (3) are fixture helpers for creating events with the websocket and reading events over rest API.

There are no code changes, just a pure "cp calendar_test.py conftest.py" and then removing the parts that aren't moving or unused imports

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
