### PR TITLE
Add index to event_type and entity_id

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -68,7 +68,7 @@ class Base(DeclarativeBase):
     """Base class for tables."""
 
 
-SCHEMA_VERSION = 40
+SCHEMA_VERSION = 41
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -348,7 +348,9 @@ class EventTypes(Base):
     __table_args__ = (_DEFAULT_TABLE_ARGS,)
     __tablename__ = TABLE_EVENT_TYPES
     event_type_id: Mapped[int] = mapped_column(Integer, Identity(), primary_key=True)
-    event_type: Mapped[str | None] = mapped_column(String(MAX_LENGTH_EVENT_EVENT_TYPE))
+    event_type: Mapped[str | None] = mapped_column(
+        String(MAX_LENGTH_EVENT_EVENT_TYPE), index=True
+    )
 
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
@@ -597,7 +599,9 @@ class StatesMeta(Base):
     __table_args__ = (_DEFAULT_TABLE_ARGS,)
     __tablename__ = TABLE_STATES_META
     metadata_id: Mapped[int] = mapped_column(Integer, Identity(), primary_key=True)
-    entity_id: Mapped[str | None] = mapped_column(String(MAX_LENGTH_STATE_ENTITY_ID))
+    entity_id: Mapped[str | None] = mapped_column(
+        String(MAX_LENGTH_STATE_ENTITY_ID), index=True
+    )
 
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1056,7 +1056,7 @@ def _apply_update(  # noqa: C901
         )
     elif new_version == 41:
         _create_index(session_maker, "event_types", "ix_event_types_event_type")
-        _create_index(session_maker, "states_metadata", "ix_states_metadata_entity_id")
+        _create_index(session_maker, "states_meta", "ix_states_meta_entity_id")
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1054,6 +1054,9 @@ def _apply_update(  # noqa: C901
             "statistics_short_term",
             "ix_statistics_short_term_metadata_id",
         )
+    elif new_version == 41:
+        _create_index(session_maker, "event_types", "ix_event_types_event_type")
+        _create_index(session_maker, "states_metadata", "ix_states_metadata_entity_id")
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


When updating the sql docs, I realized there will be manual queries that will not have access to the LRU so we need to have an index on these columns (https://github.com/home-assistant/home-assistant.io/pull/26591)

Since most of these will already be in the LRU and index was unlikely to be needed. If they have more than the size of the LRU entities or event types an index is useful.  

These indexes are expected to be tiny so they will not have a meaningful impact on database size

```
*** Page counts for all tables and indices separately *************************

STATES............................................ 36822       22.8% 
STATISTICS........................................ 25700       15.9% 
IX_STATES_CONTEXT_ID_BIN.......................... 14731        9.1% 
STATISTICS_SHORT_TERM............................. 13857        8.6% 
IX_STATES_METADATA_ID_LAST_UPDATED_TS............. 11979        7.4% 
IX_STATES_LAST_UPDATED_TS......................... 10189        6.3% 
IX_STATISTICS_STATISTIC_ID_START_TS............... 8596         5.3% 
IX_STATES_OLD_STATE_ID............................ 7682         4.7% 
IX_STATES_ATTRIBUTES_ID........................... 7187         4.4% 
IX_STATISTICS_START_TS............................ 7170         4.4% 
IX_STATES_EVENT_ID................................ 5670         3.5% 
IX_STATISTICS_SHORT_TERM_STATISTIC_ID_START_TS.... 4940         3.1% 
IX_STATISTICS_SHORT_TERM_START_TS................. 4138         2.6% 
STATE_ATTRIBUTES.................................. 1019         0.63% 
EVENTS............................................ 757          0.47% 
IX_EVENTS_CONTEXT_ID_BIN.......................... 388          0.24% 
IX_EVENTS_EVENT_TYPE_ID_TIME_FIRED_TS............. 288          0.18% 
IX_EVENTS_TIME_FIRED_TS........................... 264          0.16% 
IX_EVENTS_DATA_ID................................. 163          0.10% 
EVENT_DATA........................................ 62           0.038% 
IX_STATE_ATTRIBUTES_HASH.......................... 45           0.028% 
IX_STATISTICS_RUNS_START.......................... 28           0.017% 
STATISTICS_RUNS................................... 28           0.017% 
STATES_META....................................... 25           0.015% 
IX_STATES_META_ENTITY_ID.......................... 24           0.015% 
STATISTICS_META................................... 12           0.007% 
IX_STATISTICS_META_STATISTIC_ID................... 9            0.006% 
IX_EVENT_DATA_HASH................................ 8            0.005% 
RECORDER_RUNS..................................... 4            0.002% 
IX_RECORDER_RUNS_START_END........................ 3            0.002% 
SQLITE_SCHEMA..................................... 3            0.002% 
EVENT_TYPES....................................... 1            0.0% 
IX_EVENT_TYPES_EVENT_TYPE......................... 1            0.0% 
SCHEMA_CHANGES.................................... 1            0.0% 
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/data.home-assistant/pull/264

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [data.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
